### PR TITLE
refactor(latex): run arxiv source download retry/timeout on Effect

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -81,7 +81,6 @@
       "src/agent/node/persistedFlow.ts": 1
     },
     "new AbortController()": {
-      "packages/agent/src/index.ts": 1,
       "packages/cli/src/chat/tui/commands/handlers/slashContext.ts": 1,
       "packages/cli/src/chat/tui/state/approvalQueue.ts": 1,
       "packages/cli/src/runtime/runExecution.ts": 1,
@@ -136,14 +135,12 @@
     "import:p-retry": {
       "src/agent/core/flows/ModelInvocationNode.ts": 1,
       "src/agent/implementations/agentCreator/agentCreatorFlow.ts": 1,
-      "src/agent/modelHandlers/support/auxiliaryRetry.ts": 1,
-      "src/latex/arxivProcessor.ts": 1
+      "src/agent/modelHandlers/support/auxiliaryRetry.ts": 1
     },
     "import:p-timeout": {
       "packages/cli/src/chat/tui/input/BaseTextInput.tsx": 1,
       "packages/cli/src/runtime/clipboardText.ts": 1,
-      "src/agent/workflowScript/runWorkflowScript.ts": 1,
-      "src/latex/arxivProcessor.ts": 1
+      "src/agent/workflowScript/runWorkflowScript.ts": 1
     },
     "import:p-defer": {
       "packages/cli/src/chat/chatSessionController.ts": 1,
@@ -175,7 +172,7 @@
       "src/controllers/session/SessionBridge.ts": 6,
       "src/controllers/session/hostDraftRequests.ts": 1,
       "src/controllers/session/hostRunActions.ts": 1,
-      "src/controllers/session/sessionLayer.ts": 5,
+      "src/controllers/session/sessionLayer.ts": 3,
       "src/platform/defaults/jsonStore.ts": 1,
       "src/shared/signals.ts": 2,
       "src/telemetry/UsageLogService.ts": 5,

--- a/packages/extension/src/commands/latex/arXivCommands.ts
+++ b/packages/extension/src/commands/latex/arXivCommands.ts
@@ -9,6 +9,7 @@ import {
   type ArxivDownloadDestination,
 } from '@latex/arxivProcessor';
 import { createLog } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 
 const CHANNEL = 'arXivCommands';
 const log = createLog(CHANNEL);
@@ -70,12 +71,14 @@ export async function downloadArXivSource(): Promise<void> {
           log.info('User cancelled the download');
         });
 
-        const downloadResult = await ArxivProcessor.downloadSource(arxivId, {
-          progressCallback: (message, increment) =>
-            progress.report({ message, increment }),
-          autoIndent,
-          destination,
-        });
+        const downloadResult = await effectRuntime().runPromise(
+          ArxivProcessor.downloadSource(arxivId, {
+            progressCallback: (message, increment) =>
+              progress.report({ message, increment }),
+            autoIndent,
+            destination,
+          }),
+        );
         return downloadResult.path;
       },
     );

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -4,9 +4,8 @@ import { pipeline } from 'node:stream/promises';
 import { createGunzip } from 'node:zlib';
 
 import { parse as parseContentDisposition } from 'content-disposition';
+import { Data, Duration, Effect, Random, Schedule } from 'effect';
 import { StatusCodes } from 'http-status-codes';
-import pRetry, { AbortError } from 'p-retry';
-import pTimeout from 'p-timeout';
 import * as tar from 'tar';
 
 import { createLog } from '@logger/logUtils';
@@ -28,10 +27,67 @@ interface ExtractOptions {
   timeout?: number;
 }
 
-// AbortSignal.timeout() covers the entire request including body streaming,
-// unlike the old axios timeout which only covered header receipt. Use a
-// generous deadline so large tarballs (10s+ on a slow link) can complete.
+// The per-attempt deadline covers the entire request including body
+// streaming, unlike the old axios timeout which only covered header receipt.
+// Use a generous deadline so large tarballs (10s+ on a slow link) can
+// complete.
 const DOWNLOAD_TIMEOUT_MS = 120_000; // 2 min
+
+/** Retries after the first download attempt. */
+const DOWNLOAD_RETRIES = 2;
+
+/**
+ * A source-download failure that ends the retry loop immediately — a PDF-only
+ * submission, a 404, or another non-transient HTTP status, the failures the
+ * old p-retry `AbortError` marked permanent. `downloadSource` also fails with
+ * it for the non-download errors (invalid input, no open workspace,
+ * extraction or placement failure), which never had a retry loop to abort.
+ */
+class ArxivSourcePermanentError extends Data.TaggedError(
+  'ArxivSourcePermanentError',
+)<{ readonly message: string }> {}
+
+/**
+ * A failed download attempt worth retrying: a network-level failure, the
+ * per-attempt deadline, or a transient HTTP status (408/429/5xx, see
+ * {@link isTransientHttpStatus}). Once the retries are exhausted it is the
+ * program's failure.
+ */
+class ArxivSourceTransientError extends Data.TaggedError(
+  'ArxivSourceTransientError',
+)<{ readonly message: string; readonly cause: unknown }> {}
+
+/** The typed failures of an arXiv source download. */
+export type ArxivSourceError =
+  ArxivSourcePermanentError | ArxivSourceTransientError;
+
+/**
+ * Backoff before retry `n` (1-based): 1 s doubling, scaled by a uniform
+ * factor in [1, 2) so concurrent clients don't retry in lockstep — the window
+ * the download had under p-retry's `minTimeout: 1000, randomize: true`, the
+ * same tuning the tool fetch retry in `@tools/timeouts` uses.
+ */
+const downloadBackoff = Schedule.exponential(Duration.seconds(1)).pipe(
+  Schedule.modifyDelay(({ duration }) =>
+    Effect.map(Random.next, (random) =>
+      Duration.millis(Duration.toMillis(duration) * (1 + random)),
+    ),
+  ),
+);
+
+/**
+ * Wrap a foreign Promise edge (filesystem, tar, the formatter) as a permanent
+ * failure: only the download attempt itself is retried, so nothing else has a
+ * retry loop to abort.
+ */
+const permanent = <T>(
+  run: () => Promise<T>,
+): Effect.Effect<T, ArxivSourcePermanentError> =>
+  Effect.tryPromise({
+    try: run,
+    catch: (cause) =>
+      new ArxivSourcePermanentError({ message: toErrorMessage(cause) }),
+  });
 
 export type ArxivDownloadDestination = 'root' | 'references';
 
@@ -55,6 +111,38 @@ export function resolveArxivPaperDirectoryRelative(
   return options.destination === 'root' ? '.' : `References/${paperDirName}`;
 }
 
+/**
+ * Normalize input that may be a URL or plain ID into a valid arXiv ID.
+ * Accepts formats like:
+ * - Plain ID: 2404.12175, 2404.12175v2, cs/0501072
+ * - URLs: https://arxiv.org/abs/2404.12175, https://arxiv.org/pdf/2404.12175.pdf
+ * @returns The normalized arXiv ID, or null if extraction fails
+ */
+function normalizeArxivInput(input: string): string | null {
+  if (!input) {
+    return null;
+  }
+
+  return normaliseArxivIdentifier(input.trim());
+}
+
+/**
+ * Determine file extension from content-type header.
+ * Handles tar, gzip, and tex content types. The caller rejects a PDF content
+ * type first (no LaTeX source available), so a PDF never reaches here.
+ */
+function getExtensionFromContentType(contentType: string): string {
+  const isTar = contentType.includes('tar');
+  const isGzip = contentType.includes('gz');
+  const isTex = contentType.includes('tex') || contentType.includes('plain');
+
+  if (isTar && isGzip) return '.tar.gz';
+  if (isTar) return '.tar';
+  if (isGzip) return '.gz';
+  if (isTex) return '.tex';
+  return '';
+}
+
 class ArxivSourceProcessor {
   // NOTE: The channel string stays 'arxivProcessor' (lowercase) even
   // though the exported singleton was renamed to PascalCase in #7347. It is used
@@ -64,114 +152,116 @@ class ArxivSourceProcessor {
   private readonly channel = 'arxivProcessor';
   private readonly log = createLog(this.channel);
 
-  /** Best-effort delete that logs failures at debug level instead of throwing. */
-  private async cleanUpBestEffort(
+  /** Best-effort delete that logs failures at debug level instead of failing. */
+  private cleanUpBestEffort(
     target: string,
     description: string,
     options?: { recursive?: boolean },
-  ): Promise<void> {
-    await AbsoluteFS.delete(target, options).catch((error: unknown) => {
-      this.log.debug(`Failed to clean up ${description} ${target}`, {
-        data: error,
-      });
-    });
-  }
-
-  /**
-   * Determine file extension from content-type header.
-   * Handles tar, gzip, and tex content types.
-   * Throws if the response is a PDF (no LaTeX source available) — an
-   * `AbortError` so the download retry loop treats it as permanent.
-   */
-  private getExtensionFromContentType(contentType: string): string {
-    if (contentType.includes('pdf')) {
-      throw new AbortError(PDF_ONLY_SUBMISSION_ERROR);
-    }
-
-    const isTar = contentType.includes('tar');
-    const isGzip = contentType.includes('gz');
-    const isTex = contentType.includes('tex') || contentType.includes('plain');
-
-    if (isTar && isGzip) return '.tar.gz';
-    if (isTar) return '.tar';
-    if (isGzip) return '.gz';
-    if (isTex) return '.tex';
-    return '';
-  }
-
-  /**
-   * Normalize input that may be a URL or plain ID into a valid arXiv ID.
-   * Accepts formats like:
-   * - Plain ID: 2404.12175, 2404.12175v2, cs/0501072
-   * - URLs: https://arxiv.org/abs/2404.12175, https://arxiv.org/pdf/2404.12175.pdf
-   * @returns The normalized arXiv ID, or null if extraction fails
-   */
-  private normalizeInput(input: string): string | null {
-    if (!input) {
-      return null;
-    }
-
-    return normaliseArxivIdentifier(input.trim());
+  ): Effect.Effect<void> {
+    return Effect.tryPromise({
+      try: () => AbsoluteFS.delete(target, options),
+      catch: (error) => error,
+    }).pipe(
+      Effect.catch((error) =>
+        Effect.sync(() => {
+          this.log.debug(`Failed to clean up ${description} ${target}`, {
+            data: error,
+          });
+        }),
+      ),
+    );
   }
 
   /** @returns Error message if invalid, null if valid */
   public validateId(input: string): string | null {
     if (!input) return 'arXiv ID or URL is required';
-    return this.normalizeInput(input) ? null : INVALID_ARXIV_INPUT_ERROR;
+    return normalizeArxivInput(input) ? null : INVALID_ARXIV_INPUT_ERROR;
   }
 
   /** Sanitized directory name for a paper (e.g. `2404.12175` or `cs_0501072`). */
   public getPaperDirName(input: string): string {
-    const id = this.normalizeInput(input);
+    const id = normalizeArxivInput(input);
     return id ? id.replaceAll('/', '_') : input;
   }
 
   /**
    * Download `url` to disk, retrying transient failures — network errors,
-   * 408/429, or 5xx (see {@link isTransientHttpStatus}) — with exponential
-   * backoff. Permanent failures — other 4xx statuses or a PDF-only
-   * submission — abort the retry loop immediately.
+   * the per-attempt deadline, or 408/429/5xx (see
+   * {@link isTransientHttpStatus}) — with exponential backoff. Permanent
+   * failures — other 4xx statuses or a PDF-only submission — end the retry
+   * loop immediately. Interruption stops both the active attempt and the
+   * backoff sleep.
    */
-  public async downloadFile(
+  public downloadFile(
     url: string,
     destBasePath: string,
     timeout = 30000,
-  ): Promise<string> {
-    return pRetry(() => this.downloadFileOnce(url, destBasePath, timeout), {
-      retries: 2,
-      minTimeout: 1000,
-      // Jitter the backoff so concurrent clients don't retry in lockstep.
-      randomize: true,
-      onFailedAttempt: ({ error, retriesLeft }) => {
-        this.log.debug(
-          `Download attempt failed (${retriesLeft} retries left): ${toErrorMessage(error)}`,
-        );
-      },
-    });
+  ): Effect.Effect<string, ArxivSourceError> {
+    const log = this.log;
+    return this.downloadFileOnce(url, destBasePath).pipe(
+      Effect.timeoutOrElse({
+        duration: Duration.millis(timeout),
+        orElse: () =>
+          Effect.fail(
+            new ArxivSourceTransientError({
+              message: `Download timed out after ${timeout} ms`,
+              cause: undefined,
+            }),
+          ),
+      }),
+      Effect.tapError((error) =>
+        Effect.gen(function* () {
+          // A permanent failure ends the retry unobserved, since it never had
+          // retries left to report.
+          if (error._tag !== 'ArxivSourceTransientError') return;
+          const { attempt } = yield* Schedule.CurrentMetadata;
+          log.debug(
+            `Download attempt failed (${DOWNLOAD_RETRIES - attempt} retries left): ${error.message}`,
+          );
+        }),
+      ),
+      Effect.retry({
+        schedule: downloadBackoff,
+        times: DOWNLOAD_RETRIES,
+        while: (error) => error._tag === 'ArxivSourceTransientError',
+      }),
+    );
   }
 
-  private async downloadFileOnce(
+  private downloadFileOnce(
     url: string,
     destBasePath: string,
-    timeout: number,
-  ): Promise<string> {
+  ): Effect.Effect<string, ArxivSourceError> {
+    const log = this.log;
     let destPath = destBasePath;
-    let shouldCleanup = true;
-    try {
-      // AbortSignal.timeout covers both connection establishment and body streaming.
-      const response = await fetch(url, {
-        signal: AbortSignal.timeout(timeout),
+    return Effect.gen(function* () {
+      // The fiber's own signal aborts the in-flight fetch when the attempt is
+      // interrupted — by the per-attempt deadline in downloadFile or by the
+      // caller — covering connection establishment and body streaming.
+      const response = yield* Effect.tryPromise({
+        try: (signal) => fetch(url, { signal }),
+        catch: (cause) =>
+          new ArxivSourceTransientError({
+            message: toErrorMessage(cause),
+            cause,
+          }),
       });
 
       if (response.status === StatusCodes.NOT_FOUND) {
-        throw new AbortError('Source not available for this arXiv ID');
+        return yield* Effect.fail(
+          new ArxivSourcePermanentError({
+            message: 'Source not available for this arXiv ID',
+          }),
+        );
       }
 
       if (response.status !== StatusCodes.OK) {
         const message = `Failed to download: HTTP ${response.status}`;
-        throw isTransientHttpStatus(response.status)
-          ? new Error(message)
-          : new AbortError(message);
+        return yield* Effect.fail(
+          isTransientHttpStatus(response.status)
+            ? new ArxivSourceTransientError({ message, cause: response.status })
+            : new ArxivSourcePermanentError({ message }),
+        );
       }
 
       // Extract filename from Content-Disposition header if available.
@@ -181,20 +271,26 @@ class ArxivSourceProcessor {
       const disposition = response.headers.get('content-disposition');
       let filename: string | undefined;
       if (disposition) {
-        try {
-          filename = parseContentDisposition(disposition).parameters.filename;
-        } catch (error) {
-          // Malformed header; the content-type fallback below handles it.
-          this.log.debug(
-            'Ignoring malformed Content-Disposition header from arXiv source download',
-            {
-              data: {
-                header: disposition,
-                error: toErrorMessage(error),
-              },
-            },
-          );
-        }
+        filename = yield* Effect.try({
+          try: () => parseContentDisposition(disposition).parameters.filename,
+          catch: (error) => error,
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.sync(() => {
+              // Malformed header; the content-type fallback below handles it.
+              log.debug(
+                'Ignoring malformed Content-Disposition header from arXiv source download',
+                {
+                  data: {
+                    header: disposition,
+                    error: toErrorMessage(error),
+                  },
+                },
+              );
+              return undefined;
+            }),
+          ),
+        );
       }
       if (filename) {
         // basename prevents path traversal from a crafted header value.
@@ -204,136 +300,176 @@ class ArxivSourceProcessor {
         );
       } else {
         const contentType = response.headers.get('content-type') ?? '';
-        const extension = this.getExtensionFromContentType(contentType);
-        destPath = destBasePath + extension;
+        if (contentType.includes('pdf')) {
+          // No LaTeX source available: a permanent failure, not retried.
+          return yield* Effect.fail(
+            new ArxivSourcePermanentError({
+              message: PDF_ONLY_SUBMISSION_ERROR,
+            }),
+          );
+        }
+        destPath = destBasePath + getExtensionFromContentType(contentType);
       }
 
       if (!response.body) {
-        throw new Error('Response has no body');
+        return yield* Effect.fail(
+          new ArxivSourceTransientError({
+            message: 'Response has no body',
+            cause: undefined,
+          }),
+        );
       }
 
-      await pipeline(
-        // response.body is a web ReadableStream; Readable.fromWeb bridges to Node streams.
-        Readable.fromWeb(response.body as NodeWebReadableStream),
-        AbsoluteFS.createWriteStream(destPath),
-      );
-      shouldCleanup = false;
+      yield* Effect.tryPromise({
+        try: () =>
+          pipeline(
+            // response.body is a web ReadableStream; Readable.fromWeb bridges to Node streams.
+            Readable.fromWeb(response.body as NodeWebReadableStream),
+            AbsoluteFS.createWriteStream(destPath),
+          ),
+        catch: (cause) =>
+          new ArxivSourceTransientError({
+            message: toErrorMessage(cause),
+            cause,
+          }),
+      });
       return destPath;
-    } finally {
-      if (shouldCleanup) {
-        // Await so a retry attempt can't race this delete on the same path.
-        await this.cleanUpBestEffort(destPath, 'partial download');
-      }
-    }
+    }).pipe(
+      // A failed attempt deletes its partial download so a retry cannot race
+      // stale bytes at the same path (the old `finally` + shouldCleanup flag;
+      // `onError`'s cleanup is uninterruptible).
+      Effect.onError(() =>
+        this.cleanUpBestEffort(destPath, 'partial download'),
+      ),
+    );
   }
 
-  public async extractTarFile(
+  public extractTarFile(
     tarPath: string,
     destDir: string,
     options: ExtractOptions = {},
-  ): Promise<ExtractResult> {
+  ): Effect.Effect<ExtractResult> {
     const log = this.log;
     log.debug(`Extracting tar file: ${tarPath} to ${destDir}`);
 
-    try {
-      const extraction = tar.x({ file: tarPath, cwd: destDir });
-      if (options.timeout) {
-        await pTimeout(extraction, {
-          milliseconds: options.timeout,
-          message: 'Extraction timed out',
-        });
-      } else {
-        await extraction;
+    return Effect.tryPromise({
+      try: () => tar.x({ file: tarPath, cwd: destDir }),
+      catch: toErrorMessage,
+    }).pipe(
+      options.timeout == null
+        ? (effect) => effect
+        : Effect.timeoutOrElse({
+            duration: Duration.millis(options.timeout),
+            orElse: () => Effect.fail('Extraction timed out'),
+          }),
+      Effect.as({ success: true }),
+      Effect.catch((errorMsg) =>
+        Effect.sync((): ExtractResult => {
+          log.error(`Failed to extract tar file: ${errorMsg}`);
+          return { success: false, error: errorMsg };
+        }),
+      ),
+    );
+  }
+
+  public readonly downloadSource = Effect.fn('arxivProcessor.downloadSource')(
+    { self: this },
+    function* (
+      this: ArxivSourceProcessor,
+      input: string,
+      options: DownloadSourceOptions = {},
+    ) {
+      const {
+        progressCallback,
+        autoIndent = true,
+        destination = 'references',
+      } = options;
+      const log = this.log;
+      // Normalize input (URL or ID) to plain arXiv ID
+      const id = normalizeArxivInput(input);
+      if (!id) {
+        return yield* Effect.fail(
+          new ArxivSourcePermanentError({ message: INVALID_ARXIV_INPUT_ERROR }),
+        );
       }
-      return { success: true };
-    } catch (err) {
-      const errorMsg = toErrorMessage(err);
-      log.error(`Failed to extract tar file: ${errorMsg}`);
-      return { success: false, error: errorMsg };
-    }
-  }
 
-  public async downloadSource(
-    input: string,
-    options: DownloadSourceOptions = {},
-  ): Promise<{ path: string; alreadyExisted: boolean }> {
-    const {
-      progressCallback,
-      autoIndent = true,
-      destination = 'references',
-    } = options;
+      log.info(`Downloading arXiv source for ID: ${id}`);
 
-    // Normalize input (URL or ID) to plain arXiv ID
-    const id = this.normalizeInput(input);
-    if (!id) {
-      throw new Error(INVALID_ARXIV_INPUT_ERROR);
-    }
+      if (!WorkspaceFS.getPath()) {
+        return yield* Effect.fail(
+          new ArxivSourcePermanentError({
+            message: 'No workspace folder is open',
+          }),
+        );
+      }
 
-    this.log.info(`Downloading arXiv source for ID: ${id}`);
+      const paperDirRelative = resolveArxivPaperDirectoryRelative(id, {
+        destination,
+      });
+      const isRoot = paperDirRelative === '.';
+      const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
 
-    if (!WorkspaceFS.getPath()) {
-      throw new Error('No workspace folder is open');
-    }
-
-    const paperDirRelative = resolveArxivPaperDirectoryRelative(id, {
-      destination,
-    });
-    const isRoot = paperDirRelative === '.';
-    const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
-
-    const needsDownload = !(await this.hasExistingSource(
-      paperDirRelative,
-      isRoot,
-      paperDirFull,
-    ));
-    if (needsDownload) {
-      await this.fetchAndPlaceSource(
-        id,
+      const needsDownload = !(yield* this.hasExistingSource(
         paperDirRelative,
-        paperDirFull,
         isRoot,
-        progressCallback,
-      );
-    }
+        paperDirFull,
+      ));
+      if (needsDownload) {
+        yield* this.fetchAndPlaceSource(
+          id,
+          paperDirRelative,
+          paperDirFull,
+          isRoot,
+          progressCallback,
+        );
+      }
 
-    // Skip auto-indent for root destination to avoid reformatting existing workspace files
-    if (autoIndent && !isRoot) {
-      progressCallback?.('Formatting LaTeX files...', 85);
+      // Skip auto-indent for root destination to avoid reformatting existing workspace files
+      if (autoIndent && !isRoot) {
+        progressCallback?.('Formatting LaTeX files...', 85);
 
-      const indentResult = await indentLatexFilesInDirectory(
-        paperDirRelative,
-        progressCallback,
-      );
+        const indentResult = yield* permanent(() =>
+          indentLatexFilesInDirectory(paperDirRelative, progressCallback),
+        );
 
-      progressCallback?.(`Formatted ${indentResult.count} LaTeX files`, 95);
-    }
+        progressCallback?.(`Formatted ${indentResult.count} LaTeX files`, 95);
+      }
 
-    progressCallback?.('arXiv source downloaded successfully!', 100);
+      progressCallback?.('arXiv source downloaded successfully!', 100);
 
-    this.log.info(`arXiv source downloaded to: ${paperDirFull}`);
+      log.info(`arXiv source downloaded to: ${paperDirFull}`);
 
-    return { path: paperDirFull, alreadyExisted: !needsDownload };
-  }
+      return { path: paperDirFull, alreadyExisted: !needsDownload };
+    },
+  );
 
   /**
    * Whether a previously-downloaded source already exists at the paper directory.
    * Skipped for the workspace root, where stray .tex files would be a false
    * positive.
    */
-  private async hasExistingSource(
+  private hasExistingSource(
     paperDirRelative: string,
     isRoot: boolean,
     paperDirFull: string,
-  ): Promise<boolean> {
-    if (isRoot || !(await WorkspaceFS.exists(paperDirRelative))) {
-      return false;
-    }
-    const entries = await WorkspaceFS.readDir(paperDirRelative);
-    const hasTexFiles = entries.some(([name]) => hasExtension(name, '.tex'));
-    if (hasTexFiles) {
-      this.log.info(`arXiv source already exists at: ${paperDirFull}`);
-    }
-    return hasTexFiles;
+  ): Effect.Effect<boolean, ArxivSourceError> {
+    const log = this.log;
+    return Effect.gen(function* () {
+      if (isRoot) {
+        return false;
+      }
+      if (!(yield* permanent(() => WorkspaceFS.exists(paperDirRelative)))) {
+        return false;
+      }
+      const entries = yield* permanent(() =>
+        WorkspaceFS.readDir(paperDirRelative),
+      );
+      const hasTexFiles = entries.some(([name]) => hasExtension(name, '.tex'));
+      if (hasTexFiles) {
+        log.info(`arXiv source already exists at: ${paperDirFull}`);
+      }
+      return hasTexFiles;
+    });
   }
 
   /**
@@ -341,121 +477,139 @@ class ArxivSourceProcessor {
    * PDF-only submissions, place the source files into the paper root, then
    * remove the staging directory.
    */
-  private async fetchAndPlaceSource(
-    id: string,
-    paperDirRelative: string,
-    paperDirFull: string,
-    isRoot: boolean,
-    progressCallback: DownloadSourceOptions['progressCallback'],
-  ): Promise<void> {
-    await WorkspaceFS.ensureDir(paperDirRelative);
+  private readonly fetchAndPlaceSource = Effect.fn(
+    'arxivProcessor.fetchAndPlaceSource',
+  )(
+    { self: this },
+    function* (
+      this: ArxivSourceProcessor,
+      id: string,
+      paperDirRelative: string,
+      paperDirFull: string,
+      isRoot: boolean,
+      progressCallback: DownloadSourceOptions['progressCallback'],
+    ) {
+      yield* permanent(() => WorkspaceFS.ensureDir(paperDirRelative));
 
-    // Use a unique staging directory name to avoid clobbering an existing 'download/' folder at root
-    const stagingDirName = `.arxiv-download-${id.replaceAll('/', '_')}`;
-    const downloadDirRelative = path.join(paperDirRelative, stagingDirName);
-    await WorkspaceFS.ensureDir(downloadDirRelative);
+      // Use a unique staging directory name to avoid clobbering an existing 'download/' folder at root
+      const stagingDirName = `.arxiv-download-${id.replaceAll('/', '_')}`;
+      const downloadDirRelative = path.join(paperDirRelative, stagingDirName);
+      yield* permanent(() => WorkspaceFS.ensureDir(downloadDirRelative));
 
-    const downloadDirFull = path.join(paperDirFull, stagingDirName);
-    const downloadBasePath = path.join(downloadDirFull, 'source');
+      const downloadDirFull = path.join(paperDirFull, stagingDirName);
+      const downloadBasePath = path.join(downloadDirFull, 'source');
 
-    progressCallback?.(`Downloading arXiv source for ${id}...`, 20);
+      progressCallback?.(`Downloading arXiv source for ${id}...`, 20);
 
-    const downloadUrl = `https://arxiv.org/src/${id}`;
-    const downloadedPath = await this.downloadFile(
-      downloadUrl,
-      downloadBasePath,
-      DOWNLOAD_TIMEOUT_MS,
-    );
+      const downloadUrl = `https://arxiv.org/src/${id}`;
+      const downloadedPath = yield* this.downloadFile(
+        downloadUrl,
+        downloadBasePath,
+        DOWNLOAD_TIMEOUT_MS,
+      );
 
-    // Detect PDF-only submissions (no LaTeX source available)
-    if (hasExtension(downloadedPath, '.pdf')) {
-      await AbsoluteFS.delete(downloadedPath);
-      await this.cleanUpBestEffort(downloadDirFull, 'download dir', {
-        recursive: true,
-      });
-      // Only clean up the paper directory when it was created for this download
-      if (!isRoot) {
-        await this.cleanUpBestEffort(paperDirFull, 'paper dir', {
+      // Detect PDF-only submissions (no LaTeX source available)
+      if (hasExtension(downloadedPath, '.pdf')) {
+        yield* permanent(() => AbsoluteFS.delete(downloadedPath));
+        yield* this.cleanUpBestEffort(downloadDirFull, 'download dir', {
           recursive: true,
         });
+        // Only clean up the paper directory when it was created for this download
+        if (!isRoot) {
+          yield* this.cleanUpBestEffort(paperDirFull, 'paper dir', {
+            recursive: true,
+          });
+        }
+        return yield* Effect.fail(
+          new ArxivSourcePermanentError({ message: PDF_ONLY_SUBMISSION_ERROR }),
+        );
       }
-      throw new Error(PDF_ONLY_SUBMISSION_ERROR);
-    }
 
-    await this.placeSourceFiles(
-      downloadedPath,
-      paperDirRelative,
-      paperDirFull,
-      progressCallback,
-    );
+      yield* this.placeSourceFiles(
+        downloadedPath,
+        paperDirRelative,
+        paperDirFull,
+        progressCallback,
+      );
 
-    // Remove the temporary download directory (files are now in paper root)
-    await this.cleanUpBestEffort(downloadDirFull, 'temporary download dir', {
-      recursive: true,
-    });
-  }
+      // Remove the temporary download directory (files are now in paper root)
+      yield* this.cleanUpBestEffort(downloadDirFull, 'temporary download dir', {
+        recursive: true,
+      });
+    },
+  );
 
   /**
    * Place the downloaded source into the paper directory: extract a tar/tgz
    * archive in place, or decompress (gzip) and rename a single source file to
    * main.tex. Removes the downloaded artifact on success.
    */
-  private async placeSourceFiles(
-    downloadedPath: string,
-    paperDirRelative: string,
-    paperDirFull: string,
-    progressCallback: DownloadSourceOptions['progressCallback'],
-  ): Promise<void> {
-    const isArchive =
-      hasExtension(downloadedPath, '.tar') ||
-      downloadedPath.endsWith('.tar.gz') ||
-      hasExtension(downloadedPath, '.tgz');
-    const isGzipOnly = !isArchive && hasExtension(downloadedPath, '.gz');
+  private readonly placeSourceFiles = Effect.fn(
+    'arxivProcessor.placeSourceFiles',
+  )(
+    { self: this },
+    function* (
+      this: ArxivSourceProcessor,
+      downloadedPath: string,
+      paperDirRelative: string,
+      paperDirFull: string,
+      progressCallback: DownloadSourceOptions['progressCallback'],
+    ) {
+      const isArchive =
+        hasExtension(downloadedPath, '.tar') ||
+        downloadedPath.endsWith('.tar.gz') ||
+        hasExtension(downloadedPath, '.tgz');
+      const isGzipOnly = !isArchive && hasExtension(downloadedPath, '.gz');
 
-    if (isArchive) {
-      progressCallback?.('Extracting source files...', 60);
+      if (isArchive) {
+        progressCallback?.('Extracting source files...', 60);
 
-      const extractResult = await this.extractTarFile(
-        downloadedPath,
-        paperDirFull,
-        { timeout: 30000 },
-      );
-
-      if (!extractResult.success) {
-        throw new Error(
-          `Failed to extract arXiv source: ${extractResult.error}`,
+        const extractResult = yield* this.extractTarFile(
+          downloadedPath,
+          paperDirFull,
+          { timeout: 30000 },
         );
+
+        if (!extractResult.success) {
+          return yield* Effect.fail(
+            new ArxivSourcePermanentError({
+              message: `Failed to extract arXiv source: ${extractResult.error}`,
+            }),
+          );
+        }
+
+        progressCallback?.('Cleaning up...', 80);
+
+        // Remove the downloaded archive file
+        yield* permanent(() => AbsoluteFS.delete(downloadedPath));
+        return;
       }
 
-      progressCallback?.('Cleaning up...', 80);
+      // For gzip-compressed single files, decompress first
+      let sourceFilePath = downloadedPath;
+      if (isGzipOnly) {
+        progressCallback?.('Decompressing source file...', 60);
+        const decompressedPath = downloadedPath.replace(/\.gz$/, '');
+        yield* permanent(() =>
+          pipeline(
+            AbsoluteFS.createReadStream(downloadedPath),
+            createGunzip(),
+            AbsoluteFS.createWriteStream(decompressedPath),
+          ),
+        );
+        yield* permanent(() => AbsoluteFS.delete(downloadedPath));
+        sourceFilePath = decompressedPath;
+      }
 
-      // Remove the downloaded archive file
-      await AbsoluteFS.delete(downloadedPath);
-      return;
-    }
-
-    // For gzip-compressed single files, decompress first
-    let sourceFilePath = downloadedPath;
-    if (isGzipOnly) {
-      progressCallback?.('Decompressing source file...', 60);
-      const decompressedPath = downloadedPath.replace(/\.gz$/, '');
-      await pipeline(
-        AbsoluteFS.createReadStream(downloadedPath),
-        createGunzip(),
-        AbsoluteFS.createWriteStream(decompressedPath),
-      );
-      await AbsoluteFS.delete(downloadedPath);
-      sourceFilePath = decompressedPath;
-    }
-
-    // Rename to main.tex and move to paper root
-    const downloadedRel = WorkspaceFS.relativePath(sourceFilePath);
-    // Use forward slashes to match WorkspaceFS.relativePath() convention
-    const targetRel = [paperDirRelative, 'main.tex'].join('/');
-    if (downloadedRel !== targetRel) {
-      await WorkspaceFS.rename(downloadedRel, targetRel);
-    }
-  }
+      // Rename to main.tex and move to paper root
+      const downloadedRel = WorkspaceFS.relativePath(sourceFilePath);
+      // Use forward slashes to match WorkspaceFS.relativePath() convention
+      const targetRel = [paperDirRelative, 'main.tex'].join('/');
+      if (downloadedRel !== targetRel) {
+        yield* permanent(() => WorkspaceFS.rename(downloadedRel, targetRel));
+      }
+    },
+  );
 }
 
 export const ArxivProcessor = new ArxivSourceProcessor();

--- a/src/test-kernel/latex/ArxivProcessor.vitest.ts
+++ b/src/test-kernel/latex/ArxivProcessor.vitest.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -75,10 +76,8 @@ describe('arXiv processor logger channel', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const downloadedPath = await ArxivProcessor.downloadFile(
-      SOURCE_URL,
-      destBasePath,
-      5000,
+    const downloadedPath = await Effect.runPromise(
+      ArxivProcessor.downloadFile(SOURCE_URL, destBasePath, 5000),
     );
 
     expect(downloadedPath).toBe(destBasePath);
@@ -93,7 +92,9 @@ describe('arXiv processor logger channel', () => {
     const dir = await makeTempDir('texra-arxiv-', tempDirs);
     const missingTar = path.join(dir, 'missing.tar');
 
-    const fallback = await ArxivProcessor.extractTarFile(missingTar, dir);
+    const fallback = await Effect.runPromise(
+      ArxivProcessor.extractTarFile(missingTar, dir),
+    );
 
     expect(fallback.success).toBe(false);
     expect(error).toHaveBeenCalledWith(
@@ -109,10 +110,8 @@ describe('arXiv source download filenames', () => {
     const fetchMock = vi.fn(async () => sourceResponse());
     vi.stubGlobal('fetch', fetchMock);
 
-    const downloadedPath = await ArxivProcessor.downloadFile(
-      SOURCE_URL,
-      destBasePath,
-      5000,
+    const downloadedPath = await Effect.runPromise(
+      ArxivProcessor.downloadFile(SOURCE_URL, destBasePath, 5000),
     );
 
     expect(downloadedPath).toBe(destBasePath);
@@ -135,10 +134,8 @@ describe('arXiv source download retry classification', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const downloadedPath = await ArxivProcessor.downloadFile(
-      SOURCE_URL,
-      destBasePath,
-      5000,
+    const downloadedPath = await Effect.runPromise(
+      ArxivProcessor.downloadFile(SOURCE_URL, destBasePath, 5000),
     );
 
     expect(attempt).toBe(2);
@@ -151,7 +148,9 @@ describe('arXiv source download retry classification', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
-      ArxivProcessor.downloadFile(SOURCE_URL, destBasePath, 5000),
+      Effect.runPromise(
+        ArxivProcessor.downloadFile(SOURCE_URL, destBasePath, 5000),
+      ),
     ).rejects.toThrow('HTTP 400');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
+++ b/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const gitignoreMock = vi.hoisted(() => ({
@@ -29,10 +30,12 @@ describe('ArxivDownloadTool', () => {
       .mockReturnValue(null);
     const downloadSource = vi
       .spyOn(arxivModule.ArxivProcessor, 'downloadSource')
-      .mockResolvedValue({
-        path: '/workspace/project/sample',
-        alreadyExisted: false,
-      });
+      .mockReturnValue(
+        Effect.succeed({
+          path: '/workspace/project/sample',
+          alreadyExisted: false,
+        }),
+      );
 
     vi.spyOn(WorkspaceFS, 'relativePath').mockReturnValue('sample');
 

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -1,12 +1,14 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
-import { ArxivProcessor } from '@latex/arxivProcessor';
+import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
+import { ArxivProcessor, type ArxivSourceError } from '@latex/arxivProcessor';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { formatToolOutput } from '@tools/formatting';
-import { wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 import { nullishWithDefault } from '@tools/core/inputSchema';
 import { executed } from '@tools/core/result';
@@ -54,47 +56,65 @@ const ArxivDownloadInputSchema = z.strictObject({
 
 export type ArxivDownloadInput = z.infer<typeof ArxivDownloadInputSchema>;
 
+const download = Effect.fn('ArxivDownloadTool.execute')(function* (
+  input: ArxivDownloadInput,
+) {
+  const arxivId = input.id.trim();
+  const validationError = ArxivProcessor.validateId(arxivId);
+  if (validationError) {
+    return yield* Effect.fail(new ToolError(validationError));
+  }
+
+  const downloadResult = yield* ArxivProcessor.downloadSource(arxivId, {
+    autoIndent: input.autoIndent,
+    destination: input.destination,
+  }).pipe(
+    Effect.mapError(
+      (error: ArxivSourceError) =>
+        new ToolError(`Failed to download arXiv source: ${error.message}`, {
+          cause: error,
+        }),
+    ),
+  );
+
+  const relativePath = WorkspaceFS.relativePath(downloadResult.path) || '.';
+  const displayPath = toPosixPath(relativePath);
+
+  // A listing failure degrades to a note in the output, not a tool error:
+  // the download itself already succeeded.
+  const listingOutput = yield* Effect.tryPromise({
+    try: () => listExtractedEntries(downloadResult.path),
+    catch: (err) => err,
+  }).pipe(
+    Effect.catch((err) =>
+      Effect.succeed(`Failed to list directory: ${toErrorMessage(err)}`),
+    ),
+  );
+
+  const summary = downloadResult.alreadyExisted
+    ? `arXiv source already downloaded at ${displayPath}`
+    : `arXiv source downloaded to ${displayPath}`;
+  const output = [
+    summary,
+    '',
+    formatToolOutput(`Directory listing for ${displayPath}`, listingOutput),
+  ].join('\n');
+
+  return executed(output, summary);
+});
+
 export class ArxivDownloadTool extends defineTool({
   name: 'download_arxiv_source',
   description:
     'Download an arXiv paper source archive into the workspace and list the extracted files. Use "destination" to choose where files are placed: "references" (default) saves to References/{paper_id}, "root" saves directly to the workspace root. If the source was already downloaded, it skips re-downloading and indicates that the source already exists.',
   schema: ArxivDownloadInputSchema,
 }) {
-  protected async execute(input: ArxivDownloadInput): Promise<ToolResult> {
-    const arxivId = input.id.trim();
-    const validationError = ArxivProcessor.validateId(arxivId);
-    if (validationError) {
-      throw new ToolError(validationError);
-    }
-
-    const downloadResult = await wrapApiCall(
-      () =>
-        ArxivProcessor.downloadSource(arxivId, {
-          autoIndent: input.autoIndent,
-          destination: input.destination,
-        }),
-      'Failed to download arXiv source',
-    );
-
-    const relativePath = WorkspaceFS.relativePath(downloadResult.path) || '.';
-    const displayPath = toPosixPath(relativePath);
-
-    let listingOutput: string;
-    try {
-      listingOutput = await listExtractedEntries(downloadResult.path);
-    } catch (err) {
-      listingOutput = `Failed to list directory: ${toErrorMessage(err)}`;
-    }
-
-    const summary = downloadResult.alreadyExisted
-      ? `arXiv source already downloaded at ${displayPath}`
-      : `arXiv source downloaded to ${displayPath}`;
-    const output = [
-      summary,
-      '',
-      formatToolOutput(`Directory listing for ${displayPath}`, listingOutput),
-    ].join('\n');
-
-    return executed(output, summary);
+  protected execute(input: ArxivDownloadInput): Promise<ToolResult> {
+    // The owning agent run's cancellation enters here as interruption —
+    // without it, a cancelled run would wait out the download (and its
+    // retries) that only observe the internal deadline.
+    return effectRuntime().runPromise(download(input), {
+      signal: getCurrentToolCallContext()?.signal,
+    });
   }
 }


### PR DESCRIPTION
## Summary

Effect 4 migration lane (PRD `docs/prds/2026-08-26-effect-4-runtime-migration.md`, R1 as amended by #11919): converts `src/latex/arxivProcessor.ts`'s retry/timeout mechanisms to Effect and converts its consumers upward to the two sanctioned boundaries that consume it.

- The `p-retry` download loop becomes an exponential `Schedule` (1 s doubling, jitter in [1, 2) — the same window `p-retry`'s `minTimeout: 1000, randomize: true` gave, matching `@tools/timeouts`' tuning) that retries only transient failures. The `p-retry` `AbortError` permanent/transient classification becomes two `Data.TaggedError`s (`ArxivSourcePermanentError` / `ArxivSourceTransientError`, union exported as `ArxivSourceError`); domain results stay values, not exceptions.
- The `p-timeout` tar extraction becomes an Effect deadline (`timeoutOrElse`); `extractTarFile` still returns its `{ success, error? }` result and never fails.
- The per-attempt deadline now spans the whole attempt like the old `AbortSignal.timeout(timeout)` did, and the fetch edge receives the fiber's own `AbortSignal`, so interruption (deadline or caller) aborts the in-flight request. The partial-download cleanup rides `Effect.onError`, whose cleanup is uninterruptible (the old `finally` + flag).
- All raw catch sites in the touched files convert in the same pass (R7 / one-pass-per-file), so no new `catch:effect-importer` rows.

Consumers converted upward in the same PR: `ArxivDownloadTool` holds its logic in one `Effect.fn` program run once at the `execute()` boundary (kind b), and the extension's arXiv download command runs the program at the VS Code command entry (kind a) via `effectRuntime().runPromise`.

**Skipped under the chain-scope rule:** `src/latex/LatexMediaManager.ts` and `src/latex/extractFileDependencies.ts` (the lane's `import:p-map` rows). `LatexMediaManager`'s only upward path is the reflection flow (`runReflectionFlow.ts` constructs it, `ReflectionServices` holds it, `MediaExtractionNode` calls it) under `src/agent/implementations/`, which the main migration track owns; `extractLatexFileDependencies`'s only consumer is `LatexMediaManager`. Both are left untouched.

**Ratchet rows shrank (before → after):**

- `import:p-retry` — `src/latex/arxivProcessor.ts`: 1 → 0 (row: 5 files → 3 files)
- `import:p-timeout` — `src/latex/arxivProcessor.ts`: 1 → 0 (row: 4 files → 3 files)
- `import:p-map` — unchanged (skipped, see above)
- The regenerated baseline (`--update`, repo convention, rebased over #11967's lock-in) also locks in two stale-headroom counts already present in main's tree: `new AbortController()` drops `packages/agent/src/index.ts` (1 → 0) and `Effect.run*` lowers `src/controllers/session/sessionLayer.ts` (5 → 3).

**Inherited red:** the residual static-check failures — the `src/auth/SupabaseClient.ts` `@adapter-until` marker and six "grew" rows (`src/auth/authProgram.ts`, `packages/cli/src/runtime/initPlatform.ts`, `packages/desktop/src/main/desktopPapers.ts`, `packages/desktop/src/main/index.ts`, `packages/desktop/src/main/platform/index.ts`, `src/auth/SupabaseClient.ts`) — are identical on `origin/main` (verified against a ratchet capture taken at `origin/main`); this branch adds none.

## Issue acceptance gates

Effect 4 runtime migration (PRD `2026-08-26-effect-4-runtime-migration.md`), this lane's gates: `import:p-retry` and `import:p-timeout` rows for `src/latex/arxivProcessor.ts` removed with consumers converted to genuine boundaries — done. The `import:p-map` rows remain, owned by the main migration track via the reflection flow (chain-scope skip, recorded above).

## Single source of truth

`src/latex/arxivProcessor.ts` owns the download attempt, its transient/permanent classification (typed `ArxivSourceError` tags), and the retry schedule; `@tools/timeouts` remains the owner of the ky-based fetch retry for tools and is not duplicated (its classification is ky-specific, so the arXiv backoff keeps its own 6-line jittered schedule with a comment naming the shared tuning).

## Duplication and abstraction budget

Removed: `p-retry`/`p-timeout` mechanics, the `AbortError` throw-through-`getExtensionFromContentType`, and `wrapApiCall` usage in `ArxivDownloadTool` (its error mapping now sits in the program's `mapError`). Added abstractions: one file-local `permanent()` helper wrapping foreign Promise edges as non-retried failures (6 call sites), and the two private tagged-error classes. No pass-throughs, no `@adapter-until` markers.

## Net elements (R6)

- Files: 6 changed, +535/−359 (`src/latex/arxivProcessor.ts` rewritten in place; 2 boundary consumers, 2 test suites, regenerated migration baseline).
- Exports (`^[+-]export`): +1 type (`ArxivSourceError`, consumed by `ArxivDownloadTool`'s typed `mapError`); 0 exports removed. `ArxivSourcePermanentError`/`ArxivSourceTransientError` are module-private, mirroring `RequestFailed`/`RequestTimedOut` in `@tools/timeouts`.
- Classes/interfaces/enums: +2 private `Data.TaggedError` classes; `ArxivSourceProcessor` keeps its shape, with `downloadSource`/`fetchAndPlaceSource`/`placeSourceFiles` becoming `Effect.fn` properties (the `no-this-alias`-clean idiom from `WebFetchTool`).
- Public method signature changes: `downloadFile`, `extractTarFile`, `downloadSource` return `Effect` instead of `Promise` (same names, same arities); `validateId`, `getPaperDirName`, `resolveArxivPaperDirectoryRelative` unchanged.

## Consumer counts (R8)

Grepped production consumers of the converted surface:

- `ArxivProcessor.downloadSource`: 2 — `src/tools/arxiv/ArxivDownloadTool.ts` (tool boundary, converted) and `packages/extension/src/commands/latex/arXivCommands.ts` (host entry, converted). Plus 2 test suites, updated.
- `ArxivProcessor.downloadFile` / `extractTarFile`: 0 production consumers outside `arxivProcessor.ts` (1 internal caller each); exercised by `src/test-kernel/latex/ArxivProcessor.vitest.ts`, updated to `Effect.runPromise` (the `FormTokenClient` precedent).
- `ArxivProcessor.validateId`: 2 unchanged consumers (`ArxivMetadataTool`, `arXivCommands`) — still synchronous.
- `LatexMediaManager`: 1 consumer chain, all inside `src/agent/implementations/flows/reflection/` (owned by the main migration track) — skipped, not re-routed.
- `extractLatexFileDependencies`: 1 consumer (`LatexMediaManager`) — skipped with it.
- `wrapApiCall` (`@tools/utils`): lost 1 of its importers; other tools still use it, export untouched.

## Host impact

Extension: the arXiv download command runs the same download program through the process runtime at the command entry; prompts, progress reporting, and error surfacing unchanged. Desktop: none (no consumers). CLI: none (no consumers).

## Scheduled refactoring

The `import:p-map` conversions for `LatexMediaManager.ts` / `extractFileDependencies.ts` land with the main migration track's reflection-flow conversion (`src/agent/implementations/**`), which owns their only call chain. `package.json` is unchanged: `p-retry` (3 remaining importers), `p-timeout` (3), and `p-map` (10) all retain justified production uses.

## Validation

Rebased onto `origin/main` at #11967 (baseline lock-in) / #11936 (SDK Effect surface); the only conflict was the migration baseline, resolved by taking main's side and regenerating with `--update`.

- `npx prettier --check` on all changed files — pass.
- `npm run typecheck` (full, all six projects) — pass, exit 0.
- `npm run lint` — pass, 0 errors.
- Targeted `npx vitest run src/test-kernel/latex src/test-kernel/tools src/test-kernel/agent src/test-kernel/controllers` — 330 files / 4161 tests pass; full `npx vitest run` — 764 files / 9092 tests, 0 failures.
- `node scripts/check-effect-migration-ratchet.mjs` — this branch's failure set is main's inherited set minus the two stale-headroom rows the regenerated baseline locks in; no new failures vs `origin/main`. Baseline regenerated with `--update` and committed here.
- `npm run check:dead-code-ratchet` — pass, no new findings.
