### PR TITLE
refactor(desktop): convert the papers and main catches to typed recovery

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -193,7 +193,7 @@
       "packages/desktop/src/main/desktopAgentExecution.ts": 1,
       "packages/desktop/src/main/desktopHostRequests.ts": 4,
       "packages/desktop/src/main/desktopProcessStores.ts": 1,
-      "packages/desktop/src/main/index.ts": 15,
+      "packages/desktop/src/main/index.ts": 13,
       "packages/extension/src/progressView/ProgressViewProvider.ts": 1,
       "src/agent/index/agentYamlScanner.ts": 3,
       "src/agent/remote/RemoteAgentLoader.ts": 1,

--- a/packages/desktop/src/main/desktopPapers.ts
+++ b/packages/desktop/src/main/desktopPapers.ts
@@ -152,19 +152,25 @@ export async function readRememberedDesktopPapers(
   for (const candidate of stored) {
     const root = canonicalizeWorkspacePath(candidate);
     if (roots.includes(root) || missing.includes(root)) continue;
-    let isFolder = false;
-    try {
-      isFolder =
-        statSync(root, { throwIfNoEntry: false })?.isDirectory() ?? false;
-    } catch (error) {
-      // Persisted state validated at its boundary: an unreadable path is
-      // reported and forgotten like a missing one, so it cannot fail every
-      // launch until repaired by hand.
-      warn(
-        `Cannot read the remembered paper ${root}; forgetting it: ${toErrorMessage(error)}`,
-      );
-    }
-    (isFolder ? roots : missing).push(root);
+    const stats = effectRuntime().runSync(
+      Effect.try({
+        try: () => statSync(root, { throwIfNoEntry: false }),
+        catch: (error) => error,
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.sync(() => {
+            // Persisted state validated at its boundary: an unreadable path is
+            // reported and forgotten like a missing one, so it cannot fail
+            // every launch until repaired by hand.
+            warn(
+              `Cannot read the remembered paper ${root}; forgetting it: ${toErrorMessage(error)}`,
+            );
+            return undefined;
+          }),
+        ),
+      ),
+    );
+    (stats?.isDirectory() ? roots : missing).push(root);
   }
   const changed =
     roots.length !== stored.length ||
@@ -214,43 +220,49 @@ async function openPaperSession(
   roots: WorkspaceRoots,
 ): Promise<DesktopPaper> {
   const resources = new DisposableStore();
-  try {
-    const transcripts = await runWithWorkspaceRoots(roots, () =>
-      StreamLogStore.open(),
-    );
-    const session = openSession({
-      transcripts,
-      roots,
-      responseTextProcessing,
-    });
-    resources.add(() => session.dispose());
-    return await runInSession(session, async () => {
-      const processStores = await initializeDesktopProcessStores(session);
-      resources.add(() => processStores.dispose());
-      session.setApprovalPolicy(
-        readPlatformSetting<TexraApprovalPolicy>(
-          TEXRA_APPROVAL_POLICY_CONFIG_KEY,
-        ),
-      );
-      // Off the open path: the leftover-stream sweep reads this paper's
-      // whole storage root, so it starts on a timer nothing awaits. It is
-      // scheduled inside the session scope, which the timer inherits, so the
-      // sweep reads this paper's storage and not another's; closing the paper
-      // or shutting the process down cancels it if it has not started.
-      resources.add(scheduleLeftoverStreamSweep(session));
-      return {
-        key: roots.storage,
-        root,
-        roots,
-        session,
-        stores: processStores.stores,
-        dispose: () => runInSession(session, () => resources.dispose()),
-      };
-    });
-  } catch (error) {
-    resources.dispose();
-    throw error;
-  }
+  return effectRuntime().runPromise(
+    Effect.tryPromise({
+      try: async () => {
+        const transcripts = await runWithWorkspaceRoots(roots, () =>
+          StreamLogStore.open(),
+        );
+        const session = openSession({
+          transcripts,
+          roots,
+          responseTextProcessing,
+        });
+        resources.add(() => session.dispose());
+        return await runInSession(session, async () => {
+          const processStores = await initializeDesktopProcessStores(session);
+          resources.add(() => processStores.dispose());
+          session.setApprovalPolicy(
+            readPlatformSetting<TexraApprovalPolicy>(
+              TEXRA_APPROVAL_POLICY_CONFIG_KEY,
+            ),
+          );
+          // Off the open path: the leftover-stream sweep reads this paper's
+          // whole storage root, so it starts on a timer nothing awaits. It is
+          // scheduled inside the session scope, which the timer inherits, so the
+          // sweep reads this paper's storage and not another's; closing the paper
+          // or shutting the process down cancels it if it has not started.
+          resources.add(scheduleLeftoverStreamSweep(session));
+          return {
+            key: roots.storage,
+            root,
+            roots,
+            session,
+            stores: processStores.stores,
+            dispose: () => runInSession(session, () => resources.dispose()),
+          };
+        });
+      },
+      catch: (error) => error,
+    }).pipe(
+      // A failed open releases everything the attempt registered before the
+      // rejection reaches the caller.
+      Effect.onError(() => Effect.sync(() => resources.dispose())),
+    ),
+  );
 }
 
 /**
@@ -316,14 +328,24 @@ export async function openDesktopPaperRegistry(
   const rememberActive = (root: string) => {
     const remembered = readRememberedPapers(options.globalState, options.warn);
     if (remembered.at(-1) === root) return;
-    void writeRememberedPapers(options.globalState, [
-      ...remembered.filter((entry) => entry !== root),
-      root,
-    ]).catch((error: unknown) => {
-      options.warn(
-        `Could not remember the active paper ${root}: ${toErrorMessage(error)}`,
-      );
-    });
+    effectRuntime().runFork(
+      Effect.tryPromise({
+        try: () =>
+          writeRememberedPapers(options.globalState, [
+            ...remembered.filter((entry) => entry !== root),
+            root,
+          ]),
+        catch: (error) => error,
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.sync(() => {
+            options.warn(
+              `Could not remember the active paper ${root}: ${toErrorMessage(error)}`,
+            );
+          }),
+        ),
+      ),
+    );
   };
 
   const activate = (root: string | undefined) => {
@@ -407,15 +429,24 @@ export async function openDesktopPaperRegistry(
     async flushArtifacts() {
       const failures: string[] = [];
       for (const paper of [fallback, ...papers.values()]) {
-        try {
-          await runInSession(paper.session, () =>
-            paper.session.flushArtifacts(),
-          );
-        } catch (error) {
-          failures.push(
-            `${paper.root ?? 'no workspace'}: ${toErrorMessage(error)}`,
-          );
-        }
+        await effectRuntime().runPromise(
+          Effect.tryPromise({
+            try: async () => {
+              await runInSession(paper.session, () =>
+                paper.session.flushArtifacts(),
+              );
+            },
+            catch: (error) => error,
+          }).pipe(
+            Effect.catch((error) =>
+              Effect.sync(() => {
+                failures.push(
+                  `${paper.root ?? 'no workspace'}: ${toErrorMessage(error)}`,
+                );
+              }),
+            ),
+          ),
+        );
       }
       if (failures.length > 0) {
         throw new Error(

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -13,7 +13,7 @@ import {
 } from 'electron';
 import PQueue from 'p-queue';
 
-import { SubscriptionRef } from 'effect';
+import { Effect, SubscriptionRef } from 'effect';
 import { z } from 'zod';
 import { runInSession } from '@agent/runtime';
 import {
@@ -47,6 +47,7 @@ import { createLog } from '@logger/logUtils';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { platform } from '@platform/platform';
 import { DisposableStore } from '@platform/disposable';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   INSTRUCTION_ACTION,
   type AgentSource,
@@ -1182,59 +1183,83 @@ function createWindow(options: {
       // later "Run Setup" click can retry.
       kickoffSetup: async () => {
         const setupSession = activePaper().session;
-        try {
-          // The paper the user started setup in, taken before the first await:
-          // the run and its presentation belong to it even when the window
-          // moves to another paper while the model resolves and agents load.
-          const binding = activeBinding();
-          if (!binding) {
-            throw new Error('Open a folder before running setup.');
-          }
-          const { buildDesktopSetupExecuteMessage } =
-            await import('@controllers/onboarding/setupLaunch');
-          const message = await buildDesktopSetupExecuteMessage();
-          if (!message) {
-            throw new Error(
-              'No model is available for your current credentials. Sign in with ChatGPT or add a provider or coding-plan API key in Models, then try setup again.',
-            );
-          }
-          // Idempotent: returns the in-flight/initialized registry so a kickoff
-          // racing the startup `loadAgents()` cannot hit "Could not find agent:
-          // setup" (mirrors `setupAssistantCommand.launchSetupAssistant`).
-          await loadAgents();
-          await runInSession(binding.paper.session, async () =>
-            binding.execution.runValidated(
-              await prepareMainViewExecutionLaunch(message, agentExecutionHost),
+        await effectRuntime().runPromise(
+          Effect.tryPromise({
+            try: async () => {
+              // The paper the user started setup in, taken before the first await:
+              // the run and its presentation belong to it even when the window
+              // moves to another paper while the model resolves and agents load.
+              const binding = activeBinding();
+              if (!binding) {
+                throw new Error('Open a folder before running setup.');
+              }
+              const { buildDesktopSetupExecuteMessage } =
+                await import('@controllers/onboarding/setupLaunch');
+              const message = await buildDesktopSetupExecuteMessage();
+              if (!message) {
+                throw new Error(
+                  'No model is available for your current credentials. Sign in with ChatGPT or add a provider or coding-plan API key in Models, then try setup again.',
+                );
+              }
+              // Idempotent: returns the in-flight/initialized registry so a kickoff
+              // racing the startup `loadAgents()` cannot hit "Could not find agent:
+              // setup" (mirrors `setupAssistantCommand.launchSetupAssistant`).
+              await loadAgents();
+              await runInSession(binding.paper.session, async () =>
+                binding.execution.runValidated(
+                  await prepareMainViewExecutionLaunch(
+                    message,
+                    agentExecutionHost,
+                  ),
+                ),
+              );
+            },
+            catch: (error) => error,
+          }).pipe(
+            Effect.catch((error) =>
+              Effect.gen(function* () {
+                if (error instanceof Cancelled) return;
+                // Setup continues after its initiating request has completed.
+                const primaryError = primaryAgentError(error);
+                const presentation = agentErrorPresentation({
+                  kind: classifyAgentError(primaryError),
+                  message:
+                    primaryError instanceof Rejected
+                      ? primaryError.reason
+                      : toErrorMessage(primaryError),
+                });
+                if (presentation?.type === 'instruction') {
+                  yield* Effect.tryPromise({
+                    try: () =>
+                      Promise.resolve(
+                        setupSession.interactions.emit(
+                          'requestShowInstruction',
+                          presentation.payload,
+                          { replayWhenAttached: true },
+                        ),
+                      ),
+                    catch: (emitError) => emitError,
+                  });
+                } else if (presentation?.type === 'error') {
+                  yield* Effect.tryPromise({
+                    try: () =>
+                      Promise.resolve(
+                        setupSession.interactions.emit(
+                          'requestShowError',
+                          presentation.payload,
+                          {
+                            replayWhenAttached: true,
+                          },
+                        ),
+                      ),
+                    catch: (emitError) => emitError,
+                  });
+                }
+                return yield* Effect.fail(error);
+              }),
             ),
-          );
-        } catch (error) {
-          if (error instanceof Cancelled) return;
-          // Setup continues after its initiating request has completed.
-          const primaryError = primaryAgentError(error);
-          const presentation = agentErrorPresentation({
-            kind: classifyAgentError(primaryError),
-            message:
-              primaryError instanceof Rejected
-                ? primaryError.reason
-                : toErrorMessage(primaryError),
-          });
-          if (presentation?.type === 'instruction') {
-            await setupSession.interactions.emit(
-              'requestShowInstruction',
-              presentation.payload,
-              { replayWhenAttached: true },
-            );
-          } else if (presentation?.type === 'error') {
-            await setupSession.interactions.emit(
-              'requestShowError',
-              presentation.payload,
-              {
-                replayWhenAttached: true,
-              },
-            );
-          }
-          throw error;
-        }
+          ),
+        );
       },
       signInWithChatGpt: () => requireSettingsIpc().signInChatGpt(),
       // The desktop shell can't host the VS Code getting-started walkthrough, so
@@ -1477,11 +1502,16 @@ function createWindow(options: {
   window.once('closed', () => {
     const continueQuit = continueQuitAfterWindowClose;
     continueQuitAfterWindowClose = undefined;
-    try {
-      windowResources.dispose();
-    } catch (error) {
-      reportBackgroundError(error);
-    }
+    effectRuntime().runSync(
+      Effect.try({
+        try: () => windowResources.dispose(),
+        catch: (error) => error,
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.sync(() => reportBackgroundError(error)),
+        ),
+      ),
+    );
     if (mainWindow === window) {
       mainWindow = null;
       if (process.platform === 'darwin') {
@@ -1576,11 +1606,18 @@ if (protocolLifecycle.ownsSingleInstanceLock) {
           (root) => `${root} (no such folder; forgotten)`,
         );
         for (const root of remembered.roots) {
-          try {
-            await papers.open(root);
-          } catch (error) {
-            unopenedPapers.push(`${root}: ${toErrorMessage(error)}`);
-          }
+          await effectRuntime().runPromise(
+            Effect.tryPromise({
+              try: () => papers.open(root),
+              catch: (error) => error,
+            }).pipe(
+              Effect.catch((error) =>
+                Effect.sync(() => {
+                  unopenedPapers.push(`${root}: ${toErrorMessage(error)}`);
+                }),
+              ),
+            ),
+          );
         }
         papers.activate(papers.list().at(-1)?.root);
         // Ask the renderer to close before draining process services. A dirty


### PR DESCRIPTION
## Summary

Clears the last two unowned `catch:effect-importer` ratchet failures on main (PRD R7 + execution rule 2, `docs/prds/2026-08-26-effect-4-runtime-migration.md`), following the shape the sibling host lane #11977 established: `Effect.tryPromise` with an identity catch mapper, `Effect.catch` typed recovery, `Effect.onError` as a scope finalizer, all runs on the installed `effectRuntime()` (no bare `Effect.run*` — `BARE_EFFECT_RUN_SITES` untouched).

Rows cleared:

- `packages/desktop/src/main/desktopPapers.ts: 0 -> 4 (new file)` — all four raw catches converted, file back to 0:
  - `readRememberedDesktopPapers` stat probe: `Effect.try` + `Effect.catch` recovery that warns and treats the path as missing (same wording, same outcome), run via `runSync`.
  - `openPaperSession` open-failure cleanup: body in `Effect.tryPromise` (identity catch), resource disposal as an `Effect.onError` finalizer — a failed open still disposes what it registered and rejects with the same error value.
  - `rememberActive` fire-and-forget persist: `runFork` of the write with `Effect.catch` warn recovery (same warning text).
  - `flushArtifacts` per-paper catch: `Effect.tryPromise` + `Effect.catch` collecting the same failure strings; the aggregate `Error` throw is unchanged.
- `packages/desktop/src/main/index.ts: 15 -> 16 (grew)` — converted three sites, file now at 13 and the baseline locks that in:
  - `kickoffSetup` try/catch: typed recovery via `Effect.catch` + `Effect.gen`; the `Cancelled` early return, error presentation, `requestShowInstruction`/`requestShowError` emits, and rethrow of the original error value are all preserved.
  - Window `closed` handler disposal: `Effect.try` + `Effect.catch` to `reportBackgroundError`, run via `runSync`; disposal still starts synchronously in the handler.
  - Startup paper-reopen loop: per-paper `Effect.tryPromise` + `Effect.catch` pushing the same `unopenedPapers` strings.

Behavior is preserved: error messages, console wording, shutdown order, and rejection identities are unchanged (`effectRuntime().runPromise` rejects typed failures with the original value — verified against effect 4.0.0-rc.112). No callers changed; no public signature changed.

Sites deliberately left raw: none added. The 13 remaining raw catches in `index.ts` are the pre-existing baselined set (shrink-only row), including `desktopDiffHost.dispose().catch(reportBackgroundError)`, which `ElectronCompositionRoot.vitest.ts` pins as source text, and the outermost `app.whenReady().catch(reportFatalStartupError)` host-entry boundary.

## Issue acceptance gates

Effect 4 migration lane: `node scripts/check-effect-migration-ratchet.mjs` no longer reports either desktop `- [` row. Residual red on main is the three auth items owned by in-flight #11981 (`[Effect.run*] src/auth/authProgram.ts`, `[catch:effect-importer] src/auth/SupabaseClient.ts`, the SupabaseClient `@adapter-until` marker) — not this lane. Baseline regenerated with `--update` and committed; #11981 also regenerates it, so whoever merges second rebases and re-runs `--update`.

## Single source of truth

Unchanged: `DesktopPaperRegistry` still owns the open papers and their sessions; this PR only changes how promise rejections inside it (and three `index.ts` sites) are recovered.

## Duplication and abstraction budget

No new abstraction, no adapters, no `@adapter-until` markers. Each site converts in place with the same two combinators the merged host lanes use.

## Net elements (R6)

- Files: 3 changed (`desktopPapers.ts`, `index.ts`, `effect-migration-baseline.json`), none added or deleted.
- Exported symbols (`^[+-]export` over the diff): 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Net LoC: +199 / −131 (+68), all conversion boilerplate inside existing function bodies.

## Consumer counts (R8)

n/a — no export deleted and no emit path re-routed. `readRememberedDesktopPapers` (1 production caller, `index.ts`), `openDesktopPaperRegistry` (1 caller), and the `DesktopPaperRegistry`/`DesktopPaper` surfaces keep their exact signatures; `kickoffSetup` remains an `async () => Promise<void>` options callback consumed by `createDesktopOnboardingIpc`.

## Host impact

Extension: none.
Desktop: main-process error handling for paper open/close/flush, setup kickoff, window disposal, and paper reopen now runs through typed Effect recovery on the process runtime; same messages and ordering.
CLI: none.

## Scheduled refactoring

None. The remaining 13 baselined catches in `index.ts` shrink in later lanes per the migration plan.

## Validation

- `npx prettier --check` on changed files: pass.
- `npm run typecheck` (full): pass.
- `npm run lint`: pass.
- Targeted vitest: `ElectronCompositionRoot`, `DesktopControlSystem`, `ElectronSecretsBootstrap`, architecture `dependencyDirection` and `approvalPolicyAuthorityRatchet` suites: 58 tests pass.
- Full `npx vitest run`: 765 files passed, 1 skipped, 0 failures (9087 passed / 5 skipped).
- `node scripts/check-effect-migration-ratchet.mjs`: both desktop rows gone, no new rows; the three auth rows remain as expected (#11981). Baseline regenerated with `--update` and committed (`index.ts` 15 → 13).
- `npm run check:dead-code-ratchet`: fails on `src/controllers/session/Database.ts` — verified this failure exists on a clean `origin/main` checkout (introduced by #11972, outside this lane); this PR adds no findings.
