### PR TITLE
fix(tools): drop the retired adapter marker, keep the unref constraint it documented

### DIFF
--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -410,14 +410,15 @@ export abstract class PollingSourceBase<
   }
 
   /**
-   * @adapter-until 2026-11-05 (introduced 2026-09-06). The setInterval
-   * cadence is the one timer this file keeps off Effect's clock (PRD R8):
-   * "a polling timer must never keep a host process alive on its own", and
-   * rc.112 has no unref-capable scheduler (no `unref` anywhere in
-   * node_modules/effect/dist), so a Schedule-driven fiber would pin the CLI
-   * process. Retire when Effect gains an unref-capable clock or the hosts
-   * decide at process level that a live poller may keep the process alive;
-   * the interval only drives {@link PollingSourceBase.tick}.
+   * The setInterval cadence is the one timer this file keeps off Effect's
+   * clock (PRD R8): "a polling timer must never keep a host process alive
+   * on its own", and rc.112 has no unref-capable scheduler (no `unref`
+   * anywhere in node_modules/effect/dist), so a Schedule-driven fiber would
+   * pin the CLI process. This is a standing exception, not a temporary
+   * adapter with a date, which is why it carries no retirement marker: it
+   * ends when Effect gains an unref-capable clock, or when the hosts decide
+   * at process level that a live poller may keep the process alive. The
+   * interval only drives {@link PollingSourceBase.tick}.
    */
   private ensureTimer(): void {
     this.registerShutdownIfNeeded();


### PR DESCRIPTION
The owner retired the `@adapter-until` convention on 2026-09-06, so `check:effect-migration-ratchet` fails on any marker's presence, and one survived in `PollingSourceBase.ts`.

That timer is not a temporary adapter. Effect rc.112 has no unref-capable scheduler (no `unref` anywhere in `node_modules/effect/dist`), so a Schedule-driven fiber would keep the CLI process alive, which PRD R8 forbids. The comment now states that as a standing exception with the condition that would end it, and the code is unchanged.

This clears one of the three ways `main` currently fails its own ratchet. The other two, 52 grown counts and 11 run sites below the boundary, belong to the migration wave PRs and are analysed in #11949; this PR deliberately does not touch the baseline, because `--update` refuses while those eleven exist and allowlisting them is explicitly forbidden.

Part of #11949