### PR TITLE
fix: reject invalid inputs and preserve CLI session state

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -319,17 +319,14 @@ export function createChatSessionController(
       ),
     );
 
-  // Shared prelude of the three run-starting paths (start, resume,
-  // follow-up-wake resume): resolve the model-keyed session context and
-  // activate the config into the session meta signals in one step.
-  const beginRunContext = (
+  /** Publish the configuration of the conversation the TUI adopts. */
+  const adoptRunConfig = (
     config: Pick<
       AgentConfig,
       'agent' | 'model' | 'cli' | 'delegationAgentScope'
     >,
     modelSource?: 'history',
-  ): CliContext => {
-    const sessionContext = getSessionContext();
+  ): void => {
     const cliMultiAgentPresetId = config.cli?.multiAgentPresetId ?? undefined;
     patchSessionMeta({
       agent: config.agent,
@@ -339,7 +336,6 @@ export function createChatSessionController(
       cliMultiAgentPresetId,
       delegationAgentScope: config.delegationAgentScope ?? undefined,
     });
-    return sessionContext;
   };
 
   const supersedeInterruptedRecovery = ():
@@ -566,7 +562,8 @@ export function createChatSessionController(
 
   const startRootRun = (config: AgentConfigPayload): void => {
     void supersedeInterruptedRecovery();
-    const sessionContext = beginRunContext(config);
+    const sessionContext = getSessionContext();
+    adoptRunConfig(config);
     const { approvalsUnavailable, ownExecution, finalize } =
       setupRunHost(sessionContext);
     const executionId = generateExecutionId();
@@ -679,7 +676,7 @@ export function createChatSessionController(
         return;
       }
 
-      const sessionContext = beginRunContext(config, 'history');
+      const sessionContext = getSessionContext();
       const { approvalsUnavailable, ownExecution, finalize } =
         setupRunHost(sessionContext);
       ownExecution(id);
@@ -694,6 +691,7 @@ export function createChatSessionController(
       // honored by `isCancellationRequested`, which `resumeRun` re-reads once
       // this returns, rather than starting an agent the user cancelled.
       const adoptResumedStream = async (): Promise<void> => {
+        adoptRunConfig(config, 'history');
         clearLocalTranscript();
         followUpQueue.clear();
         session.streamId = streamId;
@@ -847,7 +845,8 @@ export function createChatSessionController(
         if (isCancellationRequested()) return false;
         const parentStreamId = snapshotStore.getParentStreamId(streamId);
 
-        const sessionContext = beginRunContext(config, 'history');
+        const sessionContext = getSessionContext();
+        adoptRunConfig(config, 'history');
 
         const runHost = setupRunHost(sessionContext);
         finalize = runHost.finalize;

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -691,6 +691,7 @@ export function createChatSessionController(
       // honored by `isCancellationRequested`, which `resumeRun` re-reads once
       // this returns, rather than starting an agent the user cancelled.
       const adoptResumedStream = async (): Promise<void> => {
+        await setCliHelperModel(config.model);
         adoptRunConfig(config, 'history');
         clearLocalTranscript();
         followUpQueue.clear();
@@ -733,7 +734,7 @@ export function createChatSessionController(
       // cleared the interrupted stream, so the follow-ups typed during the
       // interruption are lost unless both go back where they came from.
       let followUpQueueReady = false;
-      const runChain = setCliHelperModel(config.model)
+      const runChain = Promise.resolve()
         .then(() => {
           recoveryHandedOff = true;
           return resumeRun(id, {

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -1,10 +1,8 @@
 import { Cause, Exit } from 'effect';
 
 import type { SupabaseSession } from '@auth/SupabaseSession';
-import {
-  refreshSubscriptionPreferenceViews,
-  setCliSubscriptionPreference,
-} from '@cli/chat/tui/state/subscriptionPreference';
+import { bumpCodexPreferenceVersion } from '@cli/chat/tui/state/cliState';
+import { setCliSubscriptionPreference } from '@cli/chat/tui/state/subscriptionPreference';
 import {
   shouldUseSubscriptionDeviceCode,
   signInCliSubscription,
@@ -224,7 +222,7 @@ export async function logoutFromChat(
   ): Promise<void> {
     try {
       const update = await signOutCliSubscription(providerId);
-      refreshSubscriptionPreferenceViews();
+      bumpCodexPreferenceVersion();
       lines.push(ACCOUNT_OUTCOME.signedOut(label));
       lines.push(subscriptionSignOutPreferenceMessage(providerId, update));
     } catch (error: unknown) {

--- a/packages/cli/src/chat/tui/commands/handlers/modelAccessCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/modelAccessCommands.ts
@@ -1,5 +1,5 @@
 import { loadCliDetailedAccountStatusLines } from '@cli/runtime/apiStatus';
-import { refreshSubscriptionPreferenceViews } from '@cli/chat/tui/state/subscriptionPreference';
+import { bumpCodexPreferenceVersion } from '@cli/chat/tui/state/cliState';
 import { saveProviderApiKey } from '@cli/runtime/providerApiKey';
 import {
   parseCliModelAccessSelection,
@@ -31,7 +31,7 @@ export async function applyCliProviderApiKey(
   key: string,
 ): Promise<string | undefined> {
   await saveProviderApiKey(provider, key);
-  refreshSubscriptionPreferenceViews();
+  bumpCodexPreferenceVersion();
   const codingPlan = codingPlanForApiProvider(provider);
   if (!codingPlan) return undefined;
   if (!codingPlan.exclusiveCredential) {
@@ -56,7 +56,7 @@ async function applyCliModelAccessSelectionWithSignal(
     }),
     { signal },
   );
-  refreshSubscriptionPreferenceViews();
+  bumpCodexPreferenceVersion();
   output.appendOutcome(collapseWhitespace(access.message));
 }
 

--- a/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
@@ -22,7 +22,7 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 import { platformSettingsStores } from '@utils/config/platformSettings';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import { refreshSubscriptionPreferenceViews } from '../state/subscriptionPreference';
+import { bumpCodexPreferenceVersion } from '../state/cliState';
 import { AgentRosterForm } from './AgentRosterForm';
 import { ConfigForm, type ConfigFormProps } from './ConfigForm';
 import {
@@ -188,7 +188,7 @@ export function createCliConfigFormProps(
         );
     }
     if (entry.onWrite?.invalidatesModelOptions) {
-      refreshSubscriptionPreferenceViews();
+      bumpCodexPreferenceVersion();
     }
   };
   return {

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -81,8 +81,8 @@ import { onAbort } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { notify } from '../notifications/terminalNotifier';
+import { bumpCodexPreferenceVersion } from './cliState';
 import {
-  refreshSubscriptionPreferenceViews,
   setCliCodingPlanSubscription,
   setCliSubscriptionPreference,
 } from './subscriptionPreference';
@@ -542,7 +542,7 @@ function codingPlanRollbackConfig(
     needsRollback: () => runtime.getEnabled() !== previous,
     restore: async () => {
       await runtime.restoreEnabled(previous);
-      refreshSubscriptionPreferenceViews();
+      bumpCodexPreferenceVersion();
       if (runtime.getEnabled() !== previous) {
         throw new Error(
           `${runtime.descriptor.displayName} remained ${String(runtime.getEnabled())}.`,

--- a/packages/cli/src/chat/tui/state/subscriptionPreference.ts
+++ b/packages/cli/src/chat/tui/state/subscriptionPreference.ts
@@ -9,16 +9,6 @@ import type { CodingPlanSubscriptionId } from '@shared/codingPlanSubscriptions';
 import { bumpCodexPreferenceVersion } from './cliState';
 
 /**
- * Single source of truth for reacting to a subscription change (ChatGPT, Grok,
- * …) inside the running TUI: bump the preference version so dependent views
- * (model picker, status bar) re-render.
- * Call after any sign-in/out or preference flip.
- */
-export function refreshSubscriptionPreferenceViews(): void {
-  bumpCodexPreferenceVersion();
-}
-
-/**
  * Flip an OAuth subscription preference (ChatGPT, Grok) and refresh the TUI
  * views. Shared by the login commands and the retry "switch to your own API
  * key" path so the persist-then-refresh sequence lives in one place.
@@ -29,7 +19,7 @@ export async function setCliSubscriptionPreference(
 ): Promise<SubscriptionPreferenceUpdate> {
   const update =
     await subscriptionProvider(providerId).setPreferSubscription(enabled);
-  refreshSubscriptionPreferenceViews();
+  bumpCodexPreferenceVersion();
   return update;
 }
 
@@ -43,5 +33,5 @@ export async function setCliCodingPlanSubscription(
   );
   if (!runtime) throw new Error(`Unknown coding-plan subscription: ${id}`);
   await runtime.setEnabled(enabled);
-  refreshSubscriptionPreferenceViews();
+  bumpCodexPreferenceVersion();
 }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -904,6 +904,7 @@ export abstract class ModelHandler<
    */
   protected async createMediaMessage(
     mediaFiles: FileLocation[],
+    _context: MediaAttachmentContext,
   ): Promise<CreatedMedia<Media>> {
     const { entries, results } =
       await this.mediaProcessor.loadEntries(mediaFiles);
@@ -936,7 +937,10 @@ export abstract class ModelHandler<
   ): Promise<Media[]> {
     this.insertedAttachmentKinds.set(context, []);
     try {
-      const { media, entries } = await this.createMediaMessage(mediaFiles);
+      const { media, entries } = await this.createMediaMessage(
+        mediaFiles,
+        context,
+      );
       if (media.length > 0) {
         this.insertedAttachmentKinds.set(
           context,

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -3,7 +3,6 @@ import { basename } from 'node:path';
 
 import type { AgentTrace } from '@agent/trace';
 import type { MediaEntry } from '@agent/types/mediaTypes';
-import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
 import { isNonEmptyString } from '@utils/core';
 
 import { DEFAULT_ATTACHMENT_MIME_TYPE } from '../utils/toolAttachmentUtils';
@@ -24,7 +23,6 @@ interface UploadGoogleMediaEntriesOptions<T> {
   logger: AgentTrace;
   buildMedia: (source: GoogleMediaSource, mimeType: string) => T;
   buildLabel: (media: T, fileName: string) => T;
-  onInsertedEntry?: (entry: MediaEntry) => void;
 }
 
 /**
@@ -40,22 +38,12 @@ export async function uploadGoogleMediaEntries<T>(
     return [];
   }
 
-  const {
-    getClient,
-    inlineLimit,
-    logger,
-    buildMedia,
-    buildLabel,
-    onInsertedEntry,
-  } = options;
+  const { getClient, inlineLimit, logger, buildMedia, buildLabel } = options;
   const client = await getClient();
   const parts: T[] = [];
   const appendMedia = (entry: MediaEntry, media: T): void => {
     parts.push(buildLabel(media, entry.file_name), media);
-    onInsertedEntry?.(entry);
   };
-  let hadFailure = false;
-  const failures: string[] = [];
 
   for (const entry of entries) {
     const fileName = entry.file_name;
@@ -83,50 +71,28 @@ export async function uploadGoogleMediaEntries<T>(
     const uploadPath =
       entry.bytes_match_source !== false ? entry.source_path : undefined;
     if (!uploadPath) {
-      logger.error(
-        `Skipping media entry ${fileName} due to missing upload source`,
-      );
-      hadFailure = true;
-      continue;
+      throw new Error(`Media entry ${fileName} is missing an upload source.`);
     }
 
-    try {
-      logger.debug(
-        `Uploading media entry ${fileName} via Google GenAI SDK from path ${uploadPath}`,
-      );
-      const uploaded: File = await client.files.upload({
-        file: uploadPath,
-        // `fileName` may be workspace-relative; displayName is a filename.
-        config: { mimeType, displayName: basename(fileName) },
-      });
-      const fileUri = uploaded.uri;
-      if (!fileUri) {
-        logger.error(
-          `Upload result for ${fileName} is missing a URI. Skipping entry.`,
-        );
-        hadFailure = true;
-        continue;
-      }
-      const resolvedMimeType =
-        uploaded.mimeType || entry.media_type || DEFAULT_ATTACHMENT_MIME_TYPE;
-      const media = buildMedia({ uri: fileUri }, resolvedMimeType);
-      appendMedia(entry, media);
-    } catch (error) {
-      hadFailure = true;
-      failures.push(`${fileName}: ${getSdkErrorMessage(error)}`);
-    }
-  }
-
-  if (hadFailure) {
-    const failureSummary = failures.join('; ');
-    logger.warn(
-      failureSummary
-        ? `Some media files failed to upload via Google GenAI SDK: ${failureSummary}`
-        : 'Some media files failed to upload via Google GenAI SDK',
-      {
-        data: failures,
-      },
+    logger.debug(
+      `Uploading media entry ${fileName} via Google GenAI SDK from path ${uploadPath}`,
     );
+    // The caller's createMediaForRound applies the shared failure policy:
+    // initial requests fail; later rounds report the missing attachments.
+    const uploaded: File = await client.files.upload({
+      file: uploadPath,
+      // `fileName` may be workspace-relative; displayName is a filename.
+      config: { mimeType, displayName: basename(fileName) },
+    });
+    const fileUri = uploaded.uri;
+    if (!fileUri) {
+      throw new Error(`Upload result for ${fileName} is missing a URI.`);
+    }
+    const resolvedMimeType =
+      uploaded.mimeType || entry.media_type || DEFAULT_ATTACHMENT_MIME_TYPE;
+    const media = buildMedia({ uri: fileUri }, resolvedMimeType);
+    appendMedia(entry, media);
   }
+
   return parts;
 }

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -3,6 +3,11 @@ import { basename } from 'node:path';
 
 import type { AgentTrace } from '@agent/trace';
 import type { MediaEntry } from '@agent/types/mediaTypes';
+import type { CreatedMedia } from '@agent/modelHandlers/ModelHandler';
+import {
+  reportMediaAttachmentFailure,
+  type MediaAttachmentContext,
+} from '@agent/modelHandlers/support/mediaAttachmentPolicy';
 import { isNonEmptyString } from '@utils/core';
 
 import { DEFAULT_ATTACHMENT_MIME_TYPE } from '../utils/toolAttachmentUtils';
@@ -21,6 +26,7 @@ interface UploadGoogleMediaEntriesOptions<T> {
   getClient: () => Promise<GoogleGenAI>;
   inlineLimit: number;
   logger: AgentTrace;
+  context: MediaAttachmentContext;
   buildMedia: (source: GoogleMediaSource, mimeType: string) => T;
   buildLabel: (media: T, fileName: string) => T;
 }
@@ -33,66 +39,75 @@ interface UploadGoogleMediaEntriesOptions<T> {
 export async function uploadGoogleMediaEntries<T>(
   entries: MediaEntry[],
   options: UploadGoogleMediaEntriesOptions<T>,
-): Promise<T[]> {
+): Promise<CreatedMedia<T>> {
   if (entries.length === 0) {
-    return [];
+    return { media: [], entries: [] };
   }
 
   const { getClient, inlineLimit, logger, buildMedia, buildLabel } = options;
   const client = await getClient();
   const parts: T[] = [];
+  const insertedEntries: MediaEntry[] = [];
   const appendMedia = (entry: MediaEntry, media: T): void => {
     parts.push(buildLabel(media, entry.file_name), media);
+    insertedEntries.push(entry);
   };
 
   for (const entry of entries) {
-    const fileName = entry.file_name;
-    const mimeType = entry.media_type;
-    const inlinePayload = isNonEmptyString(entry.data) ? entry.data : null;
+    try {
+      const fileName = entry.file_name;
+      const mimeType = entry.media_type;
+      const inlinePayload = isNonEmptyString(entry.data) ? entry.data : null;
 
-    if (inlinePayload) {
-      const payloadBytes = Buffer.byteLength(inlinePayload, 'base64');
-      if (payloadBytes <= inlineLimit) {
+      if (inlinePayload) {
+        const payloadBytes = Buffer.byteLength(inlinePayload, 'base64');
+        if (payloadBytes <= inlineLimit) {
+          logger.debug(
+            `Attaching media entry ${fileName} inline (${payloadBytes} bytes).`,
+          );
+          const media = buildMedia({ data: inlinePayload }, mimeType);
+          appendMedia(entry, media);
+          continue;
+        }
         logger.debug(
-          `Attaching media entry ${fileName} inline (${payloadBytes} bytes).`,
+          'Media entry exceeds inline limit; falling back to upload.',
+          {
+            data: { fileName, payloadBytes, inlineLimit },
+          },
         );
-        const media = buildMedia({ data: inlinePayload }, mimeType);
-        appendMedia(entry, media);
-        continue;
       }
+
+      const uploadPath =
+        entry.bytes_match_source !== false ? entry.source_path : undefined;
+      if (!uploadPath) {
+        throw new Error(`Media entry ${fileName} is missing an upload source.`);
+      }
+
       logger.debug(
-        'Media entry exceeds inline limit; falling back to upload.',
-        {
-          data: { fileName, payloadBytes, inlineLimit },
-        },
+        `Uploading media entry ${fileName} via Google GenAI SDK from path ${uploadPath}`,
+      );
+      const uploaded: File = await client.files.upload({
+        file: uploadPath,
+        // `fileName` may be workspace-relative; displayName is a filename.
+        config: { mimeType, displayName: basename(fileName) },
+      });
+      const fileUri = uploaded.uri;
+      if (!fileUri) {
+        throw new Error(`Upload result for ${fileName} is missing a URI.`);
+      }
+      const resolvedMimeType =
+        uploaded.mimeType || entry.media_type || DEFAULT_ATTACHMENT_MIME_TYPE;
+      const media = buildMedia({ uri: fileUri }, resolvedMimeType);
+      appendMedia(entry, media);
+    } catch (error) {
+      reportMediaAttachmentFailure(
+        logger,
+        options.context,
+        error,
+        entry.file_name,
       );
     }
-
-    const uploadPath =
-      entry.bytes_match_source !== false ? entry.source_path : undefined;
-    if (!uploadPath) {
-      throw new Error(`Media entry ${fileName} is missing an upload source.`);
-    }
-
-    logger.debug(
-      `Uploading media entry ${fileName} via Google GenAI SDK from path ${uploadPath}`,
-    );
-    // The caller's createMediaForRound applies the shared failure policy:
-    // initial requests fail; later rounds report the missing attachments.
-    const uploaded: File = await client.files.upload({
-      file: uploadPath,
-      // `fileName` may be workspace-relative; displayName is a filename.
-      config: { mimeType, displayName: basename(fileName) },
-    });
-    const fileUri = uploaded.uri;
-    if (!fileUri) {
-      throw new Error(`Upload result for ${fileName} is missing a URI.`);
-    }
-    const resolvedMimeType =
-      uploaded.mimeType || entry.media_type || DEFAULT_ATTACHMENT_MIME_TYPE;
-    const media = buildMedia({ uri: fileUri }, resolvedMimeType);
-    appendMedia(entry, media);
   }
 
-  return parts;
+  return { media: parts, entries: insertedEntries };
 }

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -814,13 +814,12 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
 
   /**
    * Media blocks for the entries (inline when small enough, uploaded
-   * otherwise). Unlike the base template this reports only the entries that
-   * were actually appended, since an upload can drop one.
+   * otherwise). Upload failures propagate to the shared attachment policy;
+   * entries are returned only when the entire batch succeeds.
    */
   protected async uploadMediaEntries(
     entries: MediaEntry[],
   ): Promise<CreatedMedia<Content>> {
-    const insertedEntries: MediaEntry[] = [];
     const media = await uploadGoogleMediaEntries<Content>(entries, {
       getClient: () => this.getClient(),
       inlineLimit: this.getInlineUploadLimitBytes(),
@@ -830,9 +829,8 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         this.textMedia(
           `${media.type[0].toUpperCase()}${media.type.slice(1)}: ${fileName}`,
         ),
-      onInsertedEntry: (entry) => insertedEntries.push(entry),
     });
-    return { media, entries: insertedEntries };
+    return { media, entries };
   }
 
   // ===========================================================================

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -20,7 +20,10 @@ import {
   type AssistantTextAppendOptions,
   type CreatedMedia,
 } from '@agent/modelHandlers/ModelHandler';
-import { reportMediaAttachmentFailure } from '@agent/modelHandlers/support/mediaAttachmentPolicy';
+import {
+  reportMediaAttachmentFailure,
+  type MediaAttachmentContext,
+} from '@agent/modelHandlers/support/mediaAttachmentPolicy';
 import { parseToolInputAsObject } from '@agent/core/flows/toolCallParsing';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { K_SLICE } from '@agent/core/constants';
@@ -796,6 +799,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
 
   protected override async createMediaMessage(
     mediaFiles: FileLocation[],
+    context: MediaAttachmentContext,
   ): Promise<CreatedMedia<Content>> {
     if (!this.canAttachMedia(mediaFiles)) {
       return { media: [], entries: [] };
@@ -809,28 +813,29 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       return { media: [], entries: [] };
     }
 
-    return this.uploadMediaEntries(entries);
+    return this.uploadMediaEntries(entries, context);
   }
 
   /**
    * Media blocks for the entries (inline when small enough, uploaded
-   * otherwise). Upload failures propagate to the shared attachment policy;
-   * entries are returned only when the entire batch succeeds.
+   * otherwise). The shared attachment policy reports each failure; returned
+   * entries describe only the media that was successfully attached.
    */
   protected async uploadMediaEntries(
     entries: MediaEntry[],
+    context: MediaAttachmentContext,
   ): Promise<CreatedMedia<Content>> {
-    const media = await uploadGoogleMediaEntries<Content>(entries, {
+    return uploadGoogleMediaEntries<Content>(entries, {
       getClient: () => this.getClient(),
       inlineLimit: this.getInlineUploadLimitBytes(),
       logger: this.logger,
+      context,
       buildMedia: (source, mimeType) => this.buildMedia(source, mimeType),
       buildLabel: (media, fileName) =>
         this.textMedia(
           `${media.type[0].toUpperCase()}${media.type.slice(1)}: ${fileName}`,
         ),
     });
-    return { media, entries };
   }
 
   // ===========================================================================

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -10,6 +10,7 @@ import {
   fingerprintWorkflowAgentDependencies,
 } from '@tools/delegation/workflowScriptAgentRunner';
 import { SubagentDurabilityError } from '@tools/delegation/inBandSubagentExecution';
+import { StorageFS } from '@utils/files/storageFS';
 
 const mocks = vi.hoisted(() => ({
   executeStableSubagentInBand: vi.fn(),
@@ -245,6 +246,22 @@ describe('createWorkflowScriptAgentRunner', () => {
 
     expect(oldFingerprint).not.toBe(newFingerprint);
     expect(mocks.workspaceReadBytes).toHaveBeenCalledWith('proof.tex');
+  });
+
+  it('rejects storage files outside run output storage before reading workflow dependencies', async () => {
+    const file = StorageFS.fullPath('streamLogs/private.json');
+
+    await expect(
+      fingerprintWorkflowAgentDependencies(runExecutionId, {
+        inputFiles: [file],
+      }),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringContaining(file),
+    });
+    expect(mocks.assertWorkflowFilesExist).not.toHaveBeenCalled();
+    expect(mocks.workspaceReadBytes).not.toHaveBeenCalled();
+    expect(mocks.absoluteReadBytes).not.toHaveBeenCalled();
   });
 
   it('keeps dependency fingerprints stable for unchanged binary bytes', async () => {

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -1,3 +1,7 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { WorkflowAgentInvocation } from '@agent/workflowScript';
@@ -22,7 +26,8 @@ const mocks = vi.hoisted(() => ({
   assertWorkflowFilesExist: vi.fn(),
   rejectOversizedBibAttachments: vi.fn(),
   configureDelegatedChildApprovals: vi.fn(),
-  workspaceReadBytes: vi.fn(),
+  workspaceToAbsolute: vi.fn(),
+  realpath: vi.fn(),
   absoluteReadBytes: vi.fn(),
   readExecutionMeta: vi.fn(),
 }));
@@ -68,7 +73,11 @@ vi.mock('@tools/delegation/inputFields', () => ({
 }));
 
 vi.mock('@utils/files/workspaceFS', () => ({
-  WorkspaceFS: { readBytes: mocks.workspaceReadBytes },
+  WorkspaceFS: { toAbsolute: mocks.workspaceToAbsolute },
+}));
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs/promises')>()),
+  realpath: mocks.realpath,
 }));
 vi.mock('@utils/files/absoluteFS', () => ({
   AbsoluteFS: { readBytes: mocks.absoluteReadBytes },
@@ -223,7 +232,10 @@ describe('createWorkflowScriptAgentRunner', () => {
     mocks.assertWorkflowFilesExist.mockResolvedValue(undefined);
     mocks.rejectOversizedBibAttachments.mockResolvedValue(null);
     mocks.runStorageLocationFromAnyAbsolutePath.mockReturnValue(undefined);
-    mocks.workspaceReadBytes.mockResolvedValue(Buffer.from('workspace bytes'));
+    mocks.workspaceToAbsolute.mockImplementation((file: string) =>
+      path.resolve('/workspace', file),
+    );
+    mocks.realpath.mockImplementation(async (file: string) => file);
     mocks.absoluteReadBytes.mockResolvedValue(Buffer.from('run bytes'));
     mocks.readExecutionMeta.mockResolvedValue(undefined);
     mocks.executeStableSubagentInBand.mockImplementation(
@@ -233,40 +245,70 @@ describe('createWorkflowScriptAgentRunner', () => {
 
   it('fingerprints file bytes rather than only their paths', async () => {
     const options = { inputFiles: ['proof.tex'] };
-    mocks.workspaceReadBytes.mockResolvedValueOnce(Buffer.from('old proof'));
+    mocks.absoluteReadBytes.mockResolvedValueOnce(Buffer.from('old proof'));
     const oldFingerprint = await fingerprintWorkflowAgentDependencies(
       runExecutionId,
       options,
     );
-    mocks.workspaceReadBytes.mockResolvedValueOnce(Buffer.from('new proof'));
+    mocks.absoluteReadBytes.mockResolvedValueOnce(Buffer.from('new proof'));
     const newFingerprint = await fingerprintWorkflowAgentDependencies(
       runExecutionId,
       options,
     );
 
     expect(oldFingerprint).not.toBe(newFingerprint);
-    expect(mocks.workspaceReadBytes).toHaveBeenCalledWith('proof.tex');
+    expect(mocks.absoluteReadBytes).toHaveBeenCalledWith(
+      '/workspace/proof.tex',
+    );
   });
 
-  it('rejects storage files outside run output storage before reading workflow dependencies', async () => {
-    const file = StorageFS.fullPath('streamLogs/private.json');
+  it.each(['absolute', 'relative traversal', 'workspace symlink'] as const)(
+    'rejects a private storage file supplied through %s before reading dependencies',
+    async (spelling) => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-inputs-'));
+      const workspace = path.join(root, 'workspace');
+      const storage = path.join(root, 'storage');
+      const privateFile = path.join(storage, 'streamLogs/private.json');
+      const link = path.join(workspace, 'input.json');
+      const storagePath = vi
+        .spyOn(StorageFS, 'fullPath')
+        .mockImplementation((file: string) => path.join(storage, file));
+      try {
+        await fs.mkdir(workspace);
+        await fs.mkdir(path.dirname(privateFile), { recursive: true });
+        await fs.writeFile(privateFile, 'private transcript');
+        await fs.symlink(privateFile, link);
+        mocks.realpath.mockImplementation((file: string) => fs.realpath(file));
+        mocks.workspaceToAbsolute.mockImplementation((file: string) =>
+          path.resolve(workspace, file),
+        );
+        const spellings = {
+          absolute: privateFile,
+          'relative traversal': path.relative(workspace, privateFile),
+          'workspace symlink': 'input.json',
+        };
+        const file = spellings[spelling];
 
-    await expect(
-      fingerprintWorkflowAgentDependencies(runExecutionId, {
-        inputFiles: [file],
-      }),
-    ).rejects.toMatchObject({
-      name: 'WorkflowRunAbortError',
-      message: expect.stringContaining(file),
-    });
-    expect(mocks.assertWorkflowFilesExist).not.toHaveBeenCalled();
-    expect(mocks.workspaceReadBytes).not.toHaveBeenCalled();
-    expect(mocks.absoluteReadBytes).not.toHaveBeenCalled();
-  });
+        await expect(
+          fingerprintWorkflowAgentDependencies(runExecutionId, {
+            inputFiles: [file],
+          }),
+        ).rejects.toMatchObject({
+          name: 'WorkflowRunAbortError',
+          message: expect.stringContaining(file),
+        });
+        expect(mocks.assertWorkflowFilesExist).not.toHaveBeenCalled();
+        expect(mocks.absoluteReadBytes).not.toHaveBeenCalled();
+      } finally {
+        storagePath.mockRestore();
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it('keeps dependency fingerprints stable for unchanged binary bytes', async () => {
     const bytes = Buffer.from([0, 255, 1, 128]);
-    mocks.workspaceReadBytes.mockResolvedValue(bytes);
+    mocks.absoluteReadBytes.mockResolvedValue(bytes);
     const options = {
       inputFiles: ['proof.bin'],
       contextFiles: ['context.bin'],
@@ -307,16 +349,16 @@ describe('createWorkflowScriptAgentRunner', () => {
     await expect(runner(call)).resolves.toBe(result);
     expect(mocks.requireVisibleAgent).not.toHaveBeenCalled();
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
-      { label: 'Input file', files: ['paper.tex'] },
+      { label: 'Input file', files: ['/workspace/paper.tex'] },
     ]);
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
-      { label: 'Context file', files: ['notes.tex'] },
+      { label: 'Context file', files: ['/workspace/notes.tex'] },
     ]);
     expect(mocks.rejectOversizedBibAttachments).toHaveBeenCalledWith([
-      'notes.tex',
+      '/workspace/notes.tex',
     ]);
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
-      { label: 'Media file', files: ['figure.pdf'] },
+      { label: 'Media file', files: ['/workspace/figure.pdf'] },
     ]);
     expect(mocks.selectAvailableDelegationModel).toHaveBeenCalledWith({
       parentModel: 'parent-model',
@@ -341,9 +383,9 @@ describe('createWorkflowScriptAgentRunner', () => {
           agentCategory: 'workflow',
           model: 'child-model',
           instruction: 'Draft the section.',
-          inputFiles: ['paper.tex'],
-          contextFiles: ['notes.tex'],
-          mediaFiles: ['figure.pdf'],
+          inputFiles: ['/workspace/paper.tex'],
+          contextFiles: ['/workspace/notes.tex'],
+          mediaFiles: ['/workspace/figure.pdf'],
           workingDirectory: '/workspace',
           delegationAgentScope: {
             workflow: ['builtInWorkflow:correct'],
@@ -465,6 +507,11 @@ describe('createWorkflowScriptAgentRunner', () => {
         executionId: file === firstRequested ? 'bbbbbb222222' : 'cccccc333333',
       }),
     );
+    mocks.realpath.mockImplementation(async (file: string) => {
+      if (file === firstRequested) return firstCanonical;
+      if (file === secondRequested) return secondCanonical;
+      return file;
+    });
     const runner = defaultRunner();
 
     await runner(
@@ -493,13 +540,13 @@ describe('createWorkflowScriptAgentRunner', () => {
       secondRequested,
     );
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
-      { label: 'Input file', files: ['notes.tex'] },
+      { label: 'Input file', files: ['/workspace/notes.tex'] },
     ]);
     expect(mocks.preparedOptions[0]).toEqual(
       expect.objectContaining({
         agentName: 'merge',
         configPayload: expect.objectContaining({
-          inputFiles: [firstCanonical, 'notes.tex', secondCanonical],
+          inputFiles: [firstCanonical, '/workspace/notes.tex', secondCanonical],
         }),
       }),
     );

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -323,6 +323,44 @@ describe('createWorkflowScriptAgentRunner', () => {
     expect(first).toBe(second);
   });
 
+  it('keeps the requested workspace symlink name in the launched inputs', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-inputs-'));
+    const workspace = path.join(root, 'workspace');
+    const storage = path.join(root, 'storage');
+    const target = path.join(workspace, 'versions/v1.tex');
+    const requested = path.join(workspace, 'chapters/current.tex');
+    const storagePath = vi
+      .spyOn(StorageFS, 'fullPath')
+      .mockImplementation((file: string) => path.join(storage, file));
+    try {
+      await fs.mkdir(storage);
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      await fs.mkdir(path.dirname(requested), { recursive: true });
+      await fs.writeFile(target, 'Current chapter');
+      await fs.symlink(target, requested);
+      mocks.realpath.mockImplementation((file: string) => fs.realpath(file));
+      mocks.workspaceToAbsolute.mockImplementation((file: string) =>
+        path.resolve(workspace, file),
+      );
+
+      await defaultRunner()(
+        invocation({ inputFiles: ['chapters/current.tex'] }),
+      );
+
+      expect(mocks.preparedOptions[0]).toEqual(
+        expect.objectContaining({
+          configPayload: expect.objectContaining({
+            inputFiles: ['chapters/current.tex'],
+          }),
+        }),
+      );
+      expect(mocks.resolveChildRunOutput).not.toHaveBeenCalled();
+    } finally {
+      storagePath.mockRestore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('uses delegation policy and executes a direct in-band child', async () => {
     const call = invocation({
       inputFiles: ['paper.tex'],
@@ -355,7 +393,7 @@ describe('createWorkflowScriptAgentRunner', () => {
       { label: 'Context file', files: ['/workspace/notes.tex'] },
     ]);
     expect(mocks.rejectOversizedBibAttachments).toHaveBeenCalledWith([
-      '/workspace/notes.tex',
+      'notes.tex',
     ]);
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
       { label: 'Media file', files: ['/workspace/figure.pdf'] },
@@ -383,9 +421,9 @@ describe('createWorkflowScriptAgentRunner', () => {
           agentCategory: 'workflow',
           model: 'child-model',
           instruction: 'Draft the section.',
-          inputFiles: ['/workspace/paper.tex'],
-          contextFiles: ['/workspace/notes.tex'],
-          mediaFiles: ['/workspace/figure.pdf'],
+          inputFiles: ['paper.tex'],
+          contextFiles: ['notes.tex'],
+          mediaFiles: ['figure.pdf'],
           workingDirectory: '/workspace',
           delegationAgentScope: {
             workflow: ['builtInWorkflow:correct'],
@@ -546,7 +584,7 @@ describe('createWorkflowScriptAgentRunner', () => {
       expect.objectContaining({
         agentName: 'merge',
         configPayload: expect.objectContaining({
-          inputFiles: [firstCanonical, '/workspace/notes.tex', secondCanonical],
+          inputFiles: [firstCanonical, 'notes.tex', secondCanonical],
         }),
       }),
     );

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -53,10 +53,16 @@ function textOf(step: Step): string {
  */
 class MediaProbeHandler extends ModelHandlerGoogleInteractions {
   private stubbedMedia: Interactions.Content[] = [];
+  private stubbedEntries?: MediaEntry[];
 
   /** Canned media the loader override returns, so no platform/fs is touched. */
   setMediaContent(content: Interactions.Content[]): void {
     this.stubbedMedia = content;
+  }
+
+  /** Run loaded entries through the real upload pipeline. */
+  setMediaEntries(entries: MediaEntry[]): void {
+    this.stubbedEntries = entries;
   }
 
   /** Replace the client factory with a canned client (e.g. files.upload stub). */
@@ -72,7 +78,9 @@ class MediaProbeHandler extends ModelHandlerGoogleInteractions {
   protected override async createMediaMessage(): Promise<
     CreatedMedia<Interactions.Content>
   > {
-    return { media: this.stubbedMedia, entries: [] };
+    return this.stubbedEntries
+      ? this.uploadMediaEntries(this.stubbedEntries)
+      : { media: this.stubbedMedia, entries: [] };
   }
 }
 
@@ -218,11 +226,9 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     let uploadCalls = 0;
     handler.setClient({
       files: {
-        upload: async ({ file }: { file: string }) => {
+        upload: async () => {
           uploadCalls += 1;
-          return file === '/x/big.png'
-            ? { uri: 'files/abc', mimeType: 'image/png' }
-            : { mimeType: 'image/png' };
+          return { uri: 'files/abc', mimeType: 'image/png' };
         },
       },
     } as unknown as GoogleGenAI);
@@ -244,14 +250,6 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
         source_path: '/x/big.png',
         bytes_match_source: true,
       },
-      {
-        file_name: 'failed.png',
-        media_type: 'image/png',
-        media_category: 'image',
-        data: Buffer.from('also too big').toString('base64'),
-        source_path: '/x/failed.png',
-        bytes_match_source: true,
-      },
     ];
 
     const content = await handler.uploadEntries(entries);
@@ -270,9 +268,46 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     expect(uploaded.uri).toBe('files/abc');
     expect(uploaded.data).toBeUndefined();
     expect(uploaded.resolution).toBe('high');
-    expect(textOf({ type: 'user_input', content })).not.toContain('failed.png');
-    expect(uploadCalls).toBe(2);
+    expect(uploadCalls).toBe(1);
   });
+
+  it.each(['missing source', 'missing URI', 'upload rejection'])(
+    'rejects an initial request when its attachment has a %s',
+    async (failure) => {
+      const handler = createMediaProbe();
+      handler.setClient({
+        files: {
+          upload: async () => {
+            if (failure === 'upload rejection') {
+              throw new Error('Upload service unavailable');
+            }
+            return { mimeType: 'image/png' };
+          },
+        },
+      } as unknown as GoogleGenAI);
+      handler.setMediaEntries([
+        {
+          file_name: 'failed.png',
+          data: '',
+          media_type: 'image/png',
+          media_category: 'image',
+          source_path:
+            failure === 'missing source' ? undefined : '/x/failed.png',
+        },
+      ]);
+
+      await expect(
+        handler.initializeMessages('PREFIX', 'Explain the attached figure', [
+          { absolutePath: '/x/failed.png' } as never,
+        ]),
+      ).rejects.toThrow(
+        failure === 'upload rejection'
+          ? 'Upload service unavailable'
+          : 'failed.png',
+      );
+      expect(handler.consumeInsertedAttachmentKinds('initial')).toEqual([]);
+    },
+  );
 
   it('builds typed Interactions media content for audio, video, and documents', async () => {
     const handler = createMediaProbe();

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -1,12 +1,14 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { noopTrace } from '@agent/trace';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
 import type { CreatedMedia } from '@agent/modelHandlers/ModelHandler';
+import type { MediaAttachmentContext } from '@agent/modelHandlers/support/mediaAttachmentPolicy';
 import { GOOGLE_FINISH } from '@agent/types/StopReasonTypes';
 import type { MediaEntry } from '@agent/types/mediaTypes';
+import type { FileLocation } from '@shared/schemas';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 // Local file imports
@@ -72,14 +74,15 @@ class MediaProbeHandler extends ModelHandlerGoogleInteractions {
 
   /** Invoke the media-upload pipeline directly. */
   async uploadEntries(entries: MediaEntry[]): Promise<Interactions.Content[]> {
-    return (await this.uploadMediaEntries(entries)).media;
+    return (await this.uploadMediaEntries(entries, 'initial')).media;
   }
 
-  protected override async createMediaMessage(): Promise<
-    CreatedMedia<Interactions.Content>
-  > {
+  protected override async createMediaMessage(
+    _files: FileLocation[],
+    context: MediaAttachmentContext,
+  ): Promise<CreatedMedia<Interactions.Content>> {
     return this.stubbedEntries
-      ? this.uploadMediaEntries(this.stubbedEntries)
+      ? this.uploadMediaEntries(this.stubbedEntries, context)
       : { media: this.stubbedMedia, entries: [] };
   }
 }
@@ -308,6 +311,63 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
       expect(handler.consumeInsertedAttachmentKinds('initial')).toEqual([]);
     },
   );
+
+  it('retains valid follow-up attachments around a failed upload and reports that file', async () => {
+    const handler = createMediaProbe();
+    const error = vi.fn();
+    handler.setLogger({ ...noopTrace, error });
+    handler.setClient({
+      files: {
+        upload: async ({ file }: { file: string }) => {
+          if (file === '/x/failed.pdf') throw new Error('Upload unavailable');
+          return { uri: 'files/figure', mimeType: 'image/png' };
+        },
+      },
+    } as unknown as GoogleGenAI);
+    handler.setMediaEntries([
+      {
+        file_name: 'inline.png',
+        data: Buffer.from('figure').toString('base64'),
+        media_type: 'image/png',
+        media_category: 'image',
+      },
+      {
+        file_name: 'failed.pdf',
+        data: '',
+        source_path: '/x/failed.pdf',
+        media_type: 'application/pdf',
+        media_category: 'document',
+      },
+      {
+        file_name: 'uploaded.png',
+        data: '',
+        source_path: '/x/uploaded.png',
+        media_type: 'image/png',
+        media_category: 'image',
+      },
+    ]);
+
+    const steps = await handler.createRoundMessages([], 'Compare the figures', [
+      { absolutePath: '/x/inline.png' } as FileLocation,
+      { absolutePath: '/x/failed.pdf' } as FileLocation,
+      { absolutePath: '/x/uploaded.png' } as FileLocation,
+    ]);
+
+    const content = (steps[0] as Interactions.UserInputStep).content ?? [];
+    expect(content.filter((part) => part.type === 'image')).toEqual([
+      expect.objectContaining({
+        data: Buffer.from('figure').toString('base64'),
+      }),
+      expect.objectContaining({ uri: 'files/figure' }),
+    ]);
+    expect(textOf(steps[0])).not.toContain('failed.pdf');
+    expect(handler.consumeInsertedAttachmentKinds('followUp')).toEqual([
+      'image',
+      'image',
+    ]);
+    expect(error).toHaveBeenCalledOnce();
+    expect(error.mock.calls[0][0]).toContain('failed.pdf');
+  });
 
   it('builds typed Interactions media content for audio, video, and documents', async () => {
     const handler = createMediaProbe();

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -28,7 +28,6 @@ const mocks = vi.hoisted(() => ({
   secrets: {},
   setCliSubscriptionPreference: vi.fn(),
   setCliCodingPlanSubscription: vi.fn(),
-  refreshSubscriptionPreferenceViews: vi.fn(),
   setGLMCodingPlan: vi.fn(),
   updateGlobalState: vi.fn(),
 }));
@@ -61,7 +60,6 @@ vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
 }));
 
 vi.mock('@cli/chat/tui/state/subscriptionPreference', () => ({
-  refreshSubscriptionPreferenceViews: mocks.refreshSubscriptionPreferenceViews,
   setCliSubscriptionPreference: mocks.setCliSubscriptionPreference,
   setCliCodingPlanSubscription: mocks.setCliCodingPlanSubscription,
 }));
@@ -113,7 +111,10 @@ import {
   type ApprovalDecision,
 } from '@cli/chat/tui/state/approvalQueue';
 import { bindSessionView } from '@cli/chat/tui/state/sessionView';
-import { resetCliState } from '@cli/chat/tui/state/cliState';
+import {
+  codexPreferenceVersion,
+  resetCliState,
+} from '@cli/chat/tui/state/cliState';
 import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApprovals';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
@@ -468,7 +469,6 @@ afterEach(() => {
   mocks.notify.mockReset();
   mocks.setCliSubscriptionPreference.mockReset();
   mocks.setCliCodingPlanSubscription.mockReset();
-  mocks.refreshSubscriptionPreferenceViews.mockReset();
   mocks.setGLMCodingPlan.mockReset();
   mocks.updateGlobalState.mockReset();
 });
@@ -1034,6 +1034,7 @@ describe('TUI retry approvals', () => {
     });
 
     const { interactions } = tui();
+    const previousPreferenceVersion = codexPreferenceVersion.get();
     const result = port().requestRetry(
       kimiCodeSubscriptionRetry('kimi-prepare-fails'),
       { prepareRetry },
@@ -1050,7 +1051,9 @@ describe('TUI retry approvals', () => {
       GlobalStateKey.KIMI_CODE_PREFER,
       true,
     );
-    expect(mocks.refreshSubscriptionPreferenceViews).toHaveBeenCalled();
+    expect(codexPreferenceVersion.get()).toBeGreaterThan(
+      previousPreferenceVersion,
+    );
     expectNoPreferenceWrites();
   });
 
@@ -1144,6 +1147,7 @@ describe('TUI retry approvals', () => {
     });
 
     const { interactions } = tui();
+    const previousPreferenceVersion = codexPreferenceVersion.get();
     const result = port().requestRetry(
       kimiCodeSubscriptionRetry('kimi-rollback'),
     );
@@ -1158,7 +1162,7 @@ describe('TUI retry approvals', () => {
       GlobalStateKey.KIMI_CODE_PREFER,
       true,
     );
-    expect(mocks.refreshSubscriptionPreferenceViews).toHaveBeenCalledOnce();
+    expect(codexPreferenceVersion.get()).toBe(previousPreferenceVersion + 1);
   });
 
   it('does not offer or apply the subscription switch without an OpenAI API key', async () => {

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -1189,30 +1189,43 @@ describe('createChatSessionController', () => {
     });
   });
 
-  // A history row is advertised from its checkpoint file alone, so a run whose
-  // saved state cannot be loaded is offered and refused. The refusal has to
-  // reach the chat the user is looking at: clearing the transcript and
-  // switching the session onto the dead stream first would answer in a window
-  // that no longer holds their conversation.
-  it('refuses an unloadable checkpoint without clearing the chat or switching streams', async () => {
-    const session = makeSession();
-    // A refusal `resumeRun` reaches before its own retrieval yields resume
-    // state: the adoption hook is never called, so nothing here rearranged.
-    mocks.resumeRun.mockResolvedValueOnce({ failed: 'unusable_checkpoint' });
-    const ctrl = createChatSessionController(makeInit({ session }));
+  it.each(['unusable_checkpoint', 'owned_elsewhere'] as const)(
+    'refuses %s without changing the visible conversation or its configuration',
+    async (failure) => {
+      const session = makeSession();
+      patchSessionMeta({
+        agent: 'current-agent',
+        model: 'current-model',
+        modelSource: 'explicit-override',
+        teamName: 'Mathematician',
+        cliMultiAgentPresetId: 'mathematician',
+        delegationAgentScope: {
+          workflow: ['custom:current'],
+          toolUse: ['custom:current'],
+        },
+      });
+      const previousMetadata = sessionMeta.get();
+      installResumeExecutionStore(
+        makeResumeConfig({ cli: { multiAgentPresetId: 'physicist' } }),
+      );
+      // Both runtime refusals precede the hook that adopts the target run.
+      mocks.resumeRun.mockResolvedValueOnce({ failed: failure });
+      const ctrl = createChatSessionController(makeInit({ session }));
 
-    await ctrl.resume('exec-resume' as ExecutionId);
-    await session.runPromise;
+      await ctrl.resume('exec-resume' as ExecutionId);
+      await session.runPromise;
 
-    expect(mocks.appendLocalErrorTranscript).toHaveBeenCalledWith(
-      describeFollowUpFailure('unusable_checkpoint'),
-    );
-    expect(mocks.clearLocalTranscript).not.toHaveBeenCalled();
-    expect(session.streamId).toBeUndefined();
-    expect(session.executionId).toBeUndefined();
-    expect(rootStreamId.get()).toBeUndefined();
-    expect(session.runCompleted).toBe(true);
-  });
+      expect(mocks.appendLocalErrorTranscript).toHaveBeenCalledWith(
+        describeFollowUpFailure(failure),
+      );
+      expect(sessionMeta.get()).toEqual(previousMetadata);
+      expect(mocks.clearLocalTranscript).not.toHaveBeenCalled();
+      expect(session.streamId).toBeUndefined();
+      expect(session.executionId).toBeUndefined();
+      expect(rootStreamId.get()).toBeUndefined();
+      expect(session.runCompleted).toBe(true);
+    },
+  );
 
   it('treats a manually resumed subagent returning to WAITING as a successful turn', async () => {
     const session = makeSession({ runCompleted: true });

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -1178,9 +1178,13 @@ describe('createChatSessionController', () => {
       },
     });
     installResumeExecutionStore(config);
-    const ctrl = createChatSessionController(makeInit());
+    const session = makeSession();
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore: makeResumeSnapshotStore({ config }) }),
+    );
 
     await ctrl.resume('exec-resume' as ExecutionId);
+    await session.runPromise;
 
     expect(sessionMeta.get()).toMatchObject({
       teamName: 'Physicist',
@@ -1219,6 +1223,7 @@ describe('createChatSessionController', () => {
         describeFollowUpFailure(failure),
       );
       expect(sessionMeta.get()).toEqual(previousMetadata);
+      expect(mocks.setCliHelperModel).not.toHaveBeenCalled();
       expect(mocks.clearLocalTranscript).not.toHaveBeenCalled();
       expect(session.streamId).toBeUndefined();
       expect(session.executionId).toBeUndefined();
@@ -1263,6 +1268,7 @@ describe('createChatSessionController', () => {
     );
 
     await ctrl.resume('aaaaaa' as ExecutionId);
+    await session.runPromise;
 
     expect(session.streamId).toBe('stream-resume');
     expect(session.interruptedStreamId).toBeUndefined();
@@ -1491,12 +1497,15 @@ describe('createChatSessionController', () => {
       makeInit({ session, snapshotStore }),
     );
     mocks.resumeRun.mockImplementationOnce(
-      async (_id: ExecutionId, options: ResumeRunOptions) => ({
-        ...STARTED,
-        outcome: options.isCancellationRequested?.()
-          ? RUN_OUTCOME.CANCELLED
-          : RUN_OUTCOME.COMPLETED,
-      }),
+      async (_id: ExecutionId, options: ResumeRunOptions) => {
+        await options.onResumeResolved?.();
+        return {
+          ...STARTED,
+          outcome: options.isCancellationRequested?.()
+            ? RUN_OUTCOME.CANCELLED
+            : RUN_OUTCOME.COMPLETED,
+        };
+      },
     );
 
     const resumeStarted = ctrl.resume('aaaaaa' as ExecutionId);

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -1,5 +1,6 @@
 // Node imports
 import { createHash } from 'node:crypto';
+import { realpath } from 'node:fs/promises';
 import * as path from 'node:path';
 
 // Local imports
@@ -17,11 +18,7 @@ import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { formatError } from '@common/errors';
 import { createLog } from '@logger/logUtils';
 import { AgentCategory } from '@shared/schemas';
-import type {
-  ExecutionId,
-  RunStorageFileLocation,
-  StreamTabId,
-} from '@shared/schemas';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { configureDelegatedChildApprovals } from '@tools/approval';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { StorageFS } from '@utils/files/storageFS';
@@ -48,55 +45,64 @@ async function resolveInvocationFileList(
   label: string,
   files: readonly string[],
 ): Promise<string[]> {
-  const references = files.map((file) => {
-    const runStorage =
-      runStorageLocationFromAnyAbsolutePath(file) !== undefined;
-    if (!runStorage && path.isAbsolute(file)) {
-      const relative = path.relative(StorageFS.fullPath(''), file);
-      if (!path.isAbsolute(relative) && relative.split(path.sep)[0] !== '..') {
-        throw new WorkflowRunAbortError(
-          `Workflow ${label} could not be resolved: ${file}; ` +
-            'workspace-storage files must be declared outputs of a completed child run.',
-        );
-      }
-    }
-    return { file, runStorage };
-  });
-  const workspaceFiles = references
-    .filter((reference) => !reference.runStorage)
-    .map((reference) => reference.file);
   try {
-    await assertWorkflowFilesExist([{ label, files: workspaceFiles }]);
+    const storageRoot = await realpath(StorageFS.fullPath(''));
+    const references = await Promise.all(
+      files.map(async (file) => {
+        const absolutePath = WorkspaceFS.toAbsolute(file);
+        const canonicalPath = await realpath(absolutePath);
+        const relative = path.relative(storageRoot, canonicalPath);
+        const storagePath =
+          !path.isAbsolute(relative) && relative.split(path.sep)[0] !== '..'
+            ? StorageFS.fullPath(relative)
+            : undefined;
+        if (
+          storagePath !== undefined &&
+          runStorageLocationFromAnyAbsolutePath(storagePath) === undefined
+        ) {
+          throw new Error(
+            `${file}; workspace-storage files must be declared outputs of a completed child run.`,
+          );
+        }
+        // Explicit run paths still pass the resolver's symlink rejection,
+        // even when a workspace mirror points outside storage.
+        const runStoragePath =
+          runStorageLocationFromAnyAbsolutePath(absolutePath) !== undefined
+            ? absolutePath
+            : storagePath;
+        return { file: canonicalPath, runStoragePath };
+      }),
+    );
+    await assertWorkflowFilesExist([
+      {
+        label,
+        files: references
+          .filter((reference) => reference.runStoragePath === undefined)
+          .map((reference) => reference.file),
+      },
+    ]);
+    return await Promise.all(
+      references.map(async ({ file, runStoragePath }) => {
+        if (runStoragePath !== undefined) {
+          const output = await resolveChildRunOutput(
+            parentExecutionId,
+            runStoragePath,
+          );
+          if (!output) {
+            throw new Error(
+              `${runStoragePath}; pass a matching workflow file option whose files still exist.`,
+            );
+          }
+        }
+        return file;
+      }),
+    );
   } catch (error) {
     throw new WorkflowRunAbortError(
       formatError(`Workflow ${label} files could not be resolved`, error),
       { cause: error },
     );
   }
-  return await Promise.all(
-    references.map(async ({ file, runStorage }) => {
-      if (!runStorage) return file;
-      let output: RunStorageFileLocation | undefined;
-      try {
-        output = await resolveChildRunOutput(parentExecutionId, file);
-      } catch (error) {
-        throw new WorkflowRunAbortError(
-          formatError(
-            `Workflow ${label} could not be resolved: ${file}`,
-            error,
-          ),
-          { cause: error },
-        );
-      }
-      if (!output) {
-        throw new WorkflowRunAbortError(
-          `Workflow ${label} could not be resolved: ${file}; ` +
-            'pass a matching workflow file option whose files still exist.',
-        );
-      }
-      return output.absolutePath;
-    }),
-  );
 }
 
 /** Hash the bytes behind every file option used by one workflow agent call. */
@@ -127,10 +133,7 @@ export async function fingerprintWorkflowAgentDependencies(
       files,
     );
     for (const [index, file] of resolved.entries()) {
-      const bytes =
-        runStorageLocationFromAnyAbsolutePath(file) !== undefined
-          ? await AbsoluteFS.readBytes(file)
-          : await WorkspaceFS.readBytes(file);
+      const bytes = await AbsoluteFS.readBytes(file);
       hash.update(`${kind}\0${index}\0${bytes.length}\0`);
       hash.update(bytes);
     }

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -44,7 +44,7 @@ async function resolveInvocationFileList(
   parentExecutionId: LaunchRunContext['runScope']['executionId'],
   label: string,
   files: readonly string[],
-): Promise<string[]> {
+): Promise<{ file: string; absolutePath: string }[]> {
   try {
     const storageRoot = await realpath(StorageFS.fullPath(''));
     const references = await Promise.all(
@@ -70,7 +70,11 @@ async function resolveInvocationFileList(
           runStorageLocationFromAnyAbsolutePath(absolutePath) !== undefined
             ? absolutePath
             : storagePath;
-        return { file: canonicalPath, runStoragePath };
+        return {
+          file,
+          absolutePath: canonicalPath,
+          runStoragePath,
+        };
       }),
     );
     await assertWorkflowFilesExist([
@@ -78,11 +82,11 @@ async function resolveInvocationFileList(
         label,
         files: references
           .filter((reference) => reference.runStoragePath === undefined)
-          .map((reference) => reference.file),
+          .map((reference) => reference.absolutePath),
       },
     ]);
     return await Promise.all(
-      references.map(async ({ file, runStoragePath }) => {
+      references.map(async ({ file, absolutePath, runStoragePath }) => {
         if (runStoragePath !== undefined) {
           const output = await resolveChildRunOutput(
             parentExecutionId,
@@ -94,7 +98,11 @@ async function resolveInvocationFileList(
             );
           }
         }
-        return file;
+        // Workspace names remain the caller's prompt and output identity.
+        return {
+          file: runStoragePath === undefined ? file : absolutePath,
+          absolutePath,
+        };
       }),
     );
   } catch (error) {
@@ -132,8 +140,8 @@ export async function fingerprintWorkflowAgentDependencies(
       label,
       files,
     );
-    for (const [index, file] of resolved.entries()) {
-      const bytes = await AbsoluteFS.readBytes(file);
+    for (const [index, { absolutePath }] of resolved.entries()) {
+      const bytes = await AbsoluteFS.readBytes(absolutePath);
       hash.update(`${kind}\0${index}\0${bytes.length}\0`);
       hash.update(bytes);
     }
@@ -237,7 +245,7 @@ async function resolveWorkflowCallConfig(
     // Model resolves before any file I/O so an unavailable/invalid
     // declared model fails the call without touching the filesystem.
     const model = await workflowScriptModelSelection(call, parent);
-    const [inputFiles, contextFiles, mediaFiles] = await Promise.all([
+    const [inputs, context, media] = await Promise.all([
       resolveInvocationFileList(
         runExecutionId,
         'Input file',
@@ -254,6 +262,9 @@ async function resolveWorkflowCallConfig(
         call.options.mediaFiles ?? [],
       ),
     ]);
+    const inputFiles = inputs.map(({ file }) => file);
+    const contextFiles = context.map(({ file }) => file);
+    const mediaFiles = media.map(({ file }) => file);
     const oversizedBibRejection =
       await rejectOversizedBibAttachments(contextFiles);
     if (oversizedBibRejection) {

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -1,5 +1,6 @@
 // Node imports
 import { createHash } from 'node:crypto';
+import * as path from 'node:path';
 
 // Local imports
 import { getExecutionStore, resolveChildRunOutput } from '@agent/storage';
@@ -23,6 +24,7 @@ import type {
 } from '@shared/schemas';
 import { configureDelegatedChildApprovals } from '@tools/approval';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { StorageFS } from '@utils/files/storageFS';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { deriveExecutionId } from '@utils/core/idHash';
 import { runStorageLocationFromAnyAbsolutePath } from '@utils/files/runStorageFs';
@@ -46,10 +48,20 @@ async function resolveInvocationFileList(
   label: string,
   files: readonly string[],
 ): Promise<string[]> {
-  const references = files.map((file) => ({
-    file,
-    runStorage: runStorageLocationFromAnyAbsolutePath(file) !== undefined,
-  }));
+  const references = files.map((file) => {
+    const runStorage =
+      runStorageLocationFromAnyAbsolutePath(file) !== undefined;
+    if (!runStorage && path.isAbsolute(file)) {
+      const relative = path.relative(StorageFS.fullPath(''), file);
+      if (!path.isAbsolute(relative) && relative.split(path.sep)[0] !== '..') {
+        throw new WorkflowRunAbortError(
+          `Workflow ${label} could not be resolved: ${file}; ` +
+            'workspace-storage files must be declared outputs of a completed child run.',
+        );
+      }
+    }
+    return { file, runStorage };
+  });
   const workspaceFiles = references
     .filter((reference) => !reference.runStorage)
     .map((reference) => reference.file);


### PR DESCRIPTION
## Summary

Google attachment failures follow the shared policy: an initial request fails visibly, while a later round reports the failed file and retains its other attachments. Recorded attachment kinds describe only successfully attached media.

Workflow invocations resolve relative paths and symlinks before classifying file inputs. Private workspace-storage files are rejected regardless of their spelling. Run-storage inputs still require declared outputs of completed direct child runs. Workspace inputs retain the requested filenames for prompts and outputs, including symlinks such as `chapters/current.tex` pointing to `versions/v1.tex`; dependency fingerprints read the checked physical paths.

A refused history resume keeps the current conversation configuration and does not change the helper-model setting. Accepted history adoption persists the helper model before changing the visible conversation. Subscription and credential changes continue refreshing the CLI through the existing preference signal, with the redundant forwarding function removed.

Fixes #11297. Fixes #11807. Fixes #11840. Fixes #11895.

## Issue acceptance gates

- #11297: missing upload sources, missing response URIs, and upload exceptions reach the shared attachment-failure policy. The existing Google suite checks initial rejection and a mixed follow-up that retains two valid images around a failed upload, reports that file once, and records only the successful attachment kinds.
- #11807: physical input paths are classified against the physical workspace-storage root. The existing workflow suite checks absolute, relative-traversal, and workspace-symlink spellings of a private file before dependency bytes are read. Explicit run-storage paths retain the existing symlink rejection and child-output authority. A real filesystem regression also verifies that a legitimate workspace symlink retains its requested relative name in the launched configuration.
- #11840: helper-model persistence and conversation configuration adoption occur inside `adoptResumedStream`. Existing unusable-checkpoint and ownership-refusal cases verify that neither the current metadata nor helper setting changes.
- #11895: all seven production calls, including the config form, call `bumpCodexPreferenceVersion` directly. Existing rollback tests inspect the preference signal instead of mocking the deleted forwarding function.

## Single source of truth

`reportMediaAttachmentFailure` owns the attachment-failure policy; Google applies it per entry using the round's existing context. `StorageFS` supplies the workspace-storage root, and `resolveChildRunOutput` retains output authorization. `adoptResumedStream` owns explicit history adoption. `bumpCodexPreferenceVersion` remains the CLI preference-change notification.

## Duplication and abstraction budget

The Google upload helper returns media and the successful entries together, replacing the callback that separately recorded insertions. Each resolved input pairs its requested file identity with its checked physical read path. The launch configuration keeps the requested name, and dependency fingerprints read the physical target. The CLI preference forwarding function is removed. No production module, compatibility path, or alternative failure policy is added.

## Net elements (R6)

Against base `411c501ef8eff066311d65e2e5dd5560f15d263a`: 14 existing files changed, +440/-215 lines, net +225. Files added/deleted: 0/0. Export declarations: +0/-1. Class, interface, and enum declarations: +0/-0. The increase covers physical-path validation, preservation of requested file names, and regressions at existing behavioral boundaries. No new test file or ratchet change.

## Consumer counts (R8)

Production searches cover `src` and `packages`, excluding tests and generated output.

- `refreshSubscriptionPreferenceViews`: seven calls before, zero references after; all seven now call the existing preference signal directly.
- Google's `onInsertedEntry`: one handler assignment and one uploader invocation before, zero after. The helper's single caller receives successful media and entries in one result.
- `createMediaMessage` receives the existing round context from its one production caller, `createMediaForRound`; Google uses it for per-entry failure reporting.
- No session-event emission or subscription is added or removed.

## Host impact

Extension and desktop: Google attachment handling and workflow input authorization follow the corrected shared rules.

CLI: the same shared input rules apply; refused explicit history resumes preserve the conversation and helper settings, and preference notifications retain their ordering.

## Scheduled refactoring

None.

## Validation

- The existing runner suite reproduced the workspace-symlink filename defect before the correction.
- Five affected existing suites pass: 125 tests covering workflow inputs, prompt names, XML outputs, child-output authorization, and run-storage entry inspection.
- Changed-file Prettier, full `npm run typecheck`, `npm run lint`, and `npm run compile:fast` passed for the final filename correction.
- Full Vitest suite for the final correction: 764 test files passed, one skipped; 9,078 tests passed, six skipped (one run with four workers).
- Dead-code ratchet passed: 286 findings against 286 baseline entries.
- Independent review verified requested-name preservation, physical-path authorization, and unchanged child-output restrictions.
- `git diff --check`: passed. No added em dash, new test file, Effect execution site, or ratchet allowance.

The additional Effect migration check still reports inherited main failures: 52 counts above the baseline, 22 stale allowances, and one adapter marker. This PR adds no Effect execution site or adapter marker and does not alter that baseline.

The branch is based on `411c501ef8eff066311d65e2e5dd5560f15d263a`. Its authentication integration retains the current Effect execution and abort signal in the model-access handler, followed by the direct preference notification. Independent conflict review passed. The subsequent filename correction does not change that integration.
