### PR TITLE
refactor(lean): make LeanLanguageServices an Effect-typed port

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -179,7 +179,7 @@
       "src/tools/agentCliSessionRegistry.ts": 2,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/goal/goalStore.ts": 2,
-      "src/tools/lean/direct/directLspAdapter.ts": 4
+      "src/tools/lean/direct/directLspAdapter.ts": 3
     },
     "catch:effect-importer": {
       "packages/cli/src/chat/chatSessionController.ts": 7,
@@ -228,6 +228,6 @@
     "src/tools/agentCliSessionRegistry.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/github/PollingSourceBase.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/goal/goalStore.ts": "Phase 5 — tools subsystem",
-    "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — LeanLanguageServices becomes an Effect-typed port and the run moves to LspTools' execute()"
+    "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — the port is Effect-typed and the tool-facing runs moved to the tools' execute(); what remains is pool construction/disposal (the platform-lifetime seam) and the run-end hook's Promise seam, both owned by lane D"
   }
 }

--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1630,14 +1630,14 @@
     {
       "file": "src/tools/lean/direct/directLspAdapter.ts",
       "category": "production-dead",
-      "kind": "exports",
-      "name": "defaultResolveWorkspaceRoot"
-    },
-    {
-      "file": "src/tools/lean/direct/directLspAdapter.ts",
-      "category": "production-dead",
       "kind": "types",
       "name": "DirectLspLeanAdapterOptions"
+    },
+    {
+      "file": "src/tools/lean/direct/leanServerPool.ts",
+      "category": "production-dead",
+      "kind": "exports",
+      "name": "resolveWorkspaceRoot"
     },
     {
       "file": "src/tools/memory/memoryFileSystem.ts",

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -11,6 +11,8 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
+import { Effect, Result } from 'effect';
+
 import { promptExtensionInstall } from '@frontend/ui/instruction';
 import { openFileInEditor } from '@frontend/vscode/vscodeEditor';
 import { waitForDiagnosticsChange } from '@frontend/vscode/vscodeDiagnostics';
@@ -191,111 +193,142 @@ function getDiagnostics(filePath: string): LeanDiagnostic[] {
   return [];
 }
 
-async function executeFileCommand(
+/**
+ * One VS Code command or window call as an Effect. The host's `Thenable` is
+ * the foreign-runtime edge, so its rejection is the typed failure the port
+ * methods recover from; a synchronous throw inside `run` fails the same way.
+ */
+const tryHost = <A>(run: () => PromiseLike<A>): Effect.Effect<A, unknown> =>
+  Effect.tryPromise({ try: run, catch: (error) => error });
+
+function executeFileCommand(
   command: LeanFileCommand,
   filePath: string,
-): Promise<boolean> {
-  try {
-    const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(filePath));
-    const document = await vscode.workspace.openTextDocument(uri);
-    await vscode.window.showTextDocument(document, { preserveFocus: true });
-    if (!(await getClientProvider())) return false;
-    await vscode.commands.executeCommand(FILE_COMMAND_VSCODE_IDS[command]);
+): Effect.Effect<boolean> {
+  return Effect.gen(function* () {
+    yield* tryHost(async () => {
+      const document = await vscode.workspace.openTextDocument(
+        vscode.Uri.file(WorkspaceFS.toAbsolute(filePath)),
+      );
+      await vscode.window.showTextDocument(document, { preserveFocus: true });
+    });
+    if (!(yield* getClientProvider())) return false;
+    yield* tryHost(() =>
+      vscode.commands.executeCommand(FILE_COMMAND_VSCODE_IDS[command]),
+    );
     return true;
-  } catch {
-    return false;
-  }
+  }).pipe(Effect.catch(() => Effect.succeed(false)));
 }
 
 /**
  * Get the Lean 4 extension's client provider.
- * Returns null if the extension is not installed or not ready.
+ * Yields null if the extension is not installed or not ready.
  * Prompts user to install the extension if not found.
  */
-async function getClientProvider(): Promise<LeanClientProvider | null> {
-  const lean4Ext =
-    vscode.extensions.getExtension<Lean4ExtensionApi>(LEAN4_EXTENSION_ID);
-  if (!lean4Ext) {
-    await promptExtensionInstall({
-      suppressKey: 'lean4-install-tool',
-      message: 'Lean 4 extension is required for this operation. Install now?',
-      extensionId: LEAN4_EXTENSION_ID,
-      channel: 'lean',
-    });
-    return null;
-  }
+function getClientProvider(): Effect.Effect<
+  LeanClientProvider | null,
+  unknown
+> {
+  return tryHost(async () => {
+    const lean4Ext =
+      vscode.extensions.getExtension<Lean4ExtensionApi>(LEAN4_EXTENSION_ID);
+    if (!lean4Ext) {
+      await promptExtensionInstall({
+        suppressKey: 'lean4-install-tool',
+        message:
+          'Lean 4 extension is required for this operation. Install now?',
+        extensionId: LEAN4_EXTENSION_ID,
+        channel: 'lean',
+      });
+      return null;
+    }
 
-  const api = await lean4Ext.activate();
-  const features = await api.lean4EnabledFeatures;
-  return features.clientProvider;
+    const api = await lean4Ext.activate();
+    const features = await api.lean4EnabledFeatures;
+    return features.clientProvider;
+  });
 }
 
 /**
  * Send an LSP request at a specific position in a Lean file.
- * Opens the file first to ensure the LSP server has processed it.
+ * Opens the file first to ensure the LSP server has processed it. Each
+ * failure mode is its own `data: null` answer, as the callers' models read
+ * the error text; nothing here throws.
  */
-async function sendPositionRequest<T>(
+function sendPositionRequest<T>(
   filePath: string,
   line: number,
   column: number,
   method: string,
-): Promise<LspResult<T>> {
-  const absolutePath = WorkspaceFS.toAbsolute(filePath);
-  const uri = vscode.Uri.file(absolutePath);
-  const leanUri = createLeanFileUri(absolutePath);
+): Effect.Effect<LspResult<T>> {
+  return Effect.gen(function* () {
+    const absolutePath = WorkspaceFS.toAbsolute(filePath);
+    const uri = vscode.Uri.file(absolutePath);
+    const leanUri = createLeanFileUri(absolutePath);
 
-  const clientProvider = await getClientProvider().catch(() => null);
-  if (!clientProvider) {
-    return { data: null, error: 'Lean 4 extension not found or not activated' };
-  }
+    const clientProvider = yield* getClientProvider().pipe(
+      Effect.catch(() => Effect.succeed(null)),
+    );
+    if (!clientProvider) {
+      return {
+        data: null,
+        error: 'Lean 4 extension not found or not activated',
+      };
+    }
 
-  try {
-    const document = await vscode.workspace.openTextDocument(uri);
-    await vscode.window.showTextDocument(document, { preserveFocus: true });
-  } catch (e) {
-    return {
-      data: null,
-      error: `Failed to open file ${absolutePath}: ${toErrorMessage(e)}`,
-    };
-  }
+    const opened = yield* Effect.result(
+      tryHost(async () => {
+        const document = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(document, { preserveFocus: true });
+      }),
+    );
+    if (Result.isFailure(opened)) {
+      return {
+        data: null,
+        error: `Failed to open file ${absolutePath}: ${toErrorMessage(opened.failure)}`,
+      };
+    }
 
-  let client: LeanClient | undefined;
-  try {
-    client = clientProvider.findClient(leanUri);
-  } catch {
-    return {
-      data: null,
-      error: `Error finding Lean client for ${absolutePath}. Is this file in a Lean project?`,
-    };
-  }
-  if (!client) {
-    return {
-      data: null,
-      error: `No Lean client for ${absolutePath}. Is this file in a Lean project with a lakefile?`,
-    };
-  }
-  if (!client.isRunning()) {
-    return {
-      data: null,
-      error: 'Lean server not running. Try lean_project restart_server.',
-    };
-  }
+    const found = yield* Effect.result(
+      Effect.try({
+        try: () => clientProvider.findClient(leanUri),
+        catch: () => undefined,
+      }),
+    );
+    if (Result.isFailure(found)) {
+      return {
+        data: null,
+        error: `Error finding Lean client for ${absolutePath}. Is this file in a Lean project?`,
+      };
+    }
+    const client = found.success;
+    if (!client) {
+      return {
+        data: null,
+        error: `No Lean client for ${absolutePath}. Is this file in a Lean project with a lakefile?`,
+      };
+    }
+    if (!client.isRunning()) {
+      return {
+        data: null,
+        error: 'Lean server not running. Try lean_project restart_server.',
+      };
+    }
 
-  noteVscodeLeanServer(workspaceRootForFile(absolutePath));
+    noteVscodeLeanServer(workspaceRootForFile(absolutePath));
 
-  try {
     const params = {
       textDocument: { uri: leanUri.toString() },
       position: { line, character: column },
     };
-    const result = await client.sendRequest(method, params);
-    return { data: result as T };
-  } catch (e) {
-    return {
-      data: null,
-      error: `LSP request ${method} failed: ${toErrorMessage(e)}`,
-    };
-  }
+    return yield* Effect.tryPromise({
+      try: () => client.sendRequest(method, params),
+      catch: (e) => `LSP request ${method} failed: ${toErrorMessage(e)}`,
+    }).pipe(
+      Effect.map((result) => ({ data: result as T })),
+      Effect.catch((error) => Effect.succeed({ data: null, error })),
+    );
+  });
 }
 
 /**
@@ -307,7 +340,7 @@ function getGoalState(
   filePath: string,
   line: number,
   column: number,
-): Promise<LspResult<PlainGoal>> {
+): Effect.Effect<LspResult<PlainGoal>> {
   return sendPositionRequest<PlainGoal>(
     filePath,
     line,
@@ -325,7 +358,7 @@ function getTermGoal(
   filePath: string,
   line: number,
   column: number,
-): Promise<LspResult<PlainTermGoal>> {
+): Effect.Effect<LspResult<PlainTermGoal>> {
   return sendPositionRequest<PlainTermGoal>(
     filePath,
     line,
@@ -343,7 +376,7 @@ function getHoverInfo(
   filePath: string,
   line: number,
   column: number,
-): Promise<LspResult<LspHover>> {
+): Effect.Effect<LspResult<LspHover>> {
   return sendPositionRequest<LspHover>(
     filePath,
     line,
@@ -354,60 +387,72 @@ function getHoverInfo(
 
 /**
  * Open a Lean file, wait for diagnostics, and return them.
- * Returns null if the file could not be opened.
+ * The file that could not be opened is the `file_missing` answer; a rejected
+ * host call fails the effect.
  */
-async function fetchDiagnosticsForFile(
+function fetchDiagnosticsForFile(
   file: string,
-): Promise<FetchDiagnosticsResult> {
-  const absolutePath = WorkspaceFS.toAbsolute(file);
-  const diagnosticsWait = waitForDiagnosticsChange(
-    vscode.Uri.file(absolutePath),
-    10000,
-  );
+): Effect.Effect<FetchDiagnosticsResult, unknown> {
+  return tryHost(async (): Promise<FetchDiagnosticsResult> => {
+    const absolutePath = WorkspaceFS.toAbsolute(file);
+    const diagnosticsWait = waitForDiagnosticsChange(
+      vscode.Uri.file(absolutePath),
+      10000,
+    );
 
-  const opened = await openFileInEditor(file, { preserveFocus: true });
-  if (!opened) {
-    // Could not be opened in the editor — the file itself is the problem.
-    return {
-      ok: false,
-      kind: 'file_missing',
-      message: `Could not open ${absolutePath} in the editor.`,
-    };
-  }
+    const opened = await openFileInEditor(file, { preserveFocus: true });
+    if (!opened) {
+      // Could not be opened in the editor — the file itself is the problem.
+      return {
+        ok: false,
+        kind: 'file_missing',
+        message: `Could not open ${absolutePath} in the editor.`,
+      };
+    }
 
-  noteVscodeLeanServer(workspaceRootForFile(absolutePath));
+    noteVscodeLeanServer(workspaceRootForFile(absolutePath));
 
-  await diagnosticsWait;
-  return { ok: true, diagnostics: getDiagnostics(opened.absolutePath) };
+    await diagnosticsWait;
+    return { ok: true, diagnostics: getDiagnostics(opened.absolutePath) };
+  });
 }
 
 /** Navigate editor to first error location if present. */
-async function navigateToFirstError(
+function navigateToFirstError(
   filePath: string,
   diagnostics: LeanDiagnostic[],
-): Promise<void> {
+): Effect.Effect<void, unknown> {
   const firstError = diagnostics.find(
     (d) => d.severity === vscode.DiagnosticSeverity.Error,
   );
-  if (firstError) {
-    await openFileInEditor(filePath, { line: firstError.range.start.line + 1 });
-  }
+  if (!firstError) return Effect.void;
+  return tryHost(async () => {
+    await openFileInEditor(filePath, {
+      line: firstError.range.start.line + 1,
+    });
+  });
 }
 
-async function executeProjectCommand(
+function executeProjectCommand(
   command: LeanProjectCommand,
-): Promise<void> {
-  if (LEAN_FEATURE_PROJECT_COMMANDS.has(command)) {
-    // vscode-lean4 registers these commands in activateLean4Features(), not
-    // during its initial extension activation. Awaiting the exported feature
-    // promise prevents a race with command registration after a Lean file opens.
-    if (!(await getClientProvider())) {
-      throw new Error(
-        'The Lean 4 extension is not ready. Open a Lean file in the project, then try again.',
-      );
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    if (LEAN_FEATURE_PROJECT_COMMANDS.has(command)) {
+      // vscode-lean4 registers these commands in activateLean4Features(), not
+      // during its initial extension activation. Awaiting the exported feature
+      // promise prevents a race with command registration after a Lean file opens.
+      if (!(yield* getClientProvider())) {
+        return yield* Effect.fail(
+          new Error(
+            'The Lean 4 extension is not ready. Open a Lean file in the project, then try again.',
+          ),
+        );
+      }
     }
-  }
-  await vscode.commands.executeCommand(PROJECT_COMMAND_VSCODE_IDS[command]);
+    yield* tryHost(async () => {
+      await vscode.commands.executeCommand(PROJECT_COMMAND_VSCODE_IDS[command]);
+    });
+  });
 }
 
 /**

--- a/src/test-kernel/frontend/VscodeIntegration.vitest.ts
+++ b/src/test-kernel/frontend/VscodeIntegration.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
 
 import { vscodeLeanLanguageServices } from '@frontend/lean/VscodeIntegration';
@@ -8,7 +9,7 @@ describe('vscodeLeanLanguageServices', () => {
     const original = vscodeLeanLanguageServices.getGoalState;
     expect(() => {
       Object.assign(vscodeLeanLanguageServices, {
-        getGoalState: async () => undefined,
+        getGoalState: () => Effect.succeed({ data: null }),
       });
     }).toThrow(TypeError);
     expect(vscodeLeanLanguageServices.getGoalState).toBe(original);

--- a/src/test-kernel/tools/LeanInspectTool.vitest.ts
+++ b/src/test-kernel/tools/LeanInspectTool.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -28,14 +29,13 @@ function installServices(overrides: Partial<LeanLanguageServices>): void {
 
 describe('LeanInspectTool', () => {
   it('reports a failing language-server request with a per-type summary', async () => {
-    // The dispatch must be awaited inside execute()'s try block; a bare
-    // `return this.executeGoal(...)` settles the promise after the try has
-    // exited, so the rejection reaches the caller unwrapped and loses the
-    // summary that names which inspection failed.
+    // A port failure settles the program's run as a failed Exit, which the
+    // execute() boundary folds into a ToolError carrying the summary that
+    // names which inspection failed.
     installServices({
-      getGoalState: vi.fn(async () => {
-        throw new Error('Lean server not running');
-      }),
+      getGoalState: vi.fn(() =>
+        Effect.die(new Error('Lean server not running')),
+      ),
     });
 
     const result = await new LeanInspectTool().call(GOAL_INSPECT_INPUT);
@@ -52,7 +52,9 @@ describe('LeanInspectTool', () => {
     // A resolved "no data" answer is a normal outcome, not a thrown failure:
     // it must keep its own message instead of being wrapped as a ToolError.
     installServices({
-      getGoalState: vi.fn(async () => ({ data: null, error: 'no goal here' })),
+      getGoalState: vi.fn(() =>
+        Effect.succeed({ data: null, error: 'no goal here' }),
+      ),
     });
 
     const result = await new LeanInspectTool().call(GOAL_INSPECT_INPUT);

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -2,10 +2,11 @@
  * The direct LSP lane at its two boundaries: the `LeanServerPool` service
  * (Effect, under `it.effect`'s `TestClock` where idle eviction and the
  * diagnostics quiet window are the subject, under `it.live` where the child
- * process's real exit timing is) and the Promise edge
- * `createDirectLspLeanAdapter` returns. Servers are a fake `lake` script
- * (a real child process) or an in-memory child handed to the Node spawner
- * through the mocked `spawn`.
+ * process's real exit timing is) and the `LeanLanguageServices` port
+ * `createDirectLspLeanAdapter` returns — the pool's programs plus the
+ * interruption fold, which the adapter suites compose directly under
+ * `it.live`. Servers are a fake `lake` script (a real child process) or an
+ * in-memory child handed to the Node spawner through the mocked `spawn`.
  */
 
 // Node imports
@@ -56,7 +57,10 @@ vi.mock('node:child_process', async (importOriginal) => {
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { nodeChildProcessSpawnerLayer } from '@platform/defaults/nodeChildProcessSpawner';
 import type { ExecutionId } from '@shared/schemas';
-import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
+import {
+  createDirectLspLeanAdapter,
+  type DirectLspLeanAdapterOptions,
+} from '@tools/lean/direct/directLspAdapter';
 import { LeanServer } from '@tools/lean/direct/leanServer';
 import {
   LeanServerPool,
@@ -698,130 +702,158 @@ describe('LeanServerPool', () => {
 });
 
 describe('createDirectLspLeanAdapter', () => {
-  const fakeLakeIt = it.skipIf(process.platform === 'win32');
+  const fakeLakeIt = it.live.skipIf(process.platform === 'win32');
+
+  /**
+   * The port methods are programs; these tests compose them directly, the
+   * way a tool's execute() does after its one boundary run. The adapter's
+   * disposal rides `acquireUseRelease`, so a failing body still closes the
+   * pool's scope.
+   */
+  const withAdapter = <A>(
+    options: DirectLspLeanAdapterOptions,
+    use: (
+      adapter: ReturnType<typeof createDirectLspLeanAdapter>,
+    ) => Effect.Effect<A, unknown>,
+  ): Effect.Effect<A, unknown> =>
+    Effect.acquireUseRelease(
+      Effect.sync(() => createDirectLspLeanAdapter(options)),
+      use,
+      (adapter) => Effect.promise(() => adapter.dispose()),
+    );
 
   fakeLakeIt(
     'joins concurrent first-touch requests for the same workspace',
-    async () => {
-      const adapter = createDirectLspLeanAdapter({ lakeCommand: fakeLakePath });
-      try {
-        const [first, second] = await Promise.all([
-          adapter.fetchDiagnosticsForFile(filePath),
-          adapter.fetchDiagnosticsForFile(filePath),
-        ]);
+    () =>
+      withAdapter({ lakeCommand: fakeLakePath }, (adapter) =>
+        Effect.gen(function* () {
+          const [first, second] = yield* Effect.all(
+            [
+              adapter.fetchDiagnosticsForFile(filePath),
+              adapter.fetchDiagnosticsForFile(filePath),
+            ],
+            { concurrency: 'unbounded' },
+          );
 
-        expect(first).toMatchObject({
-          ok: true,
-          diagnostics: [{ message: 'fake diagnostic' }],
-        });
-        expect(second).toMatchObject({
-          ok: true,
-          diagnostics: [{ message: 'fake diagnostic' }],
-        });
-        expect(await countStarts()).toBe(1);
-      } finally {
-        await adapter.dispose();
-      }
-    },
+          expect(first).toMatchObject({
+            ok: true,
+            diagnostics: [{ message: 'fake diagnostic' }],
+          });
+          expect(second).toMatchObject({
+            ok: true,
+            diagnostics: [{ message: 'fake diagnostic' }],
+          });
+          expect(yield* starts).toBe(1);
+        }),
+      ),
   );
 
-  fakeLakeIt('attributes a request to the ambient agent run', async () => {
-    const adapter = createDirectLspLeanAdapter({
-      lakeCommand: fakeLakePath,
-      idleTimeoutMs: 0,
-    });
-    try {
-      await asRun('e00001', () => adapter.fetchDiagnosticsForFile(filePath));
-      expect(activeServerRoots()).toEqual([projectRoot]);
+  fakeLakeIt('attributes a request to the ambient agent run', () =>
+    withAdapter({ lakeCommand: fakeLakePath, idleTimeoutMs: 0 }, (adapter) =>
+      Effect.gen(function* () {
+        // The run id is captured when the method is called, so the call
+        // itself happens inside the ambient run context. `withRunContext`'s
+        // `T | Promise<T>` covers its async users; this callback is
+        // synchronous, so the cast only narrows that union back.
+        const program = withRunContext(
+          createRunContext({ executionId: run('e00001') }),
+          () => adapter.fetchDiagnosticsForFile(filePath),
+        ) as ReturnType<(typeof adapter)['fetchDiagnosticsForFile']>;
+        yield* program;
+        expect(activeServerRoots()).toEqual([projectRoot]);
 
-      await adapter.stopSessionsForRun?.('e00001' as ExecutionId);
+        yield* Effect.promise(async () => {
+          await adapter.stopSessionsForRun?.(run('e00001'));
+        });
 
-      expect(activeServerRoots()).toEqual([]);
-    } finally {
-      await adapter.dispose();
-    }
-  });
+        expect(activeServerRoots()).toEqual([]);
+      }),
+    ),
+  );
 
-  it('reports a missing lake command as toolchain_unavailable, not "file missing"', async () => {
-    const adapter = createDirectLspLeanAdapter({
-      lakeCommand: path.join(tempRoot, 'missing-lake'),
-    });
-    try {
-      await expect(
-        adapter.fetchDiagnosticsForFile(filePath),
-      ).resolves.toMatchObject({ ok: false, kind: 'toolchain_unavailable' });
-    } finally {
-      await adapter.dispose();
-    }
-  });
+  it.live(
+    'reports a missing lake command as toolchain_unavailable, not "file missing"',
+    () =>
+      withAdapter(
+        { lakeCommand: path.join(tempRoot, 'missing-lake') },
+        (adapter) =>
+          Effect.gen(function* () {
+            const result = yield* adapter.fetchDiagnosticsForFile(filePath);
+            expect(result).toMatchObject({
+              ok: false,
+              kind: 'toolchain_unavailable',
+            });
+          }),
+      ),
+  );
 
   fakeLakeIt(
     'reports requests a dispose interrupted mid-start as stopped',
-    async () => {
-      let spawnCount = 0;
-      // The handshake never answers, so every request below is still waiting
-      // on the server's build when `dispose()` closes the scope under it. The
-      // interruption that follows is not a failure the pool can fold, so the
-      // methods stay total only if the Promise edge folds it.
-      spawnOverride.current = () => {
-        spawnCount += 1;
-        return createFakeLeanChild({
-          initializeGate: new Promise<void>(() => {}),
-        });
-      };
-      const adapter = createDirectLspLeanAdapter({ lakeCommand: fakeLakePath });
-      const diagnostics = adapter.fetchDiagnosticsForFile(filePath);
-      const fileCommand = adapter.executeFileCommand('restart', filePath);
-      const hover = adapter.getHoverInfo(filePath, 0, 0);
-      await vi.waitFor(() => expect(spawnCount).toBe(1));
+    () =>
+      withAdapter({ lakeCommand: fakeLakePath }, (adapter) =>
+        Effect.gen(function* () {
+          let spawnCount = 0;
+          // The handshake never answers, so every request below is still
+          // waiting on the server's build when `dispose()` closes the scope
+          // under it. The interruption that follows is not a failure the pool
+          // can fold, so the methods stay total only if the port's own fold
+          // recovers it.
+          spawnOverride.current = () => {
+            spawnCount += 1;
+            return createFakeLeanChild({
+              initializeGate: new Promise<void>(() => {}),
+            });
+          };
+          const diagnostics = yield* Effect.forkChild(
+            adapter.fetchDiagnosticsForFile(filePath),
+          );
+          const fileCommand = yield* Effect.forkChild(
+            adapter.executeFileCommand('restart', filePath),
+          );
+          const hover = yield* Effect.forkChild(
+            adapter.getHoverInfo(filePath, 0, 0),
+          );
+          yield* eventually(() => expect(spawnCount).toBe(1));
 
-      await adapter.dispose();
+          yield* Effect.promise(() => adapter.dispose());
 
-      await expect(diagnostics).resolves.toEqual({
-        ok: false,
-        kind: 'toolchain_unavailable',
-        message: 'Lean adapter was stopped.',
-      });
-      await expect(fileCommand).resolves.toBe(false);
-      await expect(hover).resolves.toEqual({
-        data: null,
-        error: 'Lean adapter was stopped.',
-      });
-    },
+          expect(yield* Fiber.join(diagnostics)).toEqual({
+            ok: false,
+            kind: 'toolchain_unavailable',
+            message: 'Lean adapter was stopped.',
+          });
+          expect(yield* Fiber.join(fileCommand)).toBe(false);
+          expect(yield* Fiber.join(hover)).toEqual({
+            data: null,
+            error: 'Lean adapter was stopped.',
+          });
+        }),
+      ),
   );
 
-  fakeLakeIt(
-    'stops every server when disposed, and disposes twice',
-    async () => {
-      const adapter = createDirectLspLeanAdapter({ lakeCommand: fakeLakePath });
-      await adapter.fetchDiagnosticsForFile(filePath);
-      expect(activeServerRoots()).toEqual([projectRoot]);
+  fakeLakeIt('stops every server when disposed, and disposes twice', () =>
+    withAdapter({ lakeCommand: fakeLakePath }, (adapter) =>
+      Effect.gen(function* () {
+        yield* adapter.fetchDiagnosticsForFile(filePath);
+        expect(activeServerRoots()).toEqual([projectRoot]);
 
-      await adapter.dispose();
-      expect(activeServerRoots()).toEqual([]);
+        yield* Effect.promise(() => adapter.dispose());
+        expect(activeServerRoots()).toEqual([]);
 
-      await adapter.dispose();
-      await expect(
-        adapter.fetchDiagnosticsForFile(filePath),
-      ).resolves.toMatchObject({
-        ok: false,
-        kind: 'toolchain_unavailable',
-        message: 'Lean adapter was stopped.',
-      });
-    },
+        yield* Effect.promise(() => adapter.dispose());
+        const after = yield* adapter.fetchDiagnosticsForFile(filePath);
+        expect(after).toMatchObject({
+          ok: false,
+          kind: 'toolchain_unavailable',
+          message: 'Lean adapter was stopped.',
+        });
+      }),
+    ),
   );
 });
 
 function run(executionId: string): ExecutionId {
   return executionId as ExecutionId;
-}
-
-/** Run `fn` with the ambient run context of the given agent run. */
-function asRun<T>(
-  executionId: string,
-  fn: () => T | Promise<T>,
-): T | Promise<T> {
-  return withRunContext(createRunContext({ executionId }), fn);
 }
 
 function makeLakeProject(

--- a/src/test-kernel/tools/lean/LeanTools.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanTools.vitest.ts
@@ -7,8 +7,9 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectRuntime } from '@platform/processRuntime';
 import { findExternalToolDef } from '@tools/externalToolDefs';
-import { defaultResolveWorkspaceRoot } from '@tools/lean/direct/directLspAdapter';
+import { resolveWorkspaceRoot } from '@tools/lean/direct/leanServerPool';
 import {
   listLeanServers,
   registerLeanServer,
@@ -54,11 +55,14 @@ describe('extractHoverText', () => {
 });
 
 // ---------------------------------------------------------------------------
-// DefaultResolveWorkspaceRoot
+// ResolveWorkspaceRoot
 // ---------------------------------------------------------------------------
 
-describe('defaultResolveWorkspaceRoot', () => {
+describe('resolveWorkspaceRoot', () => {
   let scratch: string;
+
+  const resolve = (filePath: string): Promise<string | null> =>
+    effectRuntime().runPromise(resolveWorkspaceRoot(filePath));
 
   beforeEach(() => {
     scratch = mkdtempSync(path.join(tmpdir(), 'texra-lean-root-'));
@@ -71,9 +75,7 @@ describe('defaultResolveWorkspaceRoot', () => {
   it('finds lakefile.lean in the same directory', async () => {
     await writeFile(path.join(scratch, 'lakefile.lean'), '');
     await writeFile(path.join(scratch, 'Foo.lean'), '');
-    const root = await defaultResolveWorkspaceRoot(
-      path.join(scratch, 'Foo.lean'),
-    );
+    const root = await resolve(path.join(scratch, 'Foo.lean'));
     expect(root).toBe(scratch);
   });
 
@@ -82,7 +84,7 @@ describe('defaultResolveWorkspaceRoot', () => {
     const sub = path.join(scratch, 'a', 'b');
     await mkdir(sub, { recursive: true });
     await writeFile(path.join(sub, 'Foo.lean'), '');
-    const root = await defaultResolveWorkspaceRoot(path.join(sub, 'Foo.lean'));
+    const root = await resolve(path.join(sub, 'Foo.lean'));
     expect(root).toBe(scratch);
   });
 
@@ -90,7 +92,7 @@ describe('defaultResolveWorkspaceRoot', () => {
     const sub = path.join(scratch, 'no-lake');
     await mkdir(sub, { recursive: true });
     await writeFile(path.join(sub, 'Foo.lean'), '');
-    const root = await defaultResolveWorkspaceRoot(path.join(sub, 'Foo.lean'));
+    const root = await resolve(path.join(sub, 'Foo.lean'));
     expect(root).toBeNull();
   });
 });

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -1,5 +1,7 @@
+import { Cause, Effect, Exit } from 'effect';
 import { z } from 'zod';
 
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { defineTool } from '@tools/core/define';
 import { errorResult, executed } from '@tools/core/result';
@@ -131,6 +133,20 @@ If you expected errors:
 2. Make sure the file is saved
 3. Try \`lean_file\` with command "restart" to refresh the Lean server`;
 
+/**
+ * The one run of a Lean tool's program settles here (R1: the tool execute()
+ * contract is the Promise boundary). A failure — the port's typed failure, a
+ * host rejection, or an unwired-services defect — becomes the same `ToolError`
+ * the old try/catch produced, with the squashed cause as `cause`.
+ */
+function foldToolExit(
+  exit: Exit.Exit<ToolResult, unknown>,
+  onFailure: (cause: unknown) => ToolError,
+): ToolResult {
+  if (Exit.isFailure(exit)) throw onFailure(Cause.squash(exit.cause));
+  return exit.value;
+}
+
 export class LeanDiagnosticsTool extends defineTool({
   name: 'lean_diagnostics',
   description: `Get diagnostic messages (errors, warnings, info) for a Lean 4 file.
@@ -152,10 +168,20 @@ Tips:
 }) {
   protected async execute(input: LeanDiagnosticsInput): Promise<ToolResult> {
     const { command, file } = input;
+    return foldToolExit(
+      await effectRuntime().runPromiseExit(this.diagnose(file, command)),
+      (cause) =>
+        new ToolError(
+          `Error: ${toErrorMessage(cause)}\n\n${LEAN_TOOLCHAIN_HELP}`,
+          { cause, summary: 'Failed to get diagnostics' },
+        ),
+    );
+  }
 
-    try {
+  private readonly diagnose = Effect.fn('LeanDiagnosticsTool.execute')(
+    function* (file: string, command: 'list' | 'count') {
       const services = getLeanLanguageServices();
-      const result = await services.fetchDiagnosticsForFile(file);
+      const result = yield* services.fetchDiagnosticsForFile(file);
       if (!result.ok) {
         // The adapter distinguishes a genuinely missing file from a broken or
         // absent Lean toolchain — only the former is a "could not open file";
@@ -177,7 +203,7 @@ Tips:
       // Host capability: VS Code moves the editor cursor to the first error;
       // CLI/desktop adapters omit it and this is a no-op rather than a pretend
       // navigation. The tool result below still carries the diagnostic list.
-      await services.navigateToFirstError?.(file, diagnostics);
+      yield* services.navigateToFirstError?.(file, diagnostics) ?? Effect.void;
 
       const counts = countBySeverity(diagnostics);
       const countsStr = formatCounts(counts);
@@ -194,7 +220,7 @@ Tips:
           summary: countsStr,
           output: `${file}: ${countsStr}`,
           diagnostics: baseDiagnostics,
-        };
+        } as ToolResult;
       }
 
       return {
@@ -202,14 +228,9 @@ Tips:
         summary: countsStr,
         output: formatGroupedSections(diagnostics),
         diagnostics: { ...baseDiagnostics, details: diagnostics },
-      };
-    } catch (error) {
-      throw new ToolError(
-        `Error: ${toErrorMessage(error)}\n\n${LEAN_TOOLCHAIN_HELP}`,
-        { cause: error, summary: 'Failed to get diagnostics' },
-      );
-    }
-  }
+      } as ToolResult;
+    },
+  );
 }
 
 export class LeanFileTool extends defineTool({
@@ -225,25 +246,28 @@ In VS Code, these commands use the Lean 4 extension. CLI and desktop provide the
   protected async execute(input: LeanFileInput): Promise<ToolResult> {
     const { command, file } = input;
     const { description } = LEAN_FILE_COMMANDS[command];
-
-    try {
-      const success = await getLeanLanguageServices().executeFileCommand(
-        command,
-        file,
-      );
-      if (!success) {
-        return errorResult(
-          `Could not execute "${command}" on ${file}. ${LEAN_TOOLCHAIN_HELP}`,
-          { summary: 'Command failed' },
-        );
-      }
-      return executed(`Executed "${command}" on ${file}`, description);
-    } catch (error) {
-      throw new ToolError(`Error: ${toErrorMessage(error)}`, {
-        cause: error,
-        summary: 'Command failed',
-      });
-    }
+    return foldToolExit(
+      await effectRuntime().runPromiseExit(
+        Effect.gen(function* () {
+          const success = yield* getLeanLanguageServices().executeFileCommand(
+            command,
+            file,
+          );
+          if (!success) {
+            return errorResult(
+              `Could not execute "${command}" on ${file}. ${LEAN_TOOLCHAIN_HELP}`,
+              { summary: 'Command failed' },
+            );
+          }
+          return executed(`Executed "${command}" on ${file}`, description);
+        }),
+      ),
+      (cause) =>
+        new ToolError(`Error: ${toErrorMessage(cause)}`, {
+          cause,
+          summary: 'Command failed',
+        }),
+    );
   }
 }
 
@@ -259,27 +283,30 @@ In VS Code, these commands use the Lean 4 extension. CLI and desktop provide the
   protected async execute(input: LeanProjectInput): Promise<ToolResult> {
     const { command } = input;
     const { description } = LEAN_PROJECT_COMMANDS[command];
+    return foldToolExit(
+      await effectRuntime().runPromiseExit(
+        Effect.gen(function* () {
+          yield* getLeanLanguageServices().executeProjectCommand(command);
 
-    try {
-      await getLeanLanguageServices().executeProjectCommand(command);
+          if (command === 'build') {
+            return executed(
+              `Build started. Note: this command does not capture build output directly.\n\nTo check for errors and warnings, run lean_diagnostics on the relevant .lean files.`,
+              description,
+            );
+          }
 
-      if (command === 'build') {
-        return executed(
-          `Build started. Note: this command does not capture build output directly.\n\nTo check for errors and warnings, run lean_diagnostics on the relevant .lean files.`,
-          description,
-        );
-      }
-
-      return executed(`Executed "${command}" successfully`, description);
-    } catch (error) {
-      throw new ToolError(
-        `Error executing "${command}": ${toErrorMessage(error)}`,
-        {
-          cause: error,
-          summary: 'Command failed',
-        },
-      );
-    }
+          return executed(`Executed "${command}" successfully`, description);
+        }),
+      ),
+      (cause) =>
+        new ToolError(
+          `Error executing "${command}": ${toErrorMessage(cause)}`,
+          {
+            cause,
+            summary: 'Command failed',
+          },
+        ),
+    );
   }
 }
 
@@ -308,129 +335,141 @@ In VS Code, this uses the Lean 4 extension. CLI and desktop provide the correspo
     const col0 = column - 1;
     const location = `${file}:${line}:${column}`;
 
-    try {
-      switch (type) {
-        // Each dispatch is awaited inside the try so a rejected language-server
-        // request lands in the catch below and carries a summary, matching the
-        // sibling Lean tools.
-        case 'goal':
-          return await this.executeGoal(file, line0, col0, location);
-        case 'term_goal':
-          return await this.executeTermGoal(file, line0, col0, location);
-        case 'hover':
-          return await this.executeHover(file, line0, col0, location);
+    // Each dispatch composes one program, run once below: a failed
+    // language-server request settles as this run's Exit and becomes the
+    // ToolError carrying the summary that names which inspection failed.
+    let program: Effect.Effect<ToolResult, unknown>;
+    switch (type) {
+      case 'goal':
+        program = this.executeGoal(file, line0, col0, location);
+        break;
+      case 'term_goal':
+        program = this.executeTermGoal(file, line0, col0, location);
+        break;
+      case 'hover':
+        program = this.executeHover(file, line0, col0, location);
+        break;
+    }
+
+    return foldToolExit(
+      await effectRuntime().runPromiseExit(program),
+      (cause) =>
+        new ToolError(`Error: ${toErrorMessage(cause)}`, {
+          cause,
+          summary: `Failed to get ${type}`,
+        }),
+    );
+  }
+
+  private executeGoal(
+    file: string,
+    line: number,
+    column: number,
+    location: string,
+  ): Effect.Effect<ToolResult, unknown> {
+    return Effect.gen(function* () {
+      const { data, error } = yield* getLeanLanguageServices().getGoalState(
+        file,
+        line,
+        column,
+      );
+
+      if (!data) {
+        return noPositionData(
+          'Could not get goal state',
+          location,
+          'No goal state',
+          error,
+        );
       }
-    } catch (error) {
-      throw new ToolError(`Error: ${toErrorMessage(error)}`, {
-        cause: error,
-        summary: `Failed to get ${type}`,
-      });
-    }
-  }
 
-  private async executeGoal(
-    file: string,
-    line: number,
-    column: number,
-    location: string,
-  ): Promise<ToolResult> {
-    const { data, error } = await getLeanLanguageServices().getGoalState(
-      file,
-      line,
-      column,
-    );
+      if (data.goals.length === 0) {
+        return executed(
+          'No goals at this position. The proof may be complete here.',
+          'No goals',
+        );
+      }
 
-    if (!data) {
-      return this.noPositionData(
-        'Could not get goal state',
-        location,
-        'No goal state',
-        error,
-      );
-    }
-
-    if (data.goals.length === 0) {
       return executed(
-        'No goals at this position. The proof may be complete here.',
-        'No goals',
+        data.rendered,
+        formatResultCount(data.goals.length, 'goal'),
       );
-    }
-
-    return executed(
-      data.rendered,
-      formatResultCount(data.goals.length, 'goal'),
-    );
+    });
   }
 
-  private async executeTermGoal(
+  private executeTermGoal(
     file: string,
     line: number,
     column: number,
     location: string,
-  ): Promise<ToolResult> {
-    const { data, error } = await getLeanLanguageServices().getTermGoal(
-      file,
-      line,
-      column,
-    );
-
-    if (!data) {
-      return this.noPositionData(
-        'No expected type',
-        location,
-        'No term goal',
-        error,
+  ): Effect.Effect<ToolResult, unknown> {
+    return Effect.gen(function* () {
+      const { data, error } = yield* getLeanLanguageServices().getTermGoal(
+        file,
+        line,
+        column,
       );
-    }
 
-    return executed(data.goal, 'Term goal');
+      if (!data) {
+        return noPositionData(
+          'No expected type',
+          location,
+          'No term goal',
+          error,
+        );
+      }
+
+      return executed(data.goal, 'Term goal');
+    });
   }
 
-  private async executeHover(
+  private executeHover(
     file: string,
     line: number,
     column: number,
     location: string,
-  ): Promise<ToolResult> {
-    const { data, error } = await getLeanLanguageServices().getHoverInfo(
-      file,
-      line,
-      column,
-    );
-
-    if (!data) {
-      return this.noPositionData(
-        'No information',
-        location,
-        'No hover info',
-        error,
+  ): Effect.Effect<ToolResult, unknown> {
+    return Effect.gen(function* () {
+      const { data, error } = yield* getLeanLanguageServices().getHoverInfo(
+        file,
+        line,
+        column,
       );
-    }
 
-    const text = extractHoverText(data.contents);
-    if (!text) {
-      return errorResult(`Empty hover response at ${location}`, {
-        summary: 'No hover info',
-      });
-    }
+      if (!data) {
+        return noPositionData(
+          'No information',
+          location,
+          'No hover info',
+          error,
+        );
+      }
 
-    return executed(text, 'Hover info');
+      const text = extractHoverText(data.contents);
+      if (!text) {
+        return errorResult(`Empty hover response at ${location}`, {
+          summary: 'No hover info',
+        });
+      }
+
+      return executed(text, 'Hover info');
+    });
   }
+}
 
-  /**
-   * Shared "language server returned nothing" error for the three inspect
-   * dispatches. The optional LSP error string is surfaced inline so the
-   * agent sees the underlying cause.
-   */
-  private noPositionData(
-    message: string,
-    location: string,
-    summary: string,
-    error?: string,
-  ): ToolResult {
-    return errorResult(
-      `${message} at ${location}${error ? `\nError: ${error}` : ''}`,
-      { summary },
-    );
-  }
+/**
+ * Shared "language server returned nothing" error for the three inspect
+ * dispatches. The optional LSP error string is surfaced inline so the
+ * agent sees the underlying cause.
+ */
+function noPositionData(
+  message: string,
+  location: string,
+  summary: string,
+  error?: string,
+): ToolResult {
+  return errorResult(
+    `${message} at ${location}${error ? `\nError: ${error}` : ''}`,
+    { summary },
+  );
 }

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -10,11 +10,13 @@
  * unused one is otherwise stopped after thirty minutes. Servers are also torn
  * down on platform shutdown.
  *
- * This file is the Promise edge: the pool is built once into the adapter's
- * scope, every method is one run of the pool's Effect, and `dispose()` closes
- * the scope, which ends the pool and every server. Closing that scope
- * interrupts whatever is still in flight, and interruption is not a failure
- * the pool can fold into its total results, so the fold happens here.
+ * The pool's operations are already Effect programs, so each port method is
+ * the pool's program plus the interruption fold documented below; the one run
+ * of a tool-facing program sits in the calling tool's `execute()`. The runs
+ * left in this file are the construction of the pool into the adapter's scope
+ * and its disposal, which belong to the platform-lifetime seam (lane D:
+ * platform ports become Effect-typed), and the run-end hook's Promise seam,
+ * which converts with its only caller there.
  */
 
 import { Cause, Context, Duration, Effect, Exit, Layer, Scope } from 'effect';
@@ -28,11 +30,7 @@ import { effectRuntime } from '@platform/processRuntime';
 import { nodeChildProcessSpawnerLayer } from '@platform/defaults/nodeChildProcessSpawner';
 import type { ExecutionId } from '@shared/schemas';
 
-import {
-  LeanAdapterStopped,
-  LeanServerPool,
-  resolveWorkspaceRoot,
-} from './leanServerPool';
+import { LeanAdapterStopped, LeanServerPool } from './leanServerPool';
 import {
   setLeanLanguageServices,
   type LeanLanguageServices,
@@ -88,7 +86,7 @@ export function createDirectLspLeanAdapter(
   const scope = Scope.makeUnsafe();
   // Building the pool acquires no resource of its own (the map is empty
   // until first use), so the build is synchronous and the run boundary here
-  // is the constructor's; every operation below is one `runPromise`.
+  // is the constructor's.
   const pool = effectRuntime().runSync(
     Layer.build(
       LeanServerPool.layer({
@@ -104,12 +102,12 @@ export function createDirectLspLeanAdapter(
     ),
   );
 
-  // The run is captured here, before the fiber starts, because the ambient
-  // run context is a property of the calling turn, not of the scheduler the
-  // fiber resumes on.
+  // The run id is captured when the method is called, before any fiber
+  // starts, because the ambient run context is a property of the calling
+  // turn, not of the scheduler the fiber resumes on.
   return {
     fetchDiagnosticsForFile: (file) =>
-      run(pool.fetchDiagnosticsForFile(file, currentRunId()), () => ({
+      foldStopped(pool.fetchDiagnosticsForFile(file, currentRunId()), () => ({
         ok: false,
         kind: 'toolchain_unavailable',
         message: STOPPED_MESSAGE,
@@ -122,18 +120,24 @@ export function createDirectLspLeanAdapter(
     // on.
 
     executeFileCommand: (command, filePath) =>
-      run(
+      foldStopped(
         pool.executeFileCommand(command, filePath, currentRunId()),
         () => false,
       ),
 
     executeProjectCommand: (command) =>
-      run(pool.executeProjectCommand(command, currentRunId()), () => {
-        throw new LeanAdapterStopped();
-      }),
+      pool
+        .executeProjectCommand(command, currentRunId())
+        .pipe(
+          Effect.catchCause((cause) =>
+            Cause.hasInterrupts(cause)
+              ? Effect.fail(new LeanAdapterStopped())
+              : Effect.failCause(cause),
+          ),
+        ),
 
     getGoalState: (filePath, line, column) =>
-      run(
+      foldStopped(
         pool.positionRequest<PlainGoal>(
           filePath,
           line,
@@ -145,7 +149,7 @@ export function createDirectLspLeanAdapter(
       ),
 
     getTermGoal: (filePath, line, column) =>
-      run(
+      foldStopped(
         pool.positionRequest<PlainTermGoal>(
           filePath,
           line,
@@ -157,7 +161,7 @@ export function createDirectLspLeanAdapter(
       ),
 
     getHoverInfo: (filePath, line, column) =>
-      run(
+      foldStopped(
         pool.positionRequest<LspHover>(
           filePath,
           line,
@@ -168,8 +172,16 @@ export function createDirectLspLeanAdapter(
         stoppedLspResult<LspHover>,
       ),
 
+    // Promise seam of the run-end hook (see the interface): one run, folding
+    // an interrupted stop into a no-op exactly as the tool-facing folds do.
     stopSessionsForRun: (runId) =>
-      run(pool.stopSessionsForRun(runId), () => undefined),
+      effectRuntime()
+        .runPromiseExit(pool.stopSessionsForRun(runId))
+        .then((exit) => {
+          if (Exit.isSuccess(exit)) return;
+          if (Cause.hasInterrupts(exit.cause)) return;
+          throw Cause.squash(exit.cause);
+        }),
 
     dispose: () => effectRuntime().runPromise(Scope.close(scope, Exit.void)),
   };
@@ -184,36 +196,28 @@ const stoppedLspResult = <T>(): LspResult<T> => ({
 });
 
 /**
- * Run one pool operation to its `Exit`. A success and a typed failure keep
- * exactly what `runPromise` gives them (the failure is squashed and thrown, as
- * it is there). An interrupted exit is the only new outcome: `dispose()`
- * closes the pool's scope, which interrupts an in-flight build and, with it,
- * the fiber awaiting it. Interruption is not catchable inside the pool, so it
- * is folded here into the value that same call gets after `dispose()` has
- * returned, keeping {@link LeanAdapterStopped} the one shape a stopped adapter
- * reports and the total methods total.
+ * Fold an interrupted pool operation into the value that same call gets
+ * after `dispose()` has returned. `dispose()` closes the pool's scope, which
+ * interrupts an in-flight build and, with it, the fiber awaiting it;
+ * interruption is not a failure the pool can fold into its total results, so
+ * the fold happens at this port edge, keeping {@link LeanAdapterStopped} the
+ * one shape a stopped adapter reports. This is the same fold the old Promise
+ * edge applied at `runPromiseExit`, so a tool-call interruption is folded
+ * exactly as it was there.
  */
-function run<A, E>(
+const foldStopped = <A, E>(
   operation: Effect.Effect<A, E>,
   whenStopped: () => A,
-): Promise<A> {
-  return effectRuntime()
-    .runPromiseExit(operation)
-    .then((exit) => {
-      if (Exit.isSuccess(exit)) return exit.value;
-      if (Cause.hasInterrupts(exit.cause)) return whenStopped();
-      throw Cause.squash(exit.cause);
-    });
-}
+): Effect.Effect<A, E> =>
+  operation.pipe(
+    Effect.catchCause((cause) =>
+      Cause.hasInterrupts(cause)
+        ? Effect.succeed(whenStopped())
+        : Effect.failCause(cause),
+    ),
+  );
 
 /** The agent run the current tool call executes for, when it runs inside one. */
 function currentRunId(): ExecutionId | undefined {
   return getRunContextExecutionId(tryUseRunContext());
-}
-
-/** Walk up from `filePath` looking for a Lake project root. */
-export function defaultResolveWorkspaceRoot(
-  filePath: string,
-): Promise<string | null> {
-  return effectRuntime().runPromise(resolveWorkspaceRoot(filePath));
 }

--- a/src/tools/lean/leanLanguageServices.ts
+++ b/src/tools/lean/leanLanguageServices.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ExecutionId } from '@shared/schemas';
+import type { Effect } from 'effect';
 
 import type {
   LeanFileCommand,
@@ -24,27 +25,39 @@ import type {
   PlainTermGoal,
 } from './leanTypes';
 
+/**
+ * The Effect-typed port (Effect 4 runtime PRD, R1): adapters compose their
+ * host or LSP primitives into these programs, and the one run of each program
+ * sits in the calling tool's `execute()` — the tool execute() contract is an
+ * R1 boundary kind, so no runtime leaks into this seam. The adapters' failure
+ * channels are disjoint (VS Code bridge rejects with plain host errors, the
+ * direct pool fails with its tagged errors) and every consumer folds a failure
+ * into a `ToolError`, so the port declares `unknown` rather than a union no
+ * caller switches on.
+ */
 export interface LeanLanguageServices {
   executeFileCommand(
     command: LeanFileCommand,
     filePath: string,
-  ): Promise<boolean>;
+  ): Effect.Effect<boolean>;
   getGoalState(
     filePath: string,
     line: number,
     column: number,
-  ): Promise<LspResult<PlainGoal>>;
+  ): Effect.Effect<LspResult<PlainGoal>>;
   getTermGoal(
     filePath: string,
     line: number,
     column: number,
-  ): Promise<LspResult<PlainTermGoal>>;
+  ): Effect.Effect<LspResult<PlainTermGoal>>;
   getHoverInfo(
     filePath: string,
     line: number,
     column: number,
-  ): Promise<LspResult<LspHover>>;
-  fetchDiagnosticsForFile(file: string): Promise<FetchDiagnosticsResult>;
+  ): Effect.Effect<LspResult<LspHover>>;
+  fetchDiagnosticsForFile(
+    file: string,
+  ): Effect.Effect<FetchDiagnosticsResult, unknown>;
   /**
    * Move the host editor cursor to the first error in `diagnostics`, when the
    * host has an editor to move (VS Code). A host capability, not a query:
@@ -55,8 +68,10 @@ export interface LeanLanguageServices {
   navigateToFirstError?(
     filePath: string,
     diagnostics: LeanDiagnostic[],
-  ): Promise<void>;
-  executeProjectCommand(command: LeanProjectCommand): Promise<void>;
+  ): Effect.Effect<void, unknown>;
+  executeProjectCommand(
+    command: LeanProjectCommand,
+  ): Effect.Effect<void, unknown>;
   /**
    * Stop the per-worktree servers attributed to an agent run that ended.
    * A host capability like {@link navigateToFirstError}: the direct
@@ -65,6 +80,10 @@ export interface LeanLanguageServices {
    * omits it because the Lean 4 extension owns that server's lifetime.
    * Servers still leased by an in-flight request (e.g. a shared worktree's
    * other run) are marked for disposal when their final lease ends.
+   *
+   * Stays Promise-typed until runtime lane D converts its only caller, the
+   * `onRunEnd` hook of the agent run lifecycle (`executeAgent.ts`) — running
+   * an Effect there today would put a below-boundary run in a lane-D file.
    */
   stopSessionsForRun?(runId: ExecutionId): Promise<void>;
 }


### PR DESCRIPTION
## Summary

Makes the Lean language-services port Effect-typed end to end — the "Lean LSP follow-up" lane named in the effect-migration ratchet's `debtLanes` register. Both adapters (the VS Code bridge and the direct LSP pool) now return Effect programs, and each of the four Lean tools composes its program and runs it once at the `execute()` boundary, R1's tool boundary kind. The direct adapter's per-call Promise edge is deleted, and every raw catch in the touched files becomes typed recovery or a `Result` fold (R7, one pass per file).

## Issue acceptance gates

No issue; the lane is registered in `config/ratchets/effect-migration-baseline.json` (`debtLanes`: `src/tools/lean/direct/directLspAdapter.ts`).

- Port Effect-typed: done (`LeanLanguageServices` methods return `Effect`).
- Tool-facing runs moved to the tools' `execute()`: done — no run remains in `LspTools`' callees, and `LspTools` itself is an R1 boundary kind, so the `Effect.run*` row does not grow.
- Baseline shrinkage recorded: `Effect.run*` in `directLspAdapter.ts` 4 → 3.
- Not done (stated in the updated register entry): pool construction/disposal and the run-end hook's Promise seam — both belong to lane D (platform-lifetime and run-lifecycle seams), not this lane.

## Single source of truth

`LeanServerPool`'s programs remain the single implementation. The "disposed adapter answers stopped" contract now lives in one fold (`foldStopped` in `directLspAdapter.ts`) at the port edge instead of being applied per call through the deleted `run` helper.

## Duplication and abstraction budget

Deleted: the per-call `run` Promise-edge helper and the test-only `defaultResolveWorkspaceRoot` wrapper. No new abstraction layers: `foldStopped` replaces `run` one-for-one, `tryHost` is the R1 foreign-runtime edge over VS Code `Thenable`s (one wrap per host call), and `foldToolExit` is the single place tool failures become `ToolError`, replacing four try/catch copies. Adapter tests now compose the port programs directly (`it.live` + `acquireUseRelease` + fork/join) instead of a Promise shim.

## Net elements (R6)

- Files: 10 changed (+597/−453) — 4 production, 4 test, 2 ratchet baselines.
- Exported symbols: 1 deleted (`defaultResolveWorkspaceRoot`), 0 added (`^[+-]export ` over the diff).
- Classes/interfaces/enums: none added or removed; `LeanLanguageServices` method signatures change Promise → Effect.
- Net LoC: +144 (production +107, tests +39, baselines −2). The production growth is the R7 one-pass conversion of 12 raw catch sites (`VscodeIntegration` 8 → 0, `LspTools` 4 → 0) into typed recovery; the ratchet rows this lane owns only shrink.

## Consumer counts (R8)

- `defaultResolveWorkspaceRoot`: 1 consumer (`LeanTools.vitest.ts`) → now imports `resolveWorkspaceRoot` from `leanServerPool`; knip baseline entry swapped accordingly.
- `getLeanLanguageServices()`: 6 call sites, all in `LspTools.ts` — same callers, now composed into programs and run once per `execute()`.
- `LeanLanguageServices` implementors: 2 production (VS Code bridge, direct adapter) plus test fakes — all converted.
- `stopLeanServersForEndedRun`: 1 consumer (`executeAgent.ts` `onRunEnd`) — untouched; `stopSessionsForRun` stays Promise-typed until lane D converts the run-end hook.

## Host impact

Extension: `VscodeIntegration` methods are Effect programs; host `Thenable`s are wrapped once per foreign call, and the staged error answers (missing extension, open failure, no client, server down, request failure) are unchanged.
Desktop: shares the direct adapter; disposed-adapter answers and server lifetimes unchanged (covered by the adapter suite).
CLI: same tools and adapter; tool results and error text are byte-identical (ToolError messages preserved via the Exit fold).

## Scheduled refactoring

The 3 remaining below-boundary runs in `directLspAdapter.ts` — pool construction (`runSync`), the run-end hook's Promise seam, and `dispose` — are owned by lane D (platform ports become Effect-typed; `executeAgent`'s `onRunEnd` is a run-lifecycle seam), as now recorded in the `debtLanes` register.

## Validation

- `npm run typecheck:workspace` and `npm run typecheck:test-kernel` — clean.
- `npx eslint` on all changed files — clean (full `npm run lint` also clean on the same content).
- `prettier --check` on all changed files — clean.
- Affected suites: `DirectLspAdapter` (25), `LeanTools` (14), `LeanInspectTool` (2), `VscodeIntegration` (1) — 42 tests passed.
- Full Vitest suite (`npm test -- --maxWorkers=4`): 764 files / 9,092 tests passed, 1 file / 5 tests skipped (pre-existing skip).
- Ratchets: `check-effect-migration-ratchet` — baseline shrinks 4 → 3 for this lane's file; the 6 remaining failures and the `@adapter-until` marker are pre-existing on main and owned by the auth/host lanes in flight. `check:dead-code-ratchet` — OK.
- `npm run compile:fast` — clean on the same content.
