### PR TITLE
fix: isolate session aggregate lifecycles by kind

### DIFF
--- a/docs/proposals/2026-09-03-persistence-substrate-decision.md
+++ b/docs/proposals/2026-09-03-persistence-substrate-decision.md
@@ -266,6 +266,19 @@ event_sequence
   INDEX (parent_id)
 ```
 
+The ordinal column is named `commit` in the event vocabulary and quoted as
+`"commit"` at every SQL declaration and reference, including all C7 queries.
+The stage 0 host measurements rejected the unquoted SQLite keyword on every
+supported floor.
+
+Every connection sets a nonzero `PRAGMA busy_timeout` before any other
+configuration statement, including `PRAGMA journal_mode = WAL`, which can
+itself contend with another opener. Stage 0 measured 26 to 55 percent failed
+appends with no busy timeout and zero failures with it across 800 concurrent
+four-kilobyte appends. The initial timeout is 5000 ms. Exhausting it fails the
+transaction explicitly; it never permits dropping an event or assigning an
+ordinal outside the transaction.
+
 Every connection enables and verifies `PRAGMA foreign_keys = ON` before any
 transaction. Parents are inserted before dependents and an aggregate's
 sequence row before its first event. The two foreign keys make deleting a

--- a/docs/proposals/2026-09-03-persistence-substrate-decision.md
+++ b/docs/proposals/2026-09-03-persistence-substrate-decision.md
@@ -245,7 +245,7 @@ two permanent settings files (`state.json`, `config.json`).
 
 ```
 event
-  commit        INTEGER PRIMARY KEY AUTOINCREMENT   -- database-wide total order, never reused
+  "commit"      INTEGER PRIMARY KEY AUTOINCREMENT   -- database-wide total order, never reused
   aggregate_id  TEXT NOT NULL REFERENCES event_sequence(aggregate_id) ON DELETE CASCADE
   seq           INTEGER NOT NULL                    -- per-aggregate, dense from 1
   type          TEXT NOT NULL                       -- versioned, e.g. "run.start.1"
@@ -254,8 +254,8 @@ event
   data          TEXT NOT NULL                       -- Zod-validated JSON payload
   UNIQUE (aggregate_id, seq)
   INDEX (aggregate_id, type, seq)                   -- latest-of-type per stream
-  INDEX (aggregate_id, commit)                      -- bounded cross-aggregate resume reads
-  INDEX (type, commit)                              -- listing tier across streams
+  INDEX (aggregate_id, "commit")                    -- bounded cross-aggregate resume reads
+  INDEX (type, "commit")                            -- listing tier across streams
 
 event_sequence
   aggregate_id  TEXT PRIMARY KEY                    -- kind-qualified AggregateId (C2)
@@ -499,7 +499,7 @@ publisher waits for a remote renderer.
 
 **C7. Read path.** Five read queries, bounded reads, and one wake level:
 
-- `all(fromCommit, throughCommit?)`: events with `commit > fromCommit` in
+- `all(fromCommit, throughCommit?)`: events with `"commit" > fromCommit` in
   commit order. The optional inclusive upper bound makes one finite read;
   without it, this supplies the table tail and the frozen NDJSON projection,
   which needs every row including transcript rows of unsubscribed streams.
@@ -516,8 +516,8 @@ publisher waits for a remote renderer.
   aggregates, not streams: the stream aggregate plus its execution aggregate
   (via the `run.start` edge), each with its own `fromSeq`.
 - `aggregatesAfterCommit(aggregateIds, afterCommit)`: rows of only the named
-  aggregates with `commit > afterCommit`, returned in commit order through
-  `(aggregate_id, commit)`. Resume supplies the stream and execution ids and
+  aggregates with `"commit" > afterCommit`, returned in commit order through
+  `(aggregate_id, "commit")`. Resume supplies the stream and execution ids and
   the latest snapshot's commit. Execution `seq` is never reused as a stream
   cursor, and a dormant run never scans unrelated session history. The
   message-base read in runtime §2.3 uses the same execution index with an
@@ -550,7 +550,7 @@ before closing the transaction. The typed edges include a workflow's
 `checkpointId` under its `workflow-checkpoint` kind. Newly delivered streams
 and their execution, checkpoint, or inquiry aggregates receive current claims in the same batch,
 without waiting for another event. The bound is the SQLite-maintained committed ordinal,
-not `MAX(event.commit)`, which can fall when retention removes rows.
+not `MAX(event."commit")`, which can fall when retention removes rows.
 
 The batch keeps events before text/local inputs and ends with the existing
 transient `Drained` marker, extended by one field:
@@ -625,7 +625,7 @@ a `seq` value. The reserved migration aggregate is excluded from these
 session queries.
 
 **C8. Two-tier residency.** Listing facts are latest-of-type lookups over the
-`(aggregate_id, type, seq)` index, or a `GROUP BY` over `(type, commit)` for
+`(aggregate_id, type, seq)` index, or a `GROUP BY` over `(type, "commit")` for
 the whole session; they never fold transcripts. One listing fact is a set,
 not a latest: outstanding approvals are every `approval.requested` on the
 aggregate without a matching `approval.resolved`, keyed by request id, over

--- a/docs/proposals/2026-09-06-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-06-consolidation-and-native-methods-survey.md
@@ -1,7 +1,7 @@
 # Survey: code consolidation and native-method opportunities (2026-09-06)
 
 > **Status:** Written 2026-09-06 against branch HEAD `03d2cfd` (`chore(deps-dev):
-> bump the development-dependencies group across 1 directory with 6 updates`,
+bump the development-dependencies group across 1 directory with 6 updates`,
 > #11842). Scheduled routine re-ran the standing question — "find
 > duplicate/similar logic to consolidate, and hand-rolled code that a native
 > method or the standard library already covers" — three days after
@@ -56,10 +56,16 @@ were the same function:
 const s = signal(initial);
 const fiber = runtime.runFork(
   Stream.runForEachArray(changes, (arr) =>
-    Effect.sync(() => { s.set(arr.at(-1) as A); }),
+    Effect.sync(() => {
+      s.set(arr.at(-1) as A);
+    }),
   ),
 );
-return Object.assign(s, { dispose: () => { runtime.runFork(Fiber.interrupt(fiber)); } });
+return Object.assign(s, {
+  dispose: () => {
+    runtime.runFork(Fiber.interrupt(fiber));
+  },
+});
 
 // packages/cli/.../sessionView.ts — viewSignal (new in this window, #11881)
 const s = signal(SubscriptionRef.getUnsafe(view));
@@ -71,7 +77,11 @@ const fiber = runtime.runFork(
     }),
   ),
 );
-return Object.assign(s, { dispose: () => { runtime.runFork(Fiber.interrupt(fiber)); } });
+return Object.assign(s, {
+  dispose: () => {
+    runtime.runFork(Fiber.interrupt(fiber));
+  },
+});
 ```
 
 `viewSignal`'s three call-site arguments (`effectRuntime()`,

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -48,6 +48,7 @@ import {
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   LOG_LEVELS,
   MESSAGE_TYPES,
@@ -680,7 +681,7 @@ function seedStream(
   };
   publish({
     type: 'run.start',
-    aggregateId: streamId,
+    aggregateId: qualifyAggregateId('stream', streamId),
     executionId,
     identity,
     category: options.category ?? AgentCategory.ToolUse,
@@ -694,7 +695,7 @@ function seedStream(
   if (identity.kind === 'agent') {
     publish({
       type: 'run.config',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       executionId,
       config: { model: HARNESS_MODEL },
     });
@@ -710,7 +711,7 @@ function seedPhase(
   seedStream(streamId);
   publish({
     type: 'status',
-    aggregateId: streamId,
+    aggregateId: qualifyAggregateId('stream', streamId),
     phase,
     cause: 'harness',
     ...(runStartedAt !== undefined ? { runStartedAt } : {}),
@@ -720,13 +721,16 @@ function seedPhase(
 function seedDescription(streamId: StreamTabId, description: string): void {
   publish({
     type: 'updateStreamDescription',
-    aggregateId: streamId,
+    aggregateId: qualifyAggregateId('stream', streamId),
     description,
   });
 }
 
 function removeStream(streamId: StreamTabId): void {
-  publish({ type: 'stream.removed', aggregateId: streamId });
+  publish({
+    type: 'stream.removed',
+    aggregateId: qualifyAggregateId('stream', streamId),
+  });
   harnessStreams.delete(streamId);
 }
 
@@ -1263,7 +1267,7 @@ seedRows(STREAM_ID, harnessInitialEntries());
 if (QUEUED_FOLLOW_UPS.length > 0) {
   publish({
     type: 'updateQueuedFollowUps',
-    aggregateId: STREAM_ID,
+    aggregateId: qualifyAggregateId('stream', STREAM_ID),
     messages: QUEUED_FOLLOW_UPS,
   });
 }
@@ -1440,7 +1444,7 @@ if (SHOW_CHILDREN) {
     if (child.agentName === 'reviewer') {
       publish({
         type: 'usage',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         storageKey: child.executionId as ExecutionId,
         usage: { inputTokens: 52_000, outputTokens: 39_900, cost: 0.12 },
       });
@@ -1501,8 +1505,16 @@ if (SHOW_TODOS) {
     },
   };
   publish(
-    { type: 'updateTodos', aggregateId: STREAM_ID, todos: [...workPlan.todos] },
-    { type: 'updatePlan', aggregateId: STREAM_ID, plan: workPlan.plan },
+    {
+      type: 'updateTodos',
+      aggregateId: qualifyAggregateId('stream', STREAM_ID),
+      todos: [...workPlan.todos],
+    },
+    {
+      type: 'updatePlan',
+      aggregateId: qualifyAggregateId('stream', STREAM_ID),
+      plan: workPlan.plan,
+    },
   );
 }
 
@@ -1611,7 +1623,7 @@ if (SHOW_EXTERNAL_INQUIRY) {
   });
   publish({
     type: 'inquiryThreadUpdated',
-    aggregateId: EXTERNAL_INQUIRY_THREAD_ID,
+    aggregateId: qualifyAggregateId('inquiry', EXTERNAL_INQUIRY_THREAD_ID),
     threadId: EXTERNAL_INQUIRY_THREAD_ID,
     parentStreamId: STREAM_ID,
     status: 'open',

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -3,10 +3,11 @@ import { Effect, Fiber, Stream, SubscriptionRef } from 'effect';
 import { agentConfigToTaskState, type SessionHandle } from '@agent/runtime';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import { effectRuntime } from '@platform/processRuntime';
-import type {
-  ActiveChildInfo,
-  SessionEvent,
-  StreamTabId,
+import {
+  aggregateTarget,
+  type ActiveChildInfo,
+  type SessionEvent,
+  type StreamTabId,
 } from '@shared/schemas';
 import { roundStageFromStageStart } from '@shared/streams/stage';
 import { assertNever } from '@utils/core';
@@ -67,7 +68,7 @@ export type CliNdjsonProgressRecordWriter = (record: CliNdjsonRecord) => void;
 function projectCliSessionEvent(
   event: SessionEvent,
 ): CliProjectedNdjsonProgressEvent | undefined {
-  const streamId = event.aggregateId as StreamTabId;
+  const streamId = aggregateTarget(event.aggregateId).id;
   switch (event.type) {
     case 'run.activate':
       return {

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -4,6 +4,7 @@ import type { SessionHandle } from '@agent/runtime';
 import { createSessionStores } from '@controllers/session/createSessionStores';
 import { createLog } from '@logger/logUtils';
 import { effectRuntime } from '@platform/processRuntime';
+import { aggregateTarget } from '@shared/schemas';
 import { toLogData } from './desktopLogUtils.js';
 
 /**
@@ -22,11 +23,13 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
     Stream.runForEach(session.events.all(session.now()), (event) =>
       Effect.sync(() => {
         if (event.type !== 'stream.removed') return;
-        void stores.deleteStream(event.aggregateId).catch((error: unknown) => {
-          logger.warn('Failed to delete a headless desktop stream', {
-            data: toLogData(error),
+        void stores
+          .deleteStream(aggregateTarget(event.aggregateId).id)
+          .catch((error: unknown) => {
+            logger.warn('Failed to delete a headless desktop stream', {
+              data: toLogData(error),
+            });
           });
-        });
       }),
     ),
   );

--- a/packages/extension/src/frontend/events/runFactSubscriptions.ts
+++ b/packages/extension/src/frontend/events/runFactSubscriptions.ts
@@ -3,7 +3,7 @@ import { Effect, Fiber, Stream } from 'effect';
 // Local imports
 import type { SessionHandle } from '@agent/runtime';
 import { effectRuntime } from '@platform/processRuntime';
-import type { AddOutputFilesPayload } from '@shared/schemas';
+import { aggregateTarget, type AddOutputFilesPayload } from '@shared/schemas';
 
 /** Read a session's `addOutputFiles` facts from now on. */
 export function subscribeAddOutputFilesRunFact(
@@ -15,7 +15,7 @@ export function subscribeAddOutputFilesRunFact(
       Effect.sync(() => {
         if (event.type !== 'addOutputFiles') return;
         listener({
-          streamId: event.aggregateId,
+          streamId: aggregateTarget(event.aggregateId).id,
           filesByRound: event.filesByRound,
         });
       }),

--- a/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
+++ b/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
@@ -3,6 +3,7 @@ import { Effect, Fiber, Stream } from 'effect';
 // Local imports - runtime events
 import type { SessionHandle } from '@agent/runtime';
 import { effectRuntime } from '@platform/processRuntime';
+import { aggregateTarget } from '@shared/schemas';
 
 interface StatusBarSessionEventOptions {
   session: Pick<SessionHandle, 'events' | 'now' | 'status'>;
@@ -31,7 +32,7 @@ export function subscribeStatusBarSessionEvents({
         // total, so stale async events skip the refresh.
         if (
           event.type === 'usage' &&
-          session.status.isInFlight(event.aggregateId)
+          session.status.isInFlight(aggregateTarget(event.aggregateId).id)
         ) {
           onUsageChanged();
         }

--- a/packages/extension/src/progressView/frontend/sessionTransport.ts
+++ b/packages/extension/src/progressView/frontend/sessionTransport.ts
@@ -15,6 +15,7 @@ import {
   installWebviewRuntime,
   WebviewSessions,
 } from '@controllers/session/webviewSessionLayer';
+import { aggregateId as qualifyAggregateId } from '@shared/schemas';
 import { hostBridge } from '@shared/hostBridge';
 import { toSignal, type StreamSignal } from '@shared/signals';
 import type { HostSnapshot } from '@shared/session/hostSnapshot';
@@ -230,7 +231,10 @@ export function transcriptAggregates(
   if (streamId === null) return [];
   const stream = view.streams.get(streamId);
   if (!stream) return [];
-  return [streamId, stream.executionId].map((id) => ({
+  return [
+    qualifyAggregateId('stream', streamId),
+    qualifyAggregateId('execution', stream.executionId),
+  ].map((id) => ({
     id,
     fromSeq: view.folded.get(id) ?? 0,
   }));

--- a/packages/trace-viewer/src/traceFrames.ts
+++ b/packages/trace-viewer/src/traceFrames.ts
@@ -6,6 +6,7 @@
  * immutable, so every `Subscribe` is answered from these rows in full.
  */
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   END_GROUP_STATUS,
   runIdentityDisplayName,
@@ -146,7 +147,7 @@ function listingBodies(trace: TraceDocument): SessionEventDraft[] {
   const bodies: SessionEventDraft[] = [
     {
       type: 'run.start',
-      aggregateId: trace.streamId,
+      aggregateId: qualifyAggregateId('stream', trace.streamId),
       executionId,
       identity,
       userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
@@ -157,7 +158,7 @@ function listingBodies(trace: TraceDocument): SessionEventDraft[] {
     },
     {
       type: 'run.config',
-      aggregateId: trace.streamId,
+      aggregateId: qualifyAggregateId('stream', trace.streamId),
       executionId,
       config: {
         model: trace.config.model,
@@ -170,21 +171,21 @@ function listingBodies(trace: TraceDocument): SessionEventDraft[] {
   if (trace.meta?.description) {
     bodies.push({
       type: 'updateStreamDescription',
-      aggregateId: trace.streamId,
+      aggregateId: qualifyAggregateId('stream', trace.streamId),
       description: trace.meta.description,
     });
   }
   if (snapshot.conversationProgress) {
     bodies.push({
       type: 'conversation.progress',
-      aggregateId: trace.streamId,
+      aggregateId: qualifyAggregateId('stream', trace.streamId),
       progress: snapshot.conversationProgress,
     });
   }
   for (const [storageKey, usage] of Object.entries(snapshot.runUsage)) {
     bodies.push({
       type: 'usage',
-      aggregateId: trace.streamId,
+      aggregateId: qualifyAggregateId('stream', trace.streamId),
       storageKey,
       usage,
     });
@@ -193,17 +194,17 @@ function listingBodies(trace: TraceDocument): SessionEventDraft[] {
     bodies.push(
       {
         type: 'addOutputFiles',
-        aggregateId: trace.streamId,
+        aggregateId: qualifyAggregateId('stream', trace.streamId),
         filesByRound: snapshot.outputFilesByRound,
       },
       {
         type: 'updateMissingOutputs',
-        aggregateId: trace.streamId,
+        aggregateId: qualifyAggregateId('stream', trace.streamId),
         filesByRound: snapshot.missingOutputsByRound,
       },
       {
         type: 'updateCompileFailures',
-        aggregateId: trace.streamId,
+        aggregateId: qualifyAggregateId('stream', trace.streamId),
         filesByRound: snapshot.compileFailuresByRound,
       },
     );
@@ -211,10 +212,14 @@ function listingBodies(trace: TraceDocument): SessionEventDraft[] {
     bodies.push(
       {
         type: 'updateTodos',
-        aggregateId: trace.streamId,
+        aggregateId: qualifyAggregateId('stream', trace.streamId),
         todos: snapshot.todos,
       },
-      { type: 'updatePlan', aggregateId: trace.streamId, plan: snapshot.plan },
+      {
+        type: 'updatePlan',
+        aggregateId: qualifyAggregateId('stream', trace.streamId),
+        plan: snapshot.plan,
+      },
     );
   }
   const outcome = traceOutcome(trace);
@@ -222,7 +227,7 @@ function listingBodies(trace: TraceDocument): SessionEventDraft[] {
     bodies.push(
       {
         type: 'status',
-        aggregateId: trace.streamId,
+        aggregateId: qualifyAggregateId('stream', trace.streamId),
         phase: outcome,
         previousPhase: null,
         cause: 'trace',
@@ -231,7 +236,7 @@ function listingBodies(trace: TraceDocument): SessionEventDraft[] {
       },
       {
         type: 'result',
-        aggregateId: trace.streamId,
+        aggregateId: qualifyAggregateId('stream', trace.streamId),
         outcome,
         executionId,
         category,
@@ -264,7 +269,11 @@ function traceEvents(trace: TraceDocument): {
   };
   const listing = listingBodies(trace).map(stamp);
   const transcript = trace.entries.map((entry) =>
-    stamp({ type: 'transcript.entry', aggregateId: trace.streamId, entry }),
+    stamp({
+      type: 'transcript.entry',
+      aggregateId: qualifyAggregateId('stream', trace.streamId),
+      entry,
+    }),
   );
   return { listing, transcript };
 }

--- a/packages/trace-viewer/src/traceFrames.ts
+++ b/packages/trace-viewer/src/traceFrames.ts
@@ -307,7 +307,8 @@ export function traceFrame(
 ): EventsFrame {
   const { listing, transcript } = traceEvents(trace);
   const named = subscribe.aggregates.some(
-    (aggregate) => aggregate.id === trace.streamId,
+    (aggregate) =>
+      aggregate.id === qualifyAggregateId('stream', trace.streamId),
   );
   return {
     kind: 'events',

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -25,7 +25,7 @@ const nonce = 'texra-webview-smoke';
 // transcript tier for the aggregates the subscribe named), the way
 // `SessionFramer` cuts a frame.
 const SESSION_KEY = '/tmp/texra-smoke/paper';
-const OWNER = '4242:2026-09-04T00:00:00.000Z';
+const OWNER = '["test-host",4242,"2026-09-04T00:00:00.000Z"]';
 const NOW = 1_783_353_600_000;
 const STREAM = 'research#smoke0000001';
 const EXECUTION = 'a1b2c3d4e5f6';

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -97,7 +97,8 @@ function sessionLog() {
   const seqs = new Map();
   const entrySeqs = new Map();
   let commit = 0;
-  const emit = (aggregateId, at, body) => {
+  const emit = (logicalId, at, body) => {
+    const aggregateId = JSON.stringify(['stream', logicalId]);
     const seq = (seqs.get(aggregateId) ?? 0) + 1;
     seqs.set(aggregateId, seq);
     commit += 1;

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -42,11 +42,12 @@ import { createLog } from '@logger/logUtils';
 import type { CopilotRouteOverride } from '@model/copilotRouting';
 import { resolveRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import { DisposableStore } from '@platform/disposable';
-import type {
-  AgentSource,
-  ExecutionId,
-  StreamTabId,
-  UserFollowUpSupport,
+import {
+  aggregateId as qualifyAggregateId,
+  type AgentSource,
+  type ExecutionId,
+  type StreamTabId,
+  type UserFollowUpSupport,
 } from '@shared/schemas';
 import {
   AgentCategory,
@@ -444,7 +445,7 @@ async function assembleAgentLaunchContext(
       : [
           {
             type: 'run.start' as const,
-            aggregateId: streamId,
+            aggregateId: qualifyAggregateId('stream', streamId),
             executionId,
             identity: { kind: 'agent' as const, agent: config.agent },
             userFollowUpSupport:
@@ -469,7 +470,7 @@ async function assembleAgentLaunchContext(
     // Every activation, first launch and resume alike (PRD 6, item 8).
     {
       type: 'run.activate',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       category: setting.agentCategory,
       isRemote,
       background,

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -2,18 +2,19 @@ import type { ReviewIssueReport } from '@agent/review/reviewIssues';
 import type { ModelCredentialSelection } from '@agent/types/ModelHandlerContracts';
 import { createLog } from '@logger/logUtils';
 import { redactSecrets } from '@logger/redaction';
-import type {
-  AgentProposalPermission,
-  BashPermission,
-  FileLocation,
-  PermissionPayload,
-  PlanApprovalPermission,
-  ProgressPermissionKind,
-  RetryPermission,
-  StreamTabId,
-  UserQuestionAnswers,
-  ExternalInquiryPermission,
-  UserQuestionPermission,
+import {
+  aggregateId as qualifyAggregateId,
+  type AgentProposalPermission,
+  type BashPermission,
+  type FileLocation,
+  type PermissionPayload,
+  type PlanApprovalPermission,
+  type ProgressPermissionKind,
+  type RetryPermission,
+  type StreamTabId,
+  type UserQuestionAnswers,
+  type ExternalInquiryPermission,
+  type UserQuestionPermission,
 } from '@shared/schemas';
 import type { ApprovalBypassKind } from '@shared/approvalBypassKind';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
@@ -849,7 +850,7 @@ export class SessionHostInteractions implements HostInteractions {
     this.session.publish([
       {
         type: 'approval.requested',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         requestId,
         payload: redactedForFact(payload),
       },
@@ -984,7 +985,7 @@ export class SessionHostInteractions implements HostInteractions {
       this.session.publish([
         {
           type: 'approval.resolved',
-          aggregateId: pending.fact.streamId,
+          aggregateId: qualifyAggregateId('stream', pending.fact.streamId),
           requestId: pending.fact.requestId,
         },
       ]);

--- a/src/agent/runtime/SessionEvents.ts
+++ b/src/agent/runtime/SessionEvents.ts
@@ -43,13 +43,15 @@ import {
   runWithWorkspaceRoots,
   type WorkspaceRoots,
 } from '@platform/workspaceRoots';
-import type {
-  AggregateId,
-  CommitOrdinal,
-  OwnerId,
-  SessionEvent,
-  SessionEventDraft,
-  StreamTabId,
+import {
+  aggregateTarget,
+  aggregateId as qualifyAggregateId,
+  type AggregateId,
+  type CommitOrdinal,
+  type OwnerId,
+  type SessionEvent,
+  type SessionEventDraft,
+  type StreamTabId,
 } from '@shared/schemas';
 import {
   ProcessIdentity,
@@ -83,7 +85,7 @@ export function processOwnerId(processStart: string | undefined): OwnerId {
  */
 interface TranscriptRef {
   readonly type: 'transcript.ref';
-  readonly aggregateId: StreamTabId;
+  readonly aggregateId: AggregateId;
   readonly entryId: string;
   readonly seq: number;
   readonly commit: CommitOrdinal;
@@ -207,14 +209,18 @@ export class SessionEventLog extends Context.Service<
         const nextSeq = (aggregateId: AggregateId): number => {
           const seq =
             (seqs.get(aggregateId) ??
-              transcripts.get(aggregateId as StreamTabId)?.head ??
+              (aggregateTarget(aggregateId).kind === 'stream'
+                ? transcripts.get(aggregateTarget(aggregateId).id)?.head
+                : 0) ??
               0) + 1;
           seqs.set(aggregateId, seq);
           return seq;
         };
         const materialize = (row: LogRow): SessionEvent | null => {
           if (row.type !== 'transcript.ref') return row;
-          const entry = transcripts.get(row.aggregateId)?.getById(row.entryId);
+          const entry = transcripts
+            .get(aggregateTarget(row.aggregateId).id)
+            ?.getById(row.entryId);
           if (entry) {
             return {
               type: 'transcript.entry',
@@ -229,7 +235,7 @@ export class SessionEventLog extends Context.Service<
           // A deleted stream's rows are behind its tombstone on the log; a
           // stream that left residency before a reader this far behind read
           // its rows has lost them to that reader.
-          if (transcripts.has(row.aggregateId)) {
+          if (transcripts.has(aggregateTarget(row.aggregateId).id)) {
             logger.warn(
               `Transcript row ${row.entryId} of stream ${row.aggregateId} left residency before commit ${row.commit} was read; the reader does not receive it`,
             );
@@ -248,7 +254,7 @@ export class SessionEventLog extends Context.Service<
                     if (draft.type === 'transcript.entry') {
                       rows.push({
                         type: 'transcript.ref',
-                        aggregateId: draft.aggregateId as StreamTabId,
+                        aggregateId: draft.aggregateId,
                         entryId: draft.entry.id,
                         seq,
                         commit,
@@ -312,10 +318,24 @@ export class SessionEventLog extends Context.Service<
           readAggregate: (aggregateId, fromSeq) =>
             Stream.unwrap(
               Effect.gen(function* () {
+                const target = aggregateTarget(aggregateId);
+                if (target.kind !== 'stream') {
+                  return Stream.fromIterable(
+                    rows
+                      .filter(
+                        (row) =>
+                          row.aggregateId === aggregateId && row.seq > fromSeq,
+                      )
+                      .flatMap((row) => {
+                        const event = materialize(row);
+                        return event === null ? [] : [event];
+                      }),
+                  );
+                }
                 const commit = yield* SubscriptionRef.get(level);
                 const entries = yield* Effect.promise(async () =>
                   runWithWorkspaceRoots(roots, () =>
-                    transcripts.readEntries(aggregateId as StreamTabId),
+                    transcripts.readEntries(target.id),
                   ),
                 );
                 return Stream.fromIterable(
@@ -341,11 +361,12 @@ export class SessionEventLog extends Context.Service<
               () =>
                 !closed.has(aggregateId) &&
                 (seqs.has(aggregateId) ||
-                  isHistoricalStream(
-                    transcripts,
-                    historical,
-                    aggregateId as StreamTabId,
-                  )),
+                  (aggregateTarget(aggregateId).kind === 'stream' &&
+                    isHistoricalStream(
+                      transcripts,
+                      historical,
+                      aggregateTarget(aggregateId).id,
+                    ))),
             ),
         };
       }),
@@ -468,14 +489,14 @@ export function runEventDraft(
     case 'run.config':
       return {
         type: event.type,
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         executionId: event.executionId,
         config: event.config,
       };
     case 'result':
       return {
         type: event.type,
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         outcome: event.outcome,
         executionId: event.executionId,
         category: event.category,
@@ -487,7 +508,7 @@ export function runEventDraft(
     case 'stage.start':
       return {
         type: event.type,
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         id: event.id,
         label: event.label,
         parentId: event.parentId,
@@ -498,37 +519,48 @@ export function runEventDraft(
     case 'conversation.progress':
       return {
         type: event.type,
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         progress: event.progress,
       };
     case 'usage':
       return {
         type: event.type,
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         storageKey: event.payload.storageKey,
         usage: event.payload.usage,
       };
     case 'context.state':
       return {
         type: event.type,
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         inputTokens: event.inputTokens,
         contextWindow: event.contextWindow,
       };
     case 'updateTodos':
-      return { type: event.type, aggregateId: streamId, todos: event.todos };
+      return {
+        type: event.type,
+        aggregateId: qualifyAggregateId('stream', streamId),
+        todos: event.todos,
+      };
     case 'updatePlan':
-      return { type: event.type, aggregateId: streamId, plan: event.plan };
+      return {
+        type: event.type,
+        aggregateId: qualifyAggregateId('stream', streamId),
+        plan: event.plan,
+      };
     case 'addOutputFiles':
     case 'updateMissingOutputs':
     case 'updateCompileFailures':
       return {
         type: event.type,
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         filesByRound: event.filesByRound,
       } as SessionEventDraft;
     case 'goalPaused':
-      return { type: event.type, aggregateId: streamId };
+      return {
+        type: event.type,
+        aggregateId: qualifyAggregateId('stream', streamId),
+      };
     case 'child.activity':
     case 'log':
     case 'stage.end':
@@ -550,7 +582,7 @@ export function runEventDraft(
 export function statusDraft(event: StatusEvent): SessionEventDraft {
   return {
     type: 'status',
-    aggregateId: event.streamId,
+    aggregateId: qualifyAggregateId('stream', event.streamId),
     phase: event.phase,
     previousPhase: event.previousPhase,
     cause: event.cause,

--- a/src/agent/runtime/SessionEvents.ts
+++ b/src/agent/runtime/SessionEvents.ts
@@ -23,6 +23,10 @@
  * called by `SessionHandle.publish` before the log moves, so it observes
  * every fact in publish order; renderers read `all(cursor)`.
  */
+// Node imports
+import { hostname } from 'node:os';
+
+// Third-party imports
 import {
   Context,
   Effect,
@@ -61,21 +65,13 @@ import {
 
 const logger = createLog('sessionEvents');
 
-/** The start-identity half of an owner id when the host could not read its
- *  own: a process whose start no probe can compare is unprovable, never
- *  dead (`proveOwnerLiveness`). */
-const UNREADABLE_PROCESS_START = 'unreadable';
-
-/** This process's owner id (contract C5), from the host's start identity. */
+/** This process's complete owner identity (contract C5). */
 export function processOwnerId(processStart: string | undefined): OwnerId {
-  return `${process.pid}:${processStart ?? UNREADABLE_PROCESS_START}`;
-}
-
-/** The start identity an owner id carries, null when its host could not
- *  read one (the liveness probe then reports the owner unprovable). */
-export function ownerProcessStart(ownerId: OwnerId): string | null {
-  const start = ownerId.slice(ownerId.indexOf(':') + 1);
-  return start === UNREADABLE_PROCESS_START ? null : start;
+  return JSON.stringify([
+    hostname().toLowerCase(),
+    process.pid,
+    processStart ?? null,
+  ]);
 }
 
 /**

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -162,6 +162,8 @@ export class SessionHandle {
   readonly folded: SessionGraph['folded'];
   /** Ordered replay and live inputs for each transport subscription. */
   readonly inputs: SessionGraph['inputs'];
+  /** Qualified aggregate subscriptions, owned by the session graph. */
+  readonly subscriptions: SessionGraph['subscriptions'];
   /** Session-scoped status plane. */
   readonly status: StreamStatusMachine;
   /** Session-owned transcript store for run traces launched in this session. */
@@ -241,6 +243,7 @@ export class SessionHandle {
     this.folded = graph.folded;
     this.requests = graph.requests;
     this.inputs = graph.inputs;
+    this.subscriptions = graph.subscriptions;
     const status = new StreamStatusMachine(
       (event) => this.publishStatus(event),
       (streamId, detail) => this.setUnreadable(streamId, detail),
@@ -621,7 +624,7 @@ export class SessionHandle {
   ): void {
     if (this.disposed) return;
     effectRuntime().runFork(
-      this.graph.subscriptions.set(
+      this.subscriptions.set(
         port,
         set.map(({ id, fromSeq }) => ({
           id: qualifyAggregateId('stream', id),

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -58,6 +58,7 @@ import {
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
 import {
+  aggregateId as qualifyAggregateId,
   RUN_OUTCOME,
   type ApprovalPolicySnapshot,
   type CommitOrdinal,
@@ -353,7 +354,7 @@ export class SessionHandle {
     this.publish([
       {
         type: 'approval.policy',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         snapshot: this.approvalPolicySnapshotFor(streamId),
       },
     ]);
@@ -610,15 +611,24 @@ export class SessionHandle {
 
   /**
    * Replace one port's transcript subscription set (PRD 7.2, 8.1): the
-   * aggregates whose transcript tier the view folds for that port. An empty
+   * logical stream ids whose transcript tier the view folds for that port.
+   * Qualify them once when entering the event graph. An empty
    * set removes the port; the view's set is the union over every port.
    */
   setTranscriptSubscriptions(
     port: string,
-    set: readonly TranscriptSubscription[],
+    set: readonly (Omit<TranscriptSubscription, 'id'> & { id: StreamTabId })[],
   ): void {
     if (this.disposed) return;
-    effectRuntime().runFork(this.graph.subscriptions.set(port, set));
+    effectRuntime().runFork(
+      this.graph.subscriptions.set(
+        port,
+        set.map(({ id, fromSeq }) => ({
+          id: qualifyAggregateId('stream', id),
+          fromSeq,
+        })),
+      ),
+    );
   }
 
   /** The status machine's hold on a stream this process cannot read, or its

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -24,13 +24,14 @@ import {
 import { AgentError } from '@common/errors';
 import { createLog } from '@logger/logUtils';
 import type { CopilotRouteOverride } from '@model/copilotRouting';
-import type {
-  ExecutionId,
-  RequestEnsureProgressViewPayload,
-  RunOutcome,
-  StreamTabId,
-  SubagentProgressUpdate,
-  UserFollowUpSupport,
+import {
+  aggregateId as qualifyAggregateId,
+  type ExecutionId,
+  type RequestEnsureProgressViewPayload,
+  type RunOutcome,
+  type StreamTabId,
+  type SubagentProgressUpdate,
+  type UserFollowUpSupport,
 } from '@shared/schemas';
 import {
   AgentCategory,
@@ -161,7 +162,7 @@ async function launchToolUseRun(
         session.publish([
           {
             type: 'updateQueuedFollowUps',
-            aggregateId: streamId,
+            aggregateId: qualifyAggregateId('stream', streamId),
             messages: session.followUps.getAll(streamId),
           },
         ]);

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -10,6 +10,7 @@ import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
+  aggregateId as qualifyAggregateId,
   STREAM_PHASE,
   STREAM_SUBSTATE,
   type ActiveChildInfo,
@@ -776,7 +777,7 @@ export class ExecutionRegistry {
     this.publish([
       {
         type: 'setParentStream',
-        aggregateId: payload.childStreamId,
+        aggregateId: qualifyAggregateId('stream', payload.childStreamId),
         parentStreamId: payload.parentStreamId,
       },
     ]);

--- a/src/agent/runtime/historicalListing.ts
+++ b/src/agent/runtime/historicalListing.ts
@@ -21,6 +21,7 @@
  */
 import { createLog } from '@logger/logUtils';
 import {
+  aggregateId as qualifyAggregateId,
   USER_FOLLOW_UP_SUPPORT,
   type OwnerId,
   type SessionEvent,
@@ -150,7 +151,7 @@ function historicalStream(
   const drafts: SessionEventDraft[] = [
     {
       type: 'run.start',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       executionId,
       identity: meta.identity ?? null,
       userFollowUpSupport:
@@ -165,7 +166,7 @@ function historicalStream(
   if (meta.model !== undefined || meta.command !== undefined) {
     drafts.push({
       type: 'run.config',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       executionId,
       config: { model: meta.model, instruction: meta.command },
     });
@@ -173,7 +174,7 @@ function historicalStream(
   if (meta.description) {
     drafts.push({
       type: 'updateStreamDescription',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       description: meta.description,
     });
   }

--- a/src/agent/runtime/resumeRun.ts
+++ b/src/agent/runtime/resumeRun.ts
@@ -28,6 +28,7 @@ import { PersistedFlowStateError } from '@agent/node/persistedFlow';
 import { createLog } from '@logger/logUtils';
 import type { RecoveryContinuation } from '@platform/interfaces';
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   STREAM_PHASE,
   STREAM_SUBSTATE,
@@ -493,7 +494,7 @@ async function resumeQueuedToolUse(
     session.publish([
       {
         type: 'updateQueuedFollowUps',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         messages: session.followUps.getAll(streamId),
       },
     ]);

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -16,7 +16,11 @@ import {
 } from '@agent/runtime/helperModel';
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
 import { createLog } from '@logger/logUtils';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  aggregateId as qualifyAggregateId,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { isNonEmptyString } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
@@ -134,7 +138,11 @@ export async function generateSessionDescription(
 
     await writeSessionDescription(executionId, description);
     session.publish([
-      { type: 'updateStreamDescription', aggregateId: streamId, description },
+      {
+        type: 'updateStreamDescription',
+        aggregateId: qualifyAggregateId('stream', streamId),
+        description,
+      },
     ]);
     log.info(`Generated session description for ${executionId}`);
   } catch (err) {

--- a/src/controllers/progressView/progressFollowUpSubmit.ts
+++ b/src/controllers/progressView/progressFollowUpSubmit.ts
@@ -6,7 +6,10 @@ import {
 import type { SessionHandle } from '@agent/runtime';
 import type { FollowUpQueueInput } from '@agent/followUp';
 import { createLog } from '@logger/logUtils';
-import type { StreamTabId } from '@shared/schemas';
+import {
+  aggregateId as qualifyAggregateId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const logger = createLog('ProgressFollowUpSubmit');
@@ -53,7 +56,7 @@ export function submitProgressFollowUp(
       session.publish([
         {
           type: 'updateQueuedFollowUps',
-          aggregateId: streamId,
+          aggregateId: qualifyAggregateId('stream', streamId),
           messages: session.followUps.getAll(streamId),
         },
       ]);

--- a/src/controllers/session/SessionBridge.ts
+++ b/src/controllers/session/SessionBridge.ts
@@ -197,8 +197,7 @@ export class SessionBridge {
       key: this.key,
       view: session.view,
       inputs: session.inputs,
-      setTranscriptSubscriptions: (id, set) =>
-        Effect.sync(() => session.setTranscriptSubscriptions(id, set)),
+      setTranscriptSubscriptions: session.subscriptions.set,
     };
     const framer = new PortFramer(source, port, this.host);
     this.ports.set(port.id, { port, framer });

--- a/src/controllers/session/SessionFramer.ts
+++ b/src/controllers/session/SessionFramer.ts
@@ -30,12 +30,13 @@
  */
 import { Effect, Stream, SubscriptionRef, type Context } from 'effect';
 
-import type {
-  CommitOrdinal,
-  FoldInput,
-  LocalRuntimeState,
-  TextChunk,
-  TranscriptSubscription,
+import {
+  aggregateId as qualifyAggregateId,
+  type CommitOrdinal,
+  type FoldInput,
+  type LocalRuntimeState,
+  type TextChunk,
+  type TranscriptSubscription,
 } from '@shared/schemas';
 import type { SessionInputs } from '@shared/session/sessionInputs';
 import type { HostSnapshot } from '@shared/session/hostSnapshot';
@@ -106,7 +107,7 @@ function cutFrame(
         break;
       }
       case 'chunk': {
-        if (!named.has(item.streamId)) continue;
+        if (!named.has(qualifyAggregateId('stream', item.streamId))) continue;
         const rowKey = `${item.streamId}/${item.rowId}`;
         const held = chunks.get(rowKey);
         chunks.set(

--- a/src/controllers/session/SessionRequests.ts
+++ b/src/controllers/session/SessionRequests.ts
@@ -26,6 +26,7 @@ import type {
 import type { SessionEventLog } from '@agent/runtime/SessionEvents';
 import type { SessionGraph } from '@agent/runtime/sessionGraph';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { aggregateId as qualifyAggregateId } from '@shared/schemas';
 import type { StreamTabId } from '@shared/schemas';
 import {
   NotOwner,
@@ -77,7 +78,7 @@ function admit(
 ): Effect.Effect<void, RequestError> {
   const streamId = targetStream(req);
   return Effect.flatMap(
-    log.exists(streamId),
+    log.exists(qualifyAggregateId('stream', streamId)),
     (exists): Effect.Effect<void, RequestError> => {
       if (!exists) {
         return Effect.fail(

--- a/src/controllers/session/createSessionStores.ts
+++ b/src/controllers/session/createSessionStores.ts
@@ -1,5 +1,6 @@
 import { SessionStores } from '@agent/storage';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { aggregateId as qualifyAggregateId } from '@shared/schemas';
 import { releaseStreamResources } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
 
@@ -37,7 +38,7 @@ export function createSessionStores(session: SessionHandle): SessionStores {
           .filter((child) => !detached.has(child))
           .map((child) => ({
             type: 'setParentStream' as const,
-            aggregateId: child,
+            aggregateId: qualifyAggregateId('stream', child),
             parentStreamId: null,
           })),
       );

--- a/src/controllers/session/scheduleLeftoverStreamSweep.ts
+++ b/src/controllers/session/scheduleLeftoverStreamSweep.ts
@@ -1,7 +1,10 @@
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { createSessionStores } from '@controllers/session/createSessionStores';
 import { createLog } from '@logger/logUtils';
-import type { StreamTabId } from '@shared/schemas';
+import {
+  aggregateId as qualifyAggregateId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { isInFlightPhase } from '@shared/streams/streamStatus';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -67,7 +70,7 @@ export function scheduleLeftoverStreamSweep(
         session.publish(
           sweptStreams.map((streamId) => ({
             type: 'stream.removed' as const,
-            aggregateId: streamId,
+            aggregateId: qualifyAggregateId('stream', streamId),
           })),
         );
       })

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -57,6 +57,7 @@ import { createLog } from '@logger/logUtils';
 import { effectRuntime, initProcessRuntime } from '@platform/processRuntime';
 import { SHUTDOWN_PHASE_DEADLINE_MS } from '@platform/defaults/lifecycleHost';
 import {
+  aggregateId as qualifyAggregateId,
   ownerIdentity,
   type OwnerId,
   type SessionCloseReport,
@@ -219,7 +220,7 @@ const transcriptBridge = (transcripts: StreamLogStore) =>
               yield* events.publish(
                 rows.map((entry) => ({
                   type: 'transcript.entry',
-                  aggregateId: streamId,
+                  aggregateId: qualifyAggregateId('stream', streamId),
                   entry,
                 })),
               );

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -21,8 +21,6 @@
  * from the summary tier when a reader subscribes; the event table replaces
  * that.
  */
-import * as os from 'node:os';
-
 import {
   Context,
   Duration,
@@ -44,7 +42,6 @@ import { proveOwnerLiveness } from '@agent/storage/leaseOwnerLiveness';
 import { runInSession } from '@agent/runtime/RunContext';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import {
-  ownerProcessStart,
   processOwnerId,
   SessionEventLog,
   sessionEventsLayer,
@@ -60,6 +57,7 @@ import { createLog } from '@logger/logUtils';
 import { effectRuntime, initProcessRuntime } from '@platform/processRuntime';
 import { SHUTDOWN_PHASE_DEADLINE_MS } from '@platform/defaults/lifecycleHost';
 import {
+  ownerIdentity,
   type OwnerId,
   type SessionCloseReport,
   type StreamTabId,
@@ -156,11 +154,7 @@ const ownerLiveness = Layer.effectDiscard(
       const held: OwnerId[] = [];
       for (const owner of owners) {
         const liveness = yield* Effect.promise(() =>
-          proveOwnerLiveness({
-            pid: Number(owner.slice(0, owner.indexOf(':'))),
-            processStart: ownerProcessStart(owner),
-            hostname: os.hostname(),
-          }),
+          proveOwnerLiveness(ownerIdentity(owner)),
         );
         if (liveness !== 'dead') held.push(owner);
       }

--- a/src/controllers/session/sessionSources.ts
+++ b/src/controllers/session/sessionSources.ts
@@ -22,6 +22,7 @@
 import { Context, Effect, Layer, SubscriptionRef } from 'effect';
 
 import type {
+  AggregateId,
   LocalRuntimeState,
   TranscriptSubscription,
 } from '@shared/schemas';
@@ -89,7 +90,7 @@ export class TranscriptSubscriptions extends Context.Service<
       const union = (): TranscriptSubscription[] => {
         // The lowest `fromSeq` any port asks for: a port that already holds
         // an aggregate's history must not shorten another's read.
-        const byId = new Map<string, TranscriptSubscription>();
+        const byId = new Map<AggregateId, TranscriptSubscription>();
         for (const set of ports.values()) {
           for (const entry of set) {
             const held = byId.get(entry.id);

--- a/src/shared/schemas/sessionEvent.ts
+++ b/src/shared/schemas/sessionEvent.ts
@@ -86,11 +86,49 @@ export function ownerPid(ownerId: OwnerId): number {
   return ownerIdentity(ownerId).pid;
 }
 
-/** A stream id or an inquiry thread id: the `aggregate_id` half of the
- *  event key (contract C2). The fold resolves a stream aggregate by its id
- *  alone; the execution aggregate arrives with the cutover's flow rows. */
-export const AggregateIdSchema = z.string().min(1);
+/** C2 separates independent lifecycles even when their logical ids coincide. */
+const AggregateKeySchema = z.tuple([
+  z.enum([
+    'stream',
+    'execution',
+    'workflow-checkpoint',
+    'inquiry',
+    'session',
+    'migration',
+  ]),
+  z.string().min(1),
+]);
+
+/** The canonical JSON encoding of an aggregate kind and its logical id. */
+export const AggregateIdSchema = z
+  .string()
+  .refine(
+    (value) =>
+      Result.match(parseJsonWith(value, AggregateKeySchema), {
+        onSuccess: (key) => JSON.stringify(key) === value,
+        onFailure: () => false,
+      }),
+    'Expected a canonical [kind, logicalId] aggregate key',
+  )
+  .brand<'AggregateId'>();
 export type AggregateId = z.infer<typeof AggregateIdSchema>;
+
+/** Qualify a logical id once. An already-qualified key is not an input. */
+export function aggregateId(
+  kind: z.infer<typeof AggregateKeySchema>[0],
+  logicalId: string & { readonly [z.$brand]?: never },
+): AggregateId {
+  return AggregateIdSchema.parse(JSON.stringify([kind, logicalId]));
+}
+
+/** Decode a validated aggregate key at a logical-id boundary. */
+export function aggregateTarget(key: AggregateId): {
+  kind: z.infer<typeof AggregateKeySchema>[0];
+  id: string;
+} {
+  const [kind, id] = JSON.parse(key) as z.infer<typeof AggregateKeySchema>;
+  return { kind, id };
+}
 
 /** Per-aggregate append order; `run.start` is seq 1 of its stream. */
 const SeqSchema = z.int().positive();

--- a/src/shared/schemas/sessionEvent.ts
+++ b/src/shared/schemas/sessionEvent.ts
@@ -15,7 +15,10 @@
  * transport stay free of `@agent/*` (`dependencyDirection.vitest.ts` keeps the
  * shared-to-agent allowlist empty).
  */
+import { Result } from 'effect';
 import { z } from 'zod';
+
+import { parseJsonWith } from '@common/parsing/safeParseJson';
 
 import { TexraApprovalPolicySchema } from '@shared/approvalPolicy';
 import { AgentCategorySchema } from './agent';
@@ -43,19 +46,44 @@ import { StageKindSchema } from './taskGroup';
 import { TodoItemSchema } from './todo';
 import { ExtendedTokenUsageStatsSchema } from './usage';
 
+/** C5's complete process identity, encoded canonically without losing null. */
+const OwnerIdentitySchema = z.tuple([
+  z.string().min(1),
+  z.int().positive(),
+  z.string().min(1).nullable(),
+]);
+
 /**
- * The identity of a TeXRA process: `${pid}:${processStart}`, the
- * `owner_id` the substrate stamps at insert from the writing process
- * (contract C5). One value per process, stamped on every run it launched;
- * liveness is probed per owner, never per run (PRD 5.2). Never a lease token.
+ * JSON.stringify([hostname.toLowerCase(), pid, processStart]). Host identity
+ * is necessary: a missing local pid cannot prove a foreign process dead.
  */
-export const OwnerIdSchema = z.string().regex(/^\d+:.+$/);
+export const OwnerIdSchema = z.string().refine(
+  (value) =>
+    Result.match(parseJsonWith(value, OwnerIdentitySchema), {
+      onSuccess: (identity) =>
+        identity[0] === identity[0].toLowerCase() &&
+        JSON.stringify(identity) === value,
+      onFailure: () => false,
+    }),
+  'Expected a canonical [hostname, pid, processStart] process identity',
+);
 export type OwnerId = z.infer<typeof OwnerIdSchema>;
 
-/** The pid half of an owner id, the one part of a process identity a user
- *  can act on (`kill`, Activity Monitor). */
-export function ownerPid(ownerId: string): number {
-  return Number(ownerId.slice(0, ownerId.indexOf(':')));
+/** Decode an owner already validated at the event or transport boundary. */
+export function ownerIdentity(ownerId: OwnerId): {
+  hostname: string;
+  pid: number;
+  processStart: string | null;
+} {
+  const [hostname, pid, processStart] = JSON.parse(ownerId) as z.infer<
+    typeof OwnerIdentitySchema
+  >;
+  return { hostname, pid, processStart };
+}
+
+/** The recorded pid shown when another process holds a run. */
+export function ownerPid(ownerId: OwnerId): number {
+  return ownerIdentity(ownerId).pid;
 }
 
 /** A stream id or an inquiry thread id: the `aggregate_id` half of the

--- a/src/shared/session/sessionEvents.ts
+++ b/src/shared/session/sessionEvents.ts
@@ -23,7 +23,7 @@ import type {
 export type SessionCursor = CommitOrdinal;
 
 /**
- * The identity of this process, `${pid}:${processStart}` (contract C5): the
+ * The canonical hostname, pid, and nullable process-start tuple (C5): the
  * `ownerId` stamped on every event the process appends and the `self` entry
  * of its local runtime snapshot. Resolved once at each process entry, where
  * the start identity can be awaited, and provided to the process layer.

--- a/src/shared/session/sessionFold.ts
+++ b/src/shared/session/sessionFold.ts
@@ -57,6 +57,8 @@
  * followed by "no change" would be dropped, not shared.
  */
 import {
+  aggregateTarget,
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -216,7 +218,8 @@ function foldWith(
       // was away and no later read can deliver the deletion.
       const { listed } = sessionIndexesOf(next);
       for (const id of [...next.streams.keys()]) {
-        if (!listed.has(id)) foldStreamRemoved(next, id, deferred);
+        if (!listed.has(qualifyAggregateId('stream', id)))
+          foldStreamRemoved(next, id, deferred);
       }
       listed.clear();
       return next;
@@ -410,7 +413,7 @@ const NO_ROUNDS = Object.freeze({});
 
 /** A stream in its initial shape, minted by its `run.start` alone. */
 function createStream(event: RunStartEvent): StreamView {
-  const id = event.aggregateId as StreamTabId;
+  const id = aggregateTarget(event.aggregateId).id;
   const status = STREAM_STATUS.READY;
   const identity = event.identity ?? null;
   const common = {
@@ -1562,7 +1565,7 @@ function relink(
 function streamOf(event: SessionEvent): StreamTabId | null {
   return event.type === 'inquiryThreadUpdated'
     ? null
-    : (event.aggregateId as StreamTabId);
+    : aggregateTarget(event.aggregateId).id;
 }
 
 /** Returns whether the event changed anything. */
@@ -1662,7 +1665,7 @@ function foldTranscriptRow(
 ): boolean {
   const retained = view.folded.get(event.aggregateId);
   if (retained === undefined || event.seq <= retained) return false;
-  const stream = view.streams.get(event.aggregateId as StreamTabId);
+  const stream = view.streams.get(aggregateTarget(event.aggregateId).id);
   if (!stream) return false;
   writableMap(view, 'folded').set(event.aggregateId, event.seq);
   const withEntry: StreamView = {
@@ -1700,7 +1703,7 @@ function foldStreamRemoved(
   if (view.queuedFollowUps.has(stream.id)) {
     writableMap(view, 'queuedFollowUps').delete(stream.id);
   }
-  if (view.folded.has(stream.id)) writableMap(view, 'folded').delete(stream.id);
+  writableMap(view, 'folded').delete(qualifyAggregateId('stream', stream.id));
   if (view.approvals.some((a) => a.streamId === stream.id)) {
     view.approvals = view.approvals.filter((a) => a.streamId !== stream.id);
   }
@@ -1798,7 +1801,7 @@ function foldSubscriptions(
   for (const id of [...view.folded.keys()]) {
     if (subscribed.has(id)) continue;
     writableMap(view, 'folded').delete(id);
-    const stream = view.streams.get(id as StreamTabId);
+    const stream = view.streams.get(aggregateTarget(id).id);
     if (!stream) continue;
     clearInflight(view, stream);
     const evicted = withTranscriptFacts({

--- a/src/shared/session/sessionFold.ts
+++ b/src/shared/session/sessionFold.ts
@@ -1801,7 +1801,9 @@ function foldSubscriptions(
   for (const id of [...view.folded.keys()]) {
     if (subscribed.has(id)) continue;
     writableMap(view, 'folded').delete(id);
-    const stream = view.streams.get(aggregateTarget(id).id);
+    const target = aggregateTarget(id);
+    const stream =
+      target.kind === 'stream' ? view.streams.get(target.id) : undefined;
     if (!stream) continue;
     clearInflight(view, stream);
     const evicted = withTranscriptFacts({

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
+  aggregateId as qualifyAggregateId,
   RUN_OUTCOME,
   STREAM_PHASE,
   type ExecutionId,
@@ -108,7 +109,7 @@ describe('child stream progress events', () => {
 
     expect(eventsOfType(recorded.events, 'run.start')).toContainEqual(
       expect.objectContaining({
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         executionId,
         identity: { kind: 'process', tool: 'bash' },
         category: AgentCategory.ToolUse,
@@ -121,31 +122,34 @@ describe('child stream progress events', () => {
     expect(eventsOfType(recorded.events, 'run.activate')).toMatchObject([
       {
         type: 'run.activate',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         category: AgentCategory.ToolUse,
         background: true,
       },
     ]);
     expect(eventsOfType(recorded.events, 'run.config')).toContainEqual(
-      expect.objectContaining({ aggregateId: childStreamId, executionId }),
+      expect.objectContaining({
+        aggregateId: qualifyAggregateId('stream', childStreamId),
+        executionId,
+      }),
     );
     expect(
       eventsOfType(recorded.events, 'updateStreamDescription'),
     ).toContainEqual(
       expect.objectContaining({
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         description: 'Run a background bash command',
       }),
     );
     expect(eventsOfType(recorded.events, 'status')).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          aggregateId: childStreamId,
+          aggregateId: qualifyAggregateId('stream', childStreamId),
           phase: STREAM_PHASE.RUNNING,
           cause: 'lifecycle',
         }),
         expect.objectContaining({
-          aggregateId: childStreamId,
+          aggregateId: qualifyAggregateId('stream', childStreamId),
           phase: STREAM_PHASE.COMPLETED,
           previousPhase: STREAM_PHASE.RUNNING,
           cause: 'lifecycle',
@@ -174,12 +178,14 @@ describe('child stream progress events', () => {
     );
     expect(eventsOfType(recorded.events, 'setParentStream')).toContainEqual(
       expect.objectContaining({
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         parentStreamId,
       }),
     );
     expect(eventsOfType(recorded.events, 'stream.removed')).toContainEqual(
-      expect.objectContaining({ aggregateId: childStreamId }),
+      expect.objectContaining({
+        aggregateId: qualifyAggregateId('stream', childStreamId),
+      }),
     );
   });
 
@@ -231,7 +237,10 @@ describe('child stream progress events', () => {
           cause: 'resume',
           phase: STREAM_PHASE.RUNNING,
           previousPhase: STREAM_PHASE.COMPLETED,
-          aggregateId: workflowRelaunchChildStreamId,
+          aggregateId: qualifyAggregateId(
+            'stream',
+            workflowRelaunchChildStreamId,
+          ),
         }),
       );
     } finally {
@@ -269,12 +278,12 @@ describe('child stream progress events', () => {
         eventsOfType(recorded.events, 'stream.removed').map(
           (event) => event.aggregateId,
         ),
-      ).not.toContain(setupRetryChildStreamId);
+      ).not.toContain(qualifyAggregateId('stream', setupRetryChildStreamId));
       // Setup failed after the existence fact, so the started stream ended
       // with its terminal result instead of lingering as a ghost.
       expect(eventsOfType(recorded.events, 'result')).toContainEqual(
         expect.objectContaining({
-          aggregateId: setupRetryChildStreamId,
+          aggregateId: qualifyAggregateId('stream', setupRetryChildStreamId),
           outcome: RUN_OUTCOME.FAILED,
           isSubagent: true,
         }),
@@ -288,7 +297,9 @@ describe('child stream progress events', () => {
       expect(retried.childStreamId).toBe(setupRetryChildStreamId);
       expect(
         eventsOfType(recorded.events, 'run.start').filter(
-          (event) => event.aggregateId === setupRetryChildStreamId,
+          (event) =>
+            event.aggregateId ===
+            qualifyAggregateId('stream', setupRetryChildStreamId),
         ),
       ).toHaveLength(2);
       await retried.finalize({ outcome: RUN_OUTCOME.COMPLETED });
@@ -350,7 +361,7 @@ describe('child stream progress events', () => {
     expect(eventsOfType(recorded.events, 'run.start')).toEqual([
       expect.objectContaining({
         type: 'run.start',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         category: AgentCategory.ToolUse,
         parentStreamId,
       }),
@@ -373,7 +384,10 @@ describe('child stream progress events', () => {
     expect(active.events).toEqual([]);
     expect(eventsOfType(recorded.events, 'stream.removed')).toContainEqual(
       expect.objectContaining({
-        aggregateId: noProjectionAutoCloseChildStreamId,
+        aggregateId: qualifyAggregateId(
+          'stream',
+          noProjectionAutoCloseChildStreamId,
+        ),
       }),
     );
   });
@@ -389,7 +403,9 @@ describe('child stream progress events', () => {
     });
 
     expect(eventsOfType(recorded.events, 'stream.removed')).toContainEqual(
-      expect.objectContaining({ aggregateId: childStreamId }),
+      expect.objectContaining({
+        aggregateId: qualifyAggregateId('stream', childStreamId),
+      }),
     );
   });
 
@@ -467,7 +483,11 @@ describe('child stream progress events', () => {
 
     expect(
       eventsOfType(recorded.events, 'status')
-        .filter((event) => event.aggregateId === loopChildStreamId)
+        .filter(
+          (event) =>
+            event.aggregateId ===
+            qualifyAggregateId('stream', loopChildStreamId),
+        )
         .map((event) => event.phase),
     ).toEqual([
       STREAM_PHASE.WAITING,
@@ -519,7 +539,9 @@ describe('child stream progress events', () => {
     );
     expect(
       eventsOfType(recorded.events, 'status').filter(
-        (event) => event.aggregateId === stoppedChildStreamId,
+        (event) =>
+          event.aggregateId ===
+          qualifyAggregateId('stream', stoppedChildStreamId),
       ),
     ).toHaveLength(0);
     await expect(handle?.result).resolves.toMatchObject({

--- a/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
@@ -57,6 +57,8 @@ import {
   USER_FOLLOW_UP_SUPPORT,
   type ExecutionId,
   type StreamTabId,
+  aggregateId as qualifyAggregateId,
+  aggregateTarget,
   AgentCategory,
   type SessionEvent,
 } from '@shared/schemas';
@@ -154,7 +156,9 @@ function expectStartedThenFailed(
     category: AgentCategory.ToolUse,
     isRemote: false,
     background: isSubagent,
-    approvalPolicy: launch.session.approvalPolicySnapshotFor(start.aggregateId),
+    approvalPolicy: launch.session.approvalPolicySnapshotFor(
+      aggregateTarget(start.aggregateId).id,
+    ),
   });
   expectActivatedThenFailed(launch, isSubagent);
   expect(launch.result).toMatchObject({ executionId: start.executionId });
@@ -176,9 +180,9 @@ function expectActivatedThenFailed(
     aggregateId: launch.activate.aggregateId,
     isSubagent,
   });
-  expect(launch.session.status.get(launch.activate.aggregateId)).toBe(
-    STREAM_PHASE.FAILED,
-  );
+  expect(
+    launch.session.status.get(aggregateTarget(launch.activate.aggregateId).id),
+  ).toBe(STREAM_PHASE.FAILED);
 }
 
 describe('native agent launch activation', () => {
@@ -247,7 +251,9 @@ describe('native agent launch activation', () => {
       // fact, one activation on the same failure path.
       expectActivatedThenFailed(launch, isSubagent);
       expect(launch.start).toBeUndefined();
-      expect(launch.activate.aggregateId).toBe(streamId);
+      expect(launch.activate.aggregateId).toBe(
+        qualifyAggregateId('stream', streamId),
+      );
     },
   );
 });

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -27,6 +27,7 @@ import {
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import { platform } from '@platform/platform';
 import {
+  aggregateId as qualifyAggregateId,
   MESSAGE_TYPES,
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
@@ -461,7 +462,7 @@ describe('runFlowWithLifecycle', () => {
       const runningIndex = recorded.events.findIndex(
         (event) =>
           event.type === 'status' &&
-          event.aggregateId === streamId &&
+          event.aggregateId === qualifyAggregateId('stream', streamId) &&
           event.phase === STREAM_PHASE.RUNNING,
       );
 

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -15,6 +15,7 @@ import { statusDraft } from '@agent/runtime/SessionEvents';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { createSessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import {
+  aggregateId as qualifyAggregateId,
   RUN_OUTCOME,
   STREAM_PHASE,
   STREAM_STATUS,
@@ -1041,7 +1042,7 @@ describe('executionRegistry', () => {
       ).toBe(grandchildStreamId);
       expect(eventsOfType(recorded.events, 'setParentStream')).toContainEqual({
         type: 'setParentStream',
-        aggregateId: grandchildStreamId,
+        aggregateId: qualifyAggregateId('stream', grandchildStreamId),
         parentStreamId: null,
       });
     } finally {
@@ -1113,7 +1114,7 @@ describe('executionRegistry', () => {
       expect(streamStatus.get(grandchildStreamId)).toBeUndefined();
       expect(eventsOfType(recorded.events, 'setParentStream')).toContainEqual({
         type: 'setParentStream',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         parentStreamId: null,
       });
     } finally {
@@ -1384,7 +1385,7 @@ describe('executionRegistry', () => {
       ).toBe(childStreamId);
       expect(eventsOfType(recorded.events, 'setParentStream')).toContainEqual({
         type: 'setParentStream',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         parentStreamId: null,
       });
       expect(streamStatus.get(parentStreamId)).toBe(STREAM_PHASE.CANCELLED);
@@ -1421,7 +1422,7 @@ describe('executionRegistry', () => {
       });
       expect(eventsOfType(recorded.events, 'setParentStream')).toContainEqual({
         type: 'setParentStream',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         parentStreamId,
       });
       expect(childActivity.at(-1)).toMatchObject({
@@ -1447,7 +1448,7 @@ describe('executionRegistry', () => {
 
       expect(seen.events).toContainEqual({
         type: 'setParentStream',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         parentStreamId,
       });
     } finally {
@@ -1621,7 +1622,7 @@ describe('executionRegistry', () => {
 
       expect(eventsOfType(recorded.events, 'setParentStream')).toContainEqual({
         type: 'setParentStream',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         parentStreamId: null,
       });
       expect(rosters.rosters.at(-1)).toMatchObject({
@@ -1676,7 +1677,7 @@ describe('executionRegistry', () => {
 
       expect(seen.events).toContainEqual({
         type: 'setParentStream',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         parentStreamId: null,
       });
     } finally {

--- a/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
@@ -7,7 +7,11 @@ import {
   getDisplayedInstruction,
 } from '@agent/runtime/sessionDescription';
 import * as logger from '@logger/logUtils';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  aggregateId as qualifyAggregateId,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
 
@@ -114,7 +118,7 @@ describe('session description helpers', () => {
     expect(recorded.events).toMatchObject([
       {
         type: 'updateStreamDescription',
-        aggregateId: 'stream-workflow',
+        aggregateId: qualifyAggregateId('stream', 'stream-workflow'),
         description: 'Correcting derivation signs',
       },
     ]);
@@ -165,7 +169,7 @@ describe('session description helpers', () => {
     expect(recorded.events).toMatchObject([
       {
         type: 'updateStreamDescription',
-        aggregateId: 'stream-tool',
+        aggregateId: qualifyAggregateId('stream', 'stream-tool'),
         description: 'Fixing proof typos',
       },
     ]);

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.ts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.ts
@@ -12,6 +12,7 @@ import {
   type CliNdjsonProgressRecordWriter,
 } from '@cli/runtime/sessionProgressSubscription';
 import {
+  aggregateId as qualifyAggregateId,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
   STREAM_SUBSTATE,
@@ -80,7 +81,7 @@ function draft(draft: SessionEventDraft): Source {
 function statusDraft(payload: RunStatusProjectionPayload): Source {
   return draft({
     type: 'status',
-    aggregateId: payload.streamId,
+    aggregateId: qualifyAggregateId('stream', payload.streamId),
     phase: payload.status,
     cause: payload.cause,
     ...(payload.previousStatus
@@ -114,7 +115,7 @@ const PROGRESS_PROJECTION_CASES = {
   setActiveStream: {
     source: draft({
       type: 'run.activate',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       category: AgentCategory.Workflow,
       isRemote: false,
       background: false,
@@ -203,7 +204,7 @@ const PROGRESS_PROJECTION_CASES = {
   inquiryThreadUpdated: {
     source: draft({
       type: 'inquiryThreadUpdated',
-      aggregateId: inquiryThread.threadId,
+      aggregateId: qualifyAggregateId('inquiry', inquiryThread.threadId),
       ...inquiryThread,
     }),
     payload: inquiryThread,
@@ -263,7 +264,7 @@ const PROGRESS_PROJECTION_CASES = {
   updateQueuedFollowUps: {
     source: draft({
       type: 'updateQueuedFollowUps',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       messages: ['queued'],
     }),
     payload: { streamId },
@@ -275,7 +276,7 @@ const PROGRESS_PROJECTION_CASES = {
   updateStreamDescription: {
     source: draft({
       type: 'updateStreamDescription',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       description: 'Checking the compactness lemma',
     }),
     payload: { streamId, description: 'Checking the compactness lemma' },
@@ -283,19 +284,22 @@ const PROGRESS_PROJECTION_CASES = {
   setParentStream: {
     source: draft({
       type: 'setParentStream',
-      aggregateId: childStreamId,
+      aggregateId: qualifyAggregateId('stream', childStreamId),
       parentStreamId: streamId,
     }),
     payload: { childStreamId, parentStreamId: streamId },
   },
   removeStream: {
-    source: draft({ type: 'stream.removed', aggregateId: childStreamId }),
+    source: draft({
+      type: 'stream.removed',
+      aggregateId: qualifyAggregateId('stream', childStreamId),
+    }),
     payload: { streamId: childStreamId },
   },
   goalStateChanged: {
     source: draft({
       type: 'goalStateChanged',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       state: { active: false },
     }),
     payload: { streamId },
@@ -363,7 +367,7 @@ const resumingStatusPayload: RunStatusProjectionPayload = {
 
 const activation: SessionEventDraft = {
   type: 'run.activate',
-  aggregateId: streamId,
+  aggregateId: qualifyAggregateId('stream', streamId),
   category: AgentCategory.ToolUse,
   background: true,
 };
@@ -378,7 +382,7 @@ describe('attachCliSessionProgressProjection', () => {
       await publish(
         draft({
           type: 'run.start',
-          aggregateId: streamId,
+          aggregateId: qualifyAggregateId('stream', streamId),
           executionId,
           identity: { kind: 'process', tool: 'bash' },
           category: AgentCategory.ToolUse,
@@ -413,7 +417,7 @@ describe('attachCliSessionProgressProjection', () => {
     session.publish([
       {
         type: 'run.start',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         executionId,
         identity: { kind: 'agent', agent: 'polish' },
         category: AgentCategory.ToolUse,
@@ -422,14 +426,14 @@ describe('attachCliSessionProgressProjection', () => {
       },
       {
         type: 'run.activate',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         category: AgentCategory.ToolUse,
         isRemote: false,
         background: false,
       },
       {
         type: 'updateStreamDescription',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         description: 'Recorded before the resume',
       },
     ]);
@@ -441,7 +445,7 @@ describe('attachCliSessionProgressProjection', () => {
       await publish(
         draft({
           type: 'run.activate',
-          aggregateId: streamId,
+          aggregateId: qualifyAggregateId('stream', streamId),
           category: AgentCategory.ToolUse,
           isRemote: false,
           background: false,
@@ -571,7 +575,7 @@ describe('attachCliSessionProgressProjection', () => {
     await publish(
       draft({
         type: 'updateStreamDescription',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         description: 'Proofread the introduction',
       }),
     );
@@ -587,7 +591,7 @@ describe('attachCliSessionProgressProjection', () => {
     await publish(
       draft({
         type: 'updateStreamDescription',
-        aggregateId: 'stream:after-detach',
+        aggregateId: qualifyAggregateId('stream', 'stream:after-detach'),
         description: 'after detach',
       }),
     );
@@ -604,7 +608,7 @@ describe('attachCliSessionProgressProjection', () => {
     await publish(
       draft({
         type: 'transcript.entry',
-        aggregateId: 'stream:evicted',
+        aggregateId: qualifyAggregateId('stream', 'stream:evicted'),
         entry: {
           type: STREAM_LOG_ENTRY_TYPES.LOG,
           id: 'row-1',

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
@@ -14,6 +14,7 @@ import { CliExitCode } from '@cli/runtime/exitCodes';
 import { rootStreamId as rootStreamIdSignal } from '@cli/chat/tui/state/cliState';
 import { currentView } from '@cli/chat/tui/state/sessionView';
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   USER_FOLLOW_UP_SUPPORT,
   type ExecutionId,
@@ -515,7 +516,7 @@ describe('runChat signal ownership wiring', () => {
       session.publish(
         [history, ownRoot].map((streamId) => ({
           type: 'run.start' as const,
-          aggregateId: streamId,
+          aggregateId: qualifyAggregateId('stream', streamId),
           executionId: `execution:${streamId}` as ExecutionId,
           identity: { kind: 'agent' as const, agent: 'assistant' },
           userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -7,7 +7,10 @@ import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { executeCliRequest } from '@cli/runtime/runExecution';
 import { AgentError } from '@common/errors';
-import { RUN_OUTCOME } from '@shared/schemas';
+import {
+  aggregateId as qualifyAggregateId,
+  RUN_OUTCOME,
+} from '@shared/schemas';
 import type { ExecutionId, StreamTabId, TodoItem } from '@shared/schemas';
 import { createFakeHost, installFakeHost } from '@test/support/setupPlatform';
 import { createTestCliContext as cliContext } from '@test/cli/fixtures/cliContext';
@@ -544,10 +547,14 @@ describe('executeCliRequest', () => {
       defaultSession().publish([
         {
           type: 'updateStreamDescription',
-          aggregateId: streamId,
+          aggregateId: qualifyAggregateId('stream', streamId),
           description: 'chat / gpt54',
         },
-        { type: 'setParentStream', aggregateId: streamId, parentStreamId },
+        {
+          type: 'setParentStream',
+          aggregateId: qualifyAggregateId('stream', streamId),
+          parentStreamId,
+        },
       ]);
       return {
         category: 'toolUse',

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.ts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.ts
@@ -19,6 +19,7 @@ import { attachCliSessionProgressProjection } from '@cli/runtime/sessionProgress
 import { textDisplayWidth } from '@cli/runtime/terminalText';
 import type { CliContext } from '@cli/runtime/cliContext';
 import {
+  aggregateId as qualifyAggregateId,
   STREAM_PHASE,
   type ActiveChildInfo,
   type ConversationProgress,
@@ -303,7 +304,7 @@ async function publishRun(
   session.publish([
     {
       type: 'run.start',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       executionId,
       identity: { kind: 'agent', agent },
       userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -121,6 +121,7 @@ import { runOutcomeExitCode } from '@cli/runtime/terminalStatus';
 import type { CliRuntimeHost } from '@cli/runtime/cliPresentationHost';
 import type { ApiProvider } from '@model/apiProviders';
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   RUN_OUTCOME,
   USER_FOLLOW_UP_SUPPORT,
@@ -156,7 +157,7 @@ function port(): SessionHostInteractions {
     session.publish([
       {
         type: 'run.start',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         executionId: `${streamId}-exec` as ExecutionId,
         identity: { kind: 'agent', agent: 'agent' },
         userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
@@ -190,7 +191,7 @@ function port(): SessionHostInteractions {
           session.publish([
             {
               type: 'inquiryThreadUpdated',
-              aggregateId: inquiry.threadId,
+              aggregateId: qualifyAggregateId('inquiry', inquiry.threadId),
               threadId: inquiry.threadId,
               parentStreamId: (first?.streamId ?? null) as StreamTabId | null,
               status: 'open',

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
@@ -28,6 +28,7 @@ import { bindSessionView } from '@cli/chat/tui/state/sessionView';
 import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApprovals';
 import type { CliRuntimeHost } from '@cli/runtime/cliPresentationHost';
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   USER_FOLLOW_UP_SUPPORT,
   type AgentProposal,
@@ -68,7 +69,7 @@ function port(): SessionHostInteractions {
     session.publish([
       {
         type: 'run.start',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         executionId: `${streamId}-exec` as ExecutionId,
         identity: { kind: 'agent', agent: 'agent' },
         userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -49,8 +49,8 @@ import { testExecutionHandle } from '@test/support/executionHandleFixtures';
 import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 
-const SELF = '4242:self-start';
-const OTHER = '4343:other-start';
+const SELF = '["test-host",4242,"self-start"]';
+const OTHER = '["test-host",4343,"other-start"]';
 const STREAM = 'stream:framing' as StreamTabId;
 const EXECUTION = 'ab12cd' as ExecutionId;
 const OLDER = 'stream:older' as StreamTabId;

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -36,6 +36,7 @@ import { sessionInputsLayer } from '@controllers/session/sessionInputs';
 import { WorkspaceRoots } from '@controllers/session/WorkspaceRoots';
 import { SHUTDOWN_PHASE_DEADLINE_MS } from '@platform/defaults/lifecycleHost';
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   STREAM_PHASE,
   type ExecutionId,
@@ -83,7 +84,7 @@ const settle = (
 
 const runStart: SessionEventDraft = {
   type: 'run.start',
-  aggregateId: STREAM,
+  aggregateId: qualifyAggregateId('stream', STREAM),
   executionId: EXECUTION,
   identity: { kind: 'agent', agent: 'chat' },
   userFollowUpSupport: 'unsupported',
@@ -93,14 +94,14 @@ const runStart: SessionEventDraft = {
 
 const waiting: SessionEventDraft = {
   type: 'status',
-  aggregateId: STREAM,
+  aggregateId: qualifyAggregateId('stream', STREAM),
   phase: STREAM_PHASE.WAITING,
   cause: 'wait',
 };
 
 const requested: SessionEventDraft = {
   type: 'approval.requested',
-  aggregateId: STREAM,
+  aggregateId: qualifyAggregateId('stream', STREAM),
   requestId: 'req-1',
   payload: {
     kind: 'bash',
@@ -177,6 +178,38 @@ function drawnSequence(states: Iterable<ReturnType<typeof drawn>>) {
 
 describe('session events and view', () => {
   it.effect(
+    'keeps an inquiry independent of a removed stream with the same logical id',
+    () =>
+      Effect.gen(function* () {
+        const events = yield* SessionEvents;
+        const log = yield* SessionEventLog;
+        const logicalId = 'ei_012345abcdef';
+        const stream = qualifyAggregateId('stream', logicalId);
+        const inquiry = qualifyAggregateId('inquiry', logicalId);
+        yield* events.publish([
+          { ...runStart, aggregateId: stream },
+          {
+            type: 'inquiryThreadUpdated',
+            aggregateId: inquiry,
+            threadId: logicalId,
+            parentStreamId: null,
+            status: 'open',
+            lastQuestionPreview: 'Which boundary condition applies?',
+            lastActivityIso: '2026-09-06T12:00:00.000Z',
+            turnCount: 1,
+          },
+          { type: 'stream.removed', aggregateId: stream },
+        ]);
+        expect(yield* log.exists(stream)).toBe(false);
+        expect(yield* log.exists(inquiry)).toBe(true);
+        const rows = yield* Stream.runCollect(events.aggregate(inquiry, 0));
+        expect(rows.map(({ type, seq }) => ({ type, seq }))).toEqual([
+          { type: 'inquiryThreadUpdated', seq: 1 },
+        ]);
+      }).pipe(Effect.provide(graph([]))),
+  );
+
+  it.effect(
     'publishes nothing before the marker, then every commit in order',
     () =>
       Effect.gen(function* () {
@@ -200,14 +233,14 @@ describe('session events and view', () => {
         yield* events.publish([
           {
             type: 'approval.resolved',
-            aggregateId: STREAM,
+            aggregateId: qualifyAggregateId('stream', STREAM),
             requestId: 'req-1',
           },
         ]);
         yield* events.publish([
           {
             type: 'status',
-            aggregateId: STREAM,
+            aggregateId: qualifyAggregateId('stream', STREAM),
             phase: STREAM_PHASE.RUNNING,
             previousPhase: STREAM_PHASE.WAITING,
             cause: 'resume',
@@ -305,7 +338,9 @@ describe('session events and view', () => {
         // A stream born after the build enters through its own row alone,
         // above the reserved space, so a renderer attached at open sees it
         // as new.
-        yield* events.publish([{ ...runStart, aggregateId: STREAM }]);
+        yield* events.publish([
+          { ...runStart, aggregateId: qualifyAggregateId('stream', STREAM) },
+        ]);
         yield* settle(view.ref, (v) => v.streams.has(STREAM));
         const live = yield* SubscriptionRef.get(view.ref);
         expect(live.streams.get(STREAM)?.createdAt).toBeGreaterThan(

--- a/src/test-kernel/controllers/session/sessionFramer.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionFramer.vitest.ts
@@ -30,6 +30,7 @@ import { sessionInputsLayer } from '@controllers/session/sessionInputs';
 import { WebviewSessions } from '@controllers/session/webviewSessionLayer';
 import { WorkspaceRoots } from '@controllers/session/WorkspaceRoots';
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   STREAM_PHASE,
   type ExecutionId,
@@ -52,7 +53,7 @@ const PORT = 'sidebar';
 
 const runStart: SessionEventDraft = {
   type: 'run.start',
-  aggregateId: STREAM,
+  aggregateId: qualifyAggregateId('stream', STREAM),
   executionId: EXECUTION,
   identity: { kind: 'agent', agent: 'chat' },
   userFollowUpSupport: 'unsupported',
@@ -62,14 +63,14 @@ const runStart: SessionEventDraft = {
 
 const waiting: SessionEventDraft = {
   type: 'status',
-  aggregateId: STREAM,
+  aggregateId: qualifyAggregateId('stream', STREAM),
   phase: STREAM_PHASE.WAITING,
   cause: 'wait',
 };
 
 const running: SessionEventDraft = {
   type: 'status',
-  aggregateId: STREAM,
+  aggregateId: qualifyAggregateId('stream', STREAM),
   phase: STREAM_PHASE.RUNNING,
   previousPhase: STREAM_PHASE.WAITING,
   cause: 'resume',
@@ -144,7 +145,7 @@ const subscribe: Subscribe = {
   session: KEY,
   generation: 1,
   cursor: 0,
-  aggregates: [{ id: STREAM, fromSeq: 0 }],
+  aggregates: [{ id: qualifyAggregateId('stream', STREAM), fromSeq: 0 }],
 };
 
 /** A framer source over the runtime graph in context. */
@@ -260,7 +261,10 @@ describe('session framer', () => {
         const child = 'stream:second';
         const named: Subscribe = {
           ...subscribe,
-          aggregates: [...subscribe.aggregates, { id: child, fromSeq: 0 }],
+          aggregates: [
+            ...subscribe.aggregates,
+            { id: qualifyAggregateId('stream', child), fromSeq: 0 },
+          ],
         };
         // The shell: begin the generation and set its transcript set, then
         // post the Subscribe; the decoder feeds every frame that answers it.
@@ -285,7 +289,7 @@ describe('session framer', () => {
               read: 'all',
               event: {
                 type: 'stream.removed',
-                aggregateId: STREAM,
+                aggregateId: qualifyAggregateId('stream', STREAM),
                 seq: 9,
                 commit: 99,
                 ownerId: SELF,
@@ -334,7 +338,11 @@ describe('session framer', () => {
 
         // A new stream and its first prefix can become ready in one turn.
         yield* events.publish([
-          { ...runStart, aggregateId: child, executionId: 'second' },
+          {
+            ...runStart,
+            aggregateId: qualifyAggregateId('stream', child),
+            executionId: 'second',
+          },
         ]);
         yield* SubscriptionRef.update(
           chunks.ref,

--- a/src/test-kernel/controllers/session/sessionFramer.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionFramer.vitest.ts
@@ -44,7 +44,7 @@ import type { SessionView } from '@shared/session/sessionView';
 import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 
-const SELF = '4242:self-start';
+const SELF = '["test-host",4242,"self-start"]';
 const KEY = '/workspace/framing';
 const STREAM = 'stream:framing' as StreamTabId;
 const EXECUTION = 'ab12cd' as ExecutionId;

--- a/src/test-kernel/controllers/session/sessionFramer.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionFramer.vitest.ts
@@ -10,7 +10,7 @@
 import { it } from '@effect/vitest';
 import { Effect, Fiber, Layer, Queue, Stream, SubscriptionRef } from 'effect';
 import { TestClock } from 'effect/testing';
-import { describe, expect } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 
 import {
   SessionEventLog,
@@ -29,6 +29,7 @@ import { SessionViewService } from '@controllers/session/SessionView';
 import { sessionInputsLayer } from '@controllers/session/sessionInputs';
 import { WebviewSessions } from '@controllers/session/webviewSessionLayer';
 import { WorkspaceRoots } from '@controllers/session/WorkspaceRoots';
+import { SessionBridge } from '@controllers/session/SessionBridge';
 import {
   aggregateId as qualifyAggregateId,
   AgentCategory,
@@ -43,6 +44,7 @@ import type { HostSnapshot } from '@shared/session/hostSnapshot';
 import type { EventsFrame, Subscribe } from '@shared/session/sessionFrames';
 import type { SessionView } from '@shared/session/sessionView';
 import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
+import { createTestSession } from '@test/support/sessionTestUtils';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 
 const SELF = '["test-host",4242,"self-start"]';
@@ -163,6 +165,35 @@ const framerSource = Effect.gen(function* () {
 });
 
 describe('session framer', () => {
+  it('preserves stream and execution subscription keys across the webview bridge', async () => {
+    const session = createTestSession();
+    const bridge = new SessionBridge({
+      session,
+      onPortClosed: () => {},
+      handleHostRequest: async () => {
+        throw new Error('No host request is expected.');
+      },
+    });
+    const keys = [
+      qualifyAggregateId('stream', STREAM),
+      qualifyAggregateId('execution', EXECUTION),
+    ];
+    try {
+      bridge.attach({ id: PORT, send: () => {} }).receive({
+        ...subscribe,
+        session: session.roots.storage,
+        aggregates: keys.map((id) => ({ id, fromSeq: 0 })),
+      });
+      await vi.waitFor(() => {
+        expect(
+          [...SubscriptionRef.getUnsafe(session.view).folded.keys()].toSorted(),
+        ).toEqual(keys.toSorted());
+      });
+    } finally {
+      bridge.dispose();
+      session.dispose();
+    }
+  });
   it.effect(
     'answers a Subscribe with the replay, then frames the tail every 16 ms with one chunk per row',
     () =>

--- a/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
+++ b/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
@@ -2,7 +2,10 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { StreamTabId } from '@shared/schemas';
+import {
+  aggregateId as qualifyAggregateId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { waitForCondition } from '@test/support/asyncTestUtils';
 import type * as VSCode from 'vscode';
 
@@ -122,7 +125,7 @@ async function emitOutputFiles(
   session.publish([
     {
       type: 'addOutputFiles',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       filesByRound: {
         1: [
           {

--- a/src/test-kernel/shared/session/fanOutScenario.ts
+++ b/src/test-kernel/shared/session/fanOutScenario.ts
@@ -27,8 +27,8 @@ import {
 } from '@shared/session/sessionView';
 
 /** A process identity, never a lease token (contract C5). */
-export const OWNER = '4242:2026-09-04T00:00:00.000Z';
-export const OTHER_OWNER = '4343:2026-09-04T00:00:00.000Z';
+export const OWNER = '["test-host",4242,"2026-09-04T00:00:00.000Z"]';
+export const OTHER_OWNER = '["test-host",4343,"2026-09-04T00:00:00.000Z"]';
 export const ROOT = 'review#aaaaaaaaaaaa' as StreamTabId;
 export const CHILD = 'search#bbbbbbbbbbbb' as StreamTabId;
 export const GRANDCHILD = 'lint#dddddddddddd' as StreamTabId;

--- a/src/test-kernel/shared/session/fanOutScenario.ts
+++ b/src/test-kernel/shared/session/fanOutScenario.ts
@@ -6,6 +6,7 @@
 // the two can never drift.
 
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -103,13 +104,17 @@ export class Log {
     body: SessionEventBody,
     ownerId: string | null = OWNER,
   ): SessionEvent {
-    const seq = (this.seq.get(aggregateId) ?? 0) + 1;
-    this.seq.set(aggregateId, seq);
+    const key = qualifyAggregateId(
+      body.type === 'inquiryThreadUpdated' ? 'inquiry' : 'stream',
+      aggregateId,
+    );
+    const seq = (this.seq.get(key) ?? 0) + 1;
+    this.seq.set(key, seq);
     this.commit += 1;
     // A body is a distributive omit over the union, so the spread cannot be
     // typed back into the union without this assertion.
     const event = {
-      aggregateId,
+      aggregateId: key,
       seq,
       commit: this.commit,
       ownerId,
@@ -160,7 +165,7 @@ export const tail = (event: SessionEvent): FoldInput => ({
 
 export const subscribe = (...ids: StreamTabId[]): FoldInput => ({
   _tag: 'subscriptions',
-  set: ids.map((id) => ({ id, fromSeq: 0 })),
+  set: ids.map((id) => ({ id: qualifyAggregateId('stream', id), fromSeq: 0 })),
 });
 
 export function local(state: Partial<LocalRuntimeState>): FoldInput {
@@ -518,7 +523,8 @@ function ownedBy(
   ownerId: string,
 ): FoldInput[] {
   return inputs.map((input) =>
-    input._tag === 'event' && input.event.aggregateId === aggregateId
+    input._tag === 'event' &&
+    input.event.aggregateId === qualifyAggregateId('stream', aggregateId)
       ? { ...input, event: { ...input.event, ownerId } }
       : input,
   );
@@ -554,7 +560,8 @@ export function withWaitingGrandchild(): SessionView {
     (input) =>
       !(
         input._tag === 'event' &&
-        ((input.event.aggregateId === GRANDCHILD &&
+        ((input.event.aggregateId ===
+          qualifyAggregateId('stream', GRANDCHILD) &&
           settled.has(input.event.type) &&
           input.event.at === T.grandchildDone) ||
           input.event.type === 'approval.requested')

--- a/src/test-kernel/shared/session/sessionFold.vitest.ts
+++ b/src/test-kernel/shared/session/sessionFold.vitest.ts
@@ -505,6 +505,23 @@ describe('sessionFold', () => {
 
     // Subscribing later reopens from the seq the subscription names.
     const full = foldAll(scenario.events);
+    const subscriptions = [...full.folded].map(([id, fromSeq]) => ({
+      id,
+      fromSeq,
+    }));
+    const execution = qualifyAggregateId('execution', ROOT);
+    const overlapping = fold(full, {
+      _tag: 'subscriptions',
+      set: [...subscriptions, { id: execution, fromSeq: 0 }],
+    });
+    const streamOnly = fold(overlapping, {
+      _tag: 'subscriptions',
+      set: subscriptions,
+    });
+    expect(streamOnly.folded.has(execution)).toBe(false);
+    expect(stream(streamOnly, ROOT).transcript).toEqual(
+      stream(full, ROOT).transcript,
+    );
     const evicted = fold(full, subscribe(CHILD));
     expect(evicted.folded.has(qualifyAggregateId('stream', ROOT))).toBe(false);
     expect(evicted.folded.has(qualifyAggregateId('stream', CHILD))).toBe(true);

--- a/src/test-kernel/shared/session/sessionFold.vitest.ts
+++ b/src/test-kernel/shared/session/sessionFold.vitest.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -142,11 +143,13 @@ describe('sessionFold', () => {
     );
     expect(root.transcript.rows).toStrictEqual(rowsOf(scenario.rootEntries));
     // The transcript tier retained the rows: the aggregate's newest seq.
-    expect(view.folded.get(ROOT)).toBe(
+    expect(view.folded.get(qualifyAggregateId('stream', ROOT))).toBe(
       Math.max(
         ...scenario.log.events
           .filter(
-            (e) => e.aggregateId === ROOT && e.type === 'transcript.entry',
+            (e) =>
+              e.aggregateId === qualifyAggregateId('stream', ROOT) &&
+              e.type === 'transcript.entry',
           )
           .map((e) => e.seq),
       ),
@@ -456,13 +459,19 @@ describe('sessionFold', () => {
   it('keeps listing facts in commit order and transcript rows in seq order, whichever read delivers them', () => {
     const settled = foldAll(scenario.events);
     const rootStatus = scenario.log.events.find(
-      (e) => e.aggregateId === ROOT && e.type === 'status',
+      (e) =>
+        e.aggregateId === qualifyAggregateId('stream', ROOT) &&
+        e.type === 'status',
     )!;
     const rootStart = scenario.log.events.find(
-      (e) => e.aggregateId === ROOT && e.type === 'run.start',
+      (e) =>
+        e.aggregateId === qualifyAggregateId('stream', ROOT) &&
+        e.type === 'run.start',
     )!;
     const rootEntry = scenario.log.events.find(
-      (e) => e.aggregateId === ROOT && e.type === 'transcript.entry',
+      (e) =>
+        e.aggregateId === qualifyAggregateId('stream', ROOT) &&
+        e.type === 'transcript.entry',
     )!;
     // An aggregate read replaying an older status, start, or row after the
     // tail folded the current one changes nothing, and the cursor stays.
@@ -497,8 +506,8 @@ describe('sessionFold', () => {
     // Subscribing later reopens from the seq the subscription names.
     const full = foldAll(scenario.events);
     const evicted = fold(full, subscribe(CHILD));
-    expect(evicted.folded.has(ROOT)).toBe(false);
-    expect(evicted.folded.has(CHILD)).toBe(true);
+    expect(evicted.folded.has(qualifyAggregateId('stream', ROOT))).toBe(false);
+    expect(evicted.folded.has(qualifyAggregateId('stream', CHILD))).toBe(true);
     const root = stream(evicted, ROOT);
     expect(root.transcript.rows).toStrictEqual([]);
     expect(root.transcript.taskGroups).toStrictEqual([]);
@@ -515,7 +524,7 @@ describe('sessionFold', () => {
     const view = foldAll([tail(removed)], foldAll(scenario.events));
     expect(view.streams.has(ROOT)).toBe(false);
     expect(view.policy.has(ROOT)).toBe(false);
-    expect(view.folded.has(ROOT)).toBe(false);
+    expect(view.folded.has(qualifyAggregateId('stream', ROOT))).toBe(false);
     expect(view.order).toStrictEqual([PROCESS, CHILD]);
     expect(stream(view, CHILD).parentId).toBeNull();
     expect(stream(view, CHILD).ancestors).toStrictEqual([]);
@@ -526,7 +535,9 @@ describe('sessionFold', () => {
     // A read replaying the run.start beneath the tombstone does not
     // recreate the stream: the lifecycle pair shares one latest entry.
     const rootStart = scenario.log.events.find(
-      (e) => e.aggregateId === ROOT && e.type === 'run.start',
+      (e) =>
+        e.aggregateId === qualifyAggregateId('stream', ROOT) &&
+        e.type === 'run.start',
     )!;
     const replayed = fold(view, {
       _tag: 'event',
@@ -538,7 +549,9 @@ describe('sessionFold', () => {
     // Listing hydration is authoritative: at the marker, a stream no
     // listing row named is gone with everything a tombstone clears.
     const processStart = scenario.log.events.find(
-      (e) => e.aggregateId === PROCESS && e.type === 'run.start',
+      (e) =>
+        e.aggregateId === qualifyAggregateId('stream', PROCESS) &&
+        e.type === 'run.start',
     )!;
     const pruned = foldAll(
       [
@@ -560,13 +573,13 @@ describe('sessionFold', () => {
     const facts: FoldInput[] = [
       tail({
         ...stamp,
-        aggregateId: ghost,
+        aggregateId: qualifyAggregateId('stream', ghost),
         type: 'updateStreamDescription',
         description: 'boo',
       }),
       tail({
         ...stamp,
-        aggregateId: PROCESS,
+        aggregateId: qualifyAggregateId('stream', PROCESS),
         seq: 3,
         commit: 100,
         type: 'setParentStream',
@@ -598,8 +611,8 @@ describe('sessionFold', () => {
     const key = `${CHILD}/late`;
     const after = fold(before, [
       tail({
-        aggregateId: CHILD,
-        seq: before.folded.get(CHILD)! + 1,
+        aggregateId: qualifyAggregateId('stream', CHILD),
+        seq: before.folded.get(qualifyAggregateId('stream', CHILD))! + 1,
         commit: 200,
         ownerId: OWNER,
         at: 4000,
@@ -648,8 +661,8 @@ describe('sessionFold', () => {
     const logged = fold(
       after,
       tail({
-        aggregateId: CHILD,
-        seq: before.folded.get(CHILD)! + 2,
+        aggregateId: qualifyAggregateId('stream', CHILD),
+        seq: before.folded.get(qualifyAggregateId('stream', CHILD))! + 2,
         commit: 201,
         ownerId: OWNER,
         at: 4100,

--- a/src/test-kernel/support/storeTestDrivers.ts
+++ b/src/test-kernel/support/storeTestDrivers.ts
@@ -1,16 +1,17 @@
 import type { AgentEvent } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import type {
-  CompileFailure,
-  ExecutionId,
-  ExtendedTokenUsageStats,
-  OutputFileInfo,
-  Plan,
-  RoundIndexed,
-  RunIdentity,
-  StreamLogEntry,
-  StreamTabId,
-  TodoItem,
+import {
+  aggregateId as qualifyAggregateId,
+  type CompileFailure,
+  type ExecutionId,
+  type ExtendedTokenUsageStats,
+  type OutputFileInfo,
+  type Plan,
+  type RoundIndexed,
+  type RunIdentity,
+  type StreamLogEntry,
+  type StreamTabId,
+  type TodoItem,
 } from '@shared/schemas';
 import type { StreamSnapshotStore } from '@transcript';
 import type { StreamLogAppendInput } from '@transcript/StreamLog';
@@ -129,7 +130,7 @@ export function snapshotFacts(store: StreamSnapshotStore): SnapshotProjection {
     setRunStart: ({ streamId, executionId, identity }) => {
       apply({
         type: 'run.start',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         executionId,
         identity,
         category: 'toolUse',
@@ -138,45 +139,67 @@ export function snapshotFacts(store: StreamSnapshotStore): SnapshotProjection {
       });
     },
     setRunConfig: (streamId, config, executionId) => {
-      apply({ type: 'run.config', aggregateId: streamId, executionId, config });
+      apply({
+        type: 'run.config',
+        aggregateId: qualifyAggregateId('stream', streamId),
+        executionId,
+        config,
+      });
     },
     setTodos: (streamId, todos) => {
-      apply({ type: 'updateTodos', aggregateId: streamId, todos });
+      apply({
+        type: 'updateTodos',
+        aggregateId: qualifyAggregateId('stream', streamId),
+        todos,
+      });
     },
     setPlan: (streamId, plan) => {
-      apply({ type: 'updatePlan', aggregateId: streamId, plan });
+      apply({
+        type: 'updatePlan',
+        aggregateId: qualifyAggregateId('stream', streamId),
+        plan,
+      });
     },
     addOutputFiles: (streamId, filesByRound) => {
-      apply({ type: 'addOutputFiles', aggregateId: streamId, filesByRound });
+      apply({
+        type: 'addOutputFiles',
+        aggregateId: qualifyAggregateId('stream', streamId),
+        filesByRound,
+      });
     },
     updateMissingOutputs: (streamId, filesByRound) => {
       apply({
         type: 'updateMissingOutputs',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         filesByRound,
       });
     },
     updateCompileFailures: (streamId, filesByRound) => {
       apply({
         type: 'updateCompileFailures',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         filesByRound,
       });
     },
     addUsage: (streamId, storageKey, usage) => {
-      apply({ type: 'usage', aggregateId: streamId, storageKey, usage });
+      apply({
+        type: 'usage',
+        aggregateId: qualifyAggregateId('stream', streamId),
+        storageKey,
+        usage,
+      });
     },
     setDescription: (streamId, description) => {
       apply({
         type: 'updateStreamDescription',
-        aggregateId: streamId,
+        aggregateId: qualifyAggregateId('stream', streamId),
         description,
       });
     },
     setParentStream: (child, parent) => {
       apply({
         type: 'setParentStream',
-        aggregateId: child,
+        aggregateId: qualifyAggregateId('stream', child),
         parentStreamId: parent,
       });
     },

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -29,7 +29,11 @@ vi.mock('@tools/inquiry/externalInquiryStorage', () => ({
 
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import type { InquiryThreadId, StreamTabId } from '@shared/schemas';
+import {
+  aggregateId as qualifyAggregateId,
+  type InquiryThreadId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
 import { createTestSession } from '@test/support/sessionTestUtils';
 
@@ -167,7 +171,7 @@ describe('external inquiry continuation session routing', () => {
       expect(explicit.facts).toMatchObject([
         {
           type: 'inquiryThreadUpdated',
-          aggregateId: THREAD,
+          aggregateId: qualifyAggregateId('inquiry', THREAD),
           threadId: THREAD,
           parentStreamId: STREAM,
           parentExecutionId: null,
@@ -202,7 +206,7 @@ describe('external inquiry continuation session routing', () => {
       expect(run.facts).toMatchObject([
         expect.objectContaining({
           type: 'inquiryThreadUpdated',
-          aggregateId: THREAD,
+          aggregateId: qualifyAggregateId('inquiry', THREAD),
           threadId: THREAD,
           resumeOutcome: 'sent',
         }),

--- a/src/test-kernel/tools/goal/goalStore.vitest.ts
+++ b/src/test-kernel/tools/goal/goalStore.vitest.ts
@@ -9,7 +9,11 @@ import {
 } from '@agent/runtime/SessionHandle';
 import type { StateStore } from '@platform/interfaces';
 import { workspaceRoots } from '@platform/workspaceRoots';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  aggregateId as qualifyAggregateId,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
@@ -275,21 +279,21 @@ describe('subscribeGoalStateChanges', () => {
       sessionB.publish([
         {
           type: 'goalStateChanged',
-          aggregateId: 'other-session' as StreamTabId,
+          aggregateId: qualifyAggregateId('stream', 'other-session'),
           state: { active: false },
         },
       ]);
       sessionA.publish([
         {
           type: 'updateStreamDescription',
-          aggregateId: 'same-session' as StreamTabId,
+          aggregateId: qualifyAggregateId('stream', 'same-session'),
           description: 'not a goal change',
         },
       ]);
       sessionA.publish([
         {
           type: 'goalStateChanged',
-          aggregateId: 'same-session' as StreamTabId,
+          aggregateId: qualifyAggregateId('stream', 'same-session'),
           state: { active: false },
         },
       ]);

--- a/src/test-kernel/traceViewer/traceFrames.vitest.ts
+++ b/src/test-kernel/traceViewer/traceFrames.vitest.ts
@@ -7,6 +7,7 @@ import {
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
 import {
+  aggregateId as qualifyAggregateId,
   AgentCategory,
   LOG_LEVELS,
   MESSAGE_TYPES,
@@ -48,10 +49,15 @@ function foldTrace(trace: TraceDocument) {
     session: 'trace',
     generation: 1,
     cursor: 0,
-    aggregates: [{ id: trace.streamId, fromSeq: 0 }],
+    aggregates: [
+      { id: qualifyAggregateId('stream', trace.streamId), fromSeq: 0 },
+    ],
   });
   const view = fold(emptySessionView('trace', 0), [
-    { _tag: 'subscriptions', set: [{ id: trace.streamId, fromSeq: 0 }] },
+    {
+      _tag: 'subscriptions',
+      set: [{ id: qualifyAggregateId('stream', trace.streamId), fromSeq: 0 }],
+    },
     ...frame.events,
     { _tag: 'local', local: { self: [], heldBy: [], unreadable: [] } },
   ]);

--- a/src/test-kernel/traceViewer/traceFrames.vitest.ts
+++ b/src/test-kernel/traceViewer/traceFrames.vitest.ts
@@ -116,6 +116,16 @@ function legacyTrace(
 describe('traceEvents legacy-status fallback (issue #7188)', () => {
   it('replays workflow content without tool-use state', () => {
     const trace = legacyTrace(undefined);
+    trace.entries.push(
+      StreamLogEntrySchema.parse({
+        id: 'archived-log',
+        seqNo: 1,
+        timestamp: 1,
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        text: 'Archived derivation',
+      }),
+    );
 
     const replayed = foldTrace(trace);
     expect(replayed).toMatchObject({
@@ -125,6 +135,13 @@ describe('traceEvents legacy-status fallback (issue #7188)', () => {
       compileFailures: {},
     });
     expect(replayed).not.toHaveProperty('todos');
+    expect(replayed?.transcript.rows).toContainEqual(
+      expect.objectContaining({
+        id: 'archived-log',
+        kind: 'log',
+        text: expect.objectContaining({ full: 'Archived derivation' }),
+      }),
+    );
   });
 
   it('replays tool-use content without workflow output state', () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -11,6 +11,7 @@ import {
 import * as logUtils from '@logger/logUtils';
 import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
 import {
+  aggregateId as qualifyAggregateId,
   STREAM_TAB_META_SCHEMA_VERSION,
   USER_FOLLOW_UP_SUPPORT,
   AgentCategory,
@@ -306,7 +307,7 @@ describe('StreamSnapshotStore', () => {
 
     apply({
       type: 'run.start',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       executionId,
       identity: { kind: 'agent', agent: 'session-label' },
       category: AgentCategory.ToolUse,
@@ -315,50 +316,53 @@ describe('StreamSnapshotStore', () => {
     });
     apply({
       type: 'run.config',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       executionId,
       config: runConfig,
     });
     apply({
       type: 'updateTodos',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       todos: [TODO],
     });
     apply({
       type: 'updatePlan',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       plan: PLAN,
     });
     apply({
       type: 'addOutputFiles',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       filesByRound: { 1: [output] },
     });
     apply({
       type: 'updateMissingOutputs',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       filesByRound: { 1: ['paper.pdf'] },
     });
     apply({
       type: 'updateCompileFailures',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       filesByRound: { 1: [failure] },
     });
     apply({
       type: 'usage',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       storageKey: RUN,
       usage: extendedUsage,
     });
-    apply({ type: 'goalPaused', aggregateId: OTHER_STREAM });
+    apply({
+      type: 'goalPaused',
+      aggregateId: qualifyAggregateId('stream', OTHER_STREAM),
+    });
     apply({
       type: 'updateStreamDescription',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       description: 'session-search / kimi26T',
     });
     apply({
       type: 'setParentStream',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       parentStreamId: OTHER_STREAM,
     });
 
@@ -419,7 +423,7 @@ describe('StreamSnapshotStore', () => {
 
     apply({
       type: 'run.config',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       executionId,
       config: runConfig,
     });
@@ -428,7 +432,7 @@ describe('StreamSnapshotStore', () => {
 
     apply({
       type: 'run.start',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       executionId,
       identity: workflowIdentity,
       category: AgentCategory.ToolUse,
@@ -1049,7 +1053,7 @@ describe('StreamSnapshotStore', () => {
 
     apply({
       type: 'run.start',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       executionId,
       identity: { kind: 'agent', agent: 'search' },
       category: AgentCategory.ToolUse,
@@ -1064,7 +1068,7 @@ describe('StreamSnapshotStore', () => {
     });
     apply({
       type: 'updateStreamDescription',
-      aggregateId: STREAM,
+      aggregateId: qualifyAggregateId('stream', STREAM),
       description: 'Current label',
     });
     expect(store.getRunMetadata(STREAM).description).toBe('Current label');

--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -12,7 +12,11 @@ import {
 } from '@agent/runtime/SessionHandle';
 import { getStreamTabId } from '@agent/runtime/streamTab';
 import { classifyAgentError } from '@common/errors';
-import { RUN_OUTCOME, STREAM_PHASE } from '@shared/schemas';
+import {
+  aggregateId as qualifyAggregateId,
+  RUN_OUTCOME,
+  STREAM_PHASE,
+} from '@shared/schemas';
 import type {
   ExecutionId,
   RunIdentity,
@@ -132,7 +136,7 @@ export function createChildStream(
     session.publish([
       {
         type: 'run.start',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         executionId,
         identity: options.run,
         userFollowUpSupport: options.userFollowUpSupport,
@@ -156,7 +160,7 @@ export function createChildStream(
       // has no agent-registry entry to be remote.
       {
         type: 'run.activate',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         category: options.config.agentCategory,
         background: true,
       },
@@ -174,7 +178,7 @@ export function createChildStream(
     session.publish([
       {
         type: 'updateStreamDescription',
-        aggregateId: childStreamId,
+        aggregateId: qualifyAggregateId('stream', childStreamId),
         description,
       },
     ]);
@@ -375,7 +379,10 @@ async function finalizeChildStream(
 
   if (options.autoClose) {
     session.publish([
-      { type: 'stream.removed', aggregateId: handle.childStreamId },
+      {
+        type: 'stream.removed',
+        aggregateId: qualifyAggregateId('stream', handle.childStreamId),
+      },
     ]);
   }
 }

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -21,7 +21,10 @@ import {
 import { appSignals } from '@eventBus/AppSignals';
 import { createLog } from '@logger/logUtils';
 import type { Disposable } from '@platform/interfaces';
-import type { StreamTabId } from '@shared/schemas';
+import {
+  aggregateId as qualifyAggregateId,
+  type StreamTabId,
+} from '@shared/schemas';
 
 export interface SubscriptionBinding<K extends string> {
   key: K;
@@ -113,7 +116,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
           owner.publish([
             {
               type: 'updateQueuedFollowUps',
-              aggregateId: streamId,
+              aggregateId: qualifyAggregateId('stream', streamId),
               messages: owner.followUps.getAll(streamId),
             },
           ]);

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -12,6 +12,8 @@ import {
 import { effectRuntime } from '@platform/processRuntime';
 import { tryWorkspaceRoots, workspaceRoots } from '@platform/workspaceRoots';
 import {
+  aggregateId as qualifyAggregateId,
+  aggregateTarget,
   GoalSchema,
   isGoalInFlight,
   type ExecutionId,
@@ -63,7 +65,7 @@ function emitGoalStateChanged(
   target.publish([
     {
       type: 'goalStateChanged',
-      aggregateId: streamId,
+      aggregateId: qualifyAggregateId('stream', streamId),
       state: goalStateOf(readRaw(streamId)),
     },
   ]);
@@ -182,7 +184,7 @@ export function subscribeGoalStateChanges(
     Stream.runForEach(session.events.all(session.now()), (event) =>
       Effect.sync(() => {
         if (event.type === 'goalStateChanged') {
-          listener({ streamId: event.aggregateId });
+          listener({ streamId: aggregateTarget(event.aggregateId).id });
         }
       }),
     ),

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -28,6 +28,7 @@ import {
 } from '@agent/runtime/SessionHandle';
 import { createLog } from '@logger/logUtils';
 import {
+  aggregateId as qualifyAggregateId,
   InquiryThreadIdSchema,
   ToolError,
   type ExecutionId,
@@ -318,7 +319,7 @@ export class ExternalInquiryTool extends defineTool({
       session.publish([
         {
           type: 'inquiryThreadUpdated',
-          aggregateId: summary.threadId,
+          aggregateId: qualifyAggregateId('inquiry', summary.threadId),
           ...summary,
         },
       ]);

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -22,12 +22,13 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import { createLog } from '@logger/logUtils';
-import type {
-  InquiryThreadId,
-  InquiryThreadSummary,
-  InquiryThreadUpdatedEvent,
-  InquiryResumeOutcome,
-  StreamTabId,
+import {
+  aggregateId as qualifyAggregateId,
+  type InquiryThreadId,
+  type InquiryThreadSummary,
+  type InquiryThreadUpdatedEvent,
+  type InquiryResumeOutcome,
+  type StreamTabId,
 } from '@shared/schemas';
 import {
   formatRelativeTime,
@@ -118,7 +119,11 @@ async function emitInquiryThreadUpdate(
   if (!summary) return;
   const payload: InquiryThreadUpdatedEvent = { ...summary, ...extra };
   (session ?? currentSession()).publish([
-    { type: 'inquiryThreadUpdated', aggregateId: payload.threadId, ...payload },
+    {
+      type: 'inquiryThreadUpdated',
+      aggregateId: qualifyAggregateId('inquiry', payload.threadId),
+      ...payload,
+    },
   ]);
 }
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -25,6 +25,7 @@ import { isFileNotFoundError } from '@common/errors';
 import { KVStore } from '@common/storage/KVStore';
 import { createLog } from '@logger/logUtils';
 import {
+  aggregateTarget,
   CompileFailureSchema,
   cloneRoundIndexed,
   EMPTY_ROUND_INDEXED,
@@ -694,7 +695,7 @@ export class StreamSnapshotStore {
           // which enter the plane directly and never this projection.
           if (event.identity == null) return;
           this.setRunStart(
-            event.aggregateId,
+            aggregateTarget(event.aggregateId).id,
             event.executionId,
             event.identity,
             event.userFollowUpSupport,
@@ -705,47 +706,57 @@ export class StreamSnapshotStore {
           // (`runEventDraft` passes it through); the plane's schema names the
           // fields the fold reads, the sidecar keeps the run's full config.
           this.setRunConfig(
-            event.aggregateId,
+            aggregateTarget(event.aggregateId).id,
             event.config as AgentConfig,
             event.executionId,
           );
           return;
         case 'usage':
           // `addUsage`'s safeParse is the wire→domain narrowing boundary.
-          void this.addUsage(event.aggregateId, event.storageKey, event.usage);
+          void this.addUsage(
+            aggregateTarget(event.aggregateId).id,
+            event.storageKey,
+            event.usage,
+          );
           return;
         case 'updateTodos':
-          this.setTodos(event.aggregateId, event.todos);
+          this.setTodos(aggregateTarget(event.aggregateId).id, event.todos);
           return;
         case 'updatePlan':
-          this.setPlan(event.aggregateId, event.plan);
+          this.setPlan(aggregateTarget(event.aggregateId).id, event.plan);
           return;
         case 'addOutputFiles':
           this.applyRoundFieldFact(
-            event.aggregateId,
+            aggregateTarget(event.aggregateId).id,
             'outputFiles',
             event.filesByRound,
           );
           return;
         case 'updateMissingOutputs':
           this.applyRoundFieldFact(
-            event.aggregateId,
+            aggregateTarget(event.aggregateId).id,
             'missingOutputs',
             event.filesByRound,
           );
           return;
         case 'updateCompileFailures':
           this.applyRoundFieldFact(
-            event.aggregateId,
+            aggregateTarget(event.aggregateId).id,
             'compileFailures',
             event.filesByRound,
           );
           return;
         case 'updateStreamDescription':
-          this.setDescription(event.aggregateId, event.description);
+          this.setDescription(
+            aggregateTarget(event.aggregateId).id,
+            event.description,
+          );
           return;
         case 'setParentStream':
-          this.setParentStream(event.aggregateId, event.parentStreamId);
+          this.setParentStream(
+            aggregateTarget(event.aggregateId).id,
+            event.parentStreamId,
+          );
           return;
         // `status`, `run.activate`, `stage.start`, `result`, and
         // `stream.removed` carry liveness and lifecycle, which the class doc


### PR DESCRIPTION
## Summary

A stream and an inquiry can share the same logical id. Using that id as the event key gives them one sequence counter, one subscription key, and one closure state. Replace raw event keys with C2's canonical `JSON.stringify([kind, logicalId])` encoding throughout publication, subscriptions, replay, and renderer decoding.

The shared Zod schema validates the encoding and gives qualified keys a distinct TypeScript type. The constructor rejects an already-qualified key as a typed input. Logical stream, execution, and thread ids remain unchanged at external boundaries. The native session subscription method qualifies its callers' stream ids once, so the SDK's source and interface remain unchanged.

## Issue acceptance gates

C2 prerequisite for #11867's listing and persistence work, also addressing the aggregate-collision finding on #11948. This does not complete stage 2 or any store replacement. D4, resume, retention, scrubbing, and importer decisions are untouched.

Targets `cutover/persistence-substrate`. Depends on #11956: this branch includes that prerequisite so every draft and fixture uses the same owner identity. The C2 change itself is d2de214005.

## Single source of truth

`AggregateIdSchema` defines the canonical event/subscription key. `aggregateId` constructs it; `aggregateTarget` recovers logical ids at display and runtime boundaries. Fold sequence maps and subscription unions retain qualified keys.

## Duplication and abstraction budget

Delete the raw-string aggregate schema and casts that treated event keys as stream ids. Replace each producer and consumer directly. No new service, class, file, compatibility reader, or generic storage interface.

## Net elements (R6)

C2 commit: 0 files added or deleted, 2 exported functions added, no classes/interfaces/enums added, +622/-298 lines across 53 files. The size comes from changing every event-key handoff and its existing fixtures, plus the one cross-kind regression test. Including #11956, the current cutover diff is +713/-348 across 56 files.

## Consumer counts (R8)

No publisher, event arm, or subscription is deleted. Every production event-key site was searched in `src/`, `packages/`, and `scripts/`. Native `setTranscriptSubscriptions` retains its four production call sites, including the unchanged SDK caller. Host view decoders translate qualified event keys back to logical stream ids; aggregate reads and frame subscriptions keep the qualified key.

## Host impact

Extension/webview, desktop, CLI/TUI, and the trace viewer use the same qualified event keys. Display ids, execution ids, file paths, and external inquiry ids do not change. No `packages/agent/` file or ratchet baseline changes.

## Scheduled refactoring

The indexed read path and removal of file-backed listing/transcript/state persistence remain in #11867. The existing memory layer is not claimed as durable storage by this PR.

## Validation

Passed: full typecheck, lint, compile:fast, format, both real Electron webview smoke runs after the fixture updates, dead-code ratchet, and diff checks. The 18 initially affected suites passed 391 tests, including one regression showing that deleting a stream does not close or hide an inquiry with the same logical id.

The full `npm test` run passed 9064 tests and exposed four additional assertions that still passed an aggregate key to a logical-stream accessor. Those fixtures were corrected; their existing suite passes all four tests. Workspace and test-kernel typechecks and lint were repeated after that correction. No new test file was added.

The Effect ratchet still fails on #11949. Its mechanism findings are byte-identical to the C5 prerequisite, which in turn matched the untouched stage 1 worktree. No baseline is widened.
