### PR TITLE
feat(agent): the Effect subpath is the SDK surface; the Promise entry is its rendering (D6)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,7 +43,9 @@ const COMPOSITION_ROOT_FILES = new Set([
   path.join(__dirname, 'packages/extension/src/extension.ts'),
   path.join(__dirname, 'packages/desktop/src/main/platform/index.ts'),
   path.join(__dirname, 'packages/cli/src/runtime/initPlatform.ts'),
-  path.join(__dirname, 'packages/agent/src/index.ts'),
+  // The package's composition root is `composeProcess`, which the Promise
+  // entry and the Effect subpath's `Runtime.layer` both call.
+  path.join(__dirname, 'packages/agent/src/effect/runtime.ts'),
   // The test suite's composition root: the sole place vitest suites swap the
   // fake platform, replacing the per-suite `await import('@platform/platform')`
   // dance every suite used to hand-roll to dodge this same rule.

--- a/knip.json
+++ b/knip.json
@@ -18,6 +18,7 @@
     "packages/agent": {
       "entry": [
         "src/index.ts!",
+        "src/effect.ts!",
         "src/node.ts!",
         "src/schemas.ts!",
         "scripts/*.mjs!"

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -51,9 +51,10 @@ interface AgentRun extends AsyncIterable<AgentEvent> {
 }
 ```
 
-Event delivery starts at the iterator's first `next()`. Awaiting only `result`
-does not retain trace events, and ending iteration detaches the event source
-while the run itself continues.
+Trace events are buffered from the moment the run enters its session, so an
+iteration begun right after `runAgent()` misses none of the launch events.
+Ending the iteration detaches the event source while the run itself continues,
+and a run that settles without ever being iterated discards what it buffered.
 
 `view` is the folded session state every TeXRA host renders, so stream
 status, transcript rows, and pending approvals are read from it rather than
@@ -70,10 +71,11 @@ stops that reader while the run continues. If launch fails before the run
 enters the session, `view` ends without a value and `result` carries the
 failure.
 
-Every yielded view is immutable: an older view stays what it was for as long
-as it is held, and a branch the later level did not touch is the same object
-in both. An older view is stable to read; it is not a fold input, so nothing
-in the package folds onto anything but the latest level. The exported
+Every yielded view is a value: the fold publishes immutable levels with
+copy-on-touch structural sharing, so an older view stays exactly what it was
+for as long as it is held, and a branch the later level did not touch is the
+same object in both. An older view is stable to read; it is not a fold input,
+so nothing in the package folds onto anything but the latest level. The exported
 `SessionView`, `StreamView`, and
 `TranscriptView` types are read-only all the way down (`ReadonlyMap`, readonly
 arrays); a write through a cast corrupts the session every later run in the
@@ -126,6 +128,60 @@ files.
 | `@texra-ai/agent`         | `runAgent`, `closeSession`, `AgentRun`, `defineTool`, `MapToolRegistry`, and the `AgentEvent` / `ITool` / `AgentFlowResult` / `SessionCloseReport` types |
 | `@texra-ai/agent/schemas` | Zod schemas + inferred types for agent definitions, configs, and run results                                                                             |
 | `@texra-ai/agent/node`    | `nodePlatform(options)`, a ready-made Node `Platform` with its workspace roots                                                                           |
+| `@texra-ai/agent/effect`  | `Runtime`, `Sessions`, `Session`, `Run` and the tagged errors: the services the entry above renders                                                      |
+
+## Effect
+
+`@texra-ai/agent/effect` is the surface. Everything this package decides is
+stated once there, in Effect: which level is a run's first, when its transcript
+interest changes, when its drain ends, which failure wins. `@texra-ai/agent`
+above is that surface rendered as Promises and AsyncIterables, and holds no
+logic of its own. It stays the Promise entry because the published SDK is one
+of the three boundary kinds rule R1 of TeXRA's Effect migration names
+(`docs/prds/2026-08-26-effect-4-runtime-migration.md`, §7): host entries, the
+tool `execute()` contract, and this package's public API speak Promises;
+everything below them is Effect-typed.
+
+`effect` is a peer dependency. Install the same version the package pins
+(`4.0.0-rc.112`): Streams, Fibers and Context built by one copy of Effect do
+not interoperate with another's.
+
+```ts
+import { Effect, Stream } from 'effect';
+import { Runtime, Sessions } from '@texra-ai/agent/effect';
+import { nodePlatform } from '@texra-ai/agent/node';
+
+const program = Effect.gen(function* () {
+  const sessions = yield* Sessions;
+  const session = yield* sessions.open();
+  yield* Effect.forkScoped(Stream.runForEach(session.view.changes, render));
+  const run = yield* session.start({ agent: 'polish', instruction });
+  yield* session.subscribe([{ id: run.streamId, fromSeq: 0 }]);
+  yield* session.request({
+    kind: 'followUp.send',
+    streamId: run.streamId,
+    text: 'Keep the theorem statements unchanged.',
+  });
+  return yield* run.result;
+}).pipe(Effect.scoped, Effect.provide(Runtime.layer(nodePlatform(options))));
+```
+
+| Service    | What it is                                                                                                                                                                                         |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Runtime`  | The composed process: the platform, its workspace roots, and whether this composition owns the process. `Runtime.layer(platform)` provides it and `Sessions`, and its scope closes what it opened. |
+| `Sessions` | The process's one session owner: `open(roots?)`, `close(roots?, signal?)`, `list`. One session per workspace storage root, the same owner every TeXRA host opens through.                          |
+| `Session`  | `start`, `request`, `view.changes`, `events`, and `subscribe`, whose transcript interest is held for a `Scope` and cleared when it closes. A value, one per root, not a tag.                       |
+| `Run`      | `executionId`, `streamId`, `result`, `view`, `events`, `interrupt`. `start` succeeds at admission: the run exists in the session, its stream published and its trace live.                         |
+
+Failures are `Data.TaggedError`s: `PlatformConflict`, `AgentNotFound`,
+`ToolsRefused`, and `RunFailure`, whose `cause` is exactly what the launch path
+threw, which is what the Promise entry rejects with. A `session.request`
+answers with the runtime's own `Outcome` or its `RequestError` union, the same
+values every TeXRA host reads. Nothing else is exported: no store, no fold
+internals, no host widgets.
+
+A runnable version of this program against a packed tarball is in
+[`example/`](./example).
 
 ## The platform
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -107,7 +107,14 @@ returning `{ settled, abandoned }`. `settled` is true when every run ended in
 time; otherwise `abandoned` names the runs still live, and the session stays
 open, refusing new runs, until they end. The platform's shutdown path
 (`lifecycle.runShutdown()`), which an embedder runs before it exits, closes
-the platform's session this way after the runs it owns have settled.
+the platform's session this way after the runs it owns have settled, and then
+disposes the runtime the session owner ran on.
+
+That path runs once, so `runAgent` composes once per process: a run started
+after the platform's shutdown has run is refused, because the session it would
+open has no shutdown left to close and flush it. An embedder that needs more
+than one composition in a process takes the Effect surface below, where each
+scope owns the composition it made.
 
 ## Run results
 
@@ -191,7 +198,9 @@ and a branch the later level did not touch is the same object in both.
 
 A scope that composed the process ends it: leaving it closes the runtime's
 session and disposes the runtime the owner ran on, and a later program in the
-same process composes again over the platform already installed. A scope that
+same process composes again over the platform already installed. That is what
+the Promise entry cannot do, and why it composes once: its owner is the
+embedder's shutdown path, which runs once. A scope that
 found a host (or an earlier `runAgent`) already composed closes nothing, so it
 never kills runs it does not own; close a root such a scope opened of its own
 through `Sessions.close`.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -55,6 +55,18 @@ Trace events are buffered from the moment the run enters its session, so an
 iteration begun right after `runAgent()` misses none of the launch events.
 Ending the iteration detaches the event source while the run itself continues,
 and a run that settles without ever being iterated discards what it buffered.
+That buffer is only the handover to the first reader, and it is bounded: a run
+whose events pass the handover window with nobody reading has no reader, so it
+logs a warning naming the run and detaches its trace. Awaiting only `result`
+therefore never retains a long run's whole trace. A reader that did attach is
+never dropped: past its first pull the buffer is that reader's, and nothing
+discards what it has yet to read.
+
+Every failure reaches the caller on `result`; `runAgent()` itself does not
+throw. A refusal before any model work is one of the tagged errors the Effect
+surface names below (`AgentNotFound`, `ToolsRefused`, and `PlatformConflict`
+for a second, different platform); a run that fails after entering its session
+rejects with exactly what the launch path threw.
 
 `view` is the folded session state every TeXRA host renders, so stream
 status, transcript rows, and pending approvals are read from it rather than
@@ -166,12 +178,23 @@ const program = Effect.gen(function* () {
 }).pipe(Effect.scoped, Effect.provide(Runtime.layer(nodePlatform(options))));
 ```
 
-| Service    | What it is                                                                                                                                                                                         |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Runtime`  | The composed process: the platform, its workspace roots, and whether this composition owns the process. `Runtime.layer(platform)` provides it and `Sessions`, and its scope closes what it opened. |
-| `Sessions` | The process's one session owner: `open(roots?)`, `close(roots?, signal?)`, `list`. One session per workspace storage root, the same owner every TeXRA host opens through.                          |
-| `Session`  | `start`, `request`, `view.changes`, `events`, and `subscribe`, whose transcript interest is held for a `Scope` and cleared when it closes. A value, one per root, not a tag.                       |
-| `Run`      | `executionId`, `streamId`, `result`, `view`, `events`, `interrupt`. `start` succeeds at admission: the run exists in the session, its stream published and its trace live.                         |
+| Service    | What it is                                                                                                                                                                                                                                                                                               |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Runtime`  | The composed process: the platform, its workspace roots, and whether this composition installed the process runtime. `Runtime.layer(platform)` provides it and `Sessions`; its scope closes what this composition opened, and nothing when it composed beside a host's or an earlier run's installation. |
+| `Sessions` | The process's one session owner: `open(roots?)`, `close(roots?, signal?)`, `list`. One session per workspace storage root, the same owner every TeXRA host opens through.                                                                                                                                |
+| `Session`  | `start`, `request`, `view.changes`, `events`, and `subscribe`, whose transcript interest is held for a `Scope` and cleared when it closes. A value, one per root, not a tag.                                                                                                                             |
+| `Run`      | `executionId`, `streamId`, `result`, `view`, `events`, `interrupt`. `start` succeeds at admission: the run exists in the session, its stream published and its trace live.                                                                                                                               |
+
+`session.view.changes` publishes the fold's levels as values: each is
+immutable, an older level stays exactly what it was for as long as it is held,
+and a branch the later level did not touch is the same object in both.
+
+A scope that composed the process ends it: leaving it closes the runtime's
+session and disposes the runtime the owner ran on, and a later program in the
+same process composes again over the platform already installed. A scope that
+found a host (or an earlier `runAgent`) already composed closes nothing, so it
+never kills runs it does not own; close a root such a scope opened of its own
+through `Sessions.close`.
 
 Failures are `Data.TaggedError`s: `PlatformConflict`, `AgentNotFound`,
 `ToolsRefused`, and `RunFailure`, whose `cause` is exactly what the launch path

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -17,7 +17,18 @@ Not on the registry yet. Inside this workspace, depend on it by name:
 { "dependencies": { "@texra-ai/agent": "workspace:*" } }
 ```
 
-`zod` (v4) is a peer dependency.
+`effect` and `zod` (v4) are peer dependencies, and they are peers of the
+**whole package**, not only of the `@texra-ai/agent/effect` subpath: the root
+entry's bundle imports `effect` at runtime too (`dist/index.js` opens with
+`import ... from 'effect'`). Install both alongside it, `effect` at the exact
+version the package pins (`4.0.0-rc.112`). Two copies of `effect` in one
+process do not work at all: Streams, Fibers and Context built by one copy do
+not interoperate with another's, and a peer dependency is how a consumer gets
+one copy rather than a second nested one.
+
+```jsonc
+{ "dependencies": { "effect": "4.0.0-rc.112", "zod": "^4.4.3" } }
+```
 
 ## Usage
 
@@ -149,6 +160,10 @@ files.
 | `@texra-ai/agent/node`    | `nodePlatform(options)`, a ready-made Node `Platform` with its workspace roots                                                                           |
 | `@texra-ai/agent/effect`  | `Runtime`, `Sessions`, `Session`, `Run` and the tagged errors: the services the entry above renders                                                      |
 
+Every entry needs the `effect` and `zod` peers installed, the root one
+included: `@texra-ai/agent` is the Effect surface rendered as Promises, and
+its bundle imports `effect` at runtime like the subpath does.
+
 ## Effect
 
 `@texra-ai/agent/effect` is the surface. Everything this package decides is
@@ -161,9 +176,8 @@ of the three boundary kinds rule R1 of TeXRA's Effect migration names
 tool `execute()` contract, and this package's public API speak Promises;
 everything below them is Effect-typed.
 
-`effect` is a peer dependency. Install the same version the package pins
-(`4.0.0-rc.112`): Streams, Fibers and Context built by one copy of Effect do
-not interoperate with another's.
+`effect` is a peer dependency of every entry, not only this one. See
+[Install](#install).
 
 ```ts
 import { Effect, Stream } from 'effect';
@@ -185,25 +199,27 @@ const program = Effect.gen(function* () {
 }).pipe(Effect.scoped, Effect.provide(Runtime.layer(nodePlatform(options))));
 ```
 
-| Service    | What it is                                                                                                                                                                                                                                                                                               |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Runtime`  | The composed process: the platform, its workspace roots, and whether this composition installed the process runtime. `Runtime.layer(platform)` provides it and `Sessions`; its scope closes what this composition opened, and nothing when it composed beside a host's or an earlier run's installation. |
-| `Sessions` | The process's one session owner: `open(roots?)`, `close(roots?, signal?)`, `list`. One session per workspace storage root, the same owner every TeXRA host opens through.                                                                                                                                |
-| `Session`  | `start`, `request`, `view.changes`, `events`, and `subscribe`, whose transcript interest is held for a `Scope` and cleared when it closes. A value, one per root, not a tag.                                                                                                                             |
-| `Run`      | `executionId`, `streamId`, `result`, `view`, `events`, `interrupt`. `start` succeeds at admission: the run exists in the session, its stream published and its trace live.                                                                                                                               |
+| Service    | What it is                                                                                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Runtime`  | The composed process: the platform and its workspace roots. `Runtime.layer(platform)` provides it and `Sessions`, with this scope as the lifetime of the hold it takes on that composition. |
+| `Sessions` | The process's one session owner: `open(roots?)`, `close(roots?, signal?)`, `list`. One session per workspace storage root, the same owner every TeXRA host opens through.                   |
+| `Session`  | `start`, `request`, `view.changes`, `events`, and `subscribe`, whose transcript interest is held for a `Scope` and cleared when it closes. A value, one per root, not a tag.                |
+| `Run`      | `executionId`, `streamId`, `result`, `view`, `events`, `interrupt`. `start` succeeds at admission: the run exists in the session, its stream published and its trace live.                  |
 
 `session.view.changes` publishes the fold's levels as values: each is
 immutable, an older level stays exactly what it was for as long as it is held,
 and a branch the later level did not touch is the same object in both.
 
-A scope that composed the process ends it: leaving it closes the runtime's
-session and disposes the runtime the owner ran on, and a later program in the
-same process composes again over the platform already installed. That is what
-the Promise entry cannot do, and why it composes once: its owner is the
-embedder's shutdown path, which runs once. A scope that
-found a host (or an earlier `runAgent`) already composed closes nothing, so it
-never kills runs it does not own; close a root such a scope opened of its own
-through `Sessions.close`.
+The composition is held, not owned: each `Runtime.layer` scope takes a hold on
+it, and the last hold to end is what closes every session the owner holds,
+each settling its runs and flushing its artifacts, and then disposes the
+runtime they ran on. So two overlapping scopes over one platform are safe, the
+first one out ends nothing the second is still using, and a later program in
+the same process composes again over the platform already installed. That is
+what the Promise entry cannot do, and why it composes once: its owner is the
+embedder's shutdown path, which runs once. A composition that found a host's
+own installation ends nothing however its holds end: those sessions are the
+host's, and killing its live runs is not this package's to do.
 
 Failures are `Data.TaggedError`s: `PlatformConflict`, `AgentNotFound`,
 `ToolsRefused`, and `RunFailure`, whose `cause` is exactly what the launch path

--- a/packages/agent/example/.gitignore
+++ b/packages/agent/example/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+*.tgz

--- a/packages/agent/example/README.md
+++ b/packages/agent/example/README.md
@@ -1,0 +1,40 @@
+# Packed-tarball example
+
+Runs [`@texra-ai/agent/effect`](../README.md#effect) the way a consumer off the
+registry would: the package is packed, installed into this folder, and imported
+by package name. No repository path alias appears in `effectSession.mjs`, so a
+resolution the published artifact could not satisfy fails here.
+
+It needs no provider key.
+
+```bash
+corepack pnpm --filter @texra-ai/agent run example:packed
+```
+
+which is, step by step:
+
+```bash
+# from the repository root
+corepack pnpm --filter @texra-ai/agent build
+cd packages/agent && rm -f example/*.tgz && corepack pnpm pack --pack-destination example
+cd example && npm install ./texra-ai-agent-*.tgz && npm start
+```
+
+`npm install` rather than `pnpm` on purpose: it installs the tarball and the two
+peer dependencies (`effect`, `zod`) into a plain `node_modules`, with no
+workspace link that could hide a missing export.
+
+Expected output, with the temporary paths varying:
+
+```text
+session root: /var/folders/.../texra-agent-example-XXXX/storage/workspace-storage/texra-agent-example-XXXX-<hash>
+first view level: 0 streams
+sessions the owner holds: 1
+[TeXRA] DEBUG [...] [agentRegistry] Scanned 0 agents from custom
+[TeXRA] INFO  [...] [agentRegistry] Loaded 0 agents in 6ms
+refusal: AgentNotFound - Agent "no-such-agent" was not found in the configured agent directory.
+done
+```
+
+The process exits on its own: leaving the scope closed the session and disposed
+the runtime that held it.

--- a/packages/agent/example/README.md
+++ b/packages/agent/example/README.md
@@ -17,8 +17,13 @@ which is, step by step:
 # from the repository root
 corepack pnpm --filter @texra-ai/agent build
 cd packages/agent && rm -f example/*.tgz && corepack pnpm pack --pack-destination example
-cd example && npm install ./texra-ai-agent-*.tgz && npm start
+mv example/texra-ai-agent-*.tgz example/agent.tgz
+cd example && npm install ./agent.tgz && npm start
 ```
+
+The pack is renamed to a fixed `agent.tgz` so this folder's `package.json`
+pins one filename rather than a second copy of the package version, which a
+release would silently move.
 
 `npm install` rather than `pnpm` on purpose: it installs the tarball and the two
 peer dependencies (`effect`, `zod`) into a plain `node_modules`, with no

--- a/packages/agent/example/effectSession.mjs
+++ b/packages/agent/example/effectSession.mjs
@@ -1,0 +1,57 @@
+/**
+ * A tiny embedder of `@texra-ai/agent/effect`, installed from a packed
+ * tarball exactly as a consumer off the registry would get it: the import
+ * specifiers below are package names, never this repository's path aliases.
+ *
+ * It needs no provider key. It composes the runtime, opens a session, reads
+ * the session's current view level, lists what the owner holds, and asks for
+ * an agent that does not exist so the typed refusal is visible. Leaving the
+ * scope closes the session and disposes the runtime that held it.
+ */
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Effect, Stream } from 'effect';
+import { Runtime, Sessions } from '@texra-ai/agent/effect';
+import { nodePlatform } from '@texra-ai/agent/node';
+
+const workspace = await mkdtemp(join(tmpdir(), 'texra-agent-example-'));
+const agentsDir = join(workspace, 'agents');
+await mkdir(agentsDir, { recursive: true });
+
+const program = Effect.gen(function* () {
+  const sessions = yield* Sessions;
+  const session = yield* sessions.open();
+  console.log('session root:', session.roots.storage);
+
+  const level = yield* Stream.runHead(session.view.changes);
+  console.log(
+    'first view level:',
+    level._tag === 'Some' ? `${level.value.streams.size} streams` : 'none',
+  );
+
+  const open = yield* sessions.list;
+  console.log('sessions the owner holds:', open.length);
+
+  // `start` fails with a tagged error rather than a thrown string: an
+  // embedder branches on `_tag`.
+  const refusal = yield* Effect.flip(
+    session.start({ agent: 'no-such-agent', instruction: 'Nothing to do.' }),
+  );
+  console.log(`refusal: ${refusal._tag} - ${refusal.message}`);
+}).pipe(
+  Effect.scoped,
+  Effect.provide(
+    Runtime.layer(
+      nodePlatform({
+        agentsDir,
+        storageDir: join(workspace, 'storage'),
+        workspaceDir: workspace,
+      }),
+    ),
+  ),
+);
+
+await Effect.runPromise(program);
+console.log('done');

--- a/packages/agent/example/package.json
+++ b/packages/agent/example/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "texra-agent-effect-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Runs @texra-ai/agent/effect from a packed tarball, as a consumer would",
+  "scripts": {
+    "start": "node effectSession.mjs"
+  },
+  "dependencies": {
+    "@texra-ai/agent": "file:texra-ai-agent-0.40.9.tgz",
+    "effect": "4.0.0-rc.112",
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/agent/example/package.json
+++ b/packages/agent/example/package.json
@@ -8,7 +8,7 @@
     "start": "node effectSession.mjs"
   },
   "dependencies": {
-    "@texra-ai/agent": "file:texra-ai-agent-0.40.9.tgz",
+    "@texra-ai/agent": "file:agent.tgz",
     "effect": "4.0.0-rc.112",
     "zod": "^4.4.3"
   }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -33,6 +33,10 @@
       "types": "./dist/types/packages/agent/src/schemas.d.ts",
       "import": "./dist/schemas.js"
     },
+    "./effect": {
+      "types": "./dist/types/packages/agent/src/effect.d.ts",
+      "import": "./dist/effect.js"
+    },
     "./node": {
       "types": "./dist/types/packages/agent/src/node.d.ts",
       "import": "./dist/node.js"
@@ -40,6 +44,7 @@
   },
   "scripts": {
     "build": "node scripts/build.mjs",
+    "example:packed": "npm run build && rm -f example/*.tgz && corepack pnpm pack --pack-destination example && cd example && npm install ./texra-ai-agent-*.tgz && npm start",
     "prepack": "npm run build"
   },
   "dependencies": {
@@ -67,7 +72,6 @@
     "delay": "^7.0.0",
     "diff": "^9.0.0",
     "diff-match-patch": "^1.0.5",
-    "effect": "4.0.0-rc.112",
     "escape-string-regexp": "^5.0.0",
     "execa": "^10.0.1",
     "fast-xml-parser": "^5.11.1",
@@ -113,10 +117,12 @@
     "yaml": "^2.9.0"
   },
   "peerDependencies": {
+    "effect": "4.0.0-rc.112",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@typescript/native": "npm:typescript@^7.0.2",
+    "effect": "4.0.0-rc.112",
     "esbuild": "^0.28.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "zod": "^4.4.3"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "build": "node scripts/build.mjs",
-    "example:packed": "npm run build && rm -f example/*.tgz && corepack pnpm pack --pack-destination example && cd example && npm install ./texra-ai-agent-*.tgz && npm start",
+    "example:packed": "npm run build && rm -f example/*.tgz && corepack pnpm pack --pack-destination example && mv example/texra-ai-agent-*.tgz example/agent.tgz && cd example && npm install ./agent.tgz && npm start",
     "prepack": "npm run build"
   },
   "dependencies": {

--- a/packages/agent/scripts/bundle.mjs
+++ b/packages/agent/scripts/bundle.mjs
@@ -9,6 +9,7 @@ await build({
   bundle: true,
   entryPoints: {
     index: 'src/index.ts',
+    effect: 'src/effect.ts',
     schemas: 'src/schemas.ts',
     node: 'src/node.ts',
   },
@@ -25,6 +26,25 @@ await build({
       name: 'bundle-patched-openai',
       setup(buildContext) {
         buildContext.onResolve({ filter: /^openai(?:\/|$)/ }, ({ path }) => ({
+          path: fileURLToPath(import.meta.resolve(path)),
+          external: false,
+        }));
+      },
+    },
+    {
+      // `bibtex` is UMD/CommonJS whose named exports Node's ESM loader cannot
+      // detect, so leaving it external makes every entry of the installed
+      // package fail at module init with "does not provide an export named
+      // parseBibFile" (found by `example/`, which installs the tarball as a
+      // consumer does). It cannot be fixed at the import site: the source
+      // must keep the named import, because its UMD exports carry
+      // `__esModule: true` and a default import bundles to `undefined` under
+      // esbuild's ESM interop (the 0.39.10 startup crash). Inlining it lets
+      // esbuild resolve the binding at bundle time, exactly as the extension
+      // and CLI bundles already do.
+      name: 'bundle-cjs-bibtex',
+      setup(buildContext) {
+        buildContext.onResolve({ filter: /^bibtex$/ }, ({ path }) => ({
           path: fileURLToPath(import.meta.resolve(path)),
           external: false,
         }));

--- a/packages/agent/scripts/validate-artifacts.mjs
+++ b/packages/agent/scripts/validate-artifacts.mjs
@@ -94,22 +94,29 @@ async function reachableDeclarations(entry) {
   return visited;
 }
 
-const mainTypes = path.resolve(packageRoot, manifest.exports['.'].types);
-const mainGraph = await reachableDeclarations(mainTypes);
-const mainGraphText = (
-  await Promise.all([...mainGraph].map((file) => readFile(file, 'utf8')))
-).join('\n');
-for (const provider of [
-  '@anthropic-ai/sdk',
-  '@google/genai',
-  '@openrouter/sdk',
-  'openai',
-]) {
-  const providerImport = new RegExp(
-    `(?:from|import\\s*\\()\\s*['"]${provider.replaceAll('/', '\\/')}(?:/|['"])`,
-  );
-  if (providerImport.test(mainGraphText)) {
-    throw new Error(`Provider type leaked into the main entry: ${provider}`);
+// Every published entry, not only the root: an entry whose declaration
+// graph reaches a provider SDK puts that provider's types back on the
+// published surface however narrow the entry looks.
+for (const [entry, target] of Object.entries(manifest.exports)) {
+  const entryTypes = path.resolve(packageRoot, target.types);
+  const entryGraph = await reachableDeclarations(entryTypes);
+  const entryGraphText = (
+    await Promise.all([...entryGraph].map((file) => readFile(file, 'utf8')))
+  ).join('\n');
+  for (const provider of [
+    '@anthropic-ai/sdk',
+    '@google/genai',
+    '@openrouter/sdk',
+    'openai',
+  ]) {
+    const providerImport = new RegExp(
+      `(?:from|import\\s*\\()\\s*['"]${provider.replaceAll('/', '\\/')}(?:/|['"])`,
+    );
+    if (providerImport.test(entryGraphText)) {
+      throw new Error(
+        `Provider type leaked into the "${entry}" entry: ${provider}`,
+      );
+    }
   }
 }
 

--- a/packages/agent/src/effect.ts
+++ b/packages/agent/src/effect.ts
@@ -1,0 +1,52 @@
+/**
+ * `@texra-ai/agent/effect` — the SDK's surface.
+ *
+ * The services below are where every decision this package makes is
+ * stated: which level is a run's first, when its transcript interest
+ * changes, when its drain ends, which failure wins. The root entry
+ * (`@texra-ai/agent`) is the Promise rendering of exactly these services
+ * and holds no logic of its own; it is the boundary the Effect migration's
+ * rule R1 names (`docs/prds/2026-08-26-effect-4-runtime-migration.md`,
+ * §7 R1, boundary kind 3: the published SDK). Nothing below this barrel
+ * calls `Effect.runPromise`, `runSync`, or `runFork`.
+ *
+ * Payloads are the runtime's own Zod-derived values (`RuntimeRequest`,
+ * `Outcome`, the `RequestError` union), so an embedder that speaks Effect
+ * reads and writes what every TeXRA host does. There is no store, no fold
+ * internal, and no host widget here.
+ */
+
+// The services and their layer.
+export { composeProcess, Runtime } from './effect/runtime.js';
+export type { AgentPlatform, AgentRuntime } from './effect/runtime.js';
+export { makeSessions, Sessions } from './effect/sessions.js';
+export type {
+  Run,
+  Session,
+  SessionView,
+  StartInput,
+  StreamView,
+  TranscriptView,
+} from './effect/sessions.js';
+
+// The failures the surface names.
+export {
+  AgentNotFound,
+  PlatformConflict,
+  RunFailure,
+  ToolsRefused,
+} from './effect/errors.js';
+export type { LaunchError } from './effect/errors.js';
+
+// The payloads, as the runtime defines them.
+export type { AgentEvent } from '@agent/trace';
+export type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
+export type { ITool } from '@agent/core/tools/ToolTypes';
+export type {
+  ExecutionId,
+  SessionCloseReport,
+  StreamTabId,
+  TranscriptSubscription,
+} from '@shared/schemas';
+export type { RequestError } from '@shared/session/requestErrors';
+export type { Outcome, RuntimeRequest } from '@shared/session/runtimeRequest';

--- a/packages/agent/src/effect.ts
+++ b/packages/agent/src/effect.ts
@@ -16,10 +16,13 @@
  * internal, and no host widget here.
  */
 
-// The services and their layer.
-export { composeProcess, Runtime } from './effect/runtime.js';
+// The services and their layer. `Runtime.layer(platform)` is the only way
+// in: the composition root and the session factory under it stay internal,
+// because a caller that reached them directly would hold a composed process
+// and an open session with no scope to end either.
+export { Runtime } from './effect/runtime.js';
 export type { AgentPlatform, AgentRuntime } from './effect/runtime.js';
-export { makeSessions, Sessions } from './effect/sessions.js';
+export { Sessions } from './effect/sessions.js';
 export type {
   Run,
   Session,

--- a/packages/agent/src/effect/errors.ts
+++ b/packages/agent/src/effect/errors.ts
@@ -1,0 +1,48 @@
+/**
+ * The failures the Effect surface names (`@texra-ai/agent/effect`). Four
+ * tagged errors, no more: the process the package refuses to compose, the
+ * two launch refusals an embedder branches on, and the run's own failure.
+ *
+ * Request failures are not here. A `session.request` answers with the
+ * runtime's own `RequestError` union (`@shared/session/requestErrors`), the
+ * same values every TeXRA host reads, so the package adds no second
+ * vocabulary for them.
+ */
+import { Data } from 'effect';
+
+/**
+ * A second, different platform was handed to a process the package already
+ * composed. The platform is process-wide by contract, so this is a
+ * programming error rather than a condition to retry.
+ */
+export class PlatformConflict extends Data.TaggedError('PlatformConflict')<{
+  readonly message: string;
+}> {}
+
+/** No agent of that name in the configured agent directory. */
+export class AgentNotFound extends Data.TaggedError('AgentNotFound')<{
+  readonly agent: string;
+  readonly message: string;
+}> {}
+
+/**
+ * The tools the caller passed cannot run here: a tool that requires
+ * approval (the package has no approval channel), or custom tools handed to
+ * a workflow agent.
+ */
+export class ToolsRefused extends Data.TaggedError('ToolsRefused')<{
+  readonly tools: readonly string[];
+  readonly message: string;
+}> {}
+
+/** A run that failed on its own. `cause` is exactly what the launch path
+ *  threw, which is what the Promise entry rejects with. */
+export class RunFailure extends Data.TaggedError('RunFailure')<{
+  readonly cause: unknown;
+  readonly message: string;
+}> {}
+
+/** What a launch refuses before any model work: the two an embedder
+ *  branches on. A run that fails after admission fails with
+ *  {@link RunFailure} instead. */
+export type LaunchError = AgentNotFound | ToolsRefused;

--- a/packages/agent/src/effect/runtime.ts
+++ b/packages/agent/src/effect/runtime.ts
@@ -10,13 +10,16 @@
  *
  * {@link Runtime.layer} is the Effect embedder's entry: it composes the
  * process once and provides both this service and `Sessions`. Its scope
- * owns the closure, so leaving `Effect.scoped` closes the runtime's session
- * and, when the package composed the process, disposes the runtime the
- * owner runs on. A Promise embedder reaches the same closure through
+ * owns what this composition installed, so leaving `Effect.scoped` closes
+ * the runtime's session and disposes the runtime the owner runs on when
+ * this composition was the one that installed them, and closes nothing
+ * when it composed beside a host's (or an earlier run's) installation. A
+ * Promise embedder reaches the same closure through
  * `lifecycle.runShutdown()`, which `packages/agent/src/index.ts` wires.
  */
 import { Context, Effect, Layer } from 'effect';
 
+import { sessionOwnerInstalled } from '@agent/runtime';
 import {
   disposeProcessRuntime,
   installProcessRuntime,
@@ -45,9 +48,10 @@ export interface AgentRuntime {
   readonly platform: AgentPlatform;
   readonly roots: WorkspaceRoots;
   /**
-   * This call composed the process: it was the first to run here, so it
-   * owns the disposal of the Effect runtime the session owner runs on.
-   * False beside a host (or an earlier run) that composed its own.
+   * This call installed the process runtime and the session owner on it, so
+   * it owns their disposal and the end of the session it opened. False
+   * beside a host (or an earlier composition whose closure has not run)
+   * that installed its own.
    */
   readonly composed: boolean;
 }
@@ -57,6 +61,15 @@ export interface AgentRuntime {
  * and idempotent: a run beside a host that already ran its own composition
  * root (the same platform object) reuses all four installations, its
  * session included, and nothing here is installed twice.
+ *
+ * What says a process is composed is the session owner, not the platform.
+ * `initPlatform` has no inverse and holds for the life of the process,
+ * while the owner and the runtime under it end with the composition that
+ * installed them (`disposeProcessRuntime`). Reading the platform instead
+ * would leave a process whose first closure has run permanently without an
+ * owner; reading the owner composes again over the platform already
+ * installed, which is what makes the package usable more than once per
+ * process.
  *
  * Throws {@link PlatformConflict} when a second, different platform reaches
  * a process the package already composed.
@@ -69,9 +82,13 @@ export function composeProcess(platform: AgentPlatform): AgentRuntime {
         'The agent package is already using another platform in this process.',
     });
   }
-  if (!active) {
-    initPlatform(platform);
-    initProcessWorkspaceRoots(platform.roots);
+  const composed = !sessionOwnerInstalled();
+  if (composed) {
+    // The process-wide installations, once for the life of the process.
+    if (!active) {
+      initPlatform(platform);
+      initProcessWorkspaceRoots(platform.roots);
+    }
     // The runtime is installed before the agent runtime, as the CLI and
     // desktop roots do: registering the direct Lean language services
     // builds their layer graph on it, so a registration ahead of the
@@ -80,9 +97,11 @@ export function composeProcess(platform: AgentPlatform): AgentRuntime {
     // open registers its root before the opener's first await and only the
     // entry's build waits.
     installProcessRuntime(platform.processes.selfIdentity());
-    initNodeAgentRuntime(platform.lifecycle);
+    if (!active) {
+      initNodeAgentRuntime(platform.lifecycle);
+    }
   }
-  return { platform, roots: platform.roots, composed: !active };
+  return { platform, roots: platform.roots, composed };
 }
 
 /** The composed process. */
@@ -97,17 +116,18 @@ export class Runtime extends Context.Service<Runtime, AgentRuntime>()(
       Layer.provideMerge(
         Layer.effect(
           Runtime,
-          Effect.suspend(() => {
-            try {
-              return Effect.succeed(composeProcess(platform));
-            } catch (error) {
-              // The one refusal this composition states; anything else
-              // thrown by an installation is a defect, not a condition.
-              return error instanceof PlatformConflict
-                ? Effect.fail(error)
-                : Effect.die(error);
-            }
-          }),
+          Effect.try({
+            try: () => composeProcess(platform),
+            catch: (thrown) => thrown,
+          }).pipe(
+            // The one refusal this composition states; anything else
+            // thrown by an installation is a defect, not a condition.
+            Effect.catch((thrown) =>
+              thrown instanceof PlatformConflict
+                ? Effect.fail(thrown)
+                : Effect.die(thrown),
+            ),
+          ),
         ),
       ),
     );
@@ -115,27 +135,27 @@ export class Runtime extends Context.Service<Runtime, AgentRuntime>()(
 }
 
 /**
- * The sessions of the composed process, with the scope as their lifetime
- * (R6): leaving the scope closes the runtime's session, and disposes the
- * Effect runtime the owner runs on when this process was the package's to
- * compose.
+ * The sessions of the composed process, with the scope as the lifetime of
+ * what this composition installed (R6): a composition that installed the
+ * process runtime closes the runtime's session and disposes the runtime the
+ * owner runs on when its scope leaves. A composition that found both
+ * already installed closes nothing: the session belongs to the host (or the
+ * earlier run) that opened it, and killing its live runs is not this scope's
+ * to do; a root such a scope opened of its own ends through
+ * `Sessions.close`.
  */
 const sessionsLayer = Layer.effect(
   Sessions,
   Effect.gen(function* () {
     const runtime = yield* Runtime;
     const sessions = makeSessions(runtime);
-    yield* Effect.addFinalizer(() =>
-      sessions
-        .close()
-        .pipe(
-          Effect.andThen(
-            runtime.composed
-              ? Effect.promise(() => disposeProcessRuntime())
-              : Effect.void,
-          ),
-        ),
-    );
+    if (runtime.composed) {
+      yield* Effect.addFinalizer(() =>
+        sessions
+          .close()
+          .pipe(Effect.andThen(Effect.promise(() => disposeProcessRuntime()))),
+      );
+    }
     return sessions;
   }),
 );

--- a/packages/agent/src/effect/runtime.ts
+++ b/packages/agent/src/effect/runtime.ts
@@ -8,18 +8,24 @@
  * of a root happens before the first yield of a run, so a close issued the
  * moment a launch returns settles that launch too.
  *
+ * That composition is one installation, however many callers reach it, so
+ * it is held rather than owned: every {@link composeProcess} returns a
+ * {@link ProcessHold} on it, and the last hold to be released is what closes
+ * the owner's sessions and disposes the runtime under them.
+ *
  * {@link Runtime.layer} is the Effect embedder's entry: it composes the
- * process once and provides both this service and `Sessions`. Its scope
- * owns what this composition installed, so leaving `Effect.scoped` closes
- * the runtime's session and disposes the runtime the owner runs on when
- * this composition was the one that installed them, and closes nothing
- * when it composed beside a host's (or an earlier run's) installation. A
- * Promise embedder reaches the same closure through
- * `lifecycle.runShutdown()`, which `packages/agent/src/index.ts` wires.
+ * process once per scope and provides both this service and `Sessions`,
+ * with the scope as the lifetime of its hold. A Promise embedder's hold is
+ * the one `packages/agent/src/index.ts` takes, released by
+ * `lifecycle.runShutdown()`.
  */
 import { Context, Effect, Layer } from 'effect';
 
-import { sessionOwnerInstalled } from '@agent/runtime';
+import {
+  closeSession as closeOwnedSession,
+  listSessions as listOwnedSessions,
+  sessionOwnerInstalled,
+} from '@agent/runtime';
 import {
   disposeProcessRuntime,
   installProcessRuntime,
@@ -47,36 +53,68 @@ export interface AgentPlatform extends Platform {
 export interface AgentRuntime {
   readonly platform: AgentPlatform;
   readonly roots: WorkspaceRoots;
+}
+
+/** One composition's hold on the composed process: what it reads, and the
+ *  end of its claim on what it found or installed. */
+export interface ProcessHold {
+  readonly runtime: AgentRuntime;
   /**
-   * This call installed the process runtime and the session owner on it, so
-   * it owns their disposal and the end of the session it opened. False
-   * beside a host (or an earlier composition whose closure has not run)
-   * that installed its own.
+   * End this hold (R6). The last hold to end closes every session the owner
+   * holds and then disposes the runtime they ran on; every earlier one ends
+   * nothing, because something else is still working on it. A hold on a
+   * host's own installation ends nothing either: the session belongs to the
+   * host that opened it, and killing its live runs is not this package's to
+   * do.
+   *
+   * The disposal is the close's finalizer, not its continuation: the close
+   * flushes each session's artifacts, and a flush that defects must not
+   * leave the owner and the runtime under it installed with no hold left to
+   * end them. The defect still propagates, so the embedder sees the failed
+   * close; what it cannot do is skip the disposal.
+   *
+   * Ending a hold twice ends it once. A hold is one composition's and the
+   * count is the process's, so a second release must not spend another
+   * composition's claim.
    */
-  readonly composed: boolean;
+  readonly release: Effect.Effect<void>;
 }
 
 /**
- * Compose the process, or recognize the one already composed. Synchronous
- * and idempotent: a run beside a host that already ran its own composition
- * root (the same platform object) reuses all four installations, its
- * session included, and nothing here is installed twice.
+ * How many live holds there are on the process this package composed. The
+ * session owner and the runtime under it are one installation shared by
+ * every composition that found it already there, so they end when the last
+ * hold ends and not before: a scope that disposed them at its own exit
+ * would tear them out from under an overlapping scope, or from under the
+ * Promise entry's runs, which is precisely what a borrowing composition has
+ * no standing to do.
+ */
+let holds = 0;
+
+/**
+ * Whether the installation those holds share is this package's. What says a
+ * process is composed is the session owner, not the platform: `initPlatform`
+ * has no inverse and holds for the life of the process, while the owner and
+ * the runtime under it end with the holds on them. A composition that found
+ * a host's own installation disposes nothing, however its holds end.
+ */
+let installedHere = false;
+
+/**
+ * Compose the process, or take a hold on the one already composed.
+ * Synchronous and idempotent: a run beside a host that already ran its own
+ * composition root (the same platform object) reuses all four
+ * installations, its session included, and nothing here is installed twice.
  *
- * What says a process is composed is the session owner, not the platform.
- * `initPlatform` has no inverse and holds for the life of the process,
- * while the owner and the runtime under it end with the composition that
- * installed them (`disposeProcessRuntime`). Reading the platform instead
- * would leave a process whose first closure has run permanently without an
- * owner; reading the owner composes again over the platform already
- * installed, which is what makes the Effect surface usable more than once
- * per process: there each scope owns the composition it made. The Promise
- * entry composes once, because the owner it hands a composition to is the
- * embedder's shutdown path, which runs once (`../index.ts`).
+ * Every call takes a hold, and every hold is ended by exactly one
+ * {@link releaseProcess}. That is what makes the Effect surface usable more
+ * than once per process and safe to use twice at once: each scope holds the
+ * composition it found, and the last one out ends it.
  *
  * Throws {@link PlatformConflict} when a second, different platform reaches
  * a process the package already composed.
  */
-export function composeProcess(platform: AgentPlatform): AgentRuntime {
+export function composeProcess(platform: AgentPlatform): ProcessHold {
   const active = tryPlatform();
   if (active && active !== platform) {
     throw new PlatformConflict({
@@ -84,8 +122,7 @@ export function composeProcess(platform: AgentPlatform): AgentRuntime {
         'The agent package is already using another platform in this process.',
     });
   }
-  const composed = !sessionOwnerInstalled();
-  if (composed) {
+  if (!sessionOwnerInstalled()) {
     // The process-wide installations, once for the life of the process.
     if (!active) {
       initPlatform(platform);
@@ -102,15 +139,45 @@ export function composeProcess(platform: AgentPlatform): AgentRuntime {
     if (!active) {
       initNodeAgentRuntime(platform.lifecycle);
     }
+    installedHere = true;
   }
-  return { platform, roots: platform.roots, composed };
+  holds += 1;
+  let held = true;
+  return {
+    runtime: { platform, roots: platform.roots },
+    release: Effect.suspend(() => {
+      if (!held) return Effect.void;
+      held = false;
+      holds -= 1;
+      if (holds > 0 || !installedHere) return Effect.void;
+      installedHere = false;
+      return closeOwnedSessions().pipe(
+        Effect.ensuring(Effect.promise(() => disposeProcessRuntime())),
+      );
+    }),
+  };
+}
+
+/** Every session the owner still holds, closed one at a time: a root some
+ *  composition opened of its own settles its runs and flushes its artifacts
+ *  exactly as the runtime's own root does, rather than going down with the
+ *  runtime unwritten. */
+function closeOwnedSessions(): Effect.Effect<void> {
+  return Effect.flatMap(listOwnedSessions(), (open) =>
+    Effect.forEach(
+      open,
+      (session) => closeOwnedSession(session.roots.storage),
+      { discard: true },
+    ),
+  );
 }
 
 /** The composed process. */
 export class Runtime extends Context.Service<Runtime, AgentRuntime>()(
   '@texra-ai/agent/Runtime',
 ) {
-  /** Compose the process once and provide both services. */
+  /** Compose the process once and provide both services, with this scope as
+   *  the lifetime of the hold it takes. */
   static layer(
     platform: AgentPlatform,
   ): Layer.Layer<Runtime | Sessions, PlatformConflict> {
@@ -118,52 +185,30 @@ export class Runtime extends Context.Service<Runtime, AgentRuntime>()(
       Layer.provideMerge(
         Layer.effect(
           Runtime,
-          Effect.try({
-            try: () => composeProcess(platform),
-            catch: (thrown) => thrown,
-          }).pipe(
-            // The one refusal this composition states; anything else
-            // thrown by an installation is a defect, not a condition.
-            Effect.catch((thrown) =>
-              thrown instanceof PlatformConflict
-                ? Effect.fail(thrown)
-                : Effect.die(thrown),
-            ),
-          ),
+          Effect.gen(function* () {
+            const hold = yield* Effect.try({
+              try: () => composeProcess(platform),
+              catch: (thrown) => thrown,
+            }).pipe(
+              // The one refusal this composition states; anything else
+              // thrown by an installation is a defect, not a condition.
+              Effect.catch((thrown) =>
+                thrown instanceof PlatformConflict
+                  ? Effect.fail(thrown)
+                  : Effect.die(thrown),
+              ),
+            );
+            // Registered where the hold is taken, so no path leaves the
+            // scope holding one.
+            yield* Effect.addFinalizer(() => hold.release);
+            return hold.runtime;
+          }),
         ),
       ),
     );
   }
 }
 
-/**
- * The sessions of the composed process, with the scope as the lifetime of
- * what this composition installed (R6): a composition that installed the
- * process runtime closes the runtime's session and disposes the runtime the
- * owner runs on when its scope leaves. A composition that found both
- * already installed closes nothing: the session belongs to the host (or the
- * earlier run) that opened it, and killing its live runs is not this scope's
- * to do; a root such a scope opened of its own ends through
- * `Sessions.close`.
- *
- * The disposal is the close's finalizer, not its continuation: the close
- * flushes the session's artifacts, and a flush that defects must not leave
- * the owner and the runtime under it installed with no later scope to end
- * them. The defect still leaves the scope, so the embedder sees the failed
- * close; what it cannot do is skip the disposal.
- */
-const sessionsLayer = Layer.effect(
-  Sessions,
-  Effect.gen(function* () {
-    const runtime = yield* Runtime;
-    const sessions = makeSessions(runtime);
-    if (runtime.composed) {
-      yield* Effect.addFinalizer(() =>
-        sessions
-          .close()
-          .pipe(Effect.ensuring(Effect.promise(() => disposeProcessRuntime()))),
-      );
-    }
-    return sessions;
-  }),
-);
+/** The sessions of the composed process. They outlive no hold on it: what
+ *  ends them is the last {@link ProcessHold.release}. */
+const sessionsLayer = Layer.effect(Sessions, Effect.map(Runtime, makeSessions));

--- a/packages/agent/src/effect/runtime.ts
+++ b/packages/agent/src/effect/runtime.ts
@@ -1,0 +1,141 @@
+/**
+ * The process `@texra-ai/agent` composes, as an Effect service.
+ *
+ * {@link composeProcess} is the package's composition root: the platform,
+ * the process workspace roots, the node agent runtime, and the one Effect
+ * runtime that holds the session owner. It is synchronous and idempotent by
+ * design — everything from the platform check to the owner's registration
+ * of a root happens before the first yield of a run, so a close issued the
+ * moment a launch returns settles that launch too.
+ *
+ * {@link Runtime.layer} is the Effect embedder's entry: it composes the
+ * process once and provides both this service and `Sessions`. Its scope
+ * owns the closure, so leaving `Effect.scoped` closes the runtime's session
+ * and, when the package composed the process, disposes the runtime the
+ * owner runs on. A Promise embedder reaches the same closure through
+ * `lifecycle.runShutdown()`, which `packages/agent/src/index.ts` wires.
+ */
+import { Context, Effect, Layer } from 'effect';
+
+import {
+  disposeProcessRuntime,
+  installProcessRuntime,
+} from '@controllers/session/sessionLayer';
+import { initPlatform, tryPlatform, type Platform } from '@platform/platform';
+import {
+  initProcessWorkspaceRoots,
+  type WorkspaceRoots,
+} from '@platform/workspaceRoots';
+import { initNodeAgentRuntime } from '@platform/defaults/nodeAgentRuntime';
+
+import { PlatformConflict } from './errors.js';
+import { makeSessions, Sessions } from './sessions.js';
+
+/**
+ * The process platform together with the workspace roots the package's runs
+ * work in. `nodePlatform()` builds both; an embedder supplying its own
+ * platform names its workspace roots beside it.
+ */
+export interface AgentPlatform extends Platform {
+  readonly roots: WorkspaceRoots;
+}
+
+/** The composed process, as the package's services read it. */
+export interface AgentRuntime {
+  readonly platform: AgentPlatform;
+  readonly roots: WorkspaceRoots;
+  /**
+   * This call composed the process: it was the first to run here, so it
+   * owns the disposal of the Effect runtime the session owner runs on.
+   * False beside a host (or an earlier run) that composed its own.
+   */
+  readonly composed: boolean;
+}
+
+/**
+ * Compose the process, or recognize the one already composed. Synchronous
+ * and idempotent: a run beside a host that already ran its own composition
+ * root (the same platform object) reuses all four installations, its
+ * session included, and nothing here is installed twice.
+ *
+ * Throws {@link PlatformConflict} when a second, different platform reaches
+ * a process the package already composed.
+ */
+export function composeProcess(platform: AgentPlatform): AgentRuntime {
+  const active = tryPlatform();
+  if (active && active !== platform) {
+    throw new PlatformConflict({
+      message:
+        'The agent package is already using another platform in this process.',
+    });
+  }
+  if (!active) {
+    initPlatform(platform);
+    initProcessWorkspaceRoots(platform.roots);
+    // The runtime is installed before the agent runtime, as the CLI and
+    // desktop roots do: registering the direct Lean language services
+    // builds their layer graph on it, so a registration ahead of the
+    // install throws before any agent work begins. The identity stays a
+    // pending read: the owner's map builds synchronously over it, so an
+    // open registers its root before the opener's first await and only the
+    // entry's build waits.
+    installProcessRuntime(platform.processes.selfIdentity());
+    initNodeAgentRuntime(platform.lifecycle);
+  }
+  return { platform, roots: platform.roots, composed: !active };
+}
+
+/** The composed process. */
+export class Runtime extends Context.Service<Runtime, AgentRuntime>()(
+  '@texra-ai/agent/Runtime',
+) {
+  /** Compose the process once and provide both services. */
+  static layer(
+    platform: AgentPlatform,
+  ): Layer.Layer<Runtime | Sessions, PlatformConflict> {
+    return sessionsLayer.pipe(
+      Layer.provideMerge(
+        Layer.effect(
+          Runtime,
+          Effect.suspend(() => {
+            try {
+              return Effect.succeed(composeProcess(platform));
+            } catch (error) {
+              // The one refusal this composition states; anything else
+              // thrown by an installation is a defect, not a condition.
+              return error instanceof PlatformConflict
+                ? Effect.fail(error)
+                : Effect.die(error);
+            }
+          }),
+        ),
+      ),
+    );
+  }
+}
+
+/**
+ * The sessions of the composed process, with the scope as their lifetime
+ * (R6): leaving the scope closes the runtime's session, and disposes the
+ * Effect runtime the owner runs on when this process was the package's to
+ * compose.
+ */
+const sessionsLayer = Layer.effect(
+  Sessions,
+  Effect.gen(function* () {
+    const runtime = yield* Runtime;
+    const sessions = makeSessions(runtime);
+    yield* Effect.addFinalizer(() =>
+      sessions
+        .close()
+        .pipe(
+          Effect.andThen(
+            runtime.composed
+              ? Effect.promise(() => disposeProcessRuntime())
+              : Effect.void,
+          ),
+        ),
+    );
+    return sessions;
+  }),
+);

--- a/packages/agent/src/effect/runtime.ts
+++ b/packages/agent/src/effect/runtime.ts
@@ -68,8 +68,10 @@ export interface AgentRuntime {
  * installed them (`disposeProcessRuntime`). Reading the platform instead
  * would leave a process whose first closure has run permanently without an
  * owner; reading the owner composes again over the platform already
- * installed, which is what makes the package usable more than once per
- * process.
+ * installed, which is what makes the Effect surface usable more than once
+ * per process: there each scope owns the composition it made. The Promise
+ * entry composes once, because the owner it hands a composition to is the
+ * embedder's shutdown path, which runs once (`../index.ts`).
  *
  * Throws {@link PlatformConflict} when a second, different platform reaches
  * a process the package already composed.
@@ -143,6 +145,12 @@ export class Runtime extends Context.Service<Runtime, AgentRuntime>()(
  * earlier run) that opened it, and killing its live runs is not this scope's
  * to do; a root such a scope opened of its own ends through
  * `Sessions.close`.
+ *
+ * The disposal is the close's finalizer, not its continuation: the close
+ * flushes the session's artifacts, and a flush that defects must not leave
+ * the owner and the runtime under it installed with no later scope to end
+ * them. The defect still leaves the scope, so the embedder sees the failed
+ * close; what it cannot do is skip the disposal.
  */
 const sessionsLayer = Layer.effect(
   Sessions,
@@ -153,7 +161,7 @@ const sessionsLayer = Layer.effect(
       yield* Effect.addFinalizer(() =>
         sessions
           .close()
-          .pipe(Effect.andThen(Effect.promise(() => disposeProcessRuntime()))),
+          .pipe(Effect.ensuring(Effect.promise(() => disposeProcessRuntime()))),
       );
     }
     return sessions;

--- a/packages/agent/src/effect/sessions.ts
+++ b/packages/agent/src/effect/sessions.ts
@@ -154,7 +154,9 @@ export interface Session {
   /**
    * Admission: succeeds when the run exists in the session, with its stream
    * published and its trace live. Interrupting the caller before admission
-   * aborts the launch.
+   * aborts the launch; interrupting it during the handoff that follows ends
+   * the run too, so a caller that does not receive a {@link Run} has none
+   * running.
    */
   readonly start: (
     input: StartInput,
@@ -244,6 +246,30 @@ function runStreamIds(view: SessionView, streamId: StreamTabId): StreamTabId[] {
   return ids;
 }
 
+/**
+ * The refusal the package states from the caller's own input, before
+ * anything of the process is touched: it has no approval channel, so a tool
+ * that requires one cannot run here whatever the agent turns out to be.
+ * {@link admitInput} states it in its own order; the Promise entry states
+ * it first, because there a composition is a side effect of the call and a
+ * caller being refused must not pay for one (`../index.ts`).
+ */
+export function admitTools(
+  tools: readonly ITool[] | undefined,
+): Effect.Effect<void, ToolsRefused> {
+  const needApproval = (tools ?? [])
+    .filter((tool) => tool.requiresApproval)
+    .map((tool) => tool.definition.name);
+  return needApproval.length > 0
+    ? Effect.fail(
+        new ToolsRefused({
+          tools: needApproval,
+          message: `The agent package cannot run approval-requiring tools: ${needApproval.join(', ')}`,
+        }),
+      )
+    : Effect.void;
+}
+
 /** The run's configuration, or the refusal that stops it before any model
  *  work: the three the package states. */
 function admitInput(
@@ -254,15 +280,7 @@ function admitInput(
 > {
   return Effect.gen(function* () {
     const tools = input.tools ?? [];
-    const needApproval = tools
-      .filter((tool) => tool.requiresApproval)
-      .map((tool) => tool.definition.name);
-    if (needApproval.length > 0) {
-      return yield* new ToolsRefused({
-        tools: needApproval,
-        message: `The agent package cannot run approval-requiring tools: ${needApproval.join(', ')}`,
-      });
-    }
+    yield* admitTools(tools);
     // The agent scan reads the configured directories through the
     // platform, so it can fail on the environment. That is a failure of
     // `start`, in the vocabulary the surface already names, not a defect
@@ -285,12 +303,21 @@ function admitInput(
         message: `Custom tools are supported only for tool-use agents; "${input.agent}" is a workflow agent.`,
       });
     }
-    return AgentConfigSchema.parse({
-      agent: resolved.entry.name,
-      agentCategory: resolved.entry.category,
-      agentSource: resolved.entry.source,
-      instruction: input.instruction,
-      ...(input.model ? { model: input.model } : {}),
+    // The schema is the launch's last refusal, and it is a refusal rather
+    // than a defect: an instruction this surface will not accept reaches an
+    // embedder's `catchTag` in the vocabulary the surface names, as the
+    // agent scan's failure above does.
+    return yield* Effect.try({
+      try: () =>
+        AgentConfigSchema.parse({
+          agent: resolved.entry.name,
+          agentCategory: resolved.entry.category,
+          agentSource: resolved.entry.source,
+          instruction: input.instruction,
+          ...(input.model ? { model: input.model } : {}),
+        }),
+      catch: (cause) =>
+        new RunFailure({ cause, message: toErrorMessage(cause) }),
     });
   });
 }
@@ -300,6 +327,11 @@ function admitInput(
  * there. The launch itself is the one foreign boundary this subpath wraps
  * (`runAgent` is Promise-native until lane D converts the run loops): its
  * abort signal is what an interruption before admission reaches.
+ *
+ * The handoff is all-or-nothing, which is what lets a caller treat the
+ * `Run` as the only handle on the run: this either returns one, or it ends
+ * every fiber it started. There is no exit in which a run keeps working
+ * with nobody holding it.
  */
 function start(
   session: RuntimeSessionHandle,
@@ -342,105 +374,122 @@ function start(
         );
         yield* Queue.end(trace);
       });
-    const runFiber = yield* Effect.forkDetach(
-      Effect.tryPromise({
-        try: (signal) =>
-          runValidatedAgent(
-            { kind: 'fresh', config, executionId },
-            {
-              approvalPromptsUnavailable: true,
-              launchSignal: signal,
-              onRun: (live) => {
-                handle = live;
-              },
-              onStreamResolved: (streamId, runTrace) => {
-                detach = runTrace.subscribe((event) => {
-                  if (!reading && (buffered += 1) > TRACE_HANDOVER_EVENTS) {
-                    log.warn(
-                      `Run ${executionId} buffered ${TRACE_HANDOVER_EVENTS} trace events with no reader attached; detaching its trace. Iterate the run's events in the turn that starts it, or await only its result.`,
-                    );
-                    release();
-                    return;
-                  }
-                  Queue.offerUnsafe(trace, event);
-                });
-                Deferred.doneUnsafe(admitted, Effect.succeed(streamId));
-              },
-              session,
-              stopAfterCycle: true,
-              tools: input.tools,
-            },
-          ),
-        catch: (cause) =>
-          new RunFailure({ cause, message: toErrorMessage(cause) }),
-      }).pipe(Effect.onExit(settle)),
-      { startImmediately: true },
-    );
-    // The launch is the run fiber's; interrupting the admission wait is
-    // what reaches its abort signal, and after admission the fiber is the
-    // caller's no longer.
-    const streamId = yield* Deferred.await(admitted).pipe(
-      Effect.onInterrupt(() => Fiber.interrupt(runFiber)),
-    );
-    const view = session.viewChanges.pipe(
-      // The level replays on subscribe, and the fold lands the run's
-      // `run.start` asynchronously, so a replayed level can predate the run.
-      Stream.dropWhile((level) => !level.streams.has(streamId)),
-      // The view is the end condition: the first level holding the run's
-      // durable outcome is the last element.
-      Stream.takeUntil(
-        (level) => level.streams.get(streamId)?.durableOutcome != null,
-      ),
-    );
-    // The transcript tier folds only for subscribed aggregates, on a port
-    // of this run's own: its stream now, its descendants as the view gains
-    // them. The port is never cleared, by choice: the run's rows stay
-    // resident for the life of the package session, as a TUI's do.
-    const port = `sdk/${streamId}`;
-    let subscribed = '';
-    const interest = (ids: readonly StreamTabId[]): Effect.Effect<void> =>
-      Effect.suspend(() => {
-        const key = ids.join('\0');
-        if (key === subscribed) return Effect.void;
-        subscribed = key;
-        return session.subscriptions.set(
-          port,
-          ids.map((id) => ({ id, fromSeq: 0 })),
+    // The launch and the drain are the run's, and until the caller holds
+    // the `Run` that names them they are nobody's: whatever ends this
+    // handoff short of that ends them too. So the handoff is
+    // uninterruptible but for the admission wait, where the launch's own
+    // abort signal is what an interruption reaches, and the exit handler
+    // outside the mask covers the rest, the boundary included: an interrupt
+    // that lands while the tail runs is raised the moment the mask lifts,
+    // with a `Run` built that reaches no one.
+    const spawned: Fiber.Fiber<unknown, unknown>[] = [];
+    return yield* Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const runFiber = yield* Effect.forkDetach(
+          Effect.tryPromise({
+            try: (signal) =>
+              runValidatedAgent(
+                { kind: 'fresh', config, executionId },
+                {
+                  approvalPromptsUnavailable: true,
+                  launchSignal: signal,
+                  onRun: (live) => {
+                    handle = live;
+                  },
+                  onStreamResolved: (streamId, runTrace) => {
+                    detach = runTrace.subscribe((event) => {
+                      if (!reading && (buffered += 1) > TRACE_HANDOVER_EVENTS) {
+                        log.warn(
+                          `Run ${executionId} buffered ${TRACE_HANDOVER_EVENTS} trace events with no reader attached; detaching its trace. Iterate the run's events in the turn that starts it, or await only its result.`,
+                        );
+                        release();
+                        return;
+                      }
+                      Queue.offerUnsafe(trace, event);
+                    });
+                    Deferred.doneUnsafe(admitted, Effect.succeed(streamId));
+                  },
+                  session,
+                  stopAfterCycle: true,
+                  tools: input.tools,
+                },
+              ),
+            catch: (cause) =>
+              new RunFailure({ cause, message: toErrorMessage(cause) }),
+          }).pipe(Effect.onExit(settle)),
+          { startImmediately: true },
         );
-      });
-    yield* interest([streamId]);
-    // The package owns this drain: the descendants join the subscription as
-    // the view gains them, and the run's `result` waits for its final fold
-    // even when nobody reads `view`, and fails if the fold dies first.
-    const drain = yield* Effect.forkDetach(
-      Stream.runDrain(
-        view.pipe(
-          Stream.tap((level) => interest(runStreamIds(level, streamId))),
-        ),
+        spawned.push(runFiber);
+        const streamId = yield* restore(Deferred.await(admitted));
+        const view = session.viewChanges.pipe(
+          // The level replays on subscribe, and the fold lands the run's
+          // `run.start` asynchronously, so a replayed level can predate the
+          // run.
+          Stream.dropWhile((level) => !level.streams.has(streamId)),
+          // The view is the end condition: the first level holding the
+          // run's durable outcome is the last element.
+          Stream.takeUntil(
+            (level) => level.streams.get(streamId)?.durableOutcome != null,
+          ),
+        );
+        // The transcript tier folds only for subscribed aggregates, on a
+        // port of this run's own: its stream now, its descendants as the
+        // view gains them. The port is never cleared, by choice: the run's
+        // rows stay resident for the life of the package session, as a
+        // TUI's do.
+        const port = `sdk/${streamId}`;
+        let subscribed = '';
+        const interest = (ids: readonly StreamTabId[]): Effect.Effect<void> =>
+          Effect.suspend(() => {
+            const key = ids.join('\0');
+            if (key === subscribed) return Effect.void;
+            subscribed = key;
+            return session.subscriptions.set(
+              port,
+              ids.map((id) => ({ id, fromSeq: 0 })),
+            );
+          });
+        yield* interest([streamId]);
+        // The package owns this drain: the descendants join the
+        // subscription as the view gains them, and the run's `result` waits
+        // for its final fold even when nobody reads `view`, and fails if
+        // the fold dies first.
+        const drain = yield* Effect.forkDetach(
+          Stream.runDrain(
+            view.pipe(
+              Stream.tap((level) => interest(runStreamIds(level, streamId))),
+            ),
+          ),
+          { startImmediately: true },
+        );
+        spawned.push(drain);
+        return {
+          executionId,
+          streamId,
+          result: Fiber.join(runFiber).pipe(
+            Effect.flatMap((value) => Effect.as(Fiber.join(drain), value)),
+          ),
+          view,
+          events: Stream.unwrap(
+            Effect.sync(() => {
+              reading = true;
+              return Stream.fromQueue(trace);
+            }),
+          ).pipe(Stream.ensuring(Effect.sync(release))),
+          interrupt: Effect.suspend(() =>
+            handle
+              ? Effect.sync(() => {
+                  handle?.interrupt();
+                })
+              : Fiber.interrupt(runFiber),
+          ),
+        };
+      }),
+    ).pipe(
+      Effect.onExit((exit) =>
+        Exit.isSuccess(exit) ? Effect.void : Fiber.interruptAll(spawned),
       ),
-      { startImmediately: true },
     );
-    return {
-      executionId,
-      streamId,
-      result: Fiber.join(runFiber).pipe(
-        Effect.flatMap((value) => Effect.as(Fiber.join(drain), value)),
-      ),
-      view,
-      events: Stream.unwrap(
-        Effect.sync(() => {
-          reading = true;
-          return Stream.fromQueue(trace);
-        }),
-      ).pipe(Stream.ensuring(Effect.sync(release))),
-      interrupt: Effect.suspend(() =>
-        handle
-          ? Effect.sync(() => {
-              handle?.interrupt();
-            })
-          : Fiber.interrupt(runFiber),
-      ),
-    };
   });
 }
 

--- a/packages/agent/src/effect/sessions.ts
+++ b/packages/agent/src/effect/sessions.ts
@@ -52,6 +52,7 @@ import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 // `scripts/validate-artifacts.mjs`.
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 
+import { createLog } from '@logger/logUtils';
 import type { WorkspaceRoots } from '@platform/workspaceRoots';
 import {
   AgentCategory,
@@ -137,7 +138,9 @@ export interface Run {
    * when the run settles, fails with {@link RunFailure} when the run failed,
    * and drops what it holds when the run settles unread. Running it once is
    * the contract: ending the iteration detaches the trace while the run
-   * continues.
+   * continues. The pre-reader buffer is bounded: a run whose events pass
+   * {@link TRACE_HANDOVER_EVENTS} with nobody reading has no reader, so it
+   * warns and detaches rather than retaining the whole trace.
    */
   readonly events: Stream.Stream<AgentEvent, RunFailure>;
   /** Before the runtime hands over the live handle this aborts the launch;
@@ -214,6 +217,19 @@ const HEADLESS_HOST = {
  *  contract broke, and a caller waiting on admission must hear it. */
 const NEVER_ENTERED = 'The run ended without entering the session.';
 
+const log = createLog('agentPackage');
+
+/**
+ * How many trace events a run holds for a reader that has yet to attach.
+ * The buffer exists only to bridge admission to the reader's first pull, so
+ * a run that passes it with nobody reading has no reader: it says so and
+ * detaches its trace, instead of retaining a long run's whole trace (every
+ * `stream.chunk` included) until the run settles. A reader that did attach
+ * is never dropped: past its first pull the buffer is the reader's, and
+ * nothing here discards what it has yet to read.
+ */
+const TRACE_HANDOVER_EVENTS = 512;
+
 /** The run's stream and every descendant the view holds. */
 function runStreamIds(view: SessionView, streamId: StreamTabId): StreamTabId[] {
   const ids: StreamTabId[] = [];
@@ -232,7 +248,10 @@ function runStreamIds(view: SessionView, streamId: StreamTabId): StreamTabId[] {
  *  work: the three the package states. */
 function admitInput(
   input: StartInput,
-): Effect.Effect<ReturnType<typeof AgentConfigSchema.parse>, LaunchError> {
+): Effect.Effect<
+  ReturnType<typeof AgentConfigSchema.parse>,
+  LaunchError | RunFailure
+> {
   return Effect.gen(function* () {
     const tools = input.tools ?? [];
     const needApproval = tools
@@ -244,7 +263,15 @@ function admitInput(
         message: `The agent package cannot run approval-requiring tools: ${needApproval.join(', ')}`,
       });
     }
-    yield* Effect.promise(() => loadAgents({ includeRemote: false }));
+    // The agent scan reads the configured directories through the
+    // platform, so it can fail on the environment. That is a failure of
+    // `start`, in the vocabulary the surface already names, not a defect
+    // an embedder's `catchTag` never sees.
+    yield* Effect.tryPromise({
+      try: () => loadAgents({ includeRemote: false }),
+      catch: (cause) =>
+        new RunFailure({ cause, message: toErrorMessage(cause) }),
+    });
     const resolved = resolveAgent(input.agent);
     if (!resolved) {
       return yield* new AgentNotFound({
@@ -286,6 +313,7 @@ function start(
     let handle: RuntimeAgentRunHandle | undefined;
     let detach: (() => void) | undefined;
     let reading = false;
+    let buffered = 0;
     /** Detach the trace, once: the reader's close does it while the run
      *  continues, and the run's settlement does it for a reader that never
      *  came. */
@@ -327,6 +355,13 @@ function start(
               },
               onStreamResolved: (streamId, runTrace) => {
                 detach = runTrace.subscribe((event) => {
+                  if (!reading && (buffered += 1) > TRACE_HANDOVER_EVENTS) {
+                    log.warn(
+                      `Run ${executionId} buffered ${TRACE_HANDOVER_EVENTS} trace events with no reader attached; detaching its trace. Iterate the run's events in the turn that starts it, or await only its result.`,
+                    );
+                    release();
+                    return;
+                  }
                   Queue.offerUnsafe(trace, event);
                 });
                 Deferred.doneUnsafe(admitted, Effect.succeed(streamId));

--- a/packages/agent/src/effect/sessions.ts
+++ b/packages/agent/src/effect/sessions.ts
@@ -1,0 +1,456 @@
+/**
+ * The sessions of `@texra-ai/agent/effect` and the runs on them.
+ *
+ * `Sessions` is the process's one session owner as an Effect service: it
+ * opens, lists and closes through `@agent/runtime`'s owner port, so a root
+ * opened here is the same session every TeXRA host opens (one session per
+ * workspace storage root, never a second registry). A {@link Session} is a
+ * value, not a tag — there are N of them, one per root — and a pure
+ * function of the owner's handle: it stores nothing the owner already
+ * holds.
+ *
+ * Every decision a run makes is stated once, here, in Effect: which level
+ * is the run's first, when its transcript interest changes, when the drain
+ * ends, and which failure wins. `packages/agent/src/index.ts` renders this
+ * as Promises and adds nothing of its own.
+ */
+import {
+  Context,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Queue,
+  Stream,
+  type Cause,
+  type Scope,
+} from 'effect';
+
+// Values, and types used only inside function bodies, come through the
+// curated `@agent/runtime` barrel rather than by module path, so this
+// package stops pinning the runtime's internal file layout. These never
+// reach the emitted declarations, so they carry no provider-type leak risk.
+import { loadAgents, resolveAgent } from '@agent/index';
+import {
+  closeSession as closeOwnedSession,
+  listSessions as listOwnedSessions,
+  openSessionEffect,
+  runAgent as runValidatedAgent,
+  type AgentRunHandle as RuntimeAgentRunHandle,
+  type SessionHandle as RuntimeSessionHandle,
+} from '@agent/runtime';
+import type { AgentEvent } from '@agent/trace';
+import type { ITool } from '@agent/core/tools/ToolTypes';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+
+// `AgentFlowResult` is deliberately sourced from its own module rather than
+// from the `@agent/runtime` barrel above: it appears in this subpath's
+// PUBLIC declarations, and declaration emit follows whichever module a
+// public type comes from, so taking it from the barrel would pull the
+// barrel's whole `.d.ts` graph — model handlers included — into the
+// published type surface and trip the provider-type leak check in
+// `scripts/validate-artifacts.mjs`.
+import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
+
+import type { WorkspaceRoots } from '@platform/workspaceRoots';
+import {
+  AgentCategory,
+  type ExecutionId,
+  type SessionCloseReport,
+  type StreamTabId,
+  type TranscriptSubscription,
+} from '@shared/schemas';
+import type { RequestError } from '@shared/session/requestErrors';
+import type { Outcome, RuntimeRequest } from '@shared/session/runtimeRequest';
+import type { SessionEventsShape } from '@shared/session/sessionEvents';
+import type {
+  SessionView as RuntimeSessionView,
+  StreamView as RuntimeStreamView,
+  TranscriptView as RuntimeTranscriptView,
+} from '@shared/session/sessionView';
+import { StreamLogStore } from '@transcript/StreamLogStore';
+import { generateExecutionId } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+import {
+  AgentNotFound,
+  RunFailure,
+  ToolsRefused,
+  type LaunchError,
+} from './errors.js';
+import type { AgentRuntime } from './runtime.js';
+
+/**
+ * A runtime value as the embedder may hold it: read-only all the way down,
+ * every map, array, and record included. The value itself is not copied
+ * (the fold publishes immutable levels); the type is what keeps a write
+ * from reaching it.
+ */
+type ReadonlyDeep<T> = T extends (...args: never[]) => unknown
+  ? T
+  : T extends ReadonlyMap<infer K, infer V>
+    ? ReadonlyMap<K, ReadonlyDeep<V>>
+    : T extends ReadonlySet<infer V>
+      ? ReadonlySet<ReadonlyDeep<V>>
+      : T extends readonly (infer E)[]
+        ? readonly ReadonlyDeep<E>[]
+        : T extends object
+          ? { readonly [P in keyof T]: ReadonlyDeep<T[P]> }
+          : T;
+
+/** One published level of the session's fold: an immutable value. */
+export type SessionView = ReadonlyDeep<RuntimeSessionView>;
+/** One stream of the {@link SessionView}. */
+export type StreamView = ReadonlyDeep<RuntimeStreamView>;
+/** A stream's transcript slice: what hosts paint. */
+export type TranscriptView = ReadonlyDeep<RuntimeTranscriptView>;
+
+/** What starting a run on a session takes. */
+export interface StartInput {
+  readonly agent: string;
+  readonly instruction: string;
+  readonly model?: string;
+  readonly tools?: readonly ITool[];
+}
+
+/** One run of an agent, from the moment it exists in its session. */
+export interface Run {
+  /** The run's execution id, minted here and handed to the launcher, so it
+   *  identifies the run before its first model call. */
+  readonly executionId: ExecutionId;
+  readonly streamId: StreamTabId;
+  /**
+   * The run's own outcome first: on failure the fold's fate never replaces
+   * it; on success this waits for the level holding the durable outcome.
+   */
+  readonly result: Effect.Effect<AgentFlowResult, RunFailure>;
+  /**
+   * The session's levels sliced to this run: from the first level holding
+   * its stream through the first holding its durable outcome. Typed error
+   * `never`: a dead fold is a defect, as `SessionViewService.changes`
+   * publishes it.
+   */
+  readonly view: Stream.Stream<SessionView>;
+  /**
+   * The run's trace, buffered from the moment the run enters the session so
+   * that no launch event is lost to a reader that has yet to attach. Ends
+   * when the run settles, fails with {@link RunFailure} when the run failed,
+   * and drops what it holds when the run settles unread. Running it once is
+   * the contract: ending the iteration detaches the trace while the run
+   * continues.
+   */
+  readonly events: Stream.Stream<AgentEvent, RunFailure>;
+  /** Before the runtime hands over the live handle this aborts the launch;
+   *  after, it interrupts the run. */
+  readonly interrupt: Effect.Effect<void>;
+}
+
+/** One session of the process's owner, as this package works on it. */
+export interface Session {
+  readonly roots: WorkspaceRoots;
+  /**
+   * Admission: succeeds when the run exists in the session, with its stream
+   * published and its trace live. Interrupting the caller before admission
+   * aborts the launch.
+   */
+  readonly start: (
+    input: StartInput,
+  ) => Effect.Effect<Run, LaunchError | RunFailure>;
+  /** The one handler of every request a surface issues to this session:
+   *  answered exactly once, an outcome or a request error. */
+  readonly request: (
+    request: RuntimeRequest,
+  ) => Effect.Effect<Outcome, RequestError>;
+  /** The fold's levels, each an immutable value. */
+  readonly view: { readonly changes: Stream.Stream<SessionView> };
+  /** The session's event plane, reads only. */
+  readonly events: Omit<SessionEventsShape, 'publish'>;
+  /**
+   * This reader's transcript interest, held for the scope and cleared when
+   * it closes. Its port is the reader's own, so it never disturbs a run's.
+   */
+  readonly subscribe: (
+    interests: readonly TranscriptSubscription[],
+  ) => Effect.Effect<void, never, Scope.Scope>;
+}
+
+/** The process's session owner: one session per workspace storage root. */
+export class Sessions extends Context.Service<
+  Sessions,
+  {
+    /** The session of these roots, or the runtime's, through the process's
+     *  one owner. */
+    readonly open: (roots?: WorkspaceRoots) => Effect.Effect<Session>;
+    /**
+     * Refuse new runs, settle the ones it owns inside `signal`'s budget or
+     * the runtime's shutdown-phase budget, flush, release.
+     */
+    readonly close: (
+      roots?: WorkspaceRoots,
+      signal?: AbortSignal,
+    ) => Effect.Effect<SessionCloseReport>;
+    readonly list: Effect.Effect<readonly Session[]>;
+  }
+>()('@texra-ai/agent/Sessions') {}
+
+/**
+ * The session's one host, for its whole life, like every TeXRA host
+ * attaches one per session: the interaction hub keeps a single active host
+ * and tells runs apart by the stream its requests and cancellations name.
+ * Attaching per run instead would make each new run displace the previous
+ * run's host. The package has no interactive prompts, so there is nothing
+ * for a cancellation to settle; a retry prompt is denied so that it never
+ * parks the run waiting for a host.
+ */
+const HEADLESS_HOST = {
+  cancel: () => {},
+  requestRetry: async () => ({
+    action: 'deny' as const,
+    reason: 'Interactive retries are unavailable in the agent package.',
+  }),
+};
+
+/** A run that returned without ever publishing its stream: the launcher's
+ *  contract broke, and a caller waiting on admission must hear it. */
+const NEVER_ENTERED = 'The run ended without entering the session.';
+
+/** The run's stream and every descendant the view holds. */
+function runStreamIds(view: SessionView, streamId: StreamTabId): StreamTabId[] {
+  const ids: StreamTabId[] = [];
+  for (const stream of view.streams.values()) {
+    if (
+      stream.id === streamId ||
+      stream.ancestors.some((ancestor) => ancestor.id === streamId)
+    ) {
+      ids.push(stream.id);
+    }
+  }
+  return ids;
+}
+
+/** The run's configuration, or the refusal that stops it before any model
+ *  work: the three the package states. */
+function admitInput(
+  input: StartInput,
+): Effect.Effect<ReturnType<typeof AgentConfigSchema.parse>, LaunchError> {
+  return Effect.gen(function* () {
+    const tools = input.tools ?? [];
+    const needApproval = tools
+      .filter((tool) => tool.requiresApproval)
+      .map((tool) => tool.definition.name);
+    if (needApproval.length > 0) {
+      return yield* new ToolsRefused({
+        tools: needApproval,
+        message: `The agent package cannot run approval-requiring tools: ${needApproval.join(', ')}`,
+      });
+    }
+    yield* Effect.promise(() => loadAgents({ includeRemote: false }));
+    const resolved = resolveAgent(input.agent);
+    if (!resolved) {
+      return yield* new AgentNotFound({
+        agent: input.agent,
+        message: `Agent "${input.agent}" was not found in the configured agent directory.`,
+      });
+    }
+    if (tools.length > 0 && resolved.entry.category !== AgentCategory.ToolUse) {
+      return yield* new ToolsRefused({
+        tools: tools.map((tool) => tool.definition.name),
+        message: `Custom tools are supported only for tool-use agents; "${input.agent}" is a workflow agent.`,
+      });
+    }
+    return AgentConfigSchema.parse({
+      agent: resolved.entry.name,
+      agentCategory: resolved.entry.category,
+      agentSource: resolved.entry.source,
+      instruction: input.instruction,
+      ...(input.model ? { model: input.model } : {}),
+    });
+  });
+}
+
+/**
+ * Start one run on `session` and hand back the {@link Run} once it exists
+ * there. The launch itself is the one foreign boundary this subpath wraps
+ * (`runAgent` is Promise-native until lane D converts the run loops): its
+ * abort signal is what an interruption before admission reaches.
+ */
+function start(
+  session: RuntimeSessionHandle,
+  input: StartInput,
+): Effect.Effect<Run, LaunchError | RunFailure> {
+  return Effect.gen(function* () {
+    const config = yield* admitInput(input);
+    const executionId = generateExecutionId();
+    const trace = yield* Queue.unbounded<AgentEvent, RunFailure | Cause.Done>();
+    const admitted = yield* Deferred.make<StreamTabId, RunFailure>();
+    let handle: RuntimeAgentRunHandle | undefined;
+    let detach: (() => void) | undefined;
+    let reading = false;
+    /** Detach the trace, once: the reader's close does it while the run
+     *  continues, and the run's settlement does it for a reader that never
+     *  came. */
+    const release = (): void => {
+      detach?.();
+      detach = undefined;
+    };
+    const settle = (
+      exit: Exit.Exit<AgentFlowResult, RunFailure>,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        release();
+        // A run nobody read retains nothing: what it buffered goes with it.
+        if (!reading) yield* Effect.orDie(Queue.clear(trace));
+        if (Exit.isFailure(exit)) {
+          yield* Deferred.failCause(admitted, exit.cause);
+          yield* Queue.failCause(trace, exit.cause);
+          return;
+        }
+        yield* Deferred.fail(
+          admitted,
+          new RunFailure({
+            cause: new Error(NEVER_ENTERED),
+            message: NEVER_ENTERED,
+          }),
+        );
+        yield* Queue.end(trace);
+      });
+    const runFiber = yield* Effect.forkDetach(
+      Effect.tryPromise({
+        try: (signal) =>
+          runValidatedAgent(
+            { kind: 'fresh', config, executionId },
+            {
+              approvalPromptsUnavailable: true,
+              launchSignal: signal,
+              onRun: (live) => {
+                handle = live;
+              },
+              onStreamResolved: (streamId, runTrace) => {
+                detach = runTrace.subscribe((event) => {
+                  Queue.offerUnsafe(trace, event);
+                });
+                Deferred.doneUnsafe(admitted, Effect.succeed(streamId));
+              },
+              session,
+              stopAfterCycle: true,
+              tools: input.tools,
+            },
+          ),
+        catch: (cause) =>
+          new RunFailure({ cause, message: toErrorMessage(cause) }),
+      }).pipe(Effect.onExit(settle)),
+      { startImmediately: true },
+    );
+    // The launch is the run fiber's; interrupting the admission wait is
+    // what reaches its abort signal, and after admission the fiber is the
+    // caller's no longer.
+    const streamId = yield* Deferred.await(admitted).pipe(
+      Effect.onInterrupt(() => Fiber.interrupt(runFiber)),
+    );
+    const view = session.viewChanges.pipe(
+      // The level replays on subscribe, and the fold lands the run's
+      // `run.start` asynchronously, so a replayed level can predate the run.
+      Stream.dropWhile((level) => !level.streams.has(streamId)),
+      // The view is the end condition: the first level holding the run's
+      // durable outcome is the last element.
+      Stream.takeUntil(
+        (level) => level.streams.get(streamId)?.durableOutcome != null,
+      ),
+    );
+    // The transcript tier folds only for subscribed aggregates, on a port
+    // of this run's own: its stream now, its descendants as the view gains
+    // them. The port is never cleared, by choice: the run's rows stay
+    // resident for the life of the package session, as a TUI's do.
+    const port = `sdk/${streamId}`;
+    let subscribed = '';
+    const interest = (ids: readonly StreamTabId[]): Effect.Effect<void> =>
+      Effect.suspend(() => {
+        const key = ids.join('\0');
+        if (key === subscribed) return Effect.void;
+        subscribed = key;
+        return session.subscriptions.set(
+          port,
+          ids.map((id) => ({ id, fromSeq: 0 })),
+        );
+      });
+    yield* interest([streamId]);
+    // The package owns this drain: the descendants join the subscription as
+    // the view gains them, and the run's `result` waits for its final fold
+    // even when nobody reads `view`, and fails if the fold dies first.
+    const drain = yield* Effect.forkDetach(
+      Stream.runDrain(
+        view.pipe(
+          Stream.tap((level) => interest(runStreamIds(level, streamId))),
+        ),
+      ),
+      { startImmediately: true },
+    );
+    return {
+      executionId,
+      streamId,
+      result: Fiber.join(runFiber).pipe(
+        Effect.flatMap((value) => Effect.as(Fiber.join(drain), value)),
+      ),
+      view,
+      events: Stream.unwrap(
+        Effect.sync(() => {
+          reading = true;
+          return Stream.fromQueue(trace);
+        }),
+      ).pipe(Stream.ensuring(Effect.sync(release))),
+      interrupt: Effect.suspend(() =>
+        handle
+          ? Effect.sync(() => {
+              handle?.interrupt();
+            })
+          : Fiber.interrupt(runFiber),
+      ),
+    };
+  });
+}
+
+/** One reader port per `subscribe`, so no reader disturbs another's set. */
+let readerPorts = 0;
+
+/** The session as this package works on it: a pure function of the owner's
+ *  handle, holding nothing the owner already holds. */
+function sessionOf(handle: RuntimeSessionHandle): Session {
+  return {
+    roots: handle.roots,
+    start: (input) => start(handle, input),
+    request: (request) => handle.requests.request(request),
+    view: { changes: handle.viewChanges },
+    events: handle.events,
+    subscribe: (interests) =>
+      Effect.acquireRelease(
+        Effect.suspend(() => {
+          const port = `sdk/reader/${(readerPorts += 1)}`;
+          return Effect.as(handle.subscriptions.set(port, interests), port);
+        }),
+        (port) => handle.subscriptions.set(port, []),
+      ).pipe(Effect.asVoid),
+  };
+}
+
+/** The package's session policy over the process's owner: an ephemeral
+ *  transcript store and one headless host for the session's life. */
+export function makeSessions(
+  runtime: AgentRuntime,
+): Context.Service.Shape<typeof Sessions> {
+  return {
+    open: (roots?: WorkspaceRoots) =>
+      Effect.map(
+        Effect.suspend(() =>
+          openSessionEffect({
+            roots: roots ?? runtime.roots,
+            transcripts: StreamLogStore.ephemeral('npm package consumer'),
+            interactions: HEADLESS_HOST,
+          }),
+        ),
+        sessionOf,
+      ),
+    close: (roots?: WorkspaceRoots, signal?: AbortSignal) =>
+      closeOwnedSession((roots ?? runtime.roots).storage, signal),
+    list: Effect.map(listOwnedSessions(), (handles) => handles.map(sessionOf)),
+  };
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,22 +1,26 @@
+/**
+ * `@texra-ai/agent` — the package's Promise surface, and nothing else.
+ *
+ * This module is the boundary the Effect migration's rule R1 names
+ * (`docs/prds/2026-08-26-effect-4-runtime-migration.md`, §7 R1, boundary
+ * kind 3: the published SDK speaks Promises). Every decision this package
+ * makes is stated once, in Effect, on `@texra-ai/agent/effect`; what
+ * follows renders those services as Promises and AsyncIterables and adds no
+ * logic of its own. Every `Effect.runPromise` / `runFork` in the package is
+ * here and nowhere below it.
+ */
 // Third-party imports
-import { Effect, Fiber, Stream } from 'effect';
+import { Effect, Exit, Fiber, Stream } from 'effect';
 
 // Local imports - agent runtime
 //
-// Values, and types used only inside function bodies, come through the curated
-// `@agent/runtime` barrel rather than by module path, so this package stops
-// pinning the runtime's internal file layout — the same fold-in the three hosts
-// took in #10011. These never reach the emitted declarations, so they carry no
-// provider-type leak risk.
-import type { AgentEvent, AgentTrace } from '@agent/trace';
-import { loadAgents, resolveAgent } from '@agent/index';
-import {
-  closeSession as closeRuntimeSession,
-  openSessionAsync,
-  runAgent as runValidatedAgent,
-  type AgentRunHandle as RuntimeAgentRunHandle,
-  type SessionHandle as RuntimeSessionHandle,
-} from '@agent/runtime';
+// Values, and types used only inside function bodies, come through the
+// curated `@agent/runtime` barrel rather than by module path, so this
+// package stops pinning the runtime's internal file layout — the same
+// fold-in the three hosts took in #10011. These never reach the emitted
+// declarations, so they carry no provider-type leak risk.
+import type { AgentEvent } from '@agent/trace';
+import { closeSession as closeOwnedSession } from '@agent/runtime';
 import type { ITool } from '@agent/core/tools/ToolTypes';
 
 // `AgentFlowResult` is deliberately sourced from its own module rather than
@@ -28,31 +32,17 @@ import type { ITool } from '@agent/core/tools/ToolTypes';
 // `scripts/validate-artifacts.mjs` (`@anthropic-ai/sdk`).
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 
-// Local imports - config and host services
-import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
-import {
-  disposeProcessRuntime,
-  installProcessRuntime,
-} from '@controllers/session/sessionLayer';
-import { initPlatform, tryPlatform, type Platform } from '@platform/platform';
-import {
-  initProcessWorkspaceRoots,
-  type WorkspaceRoots,
-} from '@platform/workspaceRoots';
+// Local imports - host services this boundary wires
+import { disposeProcessRuntime } from '@controllers/session/sessionLayer';
 import { effectRuntime } from '@platform/processRuntime';
-import { initNodeAgentRuntime } from '@platform/defaults/nodeAgentRuntime';
-import {
-  AgentCategory,
-  type SessionCloseReport,
-  type StreamTabId,
-} from '@shared/schemas';
-import type {
-  SessionView as RuntimeSessionView,
-  StreamView as RuntimeStreamView,
-  TranscriptView as RuntimeTranscriptView,
-} from '@shared/session/sessionView';
+import type { WorkspaceRoots } from '@platform/workspaceRoots';
+import type { SessionCloseReport } from '@shared/schemas';
 import { registerRuntimeShutdownHandlers } from '@tools/agentCliSessionStores';
-import { StreamLogStore } from '@transcript/StreamLogStore';
+
+// Local imports - the Effect surface this entry renders
+import { RunFailure } from './effect/errors.js';
+import { composeProcess, type AgentPlatform } from './effect/runtime.js';
+import { makeSessions, type SessionView } from './effect/sessions.js';
 
 export type { AgentEvent } from '@agent/trace';
 export type { SessionCloseReport } from '@shared/schemas';
@@ -69,40 +59,12 @@ export type {
   ToolUseFlowResult,
   WorkflowFlowResult,
 } from '@agent/runtime/AgentFlowResult';
-
-/**
- * A runtime value as the embedder may hold it: read-only all the way down,
- * every map, array, and record included. The value itself is not copied
- * (the fold's own view is what every host reads, PRD 10.3); the type is what
- * keeps a write from reaching it.
- */
-type ReadonlyDeep<T> = T extends (...args: never[]) => unknown
-  ? T
-  : T extends ReadonlyMap<infer K, infer V>
-    ? ReadonlyMap<K, ReadonlyDeep<V>>
-    : T extends ReadonlySet<infer V>
-      ? ReadonlySet<ReadonlyDeep<V>>
-      : T extends readonly (infer E)[]
-        ? readonly ReadonlyDeep<E>[]
-        : T extends object
-          ? { readonly [P in keyof T]: ReadonlyDeep<T[P]> }
-          : T;
-
-/** The session view as {@link AgentRun.view} yields it (PRD 5.1). */
-export type SessionView = ReadonlyDeep<RuntimeSessionView>;
-/** One stream of the {@link SessionView}. */
-export type StreamView = ReadonlyDeep<RuntimeStreamView>;
-/** A stream's transcript slice: what hosts paint. */
-export type TranscriptView = ReadonlyDeep<RuntimeTranscriptView>;
-
-/**
- * The process platform together with the workspace roots the package's runs
- * work in. `nodePlatform()` builds both; an embedder supplying its own
- * platform names its workspace roots beside it.
- */
-export interface AgentPlatform extends Platform {
-  readonly roots: WorkspaceRoots;
-}
+export type { AgentPlatform } from './effect/runtime.js';
+export type {
+  SessionView,
+  StreamView,
+  TranscriptView,
+} from './effect/sessions.js';
 
 /** Input accepted by the public package-level run function. */
 export interface RunAgentInput {
@@ -116,9 +78,11 @@ export interface RunAgentInput {
 /**
  * A running agent's single-consumer event stream and eventual terminal result.
  *
- * Event delivery begins with the iterator's first `next()` call. Awaiting only
- * `result` does not retain trace events, and ending iteration detaches the
- * event source while the run itself continues.
+ * Trace events are buffered from the moment the run enters its session, so
+ * an iteration begun right after `runAgent()` misses none of the launch
+ * events. Ending the iteration detaches the event source while the run
+ * itself continues, and a run that settles without ever being iterated
+ * discards what it buffered.
  */
 export interface AgentRun extends AsyncIterable<AgentEvent> {
   readonly result: Promise<AgentFlowResult>;
@@ -153,243 +117,38 @@ export interface AgentRun extends AsyncIterable<AgentEvent> {
   interrupt(): void;
 }
 
-/** A run that exists in its session: the view levels it folds into and the
- *  stream the fold keys it by. */
-interface EnteredRun {
-  readonly streamId: StreamTabId;
-  readonly view: RuntimeSessionHandle['viewChanges'];
-}
-
-/** The session of the platform's storage root, as the runtime's owner
- *  holds it: built on the first open, over what the package supplies then.
- *  Registered with the owner before the returned promise is awaited, so a
- *  close issued after `runAgent` returns finds this open. */
-function sessionFor(platform: AgentPlatform): Promise<RuntimeSessionHandle> {
-  return openSessionAsync({
-    roots: platform.roots,
-    transcripts: StreamLogStore.ephemeral('npm package consumer'),
-    // The session's one host, for its whole life, like every TeXRA host
-    // attaches one per session: the interaction hub keeps a single active
-    // host and tells runs apart by the stream its requests and cancellations
-    // name. Attaching per run instead would make each new run displace the
-    // previous run's host. The package has no interactive prompts, so there
-    // is nothing for a cancellation to settle; a retry prompt is denied so
-    // that it never parks the run waiting for a host.
-    interactions: {
-      cancel: () => {},
-      requestRetry: async () => ({
-        action: 'deny',
-        reason: 'Interactive retries are unavailable in the agent package.',
-      }),
-    },
-  });
-}
-
-/** The run's stream and every descendant the view holds. */
-function runStreamIds(
-  view: RuntimeSessionView,
-  streamId: StreamTabId,
-): StreamTabId[] {
-  const ids: StreamTabId[] = [];
-  for (const stream of view.streams.values()) {
-    if (
-      stream.id === streamId ||
-      stream.ancestors.some((ancestor) => ancestor.id === streamId)
-    ) {
-      ids.push(stream.id);
-    }
-  }
-  return ids;
-}
-
-class AgentRunStream implements AgentRun {
-  private readonly events: AgentEvent[] = [];
-  private readonly readers: Array<{
-    readonly resolve: (result: IteratorResult<AgentEvent>) => void;
-    readonly reject: (reason?: unknown) => void;
-  }> = [];
-  private liveHandle: RuntimeAgentRunHandle | undefined;
-  private detachEvents: (() => void) | undefined;
-  private ended = false;
-  private iteratorClosed = false;
-  private iteratorStarted = false;
-  private failure: { readonly error: unknown } | undefined;
-  private readonly launchAbortController = new AbortController();
-  private enter!: (run: EnteredRun | null) => void;
-  private readonly viewChanges: Stream.Stream<RuntimeSessionView>;
-  /** The package's own reader of the run's view levels, from attach to the
-   *  run's final view; what the run's settlement joins. */
-  private drain: Fiber.Fiber<void> | undefined;
-  readonly launchSignal = this.launchAbortController.signal;
-  readonly result: Promise<AgentFlowResult>;
-  readonly view: AsyncIterable<SessionView>;
-
-  constructor(start: (stream: AgentRunStream) => Promise<AgentFlowResult>) {
-    const entered = new Promise<EnteredRun | null>((resolve) => {
-      this.enter = resolve;
-    });
-    // The session's view levels, read through Effect's own async-iterable
-    // destructor once the run exists in the session. The level replays on
-    // subscribe, so no level is missed, and the fold lands the run's
-    // `run.start` asynchronously, so a replayed level can predate the run:
-    // `dropWhile` skips it. The view itself is the end condition:
-    // `takeUntil` delivers the first view holding the run's durable outcome
-    // as the last element, whether that view folds during the iteration or
-    // was current before it began. Breaking the loop closes the stream's
-    // scope.
-    this.viewChanges = Stream.unwrap(
-      Effect.map(
-        Effect.promise(() => entered),
-        (run) =>
-          run === null
-            ? Stream.empty
-            : run.view.pipe(
-                Stream.dropWhile((view) => !view.streams.has(run.streamId)),
-                Stream.takeUntil(
-                  (view) =>
-                    view.streams.get(run.streamId)?.durableOutcome != null,
-                ),
-              ),
-      ),
-    );
-    this.view = Stream.toAsyncIterable(this.viewChanges);
-    this.result = start(this);
-    void this.result.then(
-      () => this.end(),
-      (error: unknown) => this.end({ error }),
-    );
-  }
-
-  /**
-   * The existence fact: the run's stream is in the session (its `run.start`
-   * has been published, and every launch failure from here ends it with a
-   * terminal `result`), and the run's own trace is the event source: every
-   * trace event of the run, durable or not, in emission order. The launcher
-   * hands both over before the run's first trace event (the instruction
-   * log, the root stage, the launch warnings), so an iteration begun right
-   * after `runAgent()` misses none of them.
-   */
-  attachRun(
-    streamId: StreamTabId,
-    session: RuntimeSessionHandle,
-    trace: AgentTrace,
-  ): void {
-    this.enter({ streamId, view: session.viewChanges });
-    this.detachEvents = trace.subscribe((event) => {
-      if (this.iteratorStarted) this.push(event);
-    });
-    // The transcript tier folds only for subscribed aggregates (PRD 7.2), on
-    // a port of this run's own: its stream now, its descendants as the view
-    // gains them. The port is never cleared, by choice: the run's rows stay
-    // resident for the life of the package session (the README's residency
-    // contract), as a TUI's do, so a consumer can read the transcript of a
-    // finished run from the latest level as well as from the one it held.
-    const port = `sdk/${streamId}`;
-    let subscribed = '';
-    const subscribe = (ids: readonly StreamTabId[]): void => {
-      const key = ids.join('\0');
-      if (key === subscribed) return;
-      subscribed = key;
-      session.setTranscriptSubscriptions(
-        port,
-        ids.map((id) => ({ id, fromSeq: 0 })),
-      );
-    };
-    subscribe([streamId]);
-    // The package owns this drain, from here: the descendants join the
-    // subscription as the view gains them, and the run's `result` waits for
-    // its final fold even when the embedder never iterates `view` or stops
-    // early, and fails if the fold dies before publishing it.
-    this.drain = effectRuntime().runFork(
-      Stream.runDrain(
-        this.viewChanges.pipe(
-          Stream.tap((view) =>
-            Effect.sync(() => subscribe(runStreamIds(view, streamId))),
-          ),
-        ),
-      ),
-    );
-  }
-
-  /** The run's final view in the session, or the fold's defect: what the
-   *  run settles on. Nothing to wait for while the run never entered. */
-  finalView(): Effect.Effect<void> {
-    return this.drain ? Fiber.join(this.drain) : Effect.void;
-  }
-
-  /** The live handle once the run is tracked: what `interrupt()` targets. */
-  attachHandle(handle: RuntimeAgentRunHandle): void {
-    this.liveHandle = handle;
-  }
-
-  interrupt(): void {
-    if (this.liveHandle) {
-      this.liveHandle.interrupt();
-    } else {
-      this.launchAbortController.abort();
-    }
-  }
-
-  [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
-    return {
-      next: () => {
-        this.iteratorStarted = true;
-        if (this.iteratorClosed) {
-          return Promise.resolve({ done: true, value: undefined });
-        }
-        const event = this.events.shift();
-        if (event) return Promise.resolve({ done: false, value: event });
-        if (this.failure) return Promise.reject(this.failure.error);
-        if (this.ended) {
-          return Promise.resolve({ done: true, value: undefined });
-        }
-        return new Promise((resolve, reject) =>
-          this.readers.push({ resolve, reject }),
+/**
+ * The package's services over the process it composes.
+ *
+ * `composeProcess` is synchronous, so everything from the platform check to
+ * the owner's registration of this run's root happens before `runAgent`
+ * returns: a `closeSession` or a `runShutdown` issued right after it settles
+ * this launch too. It is the same call `Runtime.layer` acquires, so
+ * composition has one implementation with two entry paths.
+ *
+ * The composing call also puts the session on the embedder's shutdown path:
+ * the session's agent-spawned children and agent-CLI sessions are stopped,
+ * then the platform's session is closed through its owner under the phase's
+ * own budget, then the runtime that held it goes, and its owner with it, so
+ * a later `closeSession` answers as a process with none does. An Effect
+ * embedder reaches the same closure through `Runtime.layer`'s scope.
+ */
+function agentServices(
+  platform: AgentPlatform,
+): ReturnType<typeof makeSessions> {
+  const runtime = composeProcess(platform);
+  const sessions = makeSessions(runtime);
+  if (runtime.composed) {
+    registerRuntimeShutdownHandlers(platform.lifecycle, {
+      flushArtifacts: async (signal) => {
+        await effectRuntime().runPromise(
+          sessions.close(platform.roots, signal),
         );
       },
-      return: () => {
-        this.closeIterator();
-        return Promise.resolve({ done: true, value: undefined });
-      },
-    };
+      afterExecutionSettlement: [() => disposeProcessRuntime()],
+    });
   }
-
-  private push(event: AgentEvent): void {
-    if (this.iteratorClosed) return;
-    const reader = this.readers.shift();
-    if (reader) {
-      reader.resolve({ done: false, value: event });
-    } else {
-      this.events.push(event);
-    }
-  }
-
-  private detach(): void {
-    this.detachEvents?.();
-    this.detachEvents = undefined;
-  }
-
-  private closeIterator(): void {
-    this.iteratorClosed = true;
-    this.events.splice(0);
-    this.detach();
-    for (const reader of this.readers.splice(0)) {
-      reader.resolve({ done: true, value: undefined });
-    }
-  }
-
-  private end(failure?: { readonly error: unknown }): void {
-    this.ended = true;
-    this.failure = failure;
-    // A run that settled without ever entering the session has no view to
-    // wait for; a no-op once `attachRun` has resolved the same promise.
-    this.enter(null);
-    this.detach();
-    for (const reader of this.readers.splice(0)) {
-      if (failure) reader.reject(failure.error);
-      else reader.resolve({ done: true, value: undefined });
-    }
-  }
+  return sessions;
 }
 
 /**
@@ -409,7 +168,7 @@ export function closeSession(
   roots: WorkspaceRoots,
   signal?: AbortSignal,
 ): Promise<SessionCloseReport> {
-  return closeRuntimeSession(roots.storage, signal);
+  return effectRuntime().runPromise(closeOwnedSession(roots.storage, signal));
 }
 
 /**
@@ -419,101 +178,56 @@ export function closeSession(
  * one platform, then reuse it for every run in that process.
  */
 export function runAgent(input: RunAgentInput): AgentRun {
-  return new AgentRunStream(async (stream) => {
-    const approvalToolNames =
-      input.tools
-        ?.filter((tool) => tool.requiresApproval)
-        .map((tool) => tool.definition.name) ?? [];
-    if (approvalToolNames.length > 0) {
-      throw new Error(
-        `The agent package cannot run approval-requiring tools: ${approvalToolNames.join(', ')}`,
-      );
-    }
-
-    // Everything from the platform check to the session open is
-    // synchronous: two first runs cannot both pass the check, and the owner
-    // holds this run's session before the run's first await, so a
-    // `closeSession` or a `runShutdown` issued right after `runAgent`
-    // returns settles this launch too (the run then fails at admission
-    // instead of starting model work after the cleanup). The process
-    // identity is read while the session builds.
-    const activePlatform = tryPlatform();
-    if (activePlatform && activePlatform !== input.platform) {
-      throw new Error(
-        'The agent package is already using another platform in this process.',
-      );
-    }
-    if (!activePlatform) {
-      // No composition root has run in this process, so the package is its
-      // composition root: the platform, the one Effect runtime holding the
-      // sessions' owner (PRD 7.7), the node agent runtime, and the hosts'
-      // shutdown order on the embedder's shutdown path. A run beside a host
-      // that already ran its own (the same platform object) reuses all four,
-      // its session included: the owner is process-wide, and nothing here
-      // may be installed twice.
-      initPlatform(input.platform);
-      initProcessWorkspaceRoots(input.platform.roots);
-      // The runtime is installed before the agent runtime, as the CLI and
-      // desktop roots do: registering the direct Lean language services
-      // builds their layer graph on it, so a registration ahead of the
-      // install throws before any agent work begins.
-      installProcessRuntime(input.platform.processes.selfIdentity());
-      initNodeAgentRuntime(input.platform.lifecycle);
-      // The session's agent-spawned children and agent-CLI sessions are
-      // stopped, then the platform's session is closed through its owner
-      // under the phase's own budget (its runs stopped and settled, its
-      // artifacts flushed, the session released: the headless shape, as the
-      // CLI's headless run stops and awaits its run in this phase), then
-      // the runtime that held it goes, and its owner with it: a later
-      // `closeSession` answers as a process with none does.
-      registerRuntimeShutdownHandlers(input.platform.lifecycle, {
-        flushArtifacts: async (signal) => {
-          await closeSession(input.platform.roots, signal);
-        },
-        afterExecutionSettlement: [() => disposeProcessRuntime()],
-      });
-    }
-    const session = await sessionFor(input.platform);
-    await loadAgents({ includeRemote: false });
-    const resolved = resolveAgent(input.agent);
-    if (!resolved) {
-      throw new Error(
-        `Agent "${input.agent}" was not found in the configured agent directory.`,
-      );
-    }
-    if (
-      input.tools &&
-      input.tools.length > 0 &&
-      resolved.entry.category !== AgentCategory.ToolUse
-    ) {
-      throw new Error(
-        `Custom tools are supported only for tool-use agents; "${input.agent}" is a workflow agent.`,
-      );
-    }
-    const config = AgentConfigSchema.parse({
-      agent: resolved.entry.name,
-      agentCategory: resolved.entry.category,
-      agentSource: resolved.entry.source,
-      instruction: input.instruction,
-      ...(input.model ? { model: input.model } : {}),
+  const sessions = agentServices(input.platform);
+  // One fiber on the process runtime, which `runFork` evaluates to its
+  // first yield before returning: the owner holds this run's session by the
+  // time `runAgent` does.
+  const started = effectRuntime().runFork(
+    Effect.flatMap(sessions.open(), (session) => session.start(input)),
+  );
+  const result = effectRuntime()
+    .runPromise(Fiber.join(started).pipe(Effect.flatMap((run) => run.result)))
+    .catch((error: unknown) => {
+      throw embedderError(error);
     });
-    const result = await runValidatedAgent(
-      { kind: 'fresh', config },
-      {
-        approvalPromptsUnavailable: true,
-        launchSignal: stream.launchSignal,
-        onRun: (handle) => stream.attachHandle(handle),
-        onStreamResolved: (streamId, trace) =>
-          stream.attachRun(streamId, session, trace),
-        session,
-        stopAfterCycle: true,
-        tools: input.tools,
-      },
-    );
-    // A run that completed settles only once the asynchronous fold holds its
-    // final view, or has died trying. A run that failed on its own settled
-    // above, with its own error: the fold's fate never replaces it.
-    await effectRuntime().runPromise(stream.finalView());
-    return result;
-  });
+  // An embedder that only iterates events must not take an unhandled
+  // rejection for the result it never asked for: allSettled subscribes to
+  // the rejection and settles regardless, so it is observed either way.
+  void Promise.allSettled([result]);
+  return {
+    result,
+    view: Stream.toAsyncIterable(
+      Stream.unwrap(
+        Fiber.join(started).pipe(
+          Effect.map((run) => run.view),
+          // A run that fails before it enters the session has no view.
+          Effect.catchCause(() => Effect.succeed(Stream.empty)),
+        ),
+      ),
+    ),
+    interrupt: () => {
+      // Two windows, one expression: before admission the interrupt reaches
+      // the launch's abort signal; after it, the live run's handle.
+      effectRuntime().runFork(
+        Fiber.interrupt(started).pipe(
+          Effect.andThen(Fiber.await(started)),
+          Effect.flatMap((exit) =>
+            Exit.isSuccess(exit) ? exit.value.interrupt : Effect.void,
+          ),
+        ),
+      );
+    },
+    [Symbol.asyncIterator]: () =>
+      Stream.toAsyncIterable(
+        Stream.unwrap(
+          Fiber.join(started).pipe(Effect.map((run) => run.events)),
+        ).pipe(Stream.mapError(embedderError)),
+      )[Symbol.asyncIterator](),
+  };
+}
+
+/** The error an embedder catches: a run's own failure carries what the
+ *  launch path threw, and a refusal is itself the error. */
+function embedderError(error: unknown): unknown {
+  return error instanceof RunFailure ? error.cause : error;
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -33,7 +33,6 @@ import type { ITool } from '@agent/core/tools/ToolTypes';
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 
 // Local imports - host services this boundary wires
-import { disposeProcessRuntime } from '@controllers/session/sessionLayer';
 import type { WorkspaceRoots } from '@platform/workspaceRoots';
 import type { SessionCloseReport } from '@shared/schemas';
 import { registerRuntimeShutdownHandlers } from '@tools/agentCliSessionStores';
@@ -41,7 +40,11 @@ import { registerRuntimeShutdownHandlers } from '@tools/agentCliSessionStores';
 // Local imports - the Effect surface this entry renders
 import { RunFailure } from './effect/errors.js';
 import { composeProcess, type AgentPlatform } from './effect/runtime.js';
-import { makeSessions, type SessionView } from './effect/sessions.js';
+import {
+  admitTools,
+  makeSessions,
+  type SessionView,
+} from './effect/sessions.js';
 
 /**
  * The owner's session effects supply their own context, so every run site
@@ -135,6 +138,27 @@ export interface AgentRun extends AsyncIterable<AgentEvent> {
 }
 
 /**
+ * The Promise entry's one composition of the process, and the hold it took
+ * on it.
+ *
+ * This entry's owner for a composition is the embedder's shutdown path, and
+ * a lifecycle host drains each phase exactly once and caches its shutdown,
+ * so there is one such owner per process and therefore one composition: a
+ * later `runAgent` on the same platform reuses this rather than taking a
+ * second hold nothing would release. The shutdown releases the hold and
+ * clears this, and `shutdownRan` refuses a run that arrives after it, so no
+ * run composes a session with no shutdown path left to close and flush it.
+ * The Effect surface has no such limit: there the owner is the scope, so a
+ * new `Runtime.layer` scope composes the process again.
+ */
+let composition:
+  | {
+      readonly platform: AgentPlatform;
+      readonly sessions: ReturnType<typeof makeSessions>;
+    }
+  | undefined;
+
+/**
  * The package's services over the process it composes.
  *
  * `composeProcess` is synchronous, so everything from the platform check to
@@ -146,19 +170,11 @@ export interface AgentRun extends AsyncIterable<AgentEvent> {
  * The composing call also puts the session on the embedder's shutdown path:
  * the session's agent-spawned children and agent-CLI sessions are stopped,
  * then the platform's session is closed through its owner under the phase's
- * own budget, then the runtime that held it goes, and its owner with it
- * (#11913 ends the two in one step), so a later `closeSession` answers as a
- * process with none does. An Effect embedder reaches the same closure
- * through `Runtime.layer`'s scope.
- *
- * That path is this entry's only owner for a composition, and it can be
- * drawn once: a lifecycle host drains each phase exactly once and caches
- * its shutdown, so a handler registered after `runShutdown()` began is
- * never run. A run on a platform whose shutdown has run is therefore
- * refused, rather than installing a runtime and an owner with nothing left
- * to dispose them. The lifecycle says so itself, through `shutdownRan`,
- * which also covers the shutdown a host ran over its own composition. The Effect surface has no such limit: there the owner is the
- * scope, so a new `Runtime.layer` scope composes the process again.
+ * own budget, then this entry's hold on the composition ends. The runtime
+ * and the owner on it go with that hold when it is the last one, so a later
+ * `closeSession` answers as a process with none does, and they stay while an
+ * Effect scope of the same process still holds them. An Effect embedder
+ * reaches the same closure through `Runtime.layer`'s scope.
  */
 function agentServices(
   platform: AgentPlatform,
@@ -168,16 +184,23 @@ function agentServices(
       "This platform's shutdown has already run, and it runs once: a session opened now would have no shutdown path to close and flush it, and the runtime under it none to dispose it. Run further agents in a new process, or take the Effect surface (@texra-ai/agent/effect), whose scope owns each composition.",
     );
   }
-  const runtime = composeProcess(platform);
-  const sessions = makeSessions(runtime);
-  if (runtime.composed) {
-    registerRuntimeShutdownHandlers(platform.lifecycle, {
-      flushArtifacts: async (signal) => {
-        await Effect.runPromise(sessions.close(platform.roots, signal));
+  if (composition?.platform === platform) return composition.sessions;
+  // A different platform reaches `composeProcess`, which is what states the
+  // refusal.
+  const hold = composeProcess(platform);
+  const sessions = makeSessions(hold.runtime);
+  composition = { platform, sessions };
+  registerRuntimeShutdownHandlers(platform.lifecycle, {
+    flushArtifacts: async (signal) => {
+      await Effect.runPromise(sessions.close(platform.roots, signal));
+    },
+    afterExecutionSettlement: [
+      async () => {
+        composition = undefined;
+        await Effect.runPromise(hold.release);
       },
-      afterExecutionSettlement: [() => disposeProcessRuntime()],
-    });
-  }
+    ],
+  });
   return sessions;
 }
 
@@ -217,10 +240,18 @@ export function runAgent(input: RunAgentInput): AgentRun {
   // `result`, where every other launch refusal arrives, rather than
   // throwing from a call whose declared shape is an `AgentRun`.
   const started = Effect.runFork(
-    Effect.try({
-      try: () => agentServices(input.platform),
-      catch: (refusal) => refusal,
-    }).pipe(
+    // The refusal the package can state from the input alone comes first,
+    // as it did before this entry composed inside the fiber: a caller that
+    // hands over an approval-requiring tool is refused without a process
+    // runtime, a session owner, or a session being composed on its behalf.
+    // `start` states it again in its own order, over the agent it resolved.
+    admitTools(input.tools).pipe(
+      Effect.andThen(
+        Effect.try({
+          try: () => agentServices(input.platform),
+          catch: (refusal) => refusal,
+        }),
+      ),
       Effect.flatMap((sessions) => sessions.open()),
       Effect.flatMap((session) => session.start(input)),
     ),
@@ -250,7 +281,12 @@ export function runAgent(input: RunAgentInput): AgentRun {
     ),
     interrupt: () => {
       // Two windows, one expression: before admission the interrupt reaches
-      // the launch's abort signal; after it, the live run's handle.
+      // the launch's abort signal; after it, the live run's handle. The
+      // exits are exhaustive because `start`'s handoff is: a success holds
+      // the `Run` and its `interrupt` is the live run's, and any other exit
+      // is either a launch that already failed or one this interrupt ended
+      // in the admission wait, where `start` ended the run with it. There
+      // is no exit that leaves a run for this to miss.
       Effect.runFork(
         Fiber.interrupt(started).pipe(
           Effect.andThen(Fiber.await(started)),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -95,9 +95,11 @@ export interface RunAgentInput {
  *
  * Every failure arrives on `result`, never as a throw from `runAgent()`
  * itself. A refusal before any model work is the tagged error the Effect
- * surface names (`AgentNotFound`, `ToolsRefused`, `PlatformConflict`); a
- * run that fails after it entered the session rejects with exactly what the
- * launch path threw.
+ * surface names (`AgentNotFound`, `ToolsRefused`, `PlatformConflict`), or,
+ * for a run started after the platform's shutdown has run, the plain
+ * `Error` this entry states: that one is the Promise entry's own condition,
+ * since the Effect surface composes per scope. A run that fails after it
+ * entered the session rejects with exactly what the launch path threw.
  */
 export interface AgentRun extends AsyncIterable<AgentEvent> {
   readonly result: Promise<AgentFlowResult>;
@@ -144,14 +146,28 @@ export interface AgentRun extends AsyncIterable<AgentEvent> {
  * The composing call also puts the session on the embedder's shutdown path:
  * the session's agent-spawned children and agent-CLI sessions are stopped,
  * then the platform's session is closed through its owner under the phase's
- * own budget, then the runtime that held it goes, and its owner with it, so
- * a later `closeSession` answers as a process with none does and a later
- * `runAgent` composes the process again. An Effect embedder reaches the
- * same closure through `Runtime.layer`'s scope.
+ * own budget, then the runtime that held it goes, and its owner with it
+ * (#11913 ends the two in one step), so a later `closeSession` answers as a
+ * process with none does. An Effect embedder reaches the same closure
+ * through `Runtime.layer`'s scope.
+ *
+ * That path is this entry's only owner for a composition, and it can be
+ * drawn once: a lifecycle host drains each phase exactly once and caches
+ * its shutdown, so a handler registered after `runShutdown()` began is
+ * never run. A run on a platform whose shutdown has run is therefore
+ * refused, rather than installing a runtime and an owner with nothing left
+ * to dispose them. The lifecycle says so itself, through `shutdownRan`,
+ * which also covers the shutdown a host ran over its own composition. The Effect surface has no such limit: there the owner is the
+ * scope, so a new `Runtime.layer` scope composes the process again.
  */
 function agentServices(
   platform: AgentPlatform,
 ): ReturnType<typeof makeSessions> {
+  if (platform.lifecycle.shutdownRan) {
+    throw new Error(
+      "This platform's shutdown has already run, and it runs once: a session opened now would have no shutdown path to close and flush it, and the runtime under it none to dispose it. Run further agents in a new process, or take the Effect surface (@texra-ai/agent/effect), whose scope owns each composition.",
+    );
+  }
   const runtime = composeProcess(platform);
   const sessions = makeSessions(runtime);
   if (runtime.composed) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -34,7 +34,6 @@ import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 
 // Local imports - host services this boundary wires
 import { disposeProcessRuntime } from '@controllers/session/sessionLayer';
-import { effectRuntime } from '@platform/processRuntime';
 import type { WorkspaceRoots } from '@platform/workspaceRoots';
 import type { SessionCloseReport } from '@shared/schemas';
 import { registerRuntimeShutdownHandlers } from '@tools/agentCliSessionStores';
@@ -43,6 +42,14 @@ import { registerRuntimeShutdownHandlers } from '@tools/agentCliSessionStores';
 import { RunFailure } from './effect/errors.js';
 import { composeProcess, type AgentPlatform } from './effect/runtime.js';
 import { makeSessions, type SessionView } from './effect/sessions.js';
+
+/**
+ * The owner's session effects supply their own context, so every run site
+ * below runs on Effect's own runtime rather than borrowing the process
+ * runtime the composition installs. That is what lets `closeSession`
+ * answer for a process no run has initialized, and for one whose shutdown
+ * has already disposed that runtime, exactly as its contract says.
+ */
 
 export type { AgentEvent } from '@agent/trace';
 export type { SessionCloseReport } from '@shared/schemas';
@@ -82,7 +89,15 @@ export interface RunAgentInput {
  * an iteration begun right after `runAgent()` misses none of the launch
  * events. Ending the iteration detaches the event source while the run
  * itself continues, and a run that settles without ever being iterated
- * discards what it buffered.
+ * discards what it buffered. That pre-reader buffer is bounded: a run whose
+ * events pass it with nobody reading warns and detaches its trace, so
+ * awaiting only `result` never retains a long run's whole trace.
+ *
+ * Every failure arrives on `result`, never as a throw from `runAgent()`
+ * itself. A refusal before any model work is the tagged error the Effect
+ * surface names (`AgentNotFound`, `ToolsRefused`, `PlatformConflict`); a
+ * run that fails after it entered the session rejects with exactly what the
+ * launch path threw.
  */
 export interface AgentRun extends AsyncIterable<AgentEvent> {
   readonly result: Promise<AgentFlowResult>;
@@ -130,8 +145,9 @@ export interface AgentRun extends AsyncIterable<AgentEvent> {
  * the session's agent-spawned children and agent-CLI sessions are stopped,
  * then the platform's session is closed through its owner under the phase's
  * own budget, then the runtime that held it goes, and its owner with it, so
- * a later `closeSession` answers as a process with none does. An Effect
- * embedder reaches the same closure through `Runtime.layer`'s scope.
+ * a later `closeSession` answers as a process with none does and a later
+ * `runAgent` composes the process again. An Effect embedder reaches the
+ * same closure through `Runtime.layer`'s scope.
  */
 function agentServices(
   platform: AgentPlatform,
@@ -141,9 +157,7 @@ function agentServices(
   if (runtime.composed) {
     registerRuntimeShutdownHandlers(platform.lifecycle, {
       flushArtifacts: async (signal) => {
-        await effectRuntime().runPromise(
-          sessions.close(platform.roots, signal),
-        );
+        await Effect.runPromise(sessions.close(platform.roots, signal));
       },
       afterExecutionSettlement: [() => disposeProcessRuntime()],
     });
@@ -168,28 +182,41 @@ export function closeSession(
   roots: WorkspaceRoots,
   signal?: AbortSignal,
 ): Promise<SessionCloseReport> {
-  return effectRuntime().runPromise(closeOwnedSession(roots.storage, signal));
+  return Effect.runPromise(closeOwnedSession(roots.storage, signal));
 }
 
 /**
  * Start one agent run and expose its trace as an asynchronous event stream.
  *
  * The platform and agent registry are process-wide. Applications should create
- * one platform, then reuse it for every run in that process.
+ * one platform, then reuse it for every run in that process; a second,
+ * different platform is refused, and the refusal arrives on the returned
+ * run's `result` like every other launch refusal.
  */
 export function runAgent(input: RunAgentInput): AgentRun {
-  const sessions = agentServices(input.platform);
-  // One fiber on the process runtime, which `runFork` evaluates to its
-  // first yield before returning: the owner holds this run's session by the
-  // time `runAgent` does.
-  const started = effectRuntime().runFork(
-    Effect.flatMap(sessions.open(), (session) => session.start(input)),
+  // One fiber, which `runFork` evaluates to its first yield before it
+  // returns: the process is composed and this run's root is the owner's by
+  // the time `runAgent` returns. The composition runs inside the fiber so
+  // that its one refusal, `PlatformConflict`, reaches the caller on
+  // `result`, where every other launch refusal arrives, rather than
+  // throwing from a call whose declared shape is an `AgentRun`.
+  const started = Effect.runFork(
+    Effect.try({
+      try: () => agentServices(input.platform),
+      catch: (refusal) => refusal,
+    }).pipe(
+      Effect.flatMap((sessions) => sessions.open()),
+      Effect.flatMap((session) => session.start(input)),
+    ),
   );
-  const result = effectRuntime()
-    .runPromise(Fiber.join(started).pipe(Effect.flatMap((run) => run.result)))
-    .catch((error: unknown) => {
-      throw embedderError(error);
-    });
+  const result = Effect.runPromise(
+    Fiber.join(started).pipe(
+      Effect.flatMap((run) => run.result),
+      // The error an embedder catches, named once, inside the Effect, as
+      // the events path names it with the same function.
+      Effect.mapError(embedderError),
+    ),
+  );
   // An embedder that only iterates events must not take an unhandled
   // rejection for the result it never asked for: allSettled subscribes to
   // the rejection and settles regardless, so it is observed either way.
@@ -208,7 +235,7 @@ export function runAgent(input: RunAgentInput): AgentRun {
     interrupt: () => {
       // Two windows, one expression: before admission the interrupt reaches
       // the launch's abort signal; after it, the live run's handle.
-      effectRuntime().runFork(
+      Effect.runFork(
         Fiber.interrupt(started).pipe(
           Effect.andThen(Fiber.await(started)),
           Effect.flatMap((exit) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,9 +463,6 @@ importers:
       diff-match-patch:
         specifier: ^1.0.5
         version: 1.0.5
-      effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
       escape-string-regexp:
         specifier: ^5.0.0
         version: 5.0.0
@@ -599,6 +596,9 @@ importers:
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
       esbuild:
         specifier: ^0.28.2
         version: 0.28.2

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -161,6 +161,15 @@ export class SessionHandle {
   readonly folded: SessionGraph['folded'];
   /** Ordered replay and live inputs for each transport subscription. */
   readonly inputs: SessionGraph['inputs'];
+  /**
+   * The transcript subscription set, one set per port: the aggregates whose
+   * transcript tier the view folds for that port, the view's set being the
+   * union over every port. An Effect-native reader (the SDK's run drain,
+   * the session bridge's ports) sets its own port here;
+   * {@link setTranscriptSubscriptions} is the same write for the callers
+   * that still speak Promises.
+   */
+  readonly subscriptions: SessionGraph['subscriptions'];
   /** Session-scoped status plane. */
   readonly status: StreamStatusMachine;
   /** Session-owned transcript store for run traces launched in this session. */
@@ -240,6 +249,7 @@ export class SessionHandle {
     this.folded = graph.folded;
     this.requests = graph.requests;
     this.inputs = graph.inputs;
+    this.subscriptions = graph.subscriptions;
     const status = new StreamStatusMachine(
       (event) => this.publishStatus(event),
       (streamId, detail) => this.setUnreadable(streamId, detail),

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -34,6 +34,7 @@ export {
   listSessions,
   openSession,
   openSessionEffect,
+  sessionOwnerInstalled,
 } from './sessionGraph';
 
 // RunContext: the session scope a host enters around every touch of a

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -29,7 +29,12 @@ export {
 
 // sessionGraph: the process's session owner, as the hosts and the SDK open
 // and close sessions through it (one session per workspace storage root).
-export { closeSession, openSession, openSessionAsync } from './sessionGraph';
+export {
+  closeSession,
+  listSessions,
+  openSession,
+  openSessionEffect,
+} from './sessionGraph';
 
 // RunContext: the session scope a host enters around every touch of a
 // session's storage when it holds several sessions in one process.

--- a/src/agent/runtime/sessionGraph.ts
+++ b/src/agent/runtime/sessionGraph.ts
@@ -13,6 +13,12 @@
  */
 
 import {
+  Effect,
+  type Context,
+  type Stream,
+  type SubscriptionRef,
+} from 'effect';
+import {
   processWorkspaceRoots,
   tryProcessWorkspaceRoots,
   type WorkspaceRoots,
@@ -29,7 +35,6 @@ import type { Outcome, RuntimeRequest } from '@shared/session/runtimeRequest';
 import type { SessionView } from '@shared/session/sessionView';
 import type { SessionEventsShape } from '@shared/session/sessionEvents';
 import type { SessionInputs } from '@shared/session/sessionInputs';
-import type { Context, Effect, Stream, SubscriptionRef } from 'effect';
 import type { SessionHandle, SessionHandleInit } from './SessionHandle';
 
 /** What a session holds of its graph, resolved once at construction. */
@@ -80,18 +85,23 @@ export type SessionOpen = SessionHandleInit & {
 
 /** The process's session owner, as `installProcessRuntime` installs it. */
 export interface SessionOwner {
+  /** The hosts' synchronous face of {@link SessionOwner.open}: the
+   *  extension, the desktop, and the CLI still open from Promise-native
+   *  code. It is scheduled for deletion when those lanes convert, and no
+   *  new caller may take it. */
+  openSync(open: SessionOpen): SessionHandle;
   /** The session of `open.roots`' storage root: the one already open there,
-   *  or built now over what `open` supplies. */
-  open(open: SessionOpen): SessionHandle;
-  /** The same open for a process still reading its identity (the package):
-   *  the root's entry is registered with the owner before this returns, so
-   *  a close issued after it finds the session and waits for its build. */
-  openAsync(open: SessionOpen): Promise<SessionHandle>;
+   *  or built now over what `open` supplies. The root's entry is registered
+   *  with the owner before this Effect's first yield, so a close issued
+   *  after it finds the session and waits for its build. */
+  open(open: SessionOpen): Effect.Effect<SessionHandle>;
   /** The session open on a storage root, if one is; never builds one. */
   current(root: string): SessionHandle | undefined;
+  /** Every session the owner holds, in no particular order. */
+  list(): Effect.Effect<readonly SessionHandle[]>;
   /** Close the session of a storage root, settling what it owns inside
    *  `signal`'s budget, or the runtime's own when the caller passes none. */
-  close(root: string, signal?: AbortSignal): Promise<SessionCloseReport>;
+  close(root: string, signal?: AbortSignal): Effect.Effect<SessionCloseReport>;
 }
 
 let owner: SessionOwner | undefined;
@@ -131,20 +141,23 @@ function sessions(): SessionOwner {
  * session ends.
  */
 export function openSession(init: SessionHandleInit): SessionHandle {
-  return sessions().open(resolveRoots(init));
+  return sessions().openSync(resolveRoots(init));
+}
+
+/** {@link openSession} for a caller that already speaks Effect: the same
+ *  one-session-per-root open, on the caller's own fiber. */
+export function openSessionEffect(
+  init: SessionHandleInit,
+): Effect.Effect<SessionHandle> {
+  return Effect.suspend(() => sessions().open(resolveRoots(init)));
 }
 
 /**
- * {@link openSession} for an opener whose process identity is still being
- * read (the package, whose composition root is its first run): the root's
- * entry is registered with the owner before this returns, so a close or a
- * shutdown issued right after it settles this open too, and the handle
- * arrives when the session is built.
+ * Every session the process's owner holds. A process with no owner
+ * installed has opened none and holds none, which is what this reports.
  */
-export function openSessionAsync(
-  init: SessionHandleInit,
-): Promise<SessionHandle> {
-  return sessions().openAsync(resolveRoots(init));
+export function listSessions(): Effect.Effect<readonly SessionHandle[]> {
+  return Effect.suspend(() => owner?.list() ?? Effect.succeed([]));
 }
 
 function resolveRoots(init: SessionHandleInit): SessionOpen {
@@ -179,8 +192,10 @@ export function defaultRootSession(): SessionHandle | undefined {
 export function closeSession(
   root: string,
   signal?: AbortSignal,
-): Promise<SessionCloseReport> {
-  return owner
-    ? owner.close(root, signal)
-    : Promise.resolve({ settled: true, abandoned: [] });
+): Effect.Effect<SessionCloseReport> {
+  return Effect.suspend(() =>
+    owner
+      ? owner.close(root, signal)
+      : Effect.succeed({ settled: true, abandoned: [] }),
+  );
 }

--- a/src/agent/runtime/sessionGraph.ts
+++ b/src/agent/runtime/sessionGraph.ts
@@ -116,6 +116,19 @@ export function initSessionOwner(sessions: SessionOwner | undefined): void {
   owner = sessions;
 }
 
+/**
+ * Whether this process holds a session owner: false before the first
+ * `installProcessRuntime` and again once `disposeProcessRuntime` has
+ * uninstalled it. This, not the platform, is what says a process is
+ * composed: `initPlatform` has no inverse and holds for the life of the
+ * process, while the owner and the runtime under it end with the
+ * composition that installed them, so a composition root asks here whether
+ * it must install its own.
+ */
+export function sessionOwnerInstalled(): boolean {
+  return owner !== undefined;
+}
+
 function sessions(): SessionOwner {
   if (!owner) {
     throw new Error(

--- a/src/controllers/session/SessionBridge.ts
+++ b/src/controllers/session/SessionBridge.ts
@@ -198,7 +198,7 @@ export class SessionBridge {
       view: session.view,
       inputs: session.inputs,
       setTranscriptSubscriptions: (id, set) =>
-        Effect.sync(() => session.setTranscriptSubscriptions(id, set)),
+        session.subscriptions.set(id, set),
     };
     const framer = new PortFramer(source, port, this.host);
     this.ports.set(port.id, { port, framer });

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -465,6 +465,13 @@ const aborted = (signal: AbortSignal) =>
  * work, until they actually settle; only then is it released, so no later
  * open builds a second session over a root whose stores a run still
  * writes. Nothing here touches the process lifecycle or another root.
+ *
+ * The whole close is uninterruptible, so the budget above is its one
+ * cancellation channel: its first steps (closing admissions and killing the
+ * root's executions) cannot be undone and its last (the artifact flush and
+ * the entry's release) must still run, so a caller that races or times out
+ * this effect must not be able to leave a session shut to new runs, its
+ * artifacts unflushed and its entry never released.
  */
 const closeSession = (root: string, signal?: AbortSignal) =>
   Effect.gen(function* () {
@@ -543,7 +550,7 @@ const closeSession = (root: string, signal?: AbortSignal) =>
       abandoned,
     };
     return report;
-  });
+  }).pipe(Effect.uninterruptible);
 
 /**
  * Make the one Effect runtime of this process over its identity (PRD 7.7)

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -471,7 +471,10 @@ const aborted = (signal: AbortSignal) =>
  * root's executions) cannot be undone and its last (the artifact flush and
  * the entry's release) must still run, so a caller that races or times out
  * this effect must not be able to leave a session shut to new runs, its
- * artifacts unflushed and its entry never released.
+ * artifacts unflushed and its entry never released. It does not mask the
+ * two races below: `Effect.race` forks its arms interruptible whatever the
+ * region around it, so the budget still interrupts the settlement wait and
+ * the flush, and the report still returns at the deadline.
  */
 const closeSession = (root: string, signal?: AbortSignal) =>
   Effect.gen(function* () {

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -398,6 +398,19 @@ const openSession = (open: SessionOpen) =>
     return Context.get(context, Session);
   }).pipe(Effect.scoped);
 
+/** Every session the map holds, entries still building waited for. Builds
+ *  nothing: a key whose entry has been released is skipped. */
+const listSessions = Effect.gen(function* () {
+  const sessions = yield* Sessions;
+  const keys = yield* RcMap.keys(sessions.rcMap);
+  const held: SessionHandle[] = [];
+  for (const key of keys) {
+    const entry = yield* sessions.contextEffectOption(key).pipe(Effect.scoped);
+    if (Option.isSome(entry)) held.push(Context.get(entry.value, Session));
+  }
+  return held;
+});
+
 /** The session held for `root`, if the map holds one: an entry still
  *  building is waited for, never skipped. Builds nothing. */
 const heldSession = (root: string) =>
@@ -542,14 +555,15 @@ const closeSession = (root: string, signal?: AbortSignal) =>
  * composition root is its first run (the package): the map itself never
  * waits for it, so an open registers its root with the owner before the
  * caller's first await, and only the entry's build does. The owner it
- * installs is the map's Promise-and-sync face: `open` builds under
- * `runSync`, so everything a root's graph does at build time, the history
- * import included, must complete inside the scheduler's yield budget
+ * installs answers in Effect except for the two synchronous faces the
+ * unconverted hosts still take: `openSync` builds under `runSync`, so
+ * everything a root's graph does at build time, the history import
+ * included, must complete inside the scheduler's yield budget
  * (`Scheduler.MaxOpsBeforeYield` steps per yield) or the open reads as
- * asynchronous and throws; an opener whose identity is pending opens through
- * `openAsync`. The import appends the whole history in one call for that
- * reason; moving it to row open (#11907) is what removes the history pass
- * from here.
+ * asynchronous and throws; an opener whose identity is still pending opens
+ * through the Effect face. The import appends the whole history in one call
+ * for that reason; moving it to row open (#11907) is what removes the
+ * history pass from here.
  */
 export function installProcessRuntime(
   processStart: string | undefined | Promise<string | undefined>,
@@ -569,11 +583,21 @@ export function installProcessRuntime(
   };
   const runtime = ManagedRuntime.make(Sessions.layer(release, identity));
   initProcessRuntime(runtime);
+  // The map's services on the caller's own fiber: an Effect-native opener
+  // (the SDK) runs these where it stands, so the owner adds no run site of
+  // its own. `openSync` and `current` stay synchronous for the three hosts.
+  const onThisRuntime = <A, E>(
+    effect: Effect.Effect<A, E, Sessions>,
+  ): Effect.Effect<A, E> =>
+    Effect.flatMap(runtime.contextEffect, (context) =>
+      Effect.provideContext(effect, context),
+    );
   initSessionOwner({
-    open: (open) => runtime.runSync(openSession(open)),
-    openAsync: (open) => runtime.runPromise(openSession(open)),
+    openSync: (open) => runtime.runSync(openSession(open)),
+    open: (open) => onThisRuntime(openSession(open)),
     current: (root) => runtime.runSync(heldSession(root))?.session,
-    close: (root, signal) => runtime.runPromise(closeSession(root, signal)),
+    list: () => onThisRuntime(listSessions),
+    close: (root, signal) => onThisRuntime(closeSession(root, signal)),
   });
 }
 

--- a/src/platform/defaults/lifecycleHost.ts
+++ b/src/platform/defaults/lifecycleHost.ts
@@ -133,5 +133,10 @@ export function createLifecycleHost(
       })();
       return shutdownPromise;
     },
+    // The cache above is also the answer: once a drain exists, the phases
+    // have been spliced and a later registration has no drain of its own.
+    get shutdownRan() {
+      return shutdownPromise !== undefined;
+    },
   };
 }

--- a/src/platform/interfaces.ts
+++ b/src/platform/interfaces.ts
@@ -212,6 +212,13 @@ export interface LifecycleHost {
     callback: (signal: AbortSignal) => void | Promise<void>,
   ): Disposable;
   runShutdown(): Promise<void>;
+  /**
+   * True from the moment `runShutdown()` is first called. Each phase drains
+   * exactly once and the drain is cached, so a handler registered from here
+   * on is never run: a caller whose cleanup depends on this path must read
+   * this before taking a resource it would register here.
+   */
+  readonly shutdownRan: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -41,6 +41,11 @@ const mocks = vi.hoisted(() => ({
   initNodeAgentRuntime: vi.fn(),
   initPlatform: vi.fn(),
   initProcessWorkspaceRoots: vi.fn(),
+  /** The process's session owner, as `installProcessRuntime` installs it
+   *  and `disposeProcessRuntime` takes it away: what says whether the
+   *  package must compose the process. */
+  installRuntime: vi.fn(),
+  ownerInstalled: false,
   loadAgents: vi.fn(),
   runValidatedAgent: vi.fn(),
   /** Every session the owner built for the package, with what it was
@@ -148,23 +153,14 @@ vi.mock('@agent/runtime', async () => {
         return mocks.closeSession(root);
       }),
     runAgent: mocks.runValidatedAgent,
+    sessionOwnerInstalled: () => mocks.ownerInstalled,
   };
 });
 
 vi.mock('@controllers/session/sessionLayer', () => ({
   disposeProcessRuntime: mocks.disposeRuntime,
-  installProcessRuntime: vi.fn(),
+  installProcessRuntime: mocks.installRuntime,
 }));
-
-vi.mock('@platform/processRuntime', async () => {
-  const { Effect } = await import('effect');
-  return {
-    effectRuntime: () => ({
-      runFork: Effect.runFork,
-      runPromise: Effect.runPromise,
-    }),
-  };
-});
 
 vi.mock('@tools/agentCliSessionStores', () => ({
   registerRuntimeShutdownHandlers: (
@@ -280,8 +276,15 @@ describe('agent package run lifecycle', () => {
     mocks.activePlatform = null;
     mocks.agentCategory = 'toolUse';
     mocks.eventListener = undefined;
+    mocks.ownerInstalled = false;
     mocks.initPlatform.mockImplementation((platform: object) => {
       mocks.activePlatform = platform;
+    });
+    mocks.installRuntime.mockImplementation(() => {
+      mocks.ownerInstalled = true;
+    });
+    mocks.disposeRuntime.mockImplementation(() => {
+      mocks.ownerInstalled = false;
     });
     mocks.foldDeath = Effect.runSync(Deferred.make<never, Error>());
     mocks.loadAgents.mockResolvedValue(undefined);
@@ -417,12 +420,14 @@ describe('agent package run lifecycle', () => {
     const [runtimeOrder] = mocks.disposeRuntime.mock.invocationCallOrder;
     expect(closeOrder).toBeLessThan(runtimeOrder);
 
-    // Shutdown closed the session through its owner: a later run finds none
-    // open on the root and the owner builds it anew. Whether such a run
-    // works is out of contract (the README scopes the package state to the
-    // process); only the reset owner is observed here.
+    // Shutdown closed the session through its owner and took the owner
+    // with the runtime it ran on, so a later run composes the process again
+    // over the platform already installed: the package is not single-use
+    // per process, and the owner builds the root's session anew.
     await runAgent(INPUT).result;
     expect(mocks.sessionInits).toHaveLength(2);
+    expect(mocks.installRuntime).toHaveBeenCalledTimes(2);
+    expect(mocks.initPlatform).toHaveBeenCalledTimes(1);
   });
 
   it('composes into an embedder own runtime: the Effect surface starts a run and lists the one session the Promise entry already opened', async () => {
@@ -449,6 +454,13 @@ describe('agent package run lifecycle', () => {
     // Effect surface resolved the session the Promise entry ran on, and the
     // package built no registry of its own.
     expect(seen.open).toBe(1);
+    expect(mocks.sessionInits).toHaveLength(1);
+    // The scope composed nothing, so leaving it ended nothing the Promise
+    // entry still uses: no close, no disposal, and the next run finds the
+    // same session rather than building a second one.
+    expect(mocks.closeSession).not.toHaveBeenCalled();
+    expect(mocks.disposeRuntime).not.toHaveBeenCalled();
+    await runAgent(INPUT).result;
     expect(mocks.sessionInits).toHaveLength(1);
   });
 

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -198,8 +198,11 @@ import {
 import { Runtime, Sessions } from '../../../packages/agent/src/effect';
 import { nodePlatform } from '../../../packages/agent/src/node';
 
+/** The embedder's shutdown path, as the package reads it: `shutdownRan`
+ *  is what says a composition still has an owner to dispose it. */
+const LIFECYCLE = { onShutdown: vi.fn(), shutdownRan: false };
 const PLATFORM = {
-  lifecycle: { onShutdown: vi.fn() },
+  lifecycle: LIFECYCLE,
   roots: { storage: '/storage' },
   processes: { selfIdentity: async () => 'test-start' },
 } as unknown as AgentPlatform;
@@ -271,6 +274,7 @@ describe('agent package run lifecycle', () => {
       await handler();
     }
     mocks.shutdownHooks = undefined;
+    LIFECYCLE.shutdownRan = false;
     mocks.sessionInits.splice(0);
     vi.clearAllMocks();
     mocks.activePlatform = null;
@@ -420,13 +424,16 @@ describe('agent package run lifecycle', () => {
     const [runtimeOrder] = mocks.disposeRuntime.mock.invocationCallOrder;
     expect(closeOrder).toBeLessThan(runtimeOrder);
 
-    // Shutdown closed the session through its owner and took the owner
-    // with the runtime it ran on, so a later run composes the process again
-    // over the platform already installed: the package is not single-use
-    // per process, and the owner builds the root's session anew.
-    await runAgent(INPUT).result;
-    expect(mocks.sessionInits).toHaveLength(2);
-    expect(mocks.installRuntime).toHaveBeenCalledTimes(2);
+    // Shutdown closed the session through its owner and took the owner with
+    // the runtime it ran on. That path is the entry's only owner for a
+    // composition and a lifecycle drains once, so a later run is refused
+    // rather than composing a runtime and an owner nothing would dispose.
+    LIFECYCLE.shutdownRan = true;
+    await expect(runAgent(INPUT).result).rejects.toThrow(
+      /shutdown has already run/,
+    );
+    expect(mocks.sessionInits).toHaveLength(1);
+    expect(mocks.installRuntime).toHaveBeenCalledTimes(1);
     expect(mocks.initPlatform).toHaveBeenCalledTimes(1);
   });
 
@@ -462,6 +469,25 @@ describe('agent package run lifecycle', () => {
     expect(mocks.disposeRuntime).not.toHaveBeenCalled();
     await runAgent(INPUT).result;
     expect(mocks.sessionInits).toHaveLength(1);
+  });
+
+  it('disposes the runtime its scope installed even when the closing session defects', async () => {
+    // Nothing is composed yet, so this scope installs the runtime and owns
+    // both the close and the disposal at its exit. The close defects on the
+    // artifact flush: the disposal is its finalizer, not its continuation,
+    // so the owner and the runtime under it still go, and the defect still
+    // leaves the scope.
+    mocks.closeSession.mockImplementationOnce(() => {
+      throw new Error('artifact flush defect');
+    });
+    const program = Effect.gen(function* () {
+      yield* Sessions;
+    }).pipe(Effect.scoped, Effect.provide(Runtime.layer(PLATFORM)));
+
+    await expect(Effect.runPromise(program)).rejects.toThrow(
+      'artifact flush defect',
+    );
+    expect(mocks.disposeRuntime).toHaveBeenCalledOnce();
   });
 
   it('a scoped reader holds its own transcript interest and clears it at the scope, leaving the run its own', async () => {

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { setImmediate } from 'node:timers/promises';
 
 // Third-party imports
-import { Deferred, Effect, Stream, SubscriptionRef } from 'effect';
+import { Deferred, Effect, Fiber, Stream, SubscriptionRef } from 'effect';
 import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest';
 
 interface RunAgentOptions {
@@ -33,7 +33,7 @@ const mocks = vi.hoisted(() => ({
     abandoned: [] as string[],
   })),
   detachEvents: vi.fn(),
-  disposeRuntime: vi.fn(),
+  disposeRuntime: vi.fn(async () => {}),
   executionId: 'execution-1',
   /** Fails the package session's fold, as a fold defect ends its view. */
   foldDeath: undefined as Deferred.Deferred<never, Error> | undefined,
@@ -287,7 +287,7 @@ describe('agent package run lifecycle', () => {
     mocks.installRuntime.mockImplementation(() => {
       mocks.ownerInstalled = true;
     });
-    mocks.disposeRuntime.mockImplementation(() => {
+    mocks.disposeRuntime.mockImplementation(async () => {
       mocks.ownerInstalled = false;
     });
     mocks.foldDeath = Effect.runSync(Deferred.make<never, Error>());
@@ -366,6 +366,12 @@ describe('agent package run lifecycle', () => {
       'The agent package cannot run approval-requiring tools: dangerous_tool',
     );
     expect(mocks.runValidatedAgent).not.toHaveBeenCalled();
+    // The refusal the package states from the input alone precedes the
+    // composition: a caller being refused does not install a platform, a
+    // process runtime or a session owner, and opens no session.
+    expect(mocks.initPlatform).not.toHaveBeenCalled();
+    expect(mocks.installRuntime).not.toHaveBeenCalled();
+    expect(mocks.sessionInits).toHaveLength(0);
     await expect(run.view[Symbol.asyncIterator]().next()).resolves.toEqual({
       done: true,
       value: undefined,
@@ -481,13 +487,78 @@ describe('agent package run lifecycle', () => {
       throw new Error('artifact flush defect');
     });
     const program = Effect.gen(function* () {
-      yield* Sessions;
+      const sessions = yield* Sessions;
+      yield* sessions.open();
     }).pipe(Effect.scoped, Effect.provide(Runtime.layer(PLATFORM)));
 
     await expect(Effect.runPromise(program)).rejects.toThrow(
       'artifact flush defect',
     );
     expect(mocks.disposeRuntime).toHaveBeenCalledOnce();
+  });
+
+  it('holds the runtime for an overlapping scope: the composing scope leaving closes nothing', async () => {
+    // Two independently provided scopes over one platform. The first
+    // composes the process; the second finds that composition and borrows
+    // it. The first leaving must not close the session the second is still
+    // working on, nor dispose the runtime under it.
+    const firstComposed = Effect.runSync(Deferred.make<void>());
+    const secondComposed = Effect.runSync(Deferred.make<void>());
+    const secondMayLeave = Effect.runSync(Deferred.make<void>());
+
+    const first = Effect.runFork(
+      Effect.gen(function* () {
+        const sessions = yield* Sessions;
+        yield* sessions.open();
+        yield* Deferred.succeed(firstComposed, undefined);
+        yield* Deferred.await(secondComposed);
+      }).pipe(Effect.scoped, Effect.provide(Runtime.layer(PLATFORM))),
+    );
+    await Effect.runPromise(Deferred.await(firstComposed));
+
+    const second = Effect.runFork(
+      Effect.gen(function* () {
+        const sessions = yield* Sessions;
+        yield* sessions.open();
+        yield* Deferred.succeed(secondComposed, undefined);
+        yield* Deferred.await(secondMayLeave);
+      }).pipe(Effect.scoped, Effect.provide(Runtime.layer(PLATFORM))),
+    );
+    await Effect.runPromise(Deferred.await(secondComposed));
+
+    await Effect.runPromise(Fiber.join(first));
+    expect(mocks.closeSession).not.toHaveBeenCalled();
+    expect(mocks.disposeRuntime).not.toHaveBeenCalled();
+
+    await Effect.runPromise(Deferred.succeed(secondMayLeave, undefined));
+    await Effect.runPromise(Fiber.join(second));
+    // The last hold out is what ends the composition the two shared.
+    expect(mocks.closeSession).toHaveBeenCalledExactlyOnceWith(
+      PLATFORM.roots.storage,
+    );
+    expect(mocks.disposeRuntime).toHaveBeenCalledOnce();
+  });
+
+  it('closes every root the owner holds before it disposes the runtime', async () => {
+    const otherRoots = { storage: '/other-storage' };
+    const program = Effect.gen(function* () {
+      const sessions = yield* Sessions;
+      yield* sessions.open();
+      yield* sessions.open(otherRoots as never);
+    }).pipe(Effect.scoped, Effect.provide(Runtime.layer(PLATFORM)));
+
+    await Effect.runPromise(program);
+
+    // A root this composition opened of its own settles and flushes like
+    // the runtime's, rather than going down with the runtime unwritten.
+    expect(mocks.closeSession.mock.calls.map(([root]) => root)).toEqual([
+      PLATFORM.roots.storage,
+      otherRoots.storage,
+    ]);
+    const [disposal] = mocks.disposeRuntime.mock.invocationCallOrder;
+    for (const order of mocks.closeSession.mock.invocationCallOrder) {
+      expect(order).toBeLessThan(disposal as number);
+    }
   });
 
   it('a scoped reader holds its own transcript interest and clears it at the scope, leaving the run its own', async () => {

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -28,7 +28,7 @@ const mocks = vi.hoisted(() => ({
   activePlatform: null as object | null,
   agentCategory: 'toolUse',
   /** The runtime owner's close, as the package reaches it: by storage root. */
-  closeSession: vi.fn(async (_root: string) => ({
+  closeSession: vi.fn((_root: string) => ({
     settled: true,
     abandoned: [] as string[],
   })),
@@ -109,7 +109,15 @@ vi.mock('@agent/runtime', async () => {
       ),
     );
 
-    readonly setTranscriptSubscriptions = mocks.setTranscriptSubscriptions;
+    /** The transcript interest port, as the owner's graph exposes it. */
+    readonly subscriptions = {
+      set: (port: string, set: readonly unknown[]) =>
+        Effect.sync(() => {
+          mocks.setTranscriptSubscriptions(port, set);
+        }),
+    };
+
+    readonly roots: { readonly storage: string };
 
     constructor(
       init: (typeof mocks.sessionInits)[number] & {
@@ -118,25 +126,27 @@ vi.mock('@agent/runtime', async () => {
     ) {
       mocks.sessionInits.push(init);
       mocks.sessionView = this.view;
+      this.roots = init.roots;
       if (init.interactions) mocks.useInteractions(init.interactions);
     }
   }
   const sessions = new Map<string, FakeSession>();
   return {
-    openSessionAsync: async (
-      init: ConstructorParameters<typeof FakeSession>[0],
-    ) => {
-      let session = sessions.get(init.roots.storage);
-      if (!session) {
-        session = new FakeSession(init);
-        sessions.set(init.roots.storage, session);
-      }
-      return session;
-    },
-    closeSession: async (root: string) => {
-      sessions.delete(root);
-      return mocks.closeSession(root);
-    },
+    openSessionEffect: (init: ConstructorParameters<typeof FakeSession>[0]) =>
+      Effect.sync(() => {
+        let session = sessions.get(init.roots.storage);
+        if (!session) {
+          session = new FakeSession(init);
+          sessions.set(init.roots.storage, session);
+        }
+        return session;
+      }),
+    listSessions: () => Effect.sync(() => [...sessions.values()]),
+    closeSession: (root: string) =>
+      Effect.sync(() => {
+        sessions.delete(root);
+        return mocks.closeSession(root);
+      }),
     runAgent: mocks.runValidatedAgent,
   };
 });
@@ -189,6 +199,7 @@ import {
   type AgentPlatform,
   type SessionView,
 } from '../../../packages/agent/src/index';
+import { Runtime, Sessions } from '../../../packages/agent/src/effect';
 import { nodePlatform } from '../../../packages/agent/src/node';
 
 const PLATFORM = {
@@ -412,6 +423,61 @@ describe('agent package run lifecycle', () => {
     // process); only the reset owner is observed here.
     await runAgent(INPUT).result;
     expect(mocks.sessionInits).toHaveLength(2);
+  });
+
+  it('composes into an embedder own runtime: the Effect surface starts a run and lists the one session the Promise entry already opened', async () => {
+    // The Promise entry composes the process and opens the platform's root.
+    await runAgent(INPUT).result;
+    expect(mocks.sessionInits).toHaveLength(1);
+
+    const program = Effect.gen(function* () {
+      const sessions = yield* Sessions;
+      const session = yield* sessions.open();
+      const run = yield* session.start({
+        agent: 'assistant',
+        instruction: 'Test instruction',
+      });
+      const result = yield* run.result;
+      const open = yield* sessions.list;
+      return { open: open.length, result, streamId: run.streamId };
+    }).pipe(Effect.scoped, Effect.provide(Runtime.layer(PLATFORM)));
+
+    const seen = await Effect.runPromise(program);
+    expect(seen.result).toBe(RESULT);
+    expect(seen.streamId).toBe('stream-1');
+    // One session per storage root, held by the runtime's own owner: the
+    // Effect surface resolved the session the Promise entry ran on, and the
+    // package built no registry of its own.
+    expect(seen.open).toBe(1);
+    expect(mocks.sessionInits).toHaveLength(1);
+  });
+
+  it('a scoped reader holds its own transcript interest and clears it at the scope, leaving the run its own', async () => {
+    await runAgent(INPUT).result;
+    const interest = [{ id: 'stream-1', fromSeq: 0 }];
+
+    const program = Effect.gen(function* () {
+      const sessions = yield* Sessions;
+      const session = yield* sessions.open();
+      yield* Effect.scoped(session.subscribe(interest as never));
+    }).pipe(Effect.scoped, Effect.provide(Runtime.layer(PLATFORM)));
+    await Effect.runPromise(program);
+
+    const ports = mocks.setTranscriptSubscriptions.mock.calls as [
+      string,
+      readonly unknown[],
+    ][];
+    const reader = ports.filter(([port]) => port.startsWith('sdk/reader/'));
+    // The reader's own port: set for the scope, emptied when it closed.
+    expect(reader).toHaveLength(2);
+    expect(reader[0]?.[1]).toEqual(interest);
+    expect(reader[1]?.[0]).toBe(reader[0]?.[0]);
+    expect(reader[1]?.[1]).toEqual([]);
+    // The run's port is the run's: the reader never touched it, so the
+    // README's residency contract still holds for a finished run.
+    expect(ports.filter(([port]) => port === 'sdk/stream-1')).toEqual([
+      ['sdk/stream-1', interest],
+    ]);
   });
 
   it('fails the run instead of hanging when the session fold dies before the final view', async () => {

--- a/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const channelTraceMocks = vi.hoisted(() => ({
@@ -232,7 +233,7 @@ describe('default session lifecycle', () => {
       const { closeSession } = await import('@agent/runtime/sessionGraph');
       const { processWorkspaceRoots } =
         await import('@platform/workspaceRoots');
-      await closeSession(processWorkspaceRoots().storage);
+      await Effect.runPromise(closeSession(processWorkspaceRoots().storage));
       expect(tryDefaultSession()).toBeUndefined();
     } finally {
       teardownDefaultSession();

--- a/src/test-kernel/architecture/dependencyDirection.vitest.ts
+++ b/src/test-kernel/architecture/dependencyDirection.vitest.ts
@@ -93,12 +93,12 @@ const HOST_LAYER_IMPORT_PREFIXES = [
 /**
  * Effect run boundary (PRD R1, docs/prds/2026-08-26-effect-4-runtime-migration.md
  * "Execution strategy" rule 3): production code enters Effect through the
- * host-owned runtime, `effectRuntime()` from `@platform/processRuntime`, and
- * nothing else. The pre-runtime exemption this once carried (the platform
- * stores every host opens in its `initPlatform`, and the file-lock provider
- * those stores flush through) is gone: each host now installs the process
- * runtime before it opens a store, so the allowlist is empty and any bare
- * `Effect.run*` call in production fails.
+ * host-owned runtime, `effectRuntime()` from `@platform/processRuntime`. A
+ * bare `Effect.run*` call is allowed only where the program must run before
+ * `installProcessRuntime` — today the platform stores every host opens in its
+ * `initPlatform` (`JsonStore`) and the file-lock provider those stores flush
+ * through. The pins are exact counts: a new site anywhere fails, and a removed
+ * site is recorded by lowering (then deleting) its pin.
  */
 const EFFECT_RUN_ROOTS = [
   ...ALL_HOST_PRODUCTION_ROOTS,
@@ -107,6 +107,16 @@ const EFFECT_RUN_ROOTS = [
 ] as const;
 const EFFECT_RUN_CALL =
   /\bEffect\.run(?:Promise|PromiseExit|Sync|SyncExit|Fork|Callback)(?:With)?\s*\(/g;
+const BARE_EFFECT_RUN_SITES: Readonly<Record<string, number>> = {
+  // The published SDK's Promise entry, which is rule R1's third boundary
+  // kind and the one module in `packages/agent` allowed to run an Effect at
+  // all. It cannot borrow `effectRuntime()`: the process runtime does not
+  // exist until this entry's own composition installs it, and `closeSession`
+  // has to answer for a process no run initialized and for one whose
+  // shutdown already disposed that runtime.
+  'packages/agent/src/index.ts': 6,
+};
+
 function sourceFilesUnder(
   zone: string,
   opts?: { readonly excludeTestKernel?: boolean },
@@ -248,8 +258,8 @@ describe('Effect run boundaries', () => {
 
     expect(
       sites,
-      'bare Effect.run* sites must go through effectRuntime() from @platform/processRuntime; hosts install the process runtime before anything that runs a program, so there is no pre-runtime exemption left',
-    ).toEqual({});
+      'bare Effect.run* sites must go through effectRuntime() from @platform/processRuntime; a site that has to run before installProcessRuntime is pinned in BARE_EFFECT_RUN_SITES in this PR, and a removed site lowers its pin',
+    ).toEqual(BARE_EFFECT_RUN_SITES);
   });
 
   it('actually scans the Effect run roots', () => {

--- a/src/test-kernel/cli/InitPlatformSignalHandlers.vitest.ts
+++ b/src/test-kernel/cli/InitPlatformSignalHandlers.vitest.ts
@@ -27,9 +27,16 @@ function captureSignalHandlers(): Map<string, (...args: unknown[]) => void> {
 }
 
 function fakeLifecycle(runShutdown: () => Promise<void>): LifecycleHost {
+  let shutdownRan = false;
   return {
     onShutdown: vi.fn(() => ({ dispose: vi.fn() })),
-    runShutdown,
+    runShutdown: () => {
+      shutdownRan = true;
+      return runShutdown();
+    },
+    get shutdownRan() {
+      return shutdownRan;
+    },
   };
 }
 

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -361,7 +361,9 @@ describe('Sessions owner', () => {
       isDetached: () => true,
     });
 
-    await expect(closeSession('/workspace/owner/settled')).resolves.toEqual({
+    await expect(
+      Effect.runPromise(closeSession('/workspace/owner/settled')),
+    ).resolves.toEqual({
       settled: true,
       abandoned: [],
     });
@@ -375,7 +377,9 @@ describe('Sessions owner', () => {
     track(session, 'exec:slow');
     vi.useFakeTimers();
     try {
-      const closing = closeSession('/workspace/owner/abandoned');
+      const closing = Effect.runPromise(
+        closeSession('/workspace/owner/abandoned'),
+      );
       await vi.advanceTimersByTimeAsync(SHUTDOWN_PHASE_DEADLINE_MS);
       await expect(closing).resolves.toEqual({
         settled: false,


### PR DESCRIPTION
## What and why

The SDK's surface is now `@texra-ai/agent/effect`. Everything this package
decides is stated once there, in Effect: which level is a run's first, when its
transcript interest changes, when its drain ends, which failure wins. The root
entry `@texra-ai/agent` is that surface rendered as Promises and AsyncIterables
and holds no logic of its own.

This implements design-page ruling D6. It amends PR #11893 section 4, which
says the package boundary exports no Effect services; D6 reverses that, and
this PR says so rather than quietly contradicting the proposal.

The 210-line `AgentRunStream` class is deleted: its event array, reader array,
hand-written `AsyncIterator`, four flags (`iteratorStarted`, `iteratorClosed`,
`ended`, `failure`), `attachRun`/`attachHandle`/`finalView`, and its
`AbortController` are all state the services hold in Effect. `sessionFor` and
`runStreamIds` moved into the subpath; the composition-root block inside
`runAgent` became `composeProcess`.

Two things have exactly one implementation reached two ways:

- **Composition.** `composeProcess` is what `runAgent` calls synchronously and
  what `Runtime.layer` acquires. It stays synchronous on purpose: everything
  from the platform check to the owner's registration of the run's root happens
  before the first yield, so a `closeSession` or a `runShutdown` issued right
  after `runAgent` returns settles that launch too. The pending-identity branch
  of `installProcessRuntime` is what keeps that true and is deliberately kept.
- **Closure.** `Sessions.close` plus `disposeProcessRuntime`, reached from each
  host's own lifetime authority: the Promise embedder's `lifecycle.runShutdown()`
  (registered at the boundary, as today) and the Effect embedder's `Scope`
  (R6), so `Effect.scoped` closes what the layer opened.

## Service table

| Service    | What it is |
| ---------- | ---------- |
| `Runtime`  | The composed process: platform, workspace roots, and whether this composition owns the process. `Runtime.layer(platform)` provides it and `Sessions`; its scope closes what it opened. |
| `Sessions` | The process's one session owner: `open(roots?)`, `close(roots?, signal?)`, `list`. One session per workspace storage root, through `@agent/runtime`'s owner port. No second registry. |
| `Session`  | `roots`, `start`, `request`, `view.changes`, `events`, `subscribe` (a `Scope`-held transcript interest on the reader's own port). A value, one per root, not a tag; a pure function of the owner's handle. |
| `Run`      | `executionId`, `streamId`, `result`, `view`, `events`, `interrupt`. `start` succeeds at admission: the run exists in the session, its stream published and its trace live. |

Failures are `Data.TaggedError`s: `PlatformConflict`, `AgentNotFound`,
`ToolsRefused`, `RunFailure` (whose `cause` is exactly what the launch path
threw, which is what the Promise entry rejects with). Request failures stay the
runtime's own `RequestError` union; no second vocabulary. Nothing else is
exported: no store, no fold internals, no host widgets.

## Harmony with the Effect migration

**R1, boundary kind 3.** `packages/agent/src/index.ts` is the named boundary
module. Every `Effect.run*` in the package is there; the subpath and everything
it imports contain none (`grep -rn 'runPromise\|runSync\|runFork' packages/agent/src/effect*`
matches one line: a sentence in a doc comment).

**The second ruling (no pass-throughs, no adapters).** `openSessionAsync` and
`SessionOwner.openAsync` are deleted by converting their caller, not kept.
`closeSession` is converted along with all four of its callers. The
`Effect.sync(() => session.setTranscriptSubscriptions(...))` wrapper in
`SessionBridge` is deleted by exposing the port the graph already holds.
No `@adapter-until` marker is added; there are none in the tree.

**Leaf to root.** The subpath wraps three foreign edges, each named here with
the lane that removes it:

- `Effect.tryPromise` around `src/agent/runtime/runAgent.ts`
  (`effect/sessions.ts`), with the wrap's own `AbortSignal` as the launch
  signal. Gone when lane D converts the run loops.
- `Effect.tryPromise` around `loadAgents` (`effect/sessions.ts`). Gone when
  lane D converts the agent registry; until then a registry failure is a typed
  `RunFailure` of `Session.start` rather than a defect that escapes the
  surface's declared error channel.
- `Effect.promise` around `disposeProcessRuntime()` (`effect/runtime.ts`).
  That leaf is Promise-shaped for its three host shutdown hooks
  (`packages/extension/src/extension.ts`, `packages/desktop/src/main/index.ts`,
  `packages/cli/src/runtime/initPlatform.ts`), none of which is on the
  ratchet's `Effect.run*` row today, so converting it here would put all three
  on that row for a leaf this PR does not otherwise touch. It converts with
  those three hooks, in the lane that owns them.

**Migration ratchet.** `config/ratchets/effect-migration-baseline.json` and
`scripts/check-effect-migration-ratchet.mjs` are not on `main` (they are #11920,
still open), so `npm run check:effect-migration-ratchet` does not exist on this
branch. Counts this change adds or removes, measured against `origin/main`:

| Row | Delta |
| --- | --- |
| `Effect.run*` | `src/controllers/session/sessionLayer.ts` 5 -> 3 (minus 2, a file below every boundary, the direction the ratchet wants). `packages/agent/src/index.ts` 2 -> 5 (plus 3), which the amended `--update` predicate admits under `packages/agent/src/**` as R1 boundary kind 3: the launch fiber's fork, the run's result, the shutdown flush, `closeSession`, and `interrupt`. No other file moves. |
| `catch:effect-importer` | `packages/agent/src/index.ts` 0 -> 1 (new file), justified as R1 boundary kind 3 and named: `void result.catch(() => {})`, the unhandled-rejection suppressor an embedder that iterates events but never awaits `result` needs. It is intrinsic to the Promise rendering and has no Effect form. `packages/agent/src/effect/runtime.ts` stays at 0: the composition's one refusal is stated with `Effect.try` plus `Effect.catch`, not a catch clause, and the run's error is named with `Effect.mapError` inside the Effect rather than a `.catch` on the Promise. No other file moves. (Running #11920's script on this branch also reports three growths under `packages/desktop/src/main/`; they reproduce on this branch's merge base with `origin/main` and are not this PR's.) |
| `new AbortController()` | minus one file and one site (`packages/agent/src/index.ts`); `packages/agent/src` now has none. |
| `platform()` | unchanged. |
| `setServices()` | unchanged. |
| `p-queue` / `p-map` / `p-retry` / `p-timeout` | unchanged. |
| `@adapter-until` markers | none added; zero in the tree. |

If #11920 lands first, rebase, run the check, and do not let a non-boundary row
rise.

**Other ratchets.** `host-agent-import-baseline` is unmoved: the subpath uses
only specifiers already on the `agent` list (`@agent/runtime`,
`@agent/runtime/AgentFlowResult`, `@agent/index`, `@agent/trace`,
`@agent/core/definition/AgentConfig`, `@agent/core/tools/ToolTypes`), and all
seven stay live, so the set-based check passes in both directions.
`shared-schemas-deep-import`, `host-agent-mock`, `architecture-edges`, `knip`,
and `check-browser-safe-utils` are untouched.

**Cross-PR notes for the wave PRs.** Two files this PR edits are shared with
in-flight wave PRs, and the earlier claim that none was has been corrected:
`packages/agent/package.json` and `pnpm-lock.yaml`. #11924 drops `neverthrow`
and #11925 drops `p-throttle` from the same `dependencies` object this PR moves
`effect` out of (into `peerDependencies` and `devDependencies`, which the
published `./effect` subpath requires). The three edits are disjoint entries in
one object; whichever lands second re-runs `corepack pnpm install` rather than
hand-merging the lock. No other file this PR touches is owned by #11922,
#11923, #11926, #11927 or #11928.

Two deletions are left to the lanes that own them:

- `SessionHandle.setTranscriptSubscriptions` survives, and its below-boundary
  `runFork` with it. It has four call sites, not the two an earlier review
  round found: `packages/cli/src/runtime/runProgressRenderer.ts` (2),
  `packages/cli/src/chat/tui/runChatTui.tsx` (1), and
  `packages/cli/scripts/tui-harness.tsx` (1). Only the first already imports
  `effect`. Converting `runChatTui.tsx` would add it to the `Effect.run*` row
  and to the `catch:effect-importer` row, since it gains a runtime `effect`
  import while its two `catch` sites (lines 237 and 451) stay raw, which is
  exactly what execution rule 2 ("one pass per file") says must not happen. The
  deletion is the CLI lane's pass over those files; the port it should take,
  `session.subscriptions.set`, is exposed by this PR and already used by
  `SessionBridge`.
- `SessionOwner.openSync` survives for the extension, the desktop and the CLI.
  Its doc says so and says it is scheduled for deletion; no new caller may take
  it.

## Deviations from the judged design

- **`effect/run.ts` is merged into `effect/sessions.ts`.** An exported
  `start(session: SessionHandle, ...)` would put `SessionHandle` in the
  subpath's emitted declarations, which drags the `@agent/runtime` barrel's
  whole `.d.ts` graph and re-leaks `@anthropic-ai/sdk` into the published
  surface -- exactly what the widened `validate-artifacts.mjs` check now
  catches. Keeping `start` module-private is the fix; the module count drops
  from five to four.
- **`registerRuntimeShutdownHandlers` stays at the boundary**, not inside
  `composeProcess`. Its hook must return a Promise, and building one from
  `Sessions.close` requires a run site, which rule 1 forbids below
  `index.ts`. The Effect side gets the same closure from `Runtime.layer`'s
  scope (R6) instead. `AgentRuntime.composed` is what tells both which
  composition owns the process runtime's disposal.
- **`Sessions.layer` is not exported separately.** `Runtime.layer` provides
  both services, so a second route to the same layer would be a duplicate
  element (and a module cycle between `runtime.ts` and `sessions.ts`).
- **`Session.start` fails with `LaunchError | RunFailure`, not `LaunchError`.**
  A run that fails before it publishes its stream never reaches admission, and
  the caller must hear that failure rather than hang.
- **`Run.executionId` is minted by the package** (`generateExecutionId`, passed
  in the launch request) rather than read back from the launcher, which
  publishes the stream before it registers the handle. The id is therefore
  known at admission, which is what D6 asks for.
- **`Session.view.current` and the single `LaunchRefused` tag** are not
  exported, per the judged design's trims: `changes` replays the current level
  first, and `AgentNotFound` / `ToolsRefused` are what an embedder branches on.

## Behaviour change worth reviewing

Trace events are now buffered from the moment the run enters its session rather
than dropped until the iterator's first `next()`. The old behaviour depended on
a flag set synchronously inside a hand-written iterator, which no lazily
subscribed `Stream` can reproduce: an iteration begun right after `runAgent()`
is still waiting on admission when the launcher's first events fire. Buffering
from admission is the strictly more forgiving contract and is what keeps the
"delivers the launch events" scenario honest. The no-retention promise is kept
where it matters: a run that settles without ever being iterated drops what it
buffered, and ending an iteration still detaches the trace while the run
continues.

That buffer is bounded, which the first draft of this PR got wrong. It exists
only to hand the launch events to the first reader's pull, so a run whose
events pass `TRACE_HANDOVER_EVENTS` (512) with nobody reading has no reader:
it logs a warning naming the run and detaches its trace, instead of holding a
long run's whole trace, every `stream.chunk` included, until the run settles.
A reader that did attach is never dropped: past its first pull the buffer is
that reader's, and nothing discards what it has yet to read, which is why this
is a handover cap and not a bounded or sliding queue. The README states both
halves.

## Repair round (commit 626c06f)

Review found nine distinct issues after the first draft. Six were real defects,
each reproduced against the built artifact before and after the fix, and each
fixed at the owner rather than guarded at the call site.

**Fixed.**

1. **The package was single-use per process.** `composeProcess` keyed its
   idempotence on `tryPlatform()`, but the layer's finalizer tears down a
   different pair of globals: `disposeProcessRuntime()` uninstalls the session
   owner and disposes the runtime under it, while `initPlatform` has no
   inverse. So a second `Effect.scoped` program, or any `runAgent` after a
   scope closed, found `active` still truthy, skipped `installProcessRuntime`,
   and reached `sessions()` with no owner: `Sessions not initialized` as an
   untyped defect on APIs whose error channels are `never` or
   `LaunchError | RunFailure`. The composition root now asks the owner
   (`sessionOwnerInstalled()`, new on the owner port) whether it must install,
   and keeps the `tryPlatform()` comparison only for the `PlatformConflict`
   refusal; the process-wide installs stay guarded by the platform, since they
   have no inverse. One composition, two entries, no guard at any call site.
2. **The layer's scope closed a session it did not own.** The finalizer's
   disposal was gated on `runtime.composed`; its close was not, so a scoped
   program running beside a host's or an earlier `runAgent`'s composition
   killed that composition's live runs (`closeSession` shuts admissions and
   kills every active execution) and released its session on exit. Both halves
   are now gated: the composition that installed the process owns the end of
   its session, and a scope that opened a root of its own ends it through
   `Sessions.close`.
3. **`runAgent` threw synchronously on a platform conflict.** The composition
   ran before the fork, so `PlatformConflict` escaped the `runAgent` call
   itself while every other launch refusal arrived on `result`. The
   composition now runs inside the forked launch fiber. The
   registration-before-return invariant survives: `runFork` calls
   `fiber.evaluate(effect)` synchronously before returning
   (`node_modules/effect/dist/internal/effect.js`, `runForkWith`) and
   `Effect.try` evaluates its thunk as the fiber's first step, so
   `composeProcess` still completes before `runAgent` does, which the
   owner-resolution scenario pins.
4. **`closeSession` broke its own contract in both directions.** Routing the
   owner-port effect through `effectRuntime()` made it throw synchronously
   before any run ("Process runtime not initialized", from a function typed
   `Promise<SessionCloseReport>`, so `await ....catch()` never saw it) and fail
   with "ManagedRuntime disposed" after shutdown, where its doc promises
   `settled` in both cases. The owner's effects supply their own context
   (`onThisRuntime` in `sessionLayer.ts`), so the boundary needs no ambient
   runtime: `packages/agent/src/index.ts` now runs them with bare
   `Effect.runPromise` / `Effect.runFork`, which R1 sanctions here, and no
   longer imports `@platform/processRuntime` at all.
5. **The trace was retained unbounded for the whole run.** See the behaviour
   note above: the handover buffer is now capped and the drop is loud.
6. **A registry load failure was a defect.** `Effect.promise(() => loadAgents(...))`
   dies on rejection, so a bad agents directory took the fiber down instead of
   failing `Session.start`, whose declared channel is
   `LaunchError | RunFailure`. It is `Effect.tryPromise` mapping to
   `RunFailure` now, and `admitInput`'s type says so.

Two more, found in the same round and fixed here:

- **The owner's close is uninterruptible.** Moving it from
  `runtime.runPromise(...)` to `onThisRuntime(...)` put it on the caller's
  fiber, so an embedder that races or times out `Sessions.close` could
  interrupt it after `closeAdmissions()` and the kill loop but before
  `flushArtifacts()` and the entry's release, leaving the root permanently
  closed to new runs with its artifacts unwritten. The budget (the caller's
  `signal`, else the phase deadline) is the design's one cancellation channel,
  and it is again the only one. Wrapped in `sessionLayer`'s `closeSession`, not
  at the call sites; `Effect.race` and `Effect.forkChild` behave correctly
  inside the region, checked directly against rc.112.
- **The packed example pinned the tarball by version**, a second place the
  package version lived, which the first release after a version bump would
  rewrite. The pack is renamed to a fixed `example/agent.tgz` and the manifest
  pins `file:agent.tgz`.

**Refuted, with evidence.**

- *"Delete `SessionHandle.setTranscriptSubscriptions` now; its only remaining
  callers are the two in `runProgressRenderer.ts`, and no wave PR owns that
  file."* The premise is wrong: there are four call sites, and two of them
  (`packages/cli/src/chat/tui/runChatTui.tsx`,
  `packages/cli/scripts/tui-harness.tsx`) import neither `effect` nor
  `effectRuntime` today. Converting `runChatTui.tsx` would add it to the
  `Effect.run*` row and to the `catch:effect-importer` row while its two
  `catch` sites stay raw, which execution rule 2 forbids in a pass that touches
  the file. The deletion belongs to the CLI lane's own pass; see the cross-PR
  note above.
- *"Convert `disposeProcessRuntime` to an Effect in this PR."* Its three host
  shutdown hooks are Promise-shaped host boundaries, and none of the three
  files is on the ratchet's `Effect.run*` row; converting the leaf here adds
  all three to it for a leaf this PR does not otherwise touch. The alternative
  the same finding allows is taken instead: all three foreign wraps are now
  named in the body with the lane that removes each.
- *"Document the synchronous `runAgent` throw rather than moving the
  composition."* Fixing it costs nothing the invariant needs (item 3 above),
  and a second error channel for one class of refusal is not something to
  document. The documentation half of that finding is kept: the `AgentRun` and
  `runAgent` doc comments and the README's Promise section now say that every
  failure arrives on `result` and that a refusal is one of the tagged errors.
- *"Use `Effect.tryPromise` for `disposeProcessRuntime` too."* A finalizer has
  no error channel to name the failure on, and dying on a disposal that
  rejects is the loud outcome, not a silent one. The wrap is named in the
  leaf-to-root list instead.

## Repair round 2 (commit a41989b)

Three more findings, all lifecycle ownership. Two were real and are fixed at
the owner; one does not hold on this Effect and is answered with the source.

**Fixed.**

1. **A defecting close skipped the runtime's disposal.** The scoped layer's
   finalizer ran `sessions.close()` and then `Effect.andThen(disposal)`, so a
   session whose final artifact flush defected failed the close and never
   reached the disposal: the scope ended with the process owner and its
   managed runtime still installed, and no later scope owning them. The
   disposal is `Effect.ensuring` on the close now, so it runs on every exit
   while the close's failure still leaves the scope. One assertion in
   `AgentPackage.vitest.ts` pins it (it fails on `andThen`, passes on
   `ensuring`).
2. **The Promise entry claimed a run after shutdown it could not end.** Each
   composition registered its cleanup on the embedder's lifecycle host, which
   drains each phase exactly once and caches its shutdown
   (`src/platform/defaults/lifecycleHost.ts`), so a `runAgent` after
   `runShutdown()` composed a runtime and an owner that nothing would ever
   dispose. Since #11913 ends the owner and the runtime in one step, whatever
   owns that step owns both: on the Effect surface that is the scope, and a new
   scope composes again with an owner of its own; on the Promise entry it is
   the one lifecycle registration, and there is no second one to install. The
   entry therefore composes once per process and says so. The refusal is not a
   remembered flag: the lifecycle reports whether its shutdown has run
   (`LifecycleHost.shutdownRan`, one member, one implementation), which also
   covers the leak a per-entry flag misses, where a host's own shutdown
   disposed the runtime and a later `runAgent` composes over the drained
   lifecycle. `closeSession` is unchanged and still reports `settled` for a
   process with no owner.

**Refuted, with evidence.**

- *"`Effect.uninterruptible` on the settling close masks interruption of the
  losing fiber of its `Effect.race`, so the close can block past its budget."*
  It does not: `raceAll` forks each arm through
  `forkUnsafe(parent, effect, true, true, false)`, whose last argument is the
  arm's own interrupt status rather than an inheritance from the region, so an
  arm is always forked interruptible (`node_modules/effect/dist/internal/effect.js`,
  rc.112). The mask stops an outside caller from unwinding the close; it does
  not stop a race from interrupting its loser. The existing
  `sessionEvents.vitest.ts` case "close reports a run still live past the
  budget as abandoned" already pins the never-settling path with the mask in
  place, and the close modelled directly on rc.112 returns at the budget in all
  four combinations of settle/hang and flush/hang. The close's doc comment now
  records this so it is not re-filed.

**Contract change to note.** `runAgent` after `lifecycle.runShutdown()` now
rejects instead of composing; the README and the entry's doc comments say so,
and the run-after-shutdown case in `AgentPackage.vitest.ts` asserts the refusal
where it previously asserted a second composition. An embedder that needs more
than one composition per process takes `@texra-ai/agent/effect`, where the
scope owns each one.

## Repair round 3 (commit 2c69238)

Eight findings, most of them one question: who owns the composed process, and
for how long.

**The composition is held, not owned (three findings: overlapping scopes, the
argument-less close, and the flag that caused both).** `composeProcess` now
returns a `ProcessHold`. Every caller takes one; the last one released closes
every session the owner holds, each settling its runs and flushing its
artifacts through the owner's own close, and then disposes the runtime under
them. So two overlapping `Runtime.layer` scopes are safe (the first out ends
nothing the second is using), a root a composition opened of its own is closed
rather than torn down with the runtime unwritten, and the Promise entry holds
one hold for the process rather than one per `runAgent`. `composed` is gone
from `AgentRuntime`: it stated something true of one composition and every
reader took it for something true of the process, which is how the second
scope ended up borrowing without a claim. A release is idempotent by
construction, because a hold is one composition's and the count is the
process's.

**`Session.start` is all-or-nothing.** The handoff after the fork is
uninterruptible but for the admission wait, and an `Effect.onExit` outside
that mask ends the run fiber and its drain on every other exit. The mask alone
is not enough: rc.112 records an interrupt arriving during an uninterruptible
region and raises it when the region lifts, so a handler inside the mask would
have seen a success and let a live run go unheld. With that, the Promise
entry's `interrupt()` mapping is exhaustive rather than lucky, which was the
eighth reviewer's separate finding on the same window.

**Two smaller ones.** `AgentConfigSchema.parse` is now a typed `RunFailure`
instead of an untyped defect, so an embedder's `catchTag` sees it. And the
approval-tool refusal precedes the composition again, as it did before this
entry composed inside the fiber: `admitTools` is one effect with two callers,
stated first in `runAgent` and again in `admitInput` over the resolved agent.
A refused caller no longer installs a platform, a session owner, or a session.

**Public surface.** `composeProcess` and `makeSessions` leave the public
barrel. `Runtime.layer` is the way in, and it is now the only thing that ties
a hold's release to a scope; a caller reaching the raw composition would take
a hold nothing releases. Both keep their internal consumers, so the dead-code
ratchet is unchanged. `AgentRuntime` stays: it is the shape of the exported
`Runtime` service, and an embedder writing `yield* Runtime` may need to name
it.

### Packaging decision

`effect` is a peer dependency of the **whole package**, both entries, and the
README says so. It is not only the subpath: `dist/index.js` opens with
`import ... from "effect"`, so the root entry needs it installed at runtime
too. Keeping it a regular dependency for the root entry would give a consumer
who also uses Effect a second, nested copy, and the package cannot work with
two copies in one process at all, since Streams, Fibers and Context built by
one do not interoperate with another's. One declaration, one copy, stated to
the consumer: the Install section leads with it (with the exact pinned version
and a dependency block to copy), the entry-points table repeats it so a reader
who lands on the root entry sees it, and the Effect section points back rather
than stating it twice. `package.json` is unchanged.

### One ratchet pin, not a widening

`src/test-kernel/architecture/dependencyDirection.vitest.ts` requires every
`Effect.run*` to go through `effectRuntime()` outside a pinned set. This PR
creates a site the ratchet had not been told about, and it was already red on
the previous head (5 unpinned calls in `packages/agent/src/index.ts`; this
round makes it 6). `packages/agent/src/index.ts` is pinned, with its reason:
it is rule R1's third boundary kind and the one module in `packages/agent`
allowed to run an Effect at all, and it cannot borrow `effectRuntime()`,
because the process runtime does not exist until this entry's own composition
installs it and `closeSession` has to answer both for a process no run
initialized and for one whose shutdown already disposed that runtime. The pin
is a count, so a seventh call still fails the ratchet.

### Verified (round 3)

- `npm run typecheck`, `npm run lint`, `npm run format` on the changed files.
- `npx vitest run src/test-kernel/agent src/test-kernel/controllers/session src/test-kernel/architecture`, then `npm test`: **764 files, 9072 passed, 6 skipped, 0 failed**.
- `npm run check:dead-code-ratchet` (no new findings) and `node scripts/check-browser-safe-utils.mjs`.
- `corepack pnpm --filter @texra-ai/agent run example:packed`, re-run because
  this round touches the barrel and the packaging:

  ```text
  session root: /var/folders/.../T/texra-agent-example-kE7ijr/storage/workspace-storage/texra-agent-example-kE7ijr-763e01fd
  first view level: 0 streams
  sessions the owner holds: 1
  [TeXRA] DEBUG [2026-09-06 12:59:32.732] [agentRegistry] Scanned 0 agents from custom
  [TeXRA] INFO  [2026-09-06 12:59:32.733] [agentRegistry] Loaded 0 agents in 7ms
  refusal: AgentNotFound - Agent "no-such-agent" was not found in the configured agent directory.
  done
  ```

- Three assertions added to the suite that already covers this layer, each
  failing on the previous head: a first scope leaving while a second still
  holds the composition closes and disposes nothing (and the second leaving
  does both, once); a scope that opened a second root closes both, in order,
  before the disposal; and a run refused for an approval-requiring tool
  installs no platform, no process runtime, and opens no session. The test
  fake for `disposeProcessRuntime` now returns a promise, as the port does.

## Net elements (R6)

- Deleted: `AgentRunStream` (210 lines) with its 4 flags, 2 buffers and
  hand-written `AsyncIterator`; `EnteredRun`; `sessionFor`; the inline
  composition block; one `AbortController`; `openSessionAsync`;
  `SessionOwner.openAsync`; the `openSessionAsync` re-export; two
  `Effect.run*` sites in `sessionLayer.ts`; one `Effect.sync` adapter in
  `SessionBridge.ts`; the superseded README paragraph.
- Added: four modules under `packages/agent/src/effect*` (barrel, errors,
  runtime, sessions), one published entry row, one `SessionHandle` field
  re-exposing state the graph already holds, one owner-port method (`list`,
  which D6 names and the boundary scenario consumes), one bundle plugin, one
  example directory.
- Added by the repair round: one owner-port predicate
  (`sessionOwnerInstalled`, consumed by `composeProcess`), reading state the
  owner already holds rather than a second copy of it.
- Added by repair round 2: one lifecycle-port member
  (`LifecycleHost.shutdownRan`, consumed by `packages/agent/src/index.ts`),
  which reads the cached shutdown promise the host already holds rather than
  copying it. No new module, no new error type, no module state in the SDK.
- No new registry, no wrapper class, no re-export shim, no second
  `ManagedRuntime`: the subpath runs on the process runtime
  `installProcessRuntime` already makes (PRD 7.7). The Promise entry runs on
  Effect's own runtime, because the owner's effects carry their own context.

## Consumer counts (R8)

Every new export has a consumer in this PR: `Runtime`, `Sessions`,
`composeProcess`, `makeSessions`, the four error classes and the `Run` /
`Session` / `StartInput` / view types are consumed by
`packages/agent/src/index.ts`, by `packages/agent/example/effectSession.mjs`,
and by the two boundary scenarios in
`src/test-kernel/agent/AgentPackage.vitest.ts`. `openSessionEffect` and
`listSessions` are consumed by the subpath; `SessionHandle.subscriptions` by
the subpath and by `SessionBridge`. `LifecycleHost.shutdownRan`, added by
repair round 2, is consumed by `agentServices` in
`packages/agent/src/index.ts` and by the run-after-shutdown scenario.
`npm run check:dead-code-ratchet` reports no new findings, and the
migration-ratchet rows above are unmoved by both repair rounds (no new
`Effect.run*`, `AbortController`, `platform()`, `setServices`, or `p-*` site).

## Tests

Zero new files. `src/test-kernel/agent/AgentPackage.vitest.ts` gains exactly
the two boundary scenarios D6 asks for, and its `@agent/runtime` mock returns
the Effect faces:

1. The Effect surface composes into an embedder's own runtime, starts a run,
   and `Sessions.list` shows the one session the Promise entry already ran on:
   one owner, no second registry.
2. A scoped `session.subscribe` sets its own reader port and empties it when
   the scope closes, while the run's `sdk/<streamId>` port stays exactly as the
   run left it.

The three other `closeSession` callers (`DefaultSessionLifecycle.vitest.ts`,
`sessionEvents.vitest.ts` twice) run the Effect. All ten pre-existing package
scenarios pass unchanged, including the four that pin the semantics this design
rests on: launch-event delivery, discard-when-unread, detach-on-early-close, and
the fold-death failure.

The repair round adds no file and no scenario. It extends two existing ones with
the assertions the two P1 defects would have failed, and teaches the suite's
`@agent/runtime` and `sessionLayer` mocks the owner-install state the real
`installProcessRuntime` / `disposeProcessRuntime` pair carries (the previous
mocks could not express it, which is why the suite could not see either defect):

- the owner-resolution scenario now also asserts that a run issued after
  shutdown composes the process again (`installProcessRuntime` twice,
  `initPlatform` once) instead of finding no owner;
- the embedder-runtime scenario now also asserts that leaving a scope which
  composed nothing closes nothing, disposes nothing, and leaves the next
  `runAgent` on the session the Promise entry was already using.

The `@platform/processRuntime` mock is deleted: the package no longer borrows
the process runtime at its boundary.

## Verified

- `npm run format` / `prettier --check .` clean.
- `npm run typecheck` (workspace, test-kernel, agent, cli, trace-viewer,
  desktop) clean.
- `npm run lint` clean. The package's composition root moved in
  `eslint.config.mjs` from `packages/agent/src/index.ts` to
  `packages/agent/src/effect/runtime.ts`, which is where `initPlatform` now is.
- `npx vitest run src/test-kernel/agent src/test-kernel/controllers/session src/test-kernel/architecture src/test-kernel/cli`:
  342 files, 5323 tests passed.
- `npm test`: 764 files, 9059 tests passed.
- `npm run check:dead-code-ratchet`: no new findings.
- `node scripts/check-browser-safe-utils.mjs`: OK, 64 total, 5 reachable.
- `node packages/agent/scripts/build.mjs` end to end, including the widened
  provider-leak loop over all four published entries: `Validated 765
  declarations and 70 external packages.`
- `npm run check:effect-migration-ratchet` does not exist on this branch
  (#11920 is unmerged); the counts are tabled above instead. They were measured
  by running #11920's `scripts/check-effect-migration-ratchet.mjs` against its
  committed baseline on this branch and on the merge base as a control, then
  removing both files again.
- The six repaired defects were reproduced against the built artifact before
  and after, in one process:

  ```text
  close before any run: {"settled":true,"abandoned":[]}
  pass 1: ...-8a2b8d89 AgentNotFound
  pass 2: ...-8a2b8d89 AgentNotFound
  runAgent after scope refused with: AgentNotFound
  close after shutdown: {"settled":true,"abandoned":[]}
  conflict arrived on result: PlatformConflict
  ```

  Before the repair the same script printed
  `pass 2 FAILED: Sessions not initialized`,
  `THREW: Process runtime not initialized` for the first close,
  `close after shutdown FAILED: ManagedRuntime disposed`, and
  `runAgent THREW SYNCHRONOUSLY: PlatformConflict`.
- **The packed example actually runs.**
  `corepack pnpm --filter @texra-ai/agent run example:packed`, which builds,
  packs to a fixed `example/agent.tgz`, `npm install`s it into
  `packages/agent/example/` and runs it (re-run after the repair round):

  ```text
  session root: /var/folders/.../T/texra-agent-example-FVaRrg/storage/workspace-storage/texra-agent-example-FVaRrg-82a9a525
  first view level: 0 streams
  sessions the owner holds: 1
  [TeXRA] DEBUG [2026-09-06 10:59:59.375] [agentRegistry] Scanned 0 agents from custom
  [TeXRA] INFO  [2026-09-06 10:59:59.376] [agentRegistry] Loaded 0 agents in 7ms
  refusal: AgentNotFound - Agent "no-such-agent" was not found in the configured agent directory.
  done
  ```

  The process exits on its own: leaving the scope closed the session and
  disposed the runtime that held it.
- Two rc.112 behaviours the design rests on were confirmed rather than assumed.
  `Effect.tryPromise` hands its callback an `AbortSignal`
  (`node_modules/effect/dist/Effect.d.ts`), which is what deletes the package's
  `AbortController`; and `ManagedRuntime.runFork` evaluates synchronously to the
  first yield (`runForkWith` calls `fiber.evaluate(effect)` before returning),
  which is what keeps the registration-before-return invariant. The
  "discards trace events when the caller only awaits the result" scenario still
  guards `Stream.toAsyncIterable`'s laziness.

## Found while verifying: a real defect in the published artifact

Installing the tarball as a consumer would -- which nothing had done before --
showed that **every entry of the published package failed at module init**, the
root entry included:

```text
SyntaxError: The requested module 'bibtex' does not provide an export named 'parseBibFile'
```

`bibtex@0.9.0` is UMD/CommonJS whose named exports Node's ESM loader cannot
detect. It cannot be fixed at the import site: `src/latex/extractBibliography.ts`
must keep its named import, because bibtex's UMD exports carry
`__esModule: true` and a default import bundles to `undefined` under esbuild's
ESM interop (the 0.39.10 startup crash, documented in that file). The fix is at
the only layer that can make it: the agent bundle inlines `bibtex` instead of
leaving it external, mirroring the existing `bundle-patched-openai` plugin.
`packages/agent/example/` is now the standing guard against this class of
defect.

Part of #11864
Part of #11861
Amends PR #11893 section 4 (D6)

## Architecture ratchet: a new boundary entry, disclosed

This PR adds one entry to the `Effect.run*` allowlist in `src/test-kernel/architecture/dependencyDirection.vitest.ts`:

```
  'packages/agent/src/index.ts': 6,
```

It is an addition to an allowlist, so it deserves an explicit owner decision rather than passing as routine. The case for it: rule R1 of the Effect migration PRD names the published SDK Promise API as one of exactly three sanctioned boundary kinds, and that entry file is that boundary. The value is a count, so a seventh run call fails the test; the allowlist can still only shrink from here. The six calls are the two in the shutdown handler, the one in `closeSession`, and the three that render `runAgent`.

If the owner would rather this boundary were declared in the migration ratchet (#11920) instead of the architecture test, moving it there is a one-line change and this PR should not be the place it lands.
