### PR TITLE
chore(ratchets): lock in effect-migration baseline shrinkage

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -10,7 +10,6 @@
       "packages/cli/src/onboarding/runOnboarding.tsx": 4,
       "packages/cli/src/runtime/apiStatus.ts": 1,
       "packages/cli/src/runtime/githubToken.ts": 3,
-      "packages/cli/src/runtime/initPlatform.ts": 1,
       "packages/cli/src/runtime/modelAccessSelection.ts": 3,
       "packages/cli/src/runtime/providerApiKey.ts": 2,
       "packages/cli/src/runtime/runExecution.ts": 1,
@@ -20,10 +19,8 @@
       "packages/desktop/src/main/desktopSettingsIpc.ts": 3,
       "packages/desktop/src/main/desktopWorkspaceIpc.ts": 6,
       "packages/desktop/src/main/index.ts": 16,
-      "packages/desktop/src/main/platform/index.ts": 1,
       "packages/extension/src/commands/git/gitCommands.ts": 1,
       "packages/extension/src/commands/setup/setupAssistantCommand.ts": 4,
-      "packages/extension/src/extension.ts": 1,
       "packages/extension/src/frontend/agents/AgentDirectoryManager.ts": 1,
       "packages/extension/src/frontend/auth/SupabaseAuthProvider.ts": 1,
       "packages/extension/src/frontend/secretManager.ts": 2,
@@ -103,8 +100,6 @@
       "packages/cli/src/chat/tui/runChatTui.tsx": 1,
       "packages/cli/src/chat/tui/sessionExitController.ts": 1,
       "packages/cli/src/chat/tui/state/subscribeApprovals.ts": 1,
-      "packages/cli/src/runtime/approval/approvalPrompts.ts": 1,
-      "packages/cli/src/runtime/cliSecrets.ts": 1,
       "packages/cli/src/runtime/logSinks.ts": 1,
       "packages/desktop/src/main/desktopSupabaseAuth.ts": 1,
       "packages/desktop/src/main/index.ts": 1,
@@ -141,7 +136,6 @@
     "import:p-retry": {
       "src/agent/core/flows/ModelInvocationNode.ts": 1,
       "src/agent/implementations/agentCreator/agentCreatorFlow.ts": 1,
-      "src/agent/index/platformAgentDirectories.ts": 1,
       "src/agent/modelHandlers/support/auxiliaryRetry.ts": 1,
       "src/latex/arxivProcessor.ts": 1
     },
@@ -182,15 +176,13 @@
       "src/controllers/session/hostDraftRequests.ts": 1,
       "src/controllers/session/hostRunActions.ts": 1,
       "src/controllers/session/sessionLayer.ts": 5,
-      "src/platform/defaults/fileLocks.ts": 1,
-      "src/platform/defaults/jsonStore.ts": 2,
+      "src/platform/defaults/jsonStore.ts": 1,
       "src/shared/signals.ts": 2,
       "src/telemetry/UsageLogService.ts": 5,
       "src/tools/agentCliSessionRegistry.ts": 2,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/goal/goalStore.ts": 2,
-      "src/tools/lean/direct/directLspAdapter.ts": 4,
-      "src/tools/memory/memoryFileSystem.ts": 1
+      "src/tools/lean/direct/directLspAdapter.ts": 4
     },
     "catch:effect-importer": {
       "packages/cli/src/chat/chatSessionController.ts": 7,
@@ -233,14 +225,12 @@
     "src/controllers/session/hostDraftRequests.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/controllers/session/hostRunActions.ts": "lane D — host composition root and session graph",
     "src/controllers/session/sessionLayer.ts": "lane D — host composition root and session graph",
-    "src/platform/defaults/fileLocks.ts": "lane D — Platform ports become Effect-typed",
     "src/platform/defaults/jsonStore.ts": "lane D — Platform ports become Effect-typed",
     "src/shared/signals.ts": "lane D — host composition root and session graph",
     "src/telemetry/UsageLogService.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/tools/agentCliSessionRegistry.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/github/PollingSourceBase.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/goal/goalStore.ts": "Phase 5 — tools subsystem",
-    "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — LeanLanguageServices becomes an Effect-typed port and the run moves to LspTools' execute()",
-    "src/tools/memory/memoryFileSystem.ts": "wave-1 rebuild — tools: memory, executions, polling sources"
+    "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — LeanLanguageServices becomes an Effect-typed port and the run moves to LspTools' execute()"
   }
 }


### PR DESCRIPTION
## Summary

Effect 4 migration lane: agent directory index & remote agent loading
(docs/prds/2026-08-26-effect-4-runtime-migration.md). The lane audit found
nothing left to convert inside the lane's scope:

- `src/agent/index/platformAgentDirectories.ts` (`import:p-retry`) is already
  converted on `main` — it uses `Schedule` + `Effect.fn` and its only
  production caller (`src/platform/defaults/nodeHost.ts`) already consumes it
  inside an Effect chain. The baseline row was stale headroom.
- The three remaining target modules are **skipped under the chain-scope
  rule** (hard rule 2 of the lane assignment; PRD execution rule 1, leaf to
  root): every upward path from them passes through a file owned by another
  lane or carries lane-D `platform()` rows, so converting them would either
  touch owned files or create a forbidden Promise → Effect → Promise
  sandwich. Details under "Issue acceptance gates".

What lands here is the mandated baseline regeneration
(`node scripts/check-effect-migration-ratchet.mjs --update`, repo convention
per gate 5 of the migration lanes): it removes the stale `import:p-retry`
entry, locks in shrinkage other lanes' merged PRs already produced in the
tree, and drops two `debtLanes` entries whose debt is gone.

Ratchet rows (baseline before → after):

- `import:p-retry`: 5 files / 5 sites → 4 files / 4 sites
  (`src/agent/index/platformAgentDirectories.ts` entry removed — this lane's row)
- `platform()`: 72 files / 159 sites → 69 files / 156 sites
- `import:p-queue`: 26 files / 26 sites → 24 files / 24 sites
- `Effect.run*`: 17 files / 44 sites → 15 files / 41 sites
- `debtLanes`: entries removed for `src/platform/defaults/fileLocks.ts` and
  `src/tools/memory/memoryFileSystem.ts` (debt gone, entry was stale)

The non-lane rows are other lanes' already-merged shrinkage; the ratchet is
global and shrink-only, and `--update` records whatever the tree has earned.

## Issue acceptance gates

Lane targets and their disposition:

- `import:p-map` — `src/agent/index/agentYamlScanner.ts`: **skipped
  (chain-scope rule)**. `scanDirectory`'s only production consumer is
  `agentRegistry.doLoad` → `loadAgents` / `refresh` / `computeAgentOptionsData`.
  Converting that chain upward to a boundary requires converting
  `src/controllers/session/hostSnapshotSource.ts` (owned: `controllers/session/**`,
  awaits `computeAgentOptionsData`) and `packages/agent/src/index.ts` (owned:
  `packages/agent/**`, awaits `loadAgents`). `agentRegistry.ts` itself also
  carries `platform()` rows assigned to lane D. No conversion is possible
  without touching owned files or keeping a Promise pass-through.
- `catch:effect-importer` — `src/agent/index/agentYamlScanner.ts` (3 sites):
  same chain, same skip.
- `catch:effect-importer` — `src/agent/remote/RemoteAgentLoader.ts` (1 site):
  **skipped (chain-scope rule)**. `loadRemoteAgent`'s only production consumer
  is `src/agent/runtime/agentLoad.ts` (owned, agent-runtime main track).
- `catch:effect-importer` — `src/agent/remote/remoteAgentList.ts` (2 sites):
  **skipped (chain-scope rule)**. `listRemoteAgents`' only production consumer
  is `src/agent/index/remoteAgentMeta.ts` (lane-D `platform()` rows, do not
  chase), which feeds the same blocked `agentRegistry` chain above.
- `import:p-retry` — `src/agent/index/platformAgentDirectories.ts`:
  **already converted on `main`** (`Schedule.min` of exponential/spaced,
  jittered, `Schedule.upTo`; `Effect.retry` with a `while` predicate on
  `ELOCKED`). Baseline entry removed by this PR.

Residual static-check red is inherited from `main`, verified identical on a
fresh `origin/main` worktree (2d98650458): six grew/new rows —
`[Effect.run*] src/auth/authProgram.ts 0 -> 1`,
`[catch:effect-importer] packages/cli/src/runtime/initPlatform.ts 0 -> 4`,
`packages/desktop/src/main/desktopPapers.ts 0 -> 4`,
`packages/desktop/src/main/index.ts 15 -> 17`,
`packages/desktop/src/main/platform/index.ts 0 -> 1`,
`src/auth/SupabaseClient.ts 0 -> 5` — plus the `@adapter-until` marker at
`src/auth/SupabaseClient.ts:168`. This branch adds no failures and removes
the 9 stale-headroom notices and 2 stale `debtLanes` entries.

## Single source of truth

`config/ratchets/effect-migration-baseline.json` remains the single
shrink-only record of pre-Effect mechanisms; no code surface changed, so no
fact or decision moved.

## Duplication and abstraction budget

None added. No adapters, pass-throughs, or second surfaces were created —
the chain-scope skips exist precisely to avoid them.

## Net elements (R6)

- Files: 1 changed (`config/ratchets/effect-migration-baseline.json`),
  +3 / −13 (diffstat).
- Exported symbols (`^[+-]export` over the diff): 0 added, 0 deleted.
- Classes/interfaces/enums: 0.
- Net LoC: −10 (JSON baseline rows only).

## Consumer counts (R8)

n/a — no export or emit path was deleted or re-routed. For the skip record,
grepped production consumer counts of the skipped surfaces:
`scanDirectory` 1 (`agentRegistry.ts`), `loadRemoteAgent` 1
(`runtime/agentLoad.ts`, owned), `listRemoteAgents` 1
(`remoteAgentMeta.ts`, lane-D rows).

## Host impact

Extension: none (baseline JSON only).
Desktop: none (baseline JSON only).
CLI: none (baseline JSON only).

## Scheduled refactoring

Convert the three skipped modules once their blockers land:
`RemoteAgentLoader.ts` after the agent-runtime main track converts
`src/agent/runtime/agentLoad.ts`; `agentYamlScanner.ts` and
`remoteAgentList.ts` after lane D converts the `platform()` rows in
`agentRegistry.ts` / `remoteAgentMeta.ts` and the owned consumers
(`controllers/session/hostSnapshotSource.ts`, `packages/agent/src`) reach
their boundaries.

## Validation

- `npx prettier --check config/ratchets/effect-migration-baseline.json` — pass
- `npm run typecheck` (all six projects) — pass
- `npm run lint` — pass
- Targeted vitest (`AgentYamlScanner`, `RemoteAgentLoader`,
  `PlatformAgentDirectories`, `AgentRegistry`, `AgentDirectoryService`,
  `AgentDirectoryWatchers`) — 39/39 pass
- Full `npx vitest run` — 764 files passed, 9087 tests passed, 0 failures
- `node scripts/check-effect-migration-ratchet.mjs` — no new failures vs a
  fresh `origin/main` worktree; residual red identical to main (see above);
  baseline regenerated with `--update` and committed here
- `npm run check:dead-code-ratchet` — pass (no new exports)
- `package.json` untouched: `p-map` and `p-retry` still have justified
  production uses owned by other lanes
