### PR TITLE
style(docs): format the consolidation survey so main's format:check passes

### DIFF
--- a/docs/proposals/2026-09-06-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-06-consolidation-and-native-methods-survey.md
@@ -1,7 +1,7 @@
 # Survey: code consolidation and native-method opportunities (2026-09-06)
 
 > **Status:** Written 2026-09-06 against branch HEAD `03d2cfd` (`chore(deps-dev):
-> bump the development-dependencies group across 1 directory with 6 updates`,
+bump the development-dependencies group across 1 directory with 6 updates`,
 > #11842). Scheduled routine re-ran the standing question — "find
 > duplicate/similar logic to consolidate, and hand-rolled code that a native
 > method or the standard library already covers" — three days after
@@ -56,10 +56,16 @@ were the same function:
 const s = signal(initial);
 const fiber = runtime.runFork(
   Stream.runForEachArray(changes, (arr) =>
-    Effect.sync(() => { s.set(arr.at(-1) as A); }),
+    Effect.sync(() => {
+      s.set(arr.at(-1) as A);
+    }),
   ),
 );
-return Object.assign(s, { dispose: () => { runtime.runFork(Fiber.interrupt(fiber)); } });
+return Object.assign(s, {
+  dispose: () => {
+    runtime.runFork(Fiber.interrupt(fiber));
+  },
+});
 
 // packages/cli/.../sessionView.ts — viewSignal (new in this window, #11881)
 const s = signal(SubscriptionRef.getUnsafe(view));
@@ -71,7 +77,11 @@ const fiber = runtime.runFork(
     }),
   ),
 );
-return Object.assign(s, { dispose: () => { runtime.runFork(Fiber.interrupt(fiber)); } });
+return Object.assign(s, {
+  dispose: () => {
+    runtime.runFork(Fiber.interrupt(fiber));
+  },
+});
 ```
 
 `viewSignal`'s three call-site arguments (`effectRuntime()`,


### PR DESCRIPTION
## Summary

`main` is red. #11930 landed `docs/proposals/2026-09-06-consolidation-and-native-methods-survey.md` without running prettier, so `pnpm run format:check` fails in the **static checks (linux)** job, which fails the **validate** gate. CI run [34027329517](https://github.com/LionSR/TeXRA/actions/runs/34027329517) on `fd32b8b` reports exactly one file:

```
$ prettier --check .
[warn] docs/proposals/2026-09-06-consolidation-and-native-methods-survey.md
[warn] Code style issues found in the above file.
```

Every open PR inherits the failure, since `format:check` runs over the whole tree.

This is prettier 3.9.6's output, unedited — `prettier --write` on that one file, nothing else touched:

- Two fenced TypeScript examples get statement-per-line bodies instead of single-line arrow bodies.
- The second line of the status blockquote loses its `> ` prefix. That prefix sat *inside* a multi-line inline code span (`` `chore(deps-dev): bump …` ``) and was being rendered literally as part of the code. Markdown's lazy continuation keeps the line in the blockquote without the marker, so the rendered document is unchanged and the stray `>` disappears from the code span.

## Issue acceptance gates

No issue is closed. This restores the base branch to green; the substance of #11930's survey is untouched.

## Single source of truth

n/a: formatting only.

## Duplication and abstraction budget

n/a: documentation only.

## Net elements (R6)

Files: 1 modified, 0 added, 0 deleted. No exported symbol, class, interface, or dependency changes. Net LoC +10, all of it prettier's line wrapping.

## Consumer counts (R8)

n/a: no emit path or code change.

## Host impact

Extension: none. Desktop: none. CLI: none.

## Scheduled refactoring

None. Worth noting for the next docs-only PR: `format:check` covers `docs/**`, so a doc added without prettier turns the whole base branch red, which is how this one slipped through.

## Validation

- `prettier --version` → 3.9.6, the pinned devDependency CI installs.
- `prettier --check docs/proposals/2026-09-06-consolidation-and-native-methods-survey.md` fails before this change and passes after.
- `node docs/scripts/check-root-docs.mjs`: unaffected — the file is under `docs/proposals/`, an internal area excluded from the published site.
- No code changed, so no typecheck, lint, or test run applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyJjcnpYcFopcGbYdWayxp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyJjcnpYcFopcGbYdWayxp)_