### PR TITLE
docs: align the desktop dock specification with its controls

### DIFF
--- a/docs/prds/2026-09-03-prd-one-fold-three-renderers.md
+++ b/docs/prds/2026-09-03-prd-one-fold-three-renderers.md
@@ -2543,8 +2543,10 @@ a component.
   the `LayerMap`.
 - **Conversation** (760 px column): the paper chip and stream title in the
   task header, the same conversation and composer as the extension, and a
-  dock with the diff count, Compile PDF, and latexdiff-vs-last-commit
-  shortcuts into the Tools sheet.
+  dock containing only the latexdiff-vs-last-commit shortcut into the Tools
+  sheet. The dock renders below the composer until `ProgressApp` provides a
+  slot for it. Compile PDF and the diff-count chip are out of scope for this
+  lane; a diff count requires a host-produced count in `HostSnapshot`.
   The desktop keeps its auxiliary IPC alongside this protocol. A PTY streams
   `desktop:terminal:data`, `:exit`, and `:error` into xterm through
   `renderer/messageRoutes.ts:180-190`, which is a continuous byte stream, not


### PR DESCRIPTION
## Summary

Correct the desktop conversation specification to match the shipped dock: a single latexdiff-vs-last-commit shortcut below the composer. Remove the obsolete promise of Compile PDF and a diff-count chip, and state that a count requires host-produced data in `HostSnapshot`.

This documentation-only follow-up now targets main after #11942 merged. Its diff contains only the specification correction.

## Issue acceptance gates

Closes #11939. Section 12.2 now agrees with the dock ruling and `conversationDockTemplate`: one shortcut, below the composer until a slot exists, with the other two controls excluded from this lane.

## Single source of truth

Section 12.2 describes the current desktop behavior implemented in `packages/desktop/src/renderer/taskShell.ts` and composed by `TeXRAApp`.

## Duplication and abstraction budget

One stale paragraph corrected. No abstraction or runtime change.

## Net elements (R6)

One existing document changed: four lines added, two removed. No new files, exports, types, dependencies, or tests.

## Consumer counts (R8)

Not applicable: no code or event path changes.

## Host impact

Extension and CLI: none. Desktop: the specification now matches the existing dock.

## Scheduled refactoring

None introduced. The future composer-slot condition records ruling 3 in #11917, as requested by #11939; it does not claim that the current component has a slot.

## Verified

Compared the paragraph with `conversationDockTemplate` and its placement in the desktop app. Confirmed that no open PR modifies this document at the time work started. The composer-color issue #11857 was separately found to be corrected already by #11916 and was closed with source evidence; no speculative CSS change is included.

## Validation

- Formatting and `git diff --check` passed.
- Full `npm run typecheck`, `npm run lint`, and `npm run compile:fast` passed.
- Full `npm test`: 9,086 passed, six skipped, across 764 passing suites.
- `npm run check:dead-code-ratchet`: 285 findings against 285 existing allowances, no new findings.
- `npm run check:guidance-refs`: all 58 documents checked successfully.
- No test suite is touched; no new test file or test case was added for this prose correction.
