### PR TITLE
fix: preserve the complete session owner identity

### DIFF
--- a/docs/proposals/2026-09-03-persistence-substrate-decision.md
+++ b/docs/proposals/2026-09-03-persistence-substrate-decision.md
@@ -266,6 +266,19 @@ event_sequence
   INDEX (parent_id)
 ```
 
+The ordinal column is named `commit` in the event vocabulary and quoted as
+`"commit"` at every SQL declaration and reference, including all C7 queries.
+The stage 0 host measurements rejected the unquoted SQLite keyword on every
+supported floor.
+
+Every connection sets a nonzero `PRAGMA busy_timeout` before any other
+configuration statement, including `PRAGMA journal_mode = WAL`, which can
+itself contend with another opener. Stage 0 measured 26 to 55 percent failed
+appends with no busy timeout and zero failures with it across 800 concurrent
+four-kilobyte appends. The initial timeout is 5000 ms. Exhausting it fails the
+transaction explicitly; it never permits dropping an event or assigning an
+ordinal outside the transaction.
+
 Every connection enables and verifies `PRAGMA foreign_keys = ON` before any
 transaction. Parents are inserted before dependents and an aggregate's
 sequence row before its first event. The two foreign keys make deleting a

--- a/docs/proposals/2026-09-03-persistence-substrate-decision.md
+++ b/docs/proposals/2026-09-03-persistence-substrate-decision.md
@@ -245,7 +245,7 @@ two permanent settings files (`state.json`, `config.json`).
 
 ```
 event
-  commit        INTEGER PRIMARY KEY AUTOINCREMENT   -- database-wide total order, never reused
+  "commit"      INTEGER PRIMARY KEY AUTOINCREMENT   -- database-wide total order, never reused
   aggregate_id  TEXT NOT NULL REFERENCES event_sequence(aggregate_id) ON DELETE CASCADE
   seq           INTEGER NOT NULL                    -- per-aggregate, dense from 1
   type          TEXT NOT NULL                       -- versioned, e.g. "run.start.1"
@@ -254,8 +254,8 @@ event
   data          TEXT NOT NULL                       -- Zod-validated JSON payload
   UNIQUE (aggregate_id, seq)
   INDEX (aggregate_id, type, seq)                   -- latest-of-type per stream
-  INDEX (aggregate_id, commit)                      -- bounded cross-aggregate resume reads
-  INDEX (type, commit)                              -- listing tier across streams
+  INDEX (aggregate_id, "commit")                    -- bounded cross-aggregate resume reads
+  INDEX (type, "commit")                            -- listing tier across streams
 
 event_sequence
   aggregate_id  TEXT PRIMARY KEY                    -- kind-qualified AggregateId (C2)
@@ -499,7 +499,7 @@ publisher waits for a remote renderer.
 
 **C7. Read path.** Five read queries, bounded reads, and one wake level:
 
-- `all(fromCommit, throughCommit?)`: events with `commit > fromCommit` in
+- `all(fromCommit, throughCommit?)`: events with `"commit" > fromCommit` in
   commit order. The optional inclusive upper bound makes one finite read;
   without it, this supplies the table tail and the frozen NDJSON projection,
   which needs every row including transcript rows of unsubscribed streams.
@@ -516,8 +516,8 @@ publisher waits for a remote renderer.
   aggregates, not streams: the stream aggregate plus its execution aggregate
   (via the `run.start` edge), each with its own `fromSeq`.
 - `aggregatesAfterCommit(aggregateIds, afterCommit)`: rows of only the named
-  aggregates with `commit > afterCommit`, returned in commit order through
-  `(aggregate_id, commit)`. Resume supplies the stream and execution ids and
+  aggregates with `"commit" > afterCommit`, returned in commit order through
+  `(aggregate_id, "commit")`. Resume supplies the stream and execution ids and
   the latest snapshot's commit. Execution `seq` is never reused as a stream
   cursor, and a dormant run never scans unrelated session history. The
   message-base read in runtime §2.3 uses the same execution index with an
@@ -550,7 +550,7 @@ before closing the transaction. The typed edges include a workflow's
 `checkpointId` under its `workflow-checkpoint` kind. Newly delivered streams
 and their execution, checkpoint, or inquiry aggregates receive current claims in the same batch,
 without waiting for another event. The bound is the SQLite-maintained committed ordinal,
-not `MAX(event.commit)`, which can fall when retention removes rows.
+not `MAX(event."commit")`, which can fall when retention removes rows.
 
 The batch keeps events before text/local inputs and ends with the existing
 transient `Drained` marker, extended by one field:
@@ -625,7 +625,7 @@ a `seq` value. The reserved migration aggregate is excluded from these
 session queries.
 
 **C8. Two-tier residency.** Listing facts are latest-of-type lookups over the
-`(aggregate_id, type, seq)` index, or a `GROUP BY` over `(type, commit)` for
+`(aggregate_id, type, seq)` index, or a `GROUP BY` over `(type, "commit")` for
 the whole session; they never fold transcripts. One listing fact is a set,
 not a latest: outstanding approvals are every `approval.requested` on the
 aggregate without a matching `approval.resolved`, keyed by request id, over

--- a/docs/proposals/2026-09-06-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-06-consolidation-and-native-methods-survey.md
@@ -1,7 +1,7 @@
 # Survey: code consolidation and native-method opportunities (2026-09-06)
 
 > **Status:** Written 2026-09-06 against branch HEAD `03d2cfd` (`chore(deps-dev):
-> bump the development-dependencies group across 1 directory with 6 updates`,
+bump the development-dependencies group across 1 directory with 6 updates`,
 > #11842). Scheduled routine re-ran the standing question — "find
 > duplicate/similar logic to consolidate, and hand-rolled code that a native
 > method or the standard library already covers" — three days after
@@ -56,10 +56,16 @@ were the same function:
 const s = signal(initial);
 const fiber = runtime.runFork(
   Stream.runForEachArray(changes, (arr) =>
-    Effect.sync(() => { s.set(arr.at(-1) as A); }),
+    Effect.sync(() => {
+      s.set(arr.at(-1) as A);
+    }),
   ),
 );
-return Object.assign(s, { dispose: () => { runtime.runFork(Fiber.interrupt(fiber)); } });
+return Object.assign(s, {
+  dispose: () => {
+    runtime.runFork(Fiber.interrupt(fiber));
+  },
+});
 
 // packages/cli/.../sessionView.ts — viewSignal (new in this window, #11881)
 const s = signal(SubscriptionRef.getUnsafe(view));
@@ -71,7 +77,11 @@ const fiber = runtime.runFork(
     }),
   ),
 );
-return Object.assign(s, { dispose: () => { runtime.runFork(Fiber.interrupt(fiber)); } });
+return Object.assign(s, {
+  dispose: () => {
+    runtime.runFork(Fiber.interrupt(fiber));
+  },
+});
 ```
 
 `viewSignal`'s three call-site arguments (`effectRuntime()`,

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -25,7 +25,7 @@ const nonce = 'texra-webview-smoke';
 // transcript tier for the aggregates the subscribe named), the way
 // `SessionFramer` cuts a frame.
 const SESSION_KEY = '/tmp/texra-smoke/paper';
-const OWNER = '4242:2026-09-04T00:00:00.000Z';
+const OWNER = '["test-host",4242,"2026-09-04T00:00:00.000Z"]';
 const NOW = 1_783_353_600_000;
 const STREAM = 'research#smoke0000001';
 const EXECUTION = 'a1b2c3d4e5f6';

--- a/src/agent/runtime/SessionEvents.ts
+++ b/src/agent/runtime/SessionEvents.ts
@@ -23,6 +23,10 @@
  * called by `SessionHandle.publish` before the log moves, so it observes
  * every fact in publish order; renderers read `all(cursor)`.
  */
+// Node imports
+import { hostname } from 'node:os';
+
+// Third-party imports
 import {
   Context,
   Effect,
@@ -61,21 +65,13 @@ import {
 
 const logger = createLog('sessionEvents');
 
-/** The start-identity half of an owner id when the host could not read its
- *  own: a process whose start no probe can compare is unprovable, never
- *  dead (`proveOwnerLiveness`). */
-const UNREADABLE_PROCESS_START = 'unreadable';
-
-/** This process's owner id (contract C5), from the host's start identity. */
+/** This process's complete owner identity (contract C5). */
 export function processOwnerId(processStart: string | undefined): OwnerId {
-  return `${process.pid}:${processStart ?? UNREADABLE_PROCESS_START}`;
-}
-
-/** The start identity an owner id carries, null when its host could not
- *  read one (the liveness probe then reports the owner unprovable). */
-export function ownerProcessStart(ownerId: OwnerId): string | null {
-  const start = ownerId.slice(ownerId.indexOf(':') + 1);
-  return start === UNREADABLE_PROCESS_START ? null : start;
+  return JSON.stringify([
+    hostname().toLowerCase(),
+    process.pid,
+    processStart ?? null,
+  ]);
 }
 
 /**

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -21,8 +21,6 @@
  * from the summary tier when a reader subscribes; the event table replaces
  * that.
  */
-import * as os from 'node:os';
-
 import {
   Context,
   Duration,
@@ -44,7 +42,6 @@ import { proveOwnerLiveness } from '@agent/storage/leaseOwnerLiveness';
 import { runInSession } from '@agent/runtime/RunContext';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import {
-  ownerProcessStart,
   processOwnerId,
   SessionEventLog,
   sessionEventsLayer,
@@ -60,6 +57,7 @@ import { createLog } from '@logger/logUtils';
 import { effectRuntime, initProcessRuntime } from '@platform/processRuntime';
 import { SHUTDOWN_PHASE_DEADLINE_MS } from '@platform/defaults/lifecycleHost';
 import {
+  ownerIdentity,
   type OwnerId,
   type SessionCloseReport,
   type StreamTabId,
@@ -156,11 +154,7 @@ const ownerLiveness = Layer.effectDiscard(
       const held: OwnerId[] = [];
       for (const owner of owners) {
         const liveness = yield* Effect.promise(() =>
-          proveOwnerLiveness({
-            pid: Number(owner.slice(0, owner.indexOf(':'))),
-            processStart: ownerProcessStart(owner),
-            hostname: os.hostname(),
-          }),
+          proveOwnerLiveness(ownerIdentity(owner)),
         );
         if (liveness !== 'dead') held.push(owner);
       }

--- a/src/shared/schemas/sessionEvent.ts
+++ b/src/shared/schemas/sessionEvent.ts
@@ -15,7 +15,10 @@
  * transport stay free of `@agent/*` (`dependencyDirection.vitest.ts` keeps the
  * shared-to-agent allowlist empty).
  */
+import { Result } from 'effect';
 import { z } from 'zod';
+
+import { parseJsonWith } from '@common/parsing/safeParseJson';
 
 import { TexraApprovalPolicySchema } from '@shared/approvalPolicy';
 import { AgentCategorySchema } from './agent';
@@ -43,19 +46,44 @@ import { StageKindSchema } from './taskGroup';
 import { TodoItemSchema } from './todo';
 import { ExtendedTokenUsageStatsSchema } from './usage';
 
+/** C5's complete process identity, encoded canonically without losing null. */
+const OwnerIdentitySchema = z.tuple([
+  z.string().min(1),
+  z.int().positive(),
+  z.string().min(1).nullable(),
+]);
+
 /**
- * The identity of a TeXRA process: `${pid}:${processStart}`, the
- * `owner_id` the substrate stamps at insert from the writing process
- * (contract C5). One value per process, stamped on every run it launched;
- * liveness is probed per owner, never per run (PRD 5.2). Never a lease token.
+ * JSON.stringify([hostname.toLowerCase(), pid, processStart]). Host identity
+ * is necessary: a missing local pid cannot prove a foreign process dead.
  */
-export const OwnerIdSchema = z.string().regex(/^\d+:.+$/);
+export const OwnerIdSchema = z.string().refine(
+  (value) =>
+    Result.match(parseJsonWith(value, OwnerIdentitySchema), {
+      onSuccess: (identity) =>
+        identity[0] === identity[0].toLowerCase() &&
+        JSON.stringify(identity) === value,
+      onFailure: () => false,
+    }),
+  'Expected a canonical [hostname, pid, processStart] process identity',
+);
 export type OwnerId = z.infer<typeof OwnerIdSchema>;
 
-/** The pid half of an owner id, the one part of a process identity a user
- *  can act on (`kill`, Activity Monitor). */
-export function ownerPid(ownerId: string): number {
-  return Number(ownerId.slice(0, ownerId.indexOf(':')));
+/** Decode an owner already validated at the event or transport boundary. */
+export function ownerIdentity(ownerId: OwnerId): {
+  hostname: string;
+  pid: number;
+  processStart: string | null;
+} {
+  const [hostname, pid, processStart] = JSON.parse(ownerId) as z.infer<
+    typeof OwnerIdentitySchema
+  >;
+  return { hostname, pid, processStart };
+}
+
+/** The recorded pid shown when another process holds a run. */
+export function ownerPid(ownerId: OwnerId): number {
+  return ownerIdentity(ownerId).pid;
 }
 
 /** A stream id or an inquiry thread id: the `aggregate_id` half of the

--- a/src/shared/session/sessionEvents.ts
+++ b/src/shared/session/sessionEvents.ts
@@ -23,7 +23,7 @@ import type {
 export type SessionCursor = CommitOrdinal;
 
 /**
- * The identity of this process, `${pid}:${processStart}` (contract C5): the
+ * The canonical hostname, pid, and nullable process-start tuple (C5): the
  * `ownerId` stamped on every event the process appends and the `self` entry
  * of its local runtime snapshot. Resolved once at each process entry, where
  * the start identity can be awaited, and provided to the process layer.

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -49,8 +49,8 @@ import { testExecutionHandle } from '@test/support/executionHandleFixtures';
 import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 
-const SELF = '4242:self-start';
-const OTHER = '4343:other-start';
+const SELF = '["test-host",4242,"self-start"]';
+const OTHER = '["test-host",4343,"other-start"]';
 const STREAM = 'stream:framing' as StreamTabId;
 const EXECUTION = 'ab12cd' as ExecutionId;
 const OLDER = 'stream:older' as StreamTabId;

--- a/src/test-kernel/controllers/session/sessionFramer.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionFramer.vitest.ts
@@ -44,7 +44,7 @@ import type { SessionView } from '@shared/session/sessionView';
 import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 
-const SELF = '4242:self-start';
+const SELF = '["test-host",4242,"self-start"]';
 const KEY = '/workspace/framing';
 const STREAM = 'stream:framing' as StreamTabId;
 const EXECUTION = 'ab12cd' as ExecutionId;

--- a/src/test-kernel/shared/session/fanOutScenario.ts
+++ b/src/test-kernel/shared/session/fanOutScenario.ts
@@ -27,8 +27,8 @@ import {
 } from '@shared/session/sessionView';
 
 /** A process identity, never a lease token (contract C5). */
-export const OWNER = '4242:2026-09-04T00:00:00.000Z';
-export const OTHER_OWNER = '4343:2026-09-04T00:00:00.000Z';
+export const OWNER = '["test-host",4242,"2026-09-04T00:00:00.000Z"]';
+export const OTHER_OWNER = '["test-host",4343,"2026-09-04T00:00:00.000Z"]';
 export const ROOT = 'review#aaaaaaaaaaaa' as StreamTabId;
 export const CHILD = 'search#bbbbbbbbbbbb' as StreamTabId;
 export const GRANDCHILD = 'lint#dddddddddddd' as StreamTabId;


### PR DESCRIPTION
## Summary

A session owner currently records only a pid and process-start string. The liveness probe supplies the local hostname when decoding that owner, so a foreign machine's identity cannot survive the round trip. Encode the complete C5 identity as `JSON.stringify([hostname.toLowerCase(), pid, processStart])` and pass the recorded identity to the existing liveness proof. A missing start identity remains null.

Delete the pid-only decoder and its `unreadable` placeholder. The shared Zod schema validates the canonical encoding at event and transport boundaries, and the displayed pid comes from that same representation.

Record stage 0's measured C1 amendments: quote the SQL `commit` column and configure a nonzero busy timeout before WAL. Also apply the repository formatter to the unrelated proposal that currently fails stage 1's static CI job.

## Issue acceptance gates

Part of #11867, stage 6's owner-identity prerequisite. This is not completion of stage 6: database claims, takeover, release, and deletion remain subsequent work. D4, retention, scrubbing, and legacy import semantics are unchanged. Targets only `cutover/persistence-substrate`.

## Single source of truth

`OwnerIdSchema` defines the process identity encoding. `ownerIdentity` decodes its validated value; `proveOwnerLiveness` remains the only liveness proof.

## Duplication and abstraction budget

Remove the `pid:start` representation, the missing-start sentinel, and the probe's separately assembled identity. No new file, service, or class.

## Net elements (R6)

Files: 0 added, 0 deleted. Exported functions: `ownerIdentity` added, `ownerProcessStart` deleted. Classes/interfaces/enums: unchanged. Diff: +82/-41 lines, including the measured contract amendments and formatting repair.

## Consumer counts (R8)

`ownerProcessStart` had one production caller, the session liveness probe. That caller now passes `ownerIdentity(owner)` directly to `proveOwnerLiveness`. `ownerPid` retains its one display-fold caller. No event publisher or subscription was removed.

## Host impact

Extension, desktop, and CLI preserve the host component in their session owner identity. Shared renderer decoding uses the same canonical schema. No host floor changes.

## Scheduled refactoring

Remaining persistence stages are tracked by #11867. This change adds no temporary compatibility reader.

## Validation

Passed: `npm run format`, full `npm run typecheck`, `npm run lint`, `npm run compile:fast`, affected session/framing/fold suites (23 tests), existing execution-lease suite, `npm test` once, dead-code ratchet, and `git diff --check`. These full checks ran with the unchanged stage 1 foundation also present; this independent commit was then based directly on the cutover branch, with workspace typecheck and lint repeated.

The Effect migration ratchet fails on the existing #11949 findings. Its output, from the first mechanism count onward, is byte-identical to the untouched stage 1 worktree. No baseline was changed. The retired-marker repair belongs to #11950 and is not included here.
