### PR TITLE
refactor(hosts): convert composition-root catches to typed recovery

### DIFF
--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -90,6 +90,11 @@ function showLifecycleError(message: string): void {
   writeTextStderr(`[error] [cli.lifecycle] ${message}`);
 }
 
+/** `Effect.tryPromise` with the identity catch every Promise boundary below
+ *  wants: the rejection value flows through unchanged as the error. */
+const tryPromise = <A>(run: () => Promise<A>): Effect.Effect<A, unknown> =>
+  Effect.tryPromise({ try: run, catch: (error) => error });
+
 const cliPlatformLog: SupabaseSessionLog = {
   debug: (channel, message) => logAt('debug', channel, message),
   info: (channel, message) => logAt('info', channel, message),
@@ -106,25 +111,27 @@ const cliPlatformLog: SupabaseSessionLog = {
  * take over SIGINT/SIGTERM exclusively once mounted and must perform the
  * same sequence the platform's own (now handed-off) handlers would have. One
  * definition means the two paths can't drift.
+ *
+ * Runs on the default runtime rather than `effectRuntime()`: the lifecycle
+ * shutdown below disposes the process runtime (`disposeProcessRuntime`)
+ * before the flushes run, and a teardown path must not depend on the thing
+ * it is tearing down.
  */
 export async function runCliPlatformShutdownSequence(
   lifecycle: LifecycleHost | undefined,
 ): Promise<void> {
-  try {
-    await lifecycle?.runShutdown();
-  } catch {
-    // Signal shutdown is best effort; output still gets one final flush.
-  }
-  try {
-    await flushTextStderr();
-  } catch {
-    // A closed stderr pipe must not prevent signal-based termination.
-  }
-  try {
-    await flushNdjsonStdout();
-  } catch {
-    // A closed stdout pipe must not prevent signal-based termination.
-  }
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      // Signal shutdown is best effort; output still gets one final flush.
+      yield* Effect.ignoreCause(
+        tryPromise(() => lifecycle?.runShutdown() ?? Promise.resolve()),
+      );
+      // A closed stderr pipe must not prevent signal-based termination.
+      yield* Effect.ignoreCause(tryPromise(flushTextStderr));
+      // A closed stdout pipe must not prevent signal-based termination.
+      yield* Effect.ignoreCause(tryPromise(flushNdjsonStdout));
+    }),
+  );
 }
 
 export function installCliShutdownSignalHandlers(
@@ -330,18 +337,25 @@ export async function initCliPlatform(
     // defaults, as the extension and desktop hosts do at startup. The list
     // lives in shared `~/.texra` state. Preferred defaults reconcile when
     // MODEL_LIST_VERSION changes; retired entries are swept on every startup.
-    try {
-      const { messages } = await refreshModelListAndLog(
-        stateStores.globalState,
-      );
-      for (const message of messages) logAt('info', 'cli.models', message);
-    } catch (error) {
-      logAt(
-        'error',
-        'cli.models',
-        `Failed to refresh model list: ${toErrorMessage(error)}`,
-      );
-    }
+    await effectRuntime().runPromise(
+      tryPromise(() => refreshModelListAndLog(stateStores.globalState)).pipe(
+        Effect.tap(({ messages }) =>
+          Effect.sync(() => {
+            for (const message of messages)
+              logAt('info', 'cli.models', message);
+          }),
+        ),
+        Effect.catch((error) =>
+          Effect.sync(() => {
+            logAt(
+              'error',
+              'cli.models',
+              `Failed to refresh model list: ${toErrorMessage(error)}`,
+            );
+          }),
+        ),
+      ),
+    );
 
     // Seed first-install defaults (e.g. disabled tools) before anything
     // writes CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION (the bundled-agent sync

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -165,14 +165,25 @@ export async function initializeElectronPlatform(
   // reconcile when MODEL_LIST_VERSION changes; retired entries and stale
   // Copilot route preferences are swept on every startup. Runs here so it is
   // upstream of the settings view's first model-list paint.
-  try {
-    const { messages } = await refreshModelListAndLog(globalStateStore);
-    for (const message of messages) console.info(`[desktop] ${message}`);
-  } catch (error) {
-    console.error(
-      `[desktop] Failed to refresh model list: ${toErrorMessage(error)}`,
-    );
-  }
+  await effectRuntime().runPromise(
+    Effect.tryPromise({
+      try: () => refreshModelListAndLog(globalStateStore),
+      catch: (error) => error,
+    }).pipe(
+      Effect.tap(({ messages }) =>
+        Effect.sync(() => {
+          for (const message of messages) console.info(`[desktop] ${message}`);
+        }),
+      ),
+      Effect.catch((error) =>
+        Effect.sync(() => {
+          console.error(
+            `[desktop] Failed to refresh model list: ${toErrorMessage(error)}`,
+          );
+        }),
+      ),
+    ),
+  );
 
   // Seed first-install defaults (e.g. disabled tools) before anything writes
   // LAST_KNOWN_VERSION, so upgrading users are not affected. Mirrors the

--- a/src/test-kernel/architecture/dependencyDirection.vitest.ts
+++ b/src/test-kernel/architecture/dependencyDirection.vitest.ts
@@ -115,6 +115,12 @@ const BARE_EFFECT_RUN_SITES: Readonly<Record<string, number>> = {
   // has to answer for a process no run initialized and for one whose
   // shutdown already disposed that runtime.
   'packages/agent/src/index.ts': 6,
+  // The CLI platform shutdown sequence, which cannot borrow `effectRuntime()`
+  // for the same reason the SDK entry cannot: `lifecycle.runShutdown()`
+  // disposes the process runtime (`disposeProcessRuntime`) before the
+  // stderr/stdout flushes run, and a teardown path must not depend on the
+  // runtime it is tearing down.
+  'packages/cli/src/runtime/initPlatform.ts': 1,
 };
 
 function sourceFilesUnder(


### PR DESCRIPTION
## Summary

Clears the two `catch:effect-importer` ratchet rows that keep origin/main's static checks red (PRD `docs/prds/2026-08-26-effect-4-runtime-migration.md` R7 + execution rule 2, one pass per file). Both files are host composition roots that already import `effect` at runtime; their raw catch sites are converted to typed recovery per each site's R7 meaning:

- **`packages/cli/src/runtime/initPlatform.ts` (4 sites → 0)**
  - `runCliPlatformShutdownSequence` (3 sites): the three best-effort steps (lifecycle shutdown, stderr flush, NDJSON stdout flush) become one `Effect.gen` of `Effect.ignoreCause(Effect.tryPromise(...))` steps, run once via `Effect.runPromise`. `ignoreCause` is the exact `catch {}` meaning (failures, defects, and interruption all swallowed; later steps still run). The sequence deliberately runs on the **default runtime**, not `effectRuntime()`: `lifecycle.runShutdown()` disposes the process runtime (`disposeProcessRuntime`, registered in `afterExecutionSettlement`) *before* the flushes run, and a teardown path must not depend on the runtime it is tearing down. That bare run is pinned in `BARE_EFFECT_RUN_SITES` (`src/test-kernel/architecture/dependencyDirection.vitest.ts`) with this justification, as that suite's failure message directs.
  - Model-list refresh (1 site): `try { await refreshModelListAndLog(...) } catch { logAt('error', ...) }` becomes `Effect.tryPromise` (identity catch mapper, the `hostDraftRequests.ts` idiom) + `Effect.tap`/`Effect.catch` on the already-installed `effectRuntime()`. Same messages on the same `cli.models` channel at the same severities.
- **`packages/desktop/src/main/platform/index.ts` (1 site → 0)**: the same model-list-refresh conversion, logging through `console.info`/`console.error` with the same `[desktop]` wording, run on the already-installed `effectRuntime()`.

**No site left raw.** None of the five sites is a foreign-runtime adapter boundary; all are expected-failure recovery or best-effort projection, which R7 assigns to typed recovery.

Behavior-preserving: shutdown ordering (lifecycle → stderr flush → stdout flush), signal exit codes (130/143), log channels/severities/wording, and best-effort semantics are unchanged, as pinned by `InitPlatformSignalHandlers`, `CliInitPlatform`, `SessionExitController`, `RunChatSignalOwnership`, and the desktop composition suites.

## Issue acceptance gates

Effect 4 migration ratchet (`node scripts/check-effect-migration-ratchet.mjs`): the two target rows are gone —

- ~~`[catch:effect-importer] packages/cli/src/runtime/initPlatform.ts: 0 -> 4 (new file)`~~
- ~~`[catch:effect-importer] packages/desktop/src/main/platform/index.ts: 0 -> 1 (new file)`~~

No new `- [` failure lines vs main's inherited set (`/tmp/gate-main2.txt`); the branch's remaining ratchet failures are exactly the inherited rows owned elsewhere (see below). `--update` regenerates nothing: neither file was ever in `config/ratchets/effect-migration-baseline.json` (they failed as "new file" rows), so there is no baseline diff to commit. A sibling lane (`effect/auth-token-provider`) is concurrently removing the `src/auth` rows and will also regenerate the baseline; if a baseline conflict arises, whoever merges second rebases and re-runs `--update`.

Residual main red and its owners (unchanged by this PR):

- `packages/desktop/src/main/index.ts`, `packages/desktop/src/main/desktopPapers.ts` catch rows — owned by the cutover PRs #11971/#11972 (out of scope here).
- `src/auth/SupabaseClient.ts` catch row, `src/auth/authProgram.ts` `Effect.run*` row, and the `@adapter-until` marker — owned by the in-flight `effect/auth-token-provider` lane.

## Single source of truth

`scripts/check-effect-migration-ratchet.mjs` remains the single owner of the catch-site accounting; the bare-`Effect.run*` allowlist stays in `BARE_EFFECT_RUN_SITES` in `src/test-kernel/architecture/dependencyDirection.vitest.ts` (one new pin, with the disposal-order justification beside it). Shutdown ordering stays owned by `runCliPlatformShutdownSequence` alone — the one definition the platform signal handlers and the chat TUI's handoff path share.

## Duplication and abstraction budget

One file-local helper added: `tryPromise` in `initPlatform.ts` (identity-catch `Effect.tryPromise`, 4 call sites in the file), mirroring the documented idiom in `src/controllers/session/hostDraftRequests.ts`. The desktop file has a single site, so it inlines the same shape without a helper (extract-only-when-repeated). No new ports, wrappers, or pass-throughs; no `@adapter-until` markers.

## Net elements (R6)

- Files: 3 changed (`packages/cli/src/runtime/initPlatform.ts` +37/−31, `packages/desktop/src/main/platform/index.ts` +19/−8, `src/test-kernel/architecture/dependencyDirection.vitest.ts` +6/−0); net +31 LoC.
- Exported symbols added/deleted: none (`^[+-]export` over the diff is empty; `runCliPlatformShutdownSequence` keeps its signature).
- Classes/interfaces/enums: none added or removed; one file-local function (`tryPromise`) added, five catch clauses deleted.

## Consumer counts (R8)

- `runCliPlatformShutdownSequence`: 2 production consumers (`installCliShutdownSignalHandlers` in the same file; `packages/cli/src/chat/tui/sessionExitController.ts`), both call it as before — signature and resolution semantics unchanged; no consumer edits.
- `initializeElectronPlatform`: 1 consumer (`packages/desktop/src/main/index.ts`, out of scope) — signature and returned record unchanged; no consumer edits.
- No emit path or export deleted or re-routed.

## Host impact

Extension: none.
Desktop: model-list refresh failure/success logging now runs through the process Effect runtime; same console output.
CLI: shutdown sequence and model-list refresh converted as above; signal exit codes and stderr/stdout flush order unchanged.

## Scheduled refactoring

None. The residual ratchet rows are owned by #11971/#11972 and the `effect/auth-token-provider` lane as noted above.

## Validation

- `npx prettier --check` on all three changed files — pass.
- `npm run typecheck` (full: workspace, test-kernel, agent, cli, trace-viewer, desktop) — pass.
- `npm run lint` — pass (clean); single-file eslint re-run on the three changed files after the pin edit — pass.
- Targeted vitest (`InitPlatformSignalHandlers`, `CliInitPlatform`, `SessionExitController`, `RunChatSignalOwnership`, `ElectronCompositionRoot`, `ElectronPlatformAdapters`, `ElectronSecretsBootstrap`, `ModelListRefresh`) — 67/67 pass.
- Full `npx vitest run` — 764 files passed / 1 skipped; 9092 tests passed, 0 failures.
- `node scripts/check-effect-migration-ratchet.mjs` — the two target rows gone, no new failure lines vs main's inherited set; `--update` produces no baseline diff (neither file was baselined).
- `npm run check:dead-code-ratchet` — OK, no new findings.
