### PR TITLE
feat: show reasoning settings in CLI model choices

### DIFF
--- a/docs/dev/verification.md
+++ b/docs/dev/verification.md
@@ -16,8 +16,7 @@ what to check by hand for the extension.
 ## Quick automated pass
 
 ```bash
-# Type checking — must be clean ON FILES YOU TOUCHED. Pre-existing errors
-# (e.g. `@openrouter/sdk/models`) are unrelated.
+# Type checking: must be clean.
 npm run typecheck
 
 # Vitest suite — host-neutral logic + Electron-facing helpers.

--- a/packages/cli/scripts/copy-resources.mjs
+++ b/packages/cli/scripts/copy-resources.mjs
@@ -11,13 +11,7 @@ const targetInput = process.env.TEXRA_CLI_RESOURCES_OUTDIR?.trim();
 const target = targetInput
   ? path.resolve(packageDir, targetInput)
   : path.resolve(packageDir, 'dist/resources');
-const runtimeResourceEntries = [
-  'agents',
-  'docs/agent-creation',
-  'goal',
-  'shared',
-  'tool_use_agents',
-];
+const runtimeResourceEntries = ['agents', 'goal', 'shared', 'tool_use_agents'];
 
 // Built (not checked-in) assets: only present once packages/trace-viewer's
 // own build has run (normally guaranteed by this package's own `build`

--- a/packages/cli/scripts/validate-pack.mjs
+++ b/packages/cli/scripts/validate-pack.mjs
@@ -10,9 +10,8 @@ const cliRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const packageName = '@texra-ai/cli';
 const packageDir = 'package/';
 
-// Templates only the VS Code extension and the desktop app read. The CLI
-// resolves agent creation through resources/docs/agent-creation, so none of
-// these belongs in the published tarball. `templates/instructionPolish.yaml`
+// Templates only the VS Code extension and the desktop app read. None of
+// these belongs in the CLI tarball. `templates/instructionPolish.yaml`
 // is deliberately absent from this list: bundledPrompts.ts keeps a polish row
 // registered for the CLI, so shipping that one later is legitimate.
 const EXTENSION_ONLY_TEMPLATES = new Set([

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -161,7 +161,10 @@ export function modelSelectItemsForCli(
 ): readonly CliModelPickerItem[] {
   return runnableCliModelAccessEntries(models).map((model) => {
     const disabledReason = getModelSwitchDisabledReason?.(model.model.value);
-    const status = formatModelStatusForCli(model);
+    const access = formatModelStatusForCli(model);
+    const status = model.model.reasoning
+      ? `${access} · reasoning setting: ${model.model.reasoning}`
+      : access;
     return {
       value: model.model.value,
       label: model.model.label || model.model.value,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -48,7 +48,6 @@ import type {
   TokenValidationResult,
 } from '@agent/types/ModelHandlerContracts';
 import { createNeutralResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
-import { supportsReasoningLevel } from '@agent/modelHandlers/support/reasoningEffort';
 import type { ServerToolExtractionResult } from '@agent/types/ServerTools';
 import {
   attachContextWindowError,
@@ -61,6 +60,7 @@ import {
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
 import { attachSdkCredentialRoute } from '@common/errors/sdkError/sdkRequestEndpoint';
 import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
+import { supportsReasoningLevel } from '@model/reasoningLevel';
 import {
   resolveDirectModelApiKeyProvider,
   resolveModelSource,

--- a/src/agent/modelHandlers/support/reasoningEffort.ts
+++ b/src/agent/modelHandlers/support/reasoningEffort.ts
@@ -1,25 +1,6 @@
-import {
-  ModelProvider,
-  ReasoningEffort,
-  type ModelCapabilities,
-  type ModelConfig,
-} from 'llm-zoo';
+import { ReasoningEffort, type ModelCapabilities } from 'llm-zoo';
 
 import type { ReasoningEffort as OpenAIReasoningEffort } from 'openai/resources/shared';
-
-/**
- * Single source of truth: user-facing reasoning level strings -> ReasoningEffort enum.
- * The reverse mapping for settings UI controls is derived from this record.
- */
-export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
-  none: ReasoningEffort.NONE,
-  minimal: ReasoningEffort.MINIMAL,
-  low: ReasoningEffort.LOW,
-  medium: ReasoningEffort.MEDIUM,
-  high: ReasoningEffort.HIGH,
-  xhigh: ReasoningEffort.XHIGH,
-  max: ReasoningEffort.MAX,
-};
 
 const REASONING_EFFORT_ORDER: readonly ReasoningEffort[] = [
   ReasoningEffort.NONE,
@@ -60,42 +41,6 @@ export function normalizeSupportedReasoningEffort(
 }
 
 type NonNullOpenAIReasoningEffort = Exclude<OpenAIReasoningEffort, null>;
-
-/** Whether the model exposes a genuine user-selectable effort range. */
-function hasConfigurableReasoningEffort(
-  capabilities: ModelCapabilities,
-): boolean {
-  if (!capabilities.supportsReasoningEffort) return false;
-
-  const exactEfforts = capabilities.supportedReasoningEfforts;
-  if (exactEfforts?.length) {
-    return new Set(exactEfforts).size > 1;
-  }
-
-  return !(
-    capabilities.reasoningEffort === ReasoningEffort.MAX &&
-    capabilities.maxReasoningEffort === undefined
-  );
-}
-
-/**
- * Whether the model exposes a user-selectable reasoning level. This is the one
- * definition behind both the handler getter (`ModelHandler
- * .supportsReasoningLevelOverride`, read on every handler construction) and the
- * Settings Models rows, so the control and the runtime can never disagree.
- *
- * DeepSeek is the extra term: its models declare `supportsReasoning` without a
- * configurable effort range, yet still honour a level override.
- */
-export function supportsReasoningLevel(
-  config: Pick<ModelConfig, 'provider' | 'capabilities'>,
-): boolean {
-  return (
-    hasConfigurableReasoningEffort(config.capabilities) ||
-    (config.provider === ModelProvider.DEEPSEEK &&
-      config.capabilities.supportsReasoning)
-  );
-}
 
 /** Read llm-zoo's declared effort ceiling using its documented fallback. */
 export function getDeclaredMaxReasoningEffort(

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -2,7 +2,6 @@ import { ModelProvider, type ModelConfig } from 'llm-zoo';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
-import { LEVEL_TO_EFFORT } from '@agent/modelHandlers/support/reasoningEffort';
 import {
   internalValidationModelHandlerEnvName,
   shouldUseInternalValidationModelHandler,
@@ -15,6 +14,7 @@ import {
 import { AgentError } from '@common/errors';
 import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { createLog } from '@logger/logUtils';
+import { LEVEL_TO_EFFORT } from '@model/reasoningLevel';
 import {
   copilotRouteUnavailableReason,
   prefersCopilotRoute,

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -1,9 +1,6 @@
 import { ModelProvider, type ModelConfig, ReasoningEffort } from 'llm-zoo';
 
-import {
-  LEVEL_TO_EFFORT,
-  supportsReasoningLevel,
-} from '@agent/modelHandlers/support/reasoningEffort';
+import { LEVEL_TO_EFFORT, supportsReasoningLevel } from '@model/reasoningLevel';
 import { preferredCopilotRouteModels } from '@model/copilotRouting';
 import { resolveModelSource } from '@model/openRouterRouting';
 import {

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -6,7 +6,11 @@ import { isPreferXaiSubscription } from '@model/xai/xaiPreference';
 import { isXaiSignedIn } from '@model/xai/xaiSignedIn';
 import type { StateStore } from '@platform/interfaces';
 import { platform } from '@platform/platform';
-import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
+import {
+  REASONING_LEVEL_LABELS,
+  type ModelAvailabilityKind,
+  type ModelOptionData,
+} from '@shared/schemas';
 import { CHATGPT_AUTH, GROK_AUTH } from '@shared/copy/accountAuth';
 import {
   DEFAULT_HELPER_MODEL,
@@ -23,6 +27,7 @@ import {
 } from '@utils/config/providerConfig';
 
 import { hasUsableApiKey, type ApiProvider } from './apiProviders';
+import { LEVEL_TO_EFFORT, supportsReasoningLevel } from './reasoningLevel';
 import { warnModelAvailability } from './modelAvailabilityWarning';
 import {
   resolveCodexSubscriptionCapabilities,
@@ -257,6 +262,7 @@ async function getPersonalAccessKindForModel(
 }
 
 interface ModelAvailabilityContext {
+  reasoningLevels: Readonly<Record<string, string>>;
   hasUsableApiKey(provider: ApiProvider): Promise<boolean>;
   hasOpenRouter: boolean;
   useOpenRouter: boolean;
@@ -358,6 +364,7 @@ async function resolveModelAvailability(
 }
 
 async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
+  const { secrets, globalState } = platform();
   const useOpenRouter = getUseOpenRouter();
   // One key check per provider per context: `apiProviders` coalesces the
   // secret read, but a rejection reaches every awaiting model, and the picker
@@ -366,15 +373,13 @@ async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
   const hasApiKey = (provider: ApiProvider): Promise<boolean> => {
     let check = keyChecks.get(provider);
     if (!check) {
-      check = hasUsableApiKey(platform().secrets, provider).catch(
-        (error: unknown) => {
-          warnModelAvailability(
-            `Failed to read ${providerDisplayName(provider)} API key status; treating it as unavailable.`,
-            error,
-          );
-          return false;
-        },
-      );
+      check = hasUsableApiKey(secrets, provider).catch((error: unknown) => {
+        warnModelAvailability(
+          `Failed to read ${providerDisplayName(provider)} API key status; treating it as unavailable.`,
+          error,
+        );
+        return false;
+      });
       keyChecks.set(provider, check);
     }
     return check;
@@ -388,6 +393,10 @@ async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
       hasApiKey('kimiCode'),
     ]);
   return {
+    reasoningLevels: globalState.get<Record<string, string>>(
+      GlobalStateKey.REASONING_LEVELS,
+      {},
+    ),
     hasUsableApiKey: hasApiKey,
     hasOpenRouter,
     useOpenRouter,
@@ -526,6 +535,27 @@ async function buildModelOptionData(
         outputPrice: availability.providerCapabilities.outputPrice,
       }
     : (copilotConfig ?? config);
+  let reasoning: string | undefined;
+  if (optionConfig.capabilities.supportsReasoning) {
+    if (availability.kind === 'copilot-access') {
+      reasoning = 'Default (provider managed)';
+    } else {
+      const defaultLevel =
+        REASONING_LEVEL_LABELS[optionConfig.capabilities.reasoningEffort];
+      if (supportsReasoningLevel(optionConfig)) {
+        const override = ctx.reasoningLevels[model];
+        const effort = override ? LEVEL_TO_EFFORT[override] : undefined;
+        reasoning =
+          effort === undefined
+            ? `Default (${defaultLevel})`
+            : REASONING_LEVEL_LABELS[effort];
+      } else {
+        reasoning = optionConfig.capabilities.supportsReasoningEffort
+          ? `${defaultLevel} (fixed)`
+          : 'Default';
+      }
+    }
+  }
   let routeLabel: string | undefined;
   if (availability.kind === 'copilot-access') {
     // The row's identity stays the base model; the badge names the route.
@@ -542,6 +572,7 @@ async function buildModelOptionData(
   return withAvailabilityFields(
     {
       ...buildBaseModelOption(model, optionConfig, config),
+      ...(reasoning ? { reasoning } : {}),
       ...(routeLabel ? { routeLabel } : {}),
     },
     availability,

--- a/src/model/reasoningLevel.ts
+++ b/src/model/reasoningLevel.ts
@@ -1,0 +1,56 @@
+import {
+  ModelProvider,
+  ReasoningEffort,
+  type ModelCapabilities,
+  type ModelConfig,
+} from 'llm-zoo';
+
+/**
+ * Single source of truth: user-facing reasoning level strings -> ReasoningEffort enum.
+ * The reverse mapping for settings UI controls is derived from this record.
+ */
+export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
+  none: ReasoningEffort.NONE,
+  minimal: ReasoningEffort.MINIMAL,
+  low: ReasoningEffort.LOW,
+  medium: ReasoningEffort.MEDIUM,
+  high: ReasoningEffort.HIGH,
+  xhigh: ReasoningEffort.XHIGH,
+  max: ReasoningEffort.MAX,
+};
+
+/** Whether the model exposes a genuine user-selectable effort range. */
+function hasConfigurableReasoningEffort(
+  capabilities: ModelCapabilities,
+): boolean {
+  if (!capabilities.supportsReasoningEffort) return false;
+
+  const exactEfforts = capabilities.supportedReasoningEfforts;
+  if (exactEfforts?.length) {
+    return new Set(exactEfforts).size > 1;
+  }
+
+  return !(
+    capabilities.reasoningEffort === ReasoningEffort.MAX &&
+    capabilities.maxReasoningEffort === undefined
+  );
+}
+
+/**
+ * Whether the model exposes a user-selectable reasoning level. This is the one
+ * definition behind both the handler getter (`ModelHandler
+ * .supportsReasoningLevelOverride`, read on every handler construction) and the
+ * model choices, so the controls and the runtime share the same definition.
+ *
+ * DeepSeek is the extra term: its models declare `supportsReasoning` without a
+ * configurable effort range, yet still honour a level override.
+ */
+export function supportsReasoningLevel(
+  config: Pick<ModelConfig, 'provider' | 'capabilities'>,
+): boolean {
+  return (
+    hasConfigurableReasoningEffort(config.capabilities) ||
+    (config.provider === ModelProvider.DEEPSEEK &&
+      config.capabilities.supportsReasoning)
+  );
+}

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -88,6 +88,8 @@ export const ModelOptionDataSchema = PickerOptionBaseSchema.extend({
   context: z.string().optional(),
   cost: z.string().optional(),
   hint: z.string().optional(),
+  /** Current reasoning setting, including default or fixed-mode context. */
+  reasoning: z.string().optional(),
   ...ModelAvailabilityFieldsSchema.shape,
 });
 export type ModelOptionData = z.infer<typeof ModelOptionDataSchema>;

--- a/src/test-kernel/cli/ModelAccess.vitest.ts
+++ b/src/test-kernel/cli/ModelAccess.vitest.ts
@@ -361,6 +361,7 @@ describe('CLI model access resolution', () => {
       model('deepseekT', {
         model: modelOption('deepseekT', {
           label: 'DeepSeek',
+          reasoning: 'Default (High)',
           availability: 'provider-key',
         }),
         status: 'api key set',
@@ -388,7 +389,7 @@ describe('CLI model access resolution', () => {
       'openrouterOnlyT',
     ]);
     expect(rows.map((row) => row.description)).toEqual([
-      'api: api key set',
+      'api: api key set · reasoning setting: Default (High)',
       'api: openrouter key',
     ]);
   });
@@ -400,6 +401,7 @@ describe('CLI model access resolution', () => {
           model('sonnet46T', {
             model: modelOption('sonnet46T', {
               label: 'Sonnet',
+              reasoning: 'Low',
               availability: 'provider-key',
             }),
             status: 'api key set',
@@ -422,7 +424,7 @@ describe('CLI model access resolution', () => {
         value: 'sonnet46T',
         label: 'Sonnet',
         description:
-          'different conversation format; start new chat; api: api key set',
+          'different conversation format; start new chat; api: api key set · reasoning setting: Low',
         disabled: true,
       },
       {

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -94,6 +94,29 @@ describe('computeModelOptionsData availability', () => {
     installTexraAccountProbes();
   });
 
+  it.each([
+    { model: 'gpt56', override: undefined, expected: 'Default (Medium)' },
+    { model: 'gpt56', override: 'low', expected: 'Low' },
+    { model: 'kimi3', override: 'low', expected: 'Max (fixed)' },
+    { model: 'sonnet45T', override: 'low', expected: 'Default' },
+    { model: 'gpt4o', override: 'high', expected: undefined },
+  ])(
+    'includes the current reasoning setting for $model ($override)',
+    async ({ model, override, expected }) => {
+      await installPlatform({
+        globalState: {
+          [GlobalStateKey.REASONING_LEVELS]:
+            override === undefined ? {} : { [model]: override },
+        },
+        secrets: OPENAI_KEY_SECRETS,
+      });
+
+      const [option] = await computeModelOptionsData([model]);
+
+      expect(option.reasoning).toBe(expected);
+    },
+  );
+
   it('uses a Kimi Code key for the plan-exclusive model', async () => {
     await installAccessPlatform({
       secrets: { [apiKeySecretName('kimiCode')]: 'sk-kimi-code' },

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -455,6 +455,7 @@ describe('Copilot route in model pickers', () => {
       {
         globalState: {
           [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['gemini31p'],
+          [GlobalStateKey.REASONING_LEVELS]: { gemini31p: 'low' },
         },
         secrets: googleKeySecrets(),
       },
@@ -470,6 +471,7 @@ describe('Copilot route in model pickers', () => {
         availability: 'copilot-access',
         availabilityLabel: 'Copilot subscription',
         routeLabel: 'Via Copilot',
+        reasoning: 'Default (provider managed)',
         context: '160K',
         cost: '$0.000/$0.000',
         disabled: false,


### PR DESCRIPTION
## Summary

CLI model choices now show the configured reasoning setting beside the access status, for example `reasoning setting: Default (Medium)` or `reasoning setting: Low`. Fixed reasoning and provider-managed defaults are identified separately. Models that think without an effort control show `Default`; this does not claim the provider's normalized request effort.

Also removes agent-creation documentation that the CLI packages but cannot access, corrects its packaging comment, and makes the verification guide require a clean full type check.

## Issue acceptance gates

No linked issue. Both the launcher and in-chat model picker receive the setting through their existing shared model-options path. Existing cases cover defaults, overrides, fixed modes, models without effort control, Copilot-managed reasoning, and switch restrictions.

## Single source of truth

`computeModelOptionsData` combines the existing runtime model configuration, selected access route, and saved reasoning levels. The existing level table and capability predicate now live in `src/model/reasoningLevel.ts`, shared by runtime construction, settings, and model choices.

## Duplication and abstraction budget

Moves the existing level table and capability predicate without a forwarding export. The CLI reads the computed description; it does not repeat routing or provider-normalization logic. The saved levels are read once from the existing platform capture for each options computation.

## Net elements (R6)

14 files changed, including one new production module. 140 lines added and 87 removed, net +53. Two exports relocated, net zero. No new class, interface, enum, or test file.

## Consumer counts (R8)

Both relocated exports have three production consumers: the level table serves model construction, settings, and model options; the capability predicate serves model handlers, settings, and model options. No consumer remains at the previous module location. The removed CLI documentation has no CLI external-root registration or direct reader.

## Host impact

Extension: additive reasoning description in shared model-option data; settings controls and execution behavior are unchanged.

Desktop: the same additive model-option data; execution behavior is unchanged.

CLI: the launcher and in-chat model picker show reasoning settings. Model JSON records also include the optional description. The package omits unreachable extension documentation.

## Scheduled refactoring

None.

## Validation

- Changed-file Prettier check and `git diff --check` pass.
- Full `npm run typecheck`, `npm run lint`, and `npm run compile:fast` pass.
- Five affected existing suites pass, 106 tests.
- `npm test -- --maxWorkers=4` passes: 764 suites, 9,068 tests; one suite and six tests skipped.
- Dead-code ratchet passes, 279 findings against 279 baselined.
- Resource-copy smoke confirms seven runtime directories remain and agent-creation docs are omitted.
- Independent review checked model defaults, provider normalization, current callers, and resource ownership.
- Additional Effect migration check reports existing failures on main `f2ec7435e6`: 39 increased counts, 15 stale counts, and an existing adapter marker. Every reported file is unchanged by this PR. The platform-call count remains 160/160, and no baseline is changed.
