### PR TITLE
fix: green main's Effect migration ratchet

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -214,7 +214,6 @@
   "debtLanes": {
     "packages/extension/src/progressView/frontend/sessionTransport.ts": "webview frontends — the progress view subscribes through an Effect-typed session plane instead of running fibers in the view",
     "src/agent/runtime/SessionHandle.ts": "Phase 3 — run lifecycle and cancellation",
-    "src/auth/authProgram.ts": "AuthTokenProvider lane — src/auth ports become Effect-typed, retiring runAuthProgram and the SupabaseClient @adapter-until",
     "src/controllers/onboarding/OnboardingRefreshQueue.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/controllers/progressView/ProgressApiKeyRetryController.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/controllers/session/SessionBridge.ts": "lane D — host composition root and session graph",

--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -193,7 +193,7 @@
       "packages/desktop/src/main/desktopAgentExecution.ts": 1,
       "packages/desktop/src/main/desktopHostRequests.ts": 4,
       "packages/desktop/src/main/desktopProcessStores.ts": 1,
-      "packages/desktop/src/main/index.ts": 15,
+      "packages/desktop/src/main/index.ts": 13,
       "packages/extension/src/progressView/ProgressViewProvider.ts": 1,
       "src/agent/index/agentYamlScanner.ts": 3,
       "src/agent/remote/RemoteAgentLoader.ts": 1,

--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1,5 +1,5 @@
 {
-  "semantics": "Single baseline for the two Knip inputs owned by scripts/check-dead-code-ratchet.mjs: the normal run preserves ordinary findings, while findings emitted by the production run but absent from the normal run are categorized as production-dead. Each finding is identified by (file, category, kind, name), never by line number. Category is unused or production-dead; kind preserves Knip\u2019s files, exports, types, or duplicates issue kind so same-name findings of different kinds remain distinct. The ratchet fails when the combined result contains a finding not in this list. Removing resolved entries is always welcome; an intentional new finding must be added in sorted order by file, category, kind, then name. Run `npm run check:dead-code-ratchet` as the authoritative dead-code check.",
+  "semantics": "Single baseline for the two Knip inputs owned by scripts/check-dead-code-ratchet.mjs: the normal run preserves ordinary findings, while findings emitted by the production run but absent from the normal run are categorized as production-dead. Each finding is identified by (file, category, kind, name), never by line number. Category is unused or production-dead; kind preserves Knip’s files, exports, types, or duplicates issue kind so same-name findings of different kinds remain distinct. The ratchet fails when the combined result contains a finding not in this list. Removing resolved entries is always welcome; an intentional new finding must be added in sorted order by file, category, kind, then name. Run `npm run check:dead-code-ratchet` as the authoritative dead-code check.",
   "findings": [
     {
       "file": "packages/cli/src/chat/tui/commands/SlashPalette.tsx",
@@ -1290,6 +1290,12 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "selectSetupCredentialModelExcludingOpenRouter"
+    },
+    {
+      "file": "src/controllers/session/Database.ts",
+      "category": "production-dead",
+      "kind": "files",
+      "name": "src/controllers/session/Database.ts"
     },
     {
       "file": "src/controllers/settingsView/LatexToolingController.ts",

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -3,6 +3,7 @@ import { Effect } from 'effect';
 
 // Local imports
 import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
+import { installAuthProgramEdge, runAuthProgram } from '@auth/authProgram';
 import { DEFAULT_OAUTH_PROVIDER, type OAuthProvider } from '@auth/config';
 import {
   refreshRemoteAgentCatalogAfterSignOut,
@@ -19,6 +20,7 @@ import {
 import type { StoredSessionState } from '@auth/TokenProvider';
 import { completeDeviceSession } from '@auth/oauth/deviceAuthorization';
 import { platform } from '@platform/platform';
+import { effectRuntime } from '@platform/processRuntime';
 import type { PlatformSecrets } from '@platform/secrets';
 
 // Local file imports
@@ -79,6 +81,10 @@ const deferredAuthLog: SupabaseSessionLog = {
 export function initializeCliSupabaseAuth(
   log?: SupabaseSessionLog,
 ): SupabaseSessionCoordinator {
+  // The auth subsystem's run edge lives at this host entry (PRD R1), installed
+  // on every init so every later Promise-facing auth surface settles on the
+  // process runtime.
+  installAuthProgramEdge((program) => effectRuntime().runPromiseExit(program));
   activeAuthLog = log ?? activeAuthLog;
   const secrets = platform().secrets;
   if (!coordinator || coordinatorSecrets !== secrets) {
@@ -103,7 +109,7 @@ export async function signInCliSupabase(
   try {
     options.signal?.throwIfAborted();
     if (options.selectAccount || options.loginHint) {
-      await authCoordinator.clearSession();
+      await runAuthProgram(authCoordinator.clearSession());
     }
     const { data, error } =
       await SupabaseClient.getClient().auth.signInWithOAuth({
@@ -171,13 +177,15 @@ export const signInCliSupabaseDeviceCode = Effect.fn(
   // The token endpoint mints a native GoTrue session (auth-github shape), so
   // standard Supabase refresh applies — no custom refresh flag.
   const session: SupabaseSession = toStorableSupabaseSession(exchange);
-  yield* completeDeviceSession(() => authCoordinator.storeSession(session));
+  yield* completeDeviceSession(() =>
+    runAuthProgram(authCoordinator.storeSession(session)),
+  );
   return session;
 });
 
 export async function signOutCliSupabase(): Promise<void> {
   const authCoordinator = initializeCliSupabaseAuth();
-  await authCoordinator.clearSession();
+  await runAuthProgram(authCoordinator.clearSession());
   await refreshRemoteAgentCatalogAfterSignOut(
     invalidateRemoteAgentsAfterSignOut,
     (message) => activeAuthLog?.warn?.('cli-auth', message),
@@ -198,7 +206,7 @@ export async function getCliAuthProfile(): Promise<CliAuthProfile> {
     };
   }
 
-  const session = await authCoordinator.loadSession();
+  const session = await runAuthProgram(authCoordinator.loadSession());
   return {
     authenticated: true,
     sessionState,

--- a/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
+++ b/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 
 // Local imports - auth
 import { Result } from 'effect';
+import { runAuthProgram } from '@auth/authProgram';
 import { AUTH_CALLBACK_TIMEOUT_MS } from '@auth/config';
 import {
   type SupabaseSession,
@@ -158,18 +159,20 @@ async function handleCallbackRequest(
       );
     }
     assertAcceptingCallbacks(attemptState);
-    const result = await authCoordinator.createSessionFromCallback({
-      path: CALLBACK_PATH,
-      query: body.query?.startsWith('?')
-        ? body.query.slice(1)
-        : (body.query ?? ''),
-    });
+    const result = await runAuthProgram(
+      authCoordinator.createSessionFromCallback({
+        path: CALLBACK_PATH,
+        query: body.query?.startsWith('?')
+          ? body.query.slice(1)
+          : (body.query ?? ''),
+      }),
+    );
     if (!result.success) throw new Error(result.error);
     assertAcceptingCallbacks(attemptState);
 
     attemptState.commitStarted = true;
     attemptState.acceptingCallbacks = false;
-    await authCoordinator.storeSession(result.session);
+    await runAuthProgram(authCoordinator.storeSession(result.session));
     writeHtml(response, 200, successHtml(result.session.account.label));
     return result.session;
   }

--- a/packages/desktop/src/main/desktopPapers.ts
+++ b/packages/desktop/src/main/desktopPapers.ts
@@ -152,19 +152,25 @@ export async function readRememberedDesktopPapers(
   for (const candidate of stored) {
     const root = canonicalizeWorkspacePath(candidate);
     if (roots.includes(root) || missing.includes(root)) continue;
-    let isFolder = false;
-    try {
-      isFolder =
-        statSync(root, { throwIfNoEntry: false })?.isDirectory() ?? false;
-    } catch (error) {
-      // Persisted state validated at its boundary: an unreadable path is
-      // reported and forgotten like a missing one, so it cannot fail every
-      // launch until repaired by hand.
-      warn(
-        `Cannot read the remembered paper ${root}; forgetting it: ${toErrorMessage(error)}`,
-      );
-    }
-    (isFolder ? roots : missing).push(root);
+    const stats = effectRuntime().runSync(
+      Effect.try({
+        try: () => statSync(root, { throwIfNoEntry: false }),
+        catch: (error) => error,
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.sync(() => {
+            // Persisted state validated at its boundary: an unreadable path is
+            // reported and forgotten like a missing one, so it cannot fail
+            // every launch until repaired by hand.
+            warn(
+              `Cannot read the remembered paper ${root}; forgetting it: ${toErrorMessage(error)}`,
+            );
+            return undefined;
+          }),
+        ),
+      ),
+    );
+    (stats?.isDirectory() ? roots : missing).push(root);
   }
   const changed =
     roots.length !== stored.length ||
@@ -214,43 +220,49 @@ async function openPaperSession(
   roots: WorkspaceRoots,
 ): Promise<DesktopPaper> {
   const resources = new DisposableStore();
-  try {
-    const transcripts = await runWithWorkspaceRoots(roots, () =>
-      StreamLogStore.open(),
-    );
-    const session = openSession({
-      transcripts,
-      roots,
-      responseTextProcessing,
-    });
-    resources.add(() => session.dispose());
-    return await runInSession(session, async () => {
-      const processStores = await initializeDesktopProcessStores(session);
-      resources.add(() => processStores.dispose());
-      session.setApprovalPolicy(
-        readPlatformSetting<TexraApprovalPolicy>(
-          TEXRA_APPROVAL_POLICY_CONFIG_KEY,
-        ),
-      );
-      // Off the open path: the leftover-stream sweep reads this paper's
-      // whole storage root, so it starts on a timer nothing awaits. It is
-      // scheduled inside the session scope, which the timer inherits, so the
-      // sweep reads this paper's storage and not another's; closing the paper
-      // or shutting the process down cancels it if it has not started.
-      resources.add(scheduleLeftoverStreamSweep(session));
-      return {
-        key: roots.storage,
-        root,
-        roots,
-        session,
-        stores: processStores.stores,
-        dispose: () => runInSession(session, () => resources.dispose()),
-      };
-    });
-  } catch (error) {
-    resources.dispose();
-    throw error;
-  }
+  return effectRuntime().runPromise(
+    Effect.tryPromise({
+      try: async () => {
+        const transcripts = await runWithWorkspaceRoots(roots, () =>
+          StreamLogStore.open(),
+        );
+        const session = openSession({
+          transcripts,
+          roots,
+          responseTextProcessing,
+        });
+        resources.add(() => session.dispose());
+        return await runInSession(session, async () => {
+          const processStores = await initializeDesktopProcessStores(session);
+          resources.add(() => processStores.dispose());
+          session.setApprovalPolicy(
+            readPlatformSetting<TexraApprovalPolicy>(
+              TEXRA_APPROVAL_POLICY_CONFIG_KEY,
+            ),
+          );
+          // Off the open path: the leftover-stream sweep reads this paper's
+          // whole storage root, so it starts on a timer nothing awaits. It is
+          // scheduled inside the session scope, which the timer inherits, so the
+          // sweep reads this paper's storage and not another's; closing the paper
+          // or shutting the process down cancels it if it has not started.
+          resources.add(scheduleLeftoverStreamSweep(session));
+          return {
+            key: roots.storage,
+            root,
+            roots,
+            session,
+            stores: processStores.stores,
+            dispose: () => runInSession(session, () => resources.dispose()),
+          };
+        });
+      },
+      catch: (error) => error,
+    }).pipe(
+      // A failed open releases everything the attempt registered before the
+      // rejection reaches the caller.
+      Effect.onError(() => Effect.sync(() => resources.dispose())),
+    ),
+  );
 }
 
 /**
@@ -316,14 +328,24 @@ export async function openDesktopPaperRegistry(
   const rememberActive = (root: string) => {
     const remembered = readRememberedPapers(options.globalState, options.warn);
     if (remembered.at(-1) === root) return;
-    void writeRememberedPapers(options.globalState, [
-      ...remembered.filter((entry) => entry !== root),
-      root,
-    ]).catch((error: unknown) => {
-      options.warn(
-        `Could not remember the active paper ${root}: ${toErrorMessage(error)}`,
-      );
-    });
+    effectRuntime().runFork(
+      Effect.tryPromise({
+        try: () =>
+          writeRememberedPapers(options.globalState, [
+            ...remembered.filter((entry) => entry !== root),
+            root,
+          ]),
+        catch: (error) => error,
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.sync(() => {
+            options.warn(
+              `Could not remember the active paper ${root}: ${toErrorMessage(error)}`,
+            );
+          }),
+        ),
+      ),
+    );
   };
 
   const activate = (root: string | undefined) => {
@@ -407,15 +429,24 @@ export async function openDesktopPaperRegistry(
     async flushArtifacts() {
       const failures: string[] = [];
       for (const paper of [fallback, ...papers.values()]) {
-        try {
-          await runInSession(paper.session, () =>
-            paper.session.flushArtifacts(),
-          );
-        } catch (error) {
-          failures.push(
-            `${paper.root ?? 'no workspace'}: ${toErrorMessage(error)}`,
-          );
-        }
+        await effectRuntime().runPromise(
+          Effect.tryPromise({
+            try: async () => {
+              await runInSession(paper.session, () =>
+                paper.session.flushArtifacts(),
+              );
+            },
+            catch: (error) => error,
+          }).pipe(
+            Effect.catch((error) =>
+              Effect.sync(() => {
+                failures.push(
+                  `${paper.root ?? 'no workspace'}: ${toErrorMessage(error)}`,
+                );
+              }),
+            ),
+          ),
+        );
       }
       if (failures.length > 0) {
         throw new Error(

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -4,6 +4,7 @@ import PQueue from 'p-queue';
 import { z } from 'zod';
 
 import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
+import { installAuthProgramEdge, runAuthProgram } from '@auth/authProgram';
 import {
   AUTH_CALLBACK_TIMEOUT_MS,
   DEFAULT_OAUTH_PROVIDER,
@@ -23,6 +24,7 @@ import {
 import type { AuthCallbackUriParts } from '@auth/authCallback';
 import type { MessageHost } from '@hosts/uiHosts';
 import type { StateStore } from '@platform/interfaces';
+import { effectRuntime } from '@platform/processRuntime';
 import type { PlatformSecrets } from '@platform/secrets';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { TEXRA_PROTOCOL } from '../shared/desktopProtocol.js';
@@ -401,10 +403,21 @@ export function createDesktopAuthCoordinator(options: {
   secrets: PlatformSecrets;
   log: DesktopAuthLog;
 }): DesktopAuthCoordinator {
-  return createHostAuthCoordinator({
+  // The auth subsystem's run edge lives at this host entry (PRD R1); the
+  // coordinator's surface is Effect-typed and this module settles it through
+  // `runAuthProgram` for the Promise interface above.
+  installAuthProgramEdge((program) => effectRuntime().runPromiseExit(program));
+  const coordinator = createHostAuthCoordinator({
     secrets: options.secrets,
     log: createSessionLog(options.log),
   });
+  return {
+    storeSession: (session) =>
+      runAuthProgram(coordinator.storeSession(session)),
+    clearSession: () => runAuthProgram(coordinator.clearSession()),
+    createSessionFromCallback: (uri) =>
+      runAuthProgram(coordinator.createSessionFromCallback(uri)),
+  };
 }
 
 async function processProtocolCallback(

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -13,7 +13,7 @@ import {
 } from 'electron';
 import PQueue from 'p-queue';
 
-import { SubscriptionRef } from 'effect';
+import { Effect, SubscriptionRef } from 'effect';
 import { z } from 'zod';
 import { runInSession } from '@agent/runtime';
 import {
@@ -47,6 +47,7 @@ import { createLog } from '@logger/logUtils';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { platform } from '@platform/platform';
 import { DisposableStore } from '@platform/disposable';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   INSTRUCTION_ACTION,
   type AgentSource,
@@ -1182,59 +1183,83 @@ function createWindow(options: {
       // later "Run Setup" click can retry.
       kickoffSetup: async () => {
         const setupSession = activePaper().session;
-        try {
-          // The paper the user started setup in, taken before the first await:
-          // the run and its presentation belong to it even when the window
-          // moves to another paper while the model resolves and agents load.
-          const binding = activeBinding();
-          if (!binding) {
-            throw new Error('Open a folder before running setup.');
-          }
-          const { buildDesktopSetupExecuteMessage } =
-            await import('@controllers/onboarding/setupLaunch');
-          const message = await buildDesktopSetupExecuteMessage();
-          if (!message) {
-            throw new Error(
-              'No model is available for your current credentials. Sign in with ChatGPT or add a provider or coding-plan API key in Models, then try setup again.',
-            );
-          }
-          // Idempotent: returns the in-flight/initialized registry so a kickoff
-          // racing the startup `loadAgents()` cannot hit "Could not find agent:
-          // setup" (mirrors `setupAssistantCommand.launchSetupAssistant`).
-          await loadAgents();
-          await runInSession(binding.paper.session, async () =>
-            binding.execution.runValidated(
-              await prepareMainViewExecutionLaunch(message, agentExecutionHost),
+        await effectRuntime().runPromise(
+          Effect.tryPromise({
+            try: async () => {
+              // The paper the user started setup in, taken before the first await:
+              // the run and its presentation belong to it even when the window
+              // moves to another paper while the model resolves and agents load.
+              const binding = activeBinding();
+              if (!binding) {
+                throw new Error('Open a folder before running setup.');
+              }
+              const { buildDesktopSetupExecuteMessage } =
+                await import('@controllers/onboarding/setupLaunch');
+              const message = await buildDesktopSetupExecuteMessage();
+              if (!message) {
+                throw new Error(
+                  'No model is available for your current credentials. Sign in with ChatGPT or add a provider or coding-plan API key in Models, then try setup again.',
+                );
+              }
+              // Idempotent: returns the in-flight/initialized registry so a kickoff
+              // racing the startup `loadAgents()` cannot hit "Could not find agent:
+              // setup" (mirrors `setupAssistantCommand.launchSetupAssistant`).
+              await loadAgents();
+              await runInSession(binding.paper.session, async () =>
+                binding.execution.runValidated(
+                  await prepareMainViewExecutionLaunch(
+                    message,
+                    agentExecutionHost,
+                  ),
+                ),
+              );
+            },
+            catch: (error) => error,
+          }).pipe(
+            Effect.catch((error) =>
+              Effect.gen(function* () {
+                if (error instanceof Cancelled) return;
+                // Setup continues after its initiating request has completed.
+                const primaryError = primaryAgentError(error);
+                const presentation = agentErrorPresentation({
+                  kind: classifyAgentError(primaryError),
+                  message:
+                    primaryError instanceof Rejected
+                      ? primaryError.reason
+                      : toErrorMessage(primaryError),
+                });
+                if (presentation?.type === 'instruction') {
+                  yield* Effect.tryPromise({
+                    try: () =>
+                      Promise.resolve(
+                        setupSession.interactions.emit(
+                          'requestShowInstruction',
+                          presentation.payload,
+                          { replayWhenAttached: true },
+                        ),
+                      ),
+                    catch: (emitError) => emitError,
+                  });
+                } else if (presentation?.type === 'error') {
+                  yield* Effect.tryPromise({
+                    try: () =>
+                      Promise.resolve(
+                        setupSession.interactions.emit(
+                          'requestShowError',
+                          presentation.payload,
+                          {
+                            replayWhenAttached: true,
+                          },
+                        ),
+                      ),
+                    catch: (emitError) => emitError,
+                  });
+                }
+                return yield* Effect.fail(error);
+              }),
             ),
-          );
-        } catch (error) {
-          if (error instanceof Cancelled) return;
-          // Setup continues after its initiating request has completed.
-          const primaryError = primaryAgentError(error);
-          const presentation = agentErrorPresentation({
-            kind: classifyAgentError(primaryError),
-            message:
-              primaryError instanceof Rejected
-                ? primaryError.reason
-                : toErrorMessage(primaryError),
-          });
-          if (presentation?.type === 'instruction') {
-            await setupSession.interactions.emit(
-              'requestShowInstruction',
-              presentation.payload,
-              { replayWhenAttached: true },
-            );
-          } else if (presentation?.type === 'error') {
-            await setupSession.interactions.emit(
-              'requestShowError',
-              presentation.payload,
-              {
-                replayWhenAttached: true,
-              },
-            );
-          }
-          throw error;
-        }
+          ),
+        );
       },
       signInWithChatGpt: () => requireSettingsIpc().signInChatGpt(),
       // The desktop shell can't host the VS Code getting-started walkthrough, so
@@ -1477,11 +1502,16 @@ function createWindow(options: {
   window.once('closed', () => {
     const continueQuit = continueQuitAfterWindowClose;
     continueQuitAfterWindowClose = undefined;
-    try {
-      windowResources.dispose();
-    } catch (error) {
-      reportBackgroundError(error);
-    }
+    effectRuntime().runSync(
+      Effect.try({
+        try: () => windowResources.dispose(),
+        catch: (error) => error,
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.sync(() => reportBackgroundError(error)),
+        ),
+      ),
+    );
     if (mainWindow === window) {
       mainWindow = null;
       if (process.platform === 'darwin') {
@@ -1576,11 +1606,18 @@ if (protocolLifecycle.ownsSingleInstanceLock) {
           (root) => `${root} (no such folder; forgotten)`,
         );
         for (const root of remembered.roots) {
-          try {
-            await papers.open(root);
-          } catch (error) {
-            unopenedPapers.push(`${root}: ${toErrorMessage(error)}`);
-          }
+          await effectRuntime().runPromise(
+            Effect.tryPromise({
+              try: () => papers.open(root),
+              catch: (error) => error,
+            }).pipe(
+              Effect.catch((error) =>
+                Effect.sync(() => {
+                  unopenedPapers.push(`${root}: ${toErrorMessage(error)}`);
+                }),
+              ),
+            ),
+          );
         }
         papers.activate(papers.list().at(-1)?.root);
         // Ask the renderer to close before draining process services. A dirty

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -6,6 +6,12 @@ import { z } from 'zod';
 
 import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
 import { refreshRemoteAgentCatalogAfterSignOut } from '@auth/authFlowEffects';
+import {
+  callPort,
+  installAuthProgramEdge,
+  runAuthProgram,
+} from '@auth/authProgram';
+import { withPkcePermit } from '@auth/pkcePermit';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   AUTH_BRIDGE_URL,
@@ -24,6 +30,7 @@ import {
 import { classifyAuthFailureStatus } from '@auth/TokenProvider';
 import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
+import { effectRuntime } from '@platform/processRuntime';
 import type { PlatformSecrets } from '@platform/secrets';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { SupabaseUriHandler } from './UriHandler';
@@ -77,6 +84,11 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   private activeAttempt: ExtensionAuthAttempt | undefined;
 
   constructor(private readonly notifier: AuthNotifier) {
+    // The auth subsystem's run edge lives at this host entry (PRD R1): every
+    // Promise-facing auth surface settles on the process runtime from here.
+    installAuthProgramEdge((program) =>
+      effectRuntime().runPromiseExit(program),
+    );
     const hostPlatform = platform();
     this.secrets = hostPlatform.secrets;
     this.sessionCoordinator = createHostAuthCoordinator({
@@ -243,7 +255,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
   /** Store a newly created session and fire the session-change event. */
   private async storeSession(session: SupabaseSession): Promise<void> {
-    await this.sessionCoordinator.storeSession(session);
+    await runAuthProgram(this.sessionCoordinator.storeSession(session));
     this._onDidChangeSessions.fire({
       added: [this.toVSCodeSession(session)],
       removed: [],
@@ -286,13 +298,17 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       const flowId = await this.claimCallback(uri.query);
       if (!flowId) return;
 
-      const existingSession = await this.sessionCoordinator.loadSession();
+      const existingSession = await runAuthProgram(
+        this.sessionCoordinator.loadSession(),
+      );
       if (existingSession) return;
 
-      const result = await SupabaseClient.runPkceOperation(() =>
-        this.sessionCoordinator.createSessionFromCallback(
-          { path: uri.path, query: uri.query },
-          flowId,
+      const result = await runAuthProgram(
+        withPkcePermit(
+          this.sessionCoordinator.createSessionFromCallback(
+            { path: uri.path, query: uri.query },
+            flowId,
+          ),
         ),
       );
 
@@ -323,14 +339,16 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     _scopes?: readonly string[],
     _options?: vscode.AuthenticationProviderSessionOptions,
   ): Promise<vscode.AuthenticationSession[]> {
-    const session = await this.sessionCoordinator.loadSession();
+    const session = await runAuthProgram(this.sessionCoordinator.loadSession());
     if (!session) {
       return [];
     }
 
     try {
       if (Date.now() >= session.expiresAt) {
-        const refreshed = await this.sessionCoordinator.refreshSession(session);
+        const refreshed = await runAuthProgram(
+          this.sessionCoordinator.refreshSession(session),
+        );
         if (!refreshed) {
           if (this.sessionCoordinator.getLastRefreshFailure() === 'invalid') {
             await this.handleInvalidSession(session, 'expired');
@@ -479,11 +497,15 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
           if (this.activeAttempt !== attempt) throw interruptedError();
 
           const options = await this.buildOAuthOptions(attempt.nonce);
-          const { data, error } = await SupabaseClient.runPkceOperation(() =>
-            SupabaseClient.getClient().auth.signInWithOAuth({
-              provider,
-              options,
-            }),
+          const { data, error } = await runAuthProgram(
+            withPkcePermit(
+              callPort(() =>
+                SupabaseClient.getClient().auth.signInWithOAuth({
+                  provider,
+                  options,
+                }),
+              ),
+            ),
           );
 
           if (error || !data.url) {
@@ -508,7 +530,9 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
             if (this.activeAttempt !== attempt) return;
             await this.storeSession(session);
             if (this.activeAttempt !== attempt) {
-              await this.sessionCoordinator.clearSessionIfCurrent(session);
+              await runAuthProgram(
+                this.sessionCoordinator.clearSessionIfCurrent(session),
+              );
             }
           });
           if (this.activeAttempt !== attempt) throw interruptedError();
@@ -555,9 +579,12 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
    * its own sign-in prompt and duplicate the caller's authentication action.
    */
   async clearStoredSession(): Promise<boolean> {
-    const session = await this.sessionCoordinator.loadSession();
+    const session = await runAuthProgram(this.sessionCoordinator.loadSession());
     if (!session) return false;
-    if ((await this.sessionCoordinator.getStoredSessionState()) !== 'invalid') {
+    const storedState = await runAuthProgram(
+      this.sessionCoordinator.getStoredSessionState(),
+    );
+    if (storedState !== 'invalid') {
       return false;
     }
     return this.clearLocalSessionIfCurrent(session);
@@ -566,22 +593,23 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   /** Remove the currently stored session without resolving it. */
   async removeStoredSession(): Promise<boolean> {
     await this.cancelPendingAttempt();
-    const session = await this.sessionCoordinator.loadSession();
+    const session = await runAuthProgram(this.sessionCoordinator.loadSession());
     if (!session) return false;
     await this.clearLocalSession(session.id);
     return true;
   }
 
   private async clearLocalSession(sessionId: string): Promise<void> {
-    await this.sessionCoordinator.clearSession();
+    await runAuthProgram(this.sessionCoordinator.clearSession());
     await this.afterLocalSessionCleared(sessionId);
   }
 
   private async clearLocalSessionIfCurrent(
     session: SupabaseSession,
   ): Promise<boolean> {
-    const cleared =
-      await this.sessionCoordinator.clearSessionIfCurrent(session);
+    const cleared = await runAuthProgram(
+      this.sessionCoordinator.clearSessionIfCurrent(session),
+    );
     if (!cleared) return false;
     await this.afterLocalSessionCleared(session.id);
     return true;
@@ -640,10 +668,12 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
           if (!flowId) return;
           cleanupListeners();
 
-          const result = await SupabaseClient.runPkceOperation(() =>
-            this.sessionCoordinator.createSessionFromCallback(
-              { path: uri.path, query: uri.query },
-              flowId,
+          const result = await runAuthProgram(
+            withPkcePermit(
+              this.sessionCoordinator.createSessionFromCallback(
+                { path: uri.path, query: uri.query },
+                flowId,
+              ),
             ),
           );
 

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -1,4 +1,3 @@
-import { Semaphore } from 'effect';
 import {
   createClient,
   SupabaseClient as Client,
@@ -7,7 +6,7 @@ import {
 } from '@supabase/supabase-js';
 import { createLog } from '@logger/logUtils';
 import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
-import { callPort, runAuthProgram } from './authProgram';
+import { runAuthProgram } from './authProgram';
 import { SUPABASE_GOTRUE_STORAGE_KEY } from './config';
 import type { SessionSecretStore } from './oauth/sessionAccess';
 import type { AuthTokenProvider, StoredSessionState } from './TokenProvider';
@@ -98,7 +97,6 @@ export class SupabaseClient {
   private static instance: Client | null = null;
   private static config: { url: string; publicKey: string } | null = null;
   private static authProvider: AuthTokenProvider | null = null;
-  private static pkceOperations = Semaphore.makeUnsafe(1);
 
   /**
    * Error that occurred during initialization, if any.
@@ -122,19 +120,6 @@ export class SupabaseClient {
     this.authProvider = null;
     this.initError = null;
     this.readinessError = null;
-    this.pkceOperations = Semaphore.makeUnsafe(1);
-  }
-
-  /**
-   * Serialize PKCE callback exchange with OAuth initialization. Auth-js keeps
-   * each verifier in a flow-specific slot, while this single permit prevents
-   * an older exchange from racing initialization in the same extension host.
-   * The operation's own rejection reaches the caller unchanged.
-   */
-  static async runPkceOperation<T>(operation: () => Promise<T>): Promise<T> {
-    return runAuthProgram(
-      this.pkceOperations.withPermits(1)(callPort(operation)),
-    );
   }
 
   /**
@@ -152,20 +137,16 @@ export class SupabaseClient {
     return this.initError ?? this.readinessError;
   }
 
-  // `isReady`, `getAccessToken`, `getUser`, and `getStoredAccountLabel` stay
-  // Promise-native, catch clauses included: each wraps the `AuthTokenProvider`
-  // port (src/auth/TokenProvider.ts), which this subsystem's own
-  // SupabaseSessionCoordinator implements behind a Promise edge, so running
-  // them as programs here would put Effect on both sides of a Promise.
-  // `runPkceOperation` is the same seam from the other side: the host passes
-  // `SupabaseSessionCoordinator.createSessionFromCallback`, a Promise edge
-  // over a program, so that call nests Promise → Effect → Promise → Effect
-  // (execution-strategy rule 1). Retirement condition (R10): the port becomes
-  // Effect-typed, these convert with it in that PR, and the host hands the
-  // coordinator's exchange program to an Effect-typed sibling of
-  // `runPkceOperation` composed under the same permit, retiring the Promise
-  // callback with its suite. Introduced 2026-09-06 (lane w2 of the Effect 4
-  // migration). @adapter-until 2026-11-05
+  // `isReady`, `getAccessToken`, `getUser`, `getStoredSessionState`, and
+  // `getStoredAccountLabel` are this subsystem's Promise rendering for
+  // consumers in zones other lanes own: src/controllers and src/telemetry
+  // (wave-1 rebuild), src/agent (agent-index-remote lane), src/tools
+  // (Phase 5), and packages/desktop/src/main/index.ts (cutover PR #11972).
+  // Each settles the Effect-typed AuthTokenProvider port through
+  // `runAuthProgram`, whose run edge the host entry installs at the
+  // sanctioned boundary. As those lanes convert their callers, the methods
+  // here delete in favor of the port. The PKCE permit the extension host
+  // composes is `withPkcePermit` (src/auth/pkcePermit.ts).
   /**
    * Check if auth system is fully initialized and ready for use.
    */
@@ -179,7 +160,7 @@ export class SupabaseClient {
     }
 
     try {
-      await this.authProvider.whenReady();
+      await runAuthProgram(this.authProvider.whenReady());
       this.readinessError = null;
       return true;
     } catch (error) {
@@ -254,7 +235,7 @@ export class SupabaseClient {
     }
 
     try {
-      return await this.authProvider.ensureFreshToken();
+      return await runAuthProgram(this.authProvider.ensureFreshToken());
     } catch (error) {
       log.error(`Error getting access token: ${toErrorMessage(error)}`);
       return null;
@@ -291,7 +272,7 @@ export class SupabaseClient {
    */
   static async getStoredSessionState(): Promise<StoredSessionState> {
     if (!this.authProvider) return 'none';
-    return this.authProvider.getStoredSessionState();
+    return runAuthProgram(this.authProvider.getStoredSessionState());
   }
 
   /**
@@ -302,7 +283,7 @@ export class SupabaseClient {
   static async getStoredAccountLabel(): Promise<string | null> {
     if (!this.authProvider) return null;
     try {
-      return await this.authProvider.getStoredAccountLabel();
+      return await runAuthProgram(this.authProvider.getStoredAccountLabel());
     } catch (error) {
       // A failed read is otherwise indistinguishable from "no session
       // stored", and both collapse to the generic account label in the UI.

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -5,12 +5,7 @@ import {
   parseAuthCallbackCode,
   type AuthCallbackUriParts,
 } from './authCallback';
-import {
-  callPort,
-  runAuthProgram,
-  SerializedWrites,
-  type AuthPortError,
-} from './authProgram';
+import { callPort, SerializedWrites, type AuthPortError } from './authProgram';
 import {
   parseStoredSupabaseSession,
   toStorableSupabaseSession,
@@ -61,9 +56,10 @@ const NOOP_SUPABASE_SESSION_LOG: Required<SupabaseSessionLog> = {
  * Host-neutral coordinator for Supabase session storage, token freshness,
  * OAuth callback conversion, and refresh. Host wrappers own UI and registration.
  *
- * The Promise methods are the boundary; each runs one of the Effect programs
- * below through {@link runAuthProgram}. Storage and GoTrue rejections travel
- * as {@link AuthPortError} and reach the caller as the port's own error.
+ * The public surface is Effect-typed (PRD R1): each method is one of the
+ * programs below, and the caller's edge runs it. Storage and GoTrue rejections
+ * travel as {@link AuthPortError}; `SupabaseClient`'s Promise facade settles
+ * them through `runAuthProgram`, whose edge unwraps the port's own error.
  */
 export class SupabaseSessionCoordinator implements AuthTokenProvider {
   private refreshInFlight: Deferred.Deferred<SupabaseSession | null> | null =
@@ -81,22 +77,20 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     this.log = { ...NOOP_SUPABASE_SESSION_LOG, ...options.log };
   }
 
-  async whenReady(): Promise<void> {
-    await this.options.whenReady();
+  whenReady(): Effect.Effect<void, AuthPortError> {
+    return callPort(() => this.options.whenReady());
   }
 
-  async loadSession(): Promise<SupabaseSession | null> {
-    return runAuthProgram(this.load());
+  loadSession(): Effect.Effect<SupabaseSession | null, AuthPortError> {
+    return this.load();
   }
 
-  async storeSession(session: SupabaseSession): Promise<void> {
-    await runAuthProgram(this.mutate(this.write(session)));
+  storeSession(session: SupabaseSession): Effect.Effect<void, AuthPortError> {
+    return this.mutate(this.write(session));
   }
 
-  async clearSession(): Promise<void> {
-    await runAuthProgram(
-      this.mutate(callPort(() => this.options.storage.delete())),
-    );
+  clearSession(): Effect.Effect<void, AuthPortError> {
+    return this.mutate(callPort(() => this.options.storage.delete()));
   }
 
   /**
@@ -105,23 +99,21 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    * while an older validation request is in flight; that older result must not
    * delete the replacement.
    */
-  async clearSessionIfCurrent(expected: SupabaseSession): Promise<boolean> {
-    return runAuthProgram(
-      this.sessionMutations.run(this.clearIfCurrent(expected)),
-    );
+  clearSessionIfCurrent(
+    expected: SupabaseSession,
+  ): Effect.Effect<boolean, AuthPortError> {
+    return this.sessionMutations.run(this.clearIfCurrent(expected));
   }
 
   /**
    * Ensure the access token is fresh, refreshing proactively if near expiry.
-   *
-   * @returns Fresh access token, or null if no session or refresh failed.
+   * Resolves to the fresh access token, or null if no session or refresh
+   * failed; a port rejection is logged where its disposition is decided.
    */
-  async ensureFreshToken(): Promise<string | null> {
-    return runAuthProgram(
-      Effect.map(
-        this.freshSession(),
-        (session) => session?.accessToken ?? null,
-      ),
+  ensureFreshToken(): Effect.Effect<string | null> {
+    return Effect.map(
+      this.freshSession(),
+      (session) => session?.accessToken ?? null,
     );
   }
 
@@ -130,31 +122,27 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    * session while refresh is in flight; in that case retry rather than apply
    * the old credential's failure to the new one.
    */
-  async getStoredSessionState(): Promise<StoredSessionState> {
-    return runAuthProgram(
-      this.storedSessionState().pipe(
-        Effect.catchTag('AuthPortError', (error) =>
-          Effect.sync(() => {
-            this.log.error(
-              'SupabaseSession',
-              `Error classifying stored session: ${toErrorMessage(error.cause)}`,
-            );
-            return 'transient' as const;
-          }),
-        ),
+  getStoredSessionState(): Effect.Effect<StoredSessionState> {
+    return this.storedSessionState().pipe(
+      Effect.catchTag('AuthPortError', (error) =>
+        Effect.sync(() => {
+          this.log.error(
+            'SupabaseSession',
+            `Error classifying stored session: ${toErrorMessage(error.cause)}`,
+          );
+          return 'transient' as const;
+        }),
       ),
     );
   }
 
   /**
    * Read the stored session's account label without attempting a token
-   * refresh. Returns null when no session is stored or the data is
-   * unreadable — the caller decides what to show in its place.
+   * refresh. Returns null when no session is stored; a storage rejection
+   * travels as {@link AuthPortError} and the caller decides what to show.
    */
-  async getStoredAccountLabel(): Promise<string | null> {
-    return runAuthProgram(
-      Effect.map(this.load(), (session) => session?.account.label ?? null),
-    );
+  getStoredAccountLabel(): Effect.Effect<string | null, AuthPortError> {
+    return Effect.map(this.load(), (session) => session?.account.label ?? null);
   }
 
   getLastRefreshFailure(): SessionRefreshFailure | null {
@@ -162,36 +150,34 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   }
 
   /** Get access and refresh tokens from secure storage. */
-  async getSessionTokens(): Promise<SessionTokens | null> {
-    return runAuthProgram(
-      Effect.map(this.freshSession(), (session) =>
-        session
-          ? {
-              accessToken: session.accessToken,
-              refreshToken: session.refreshToken,
-            }
-          : null,
-      ),
+  getSessionTokens(): Effect.Effect<SessionTokens | null> {
+    return Effect.map(this.freshSession(), (session) =>
+      session
+        ? {
+            accessToken: session.accessToken,
+            refreshToken: session.refreshToken,
+          }
+        : null,
     );
   }
 
   /** Convert a PKCE OAuth callback into a host-neutral session record. */
-  async createSessionFromCallback(
+  createSessionFromCallback(
     uri: AuthCallbackUriParts,
     flowId?: string,
-  ): Promise<SupabaseCallbackResult> {
+  ): Effect.Effect<SupabaseCallbackResult, AuthPortError> {
     const parsedCode = parseAuthCallbackCode(uri);
     return parsedCode.success
-      ? runAuthProgram(this.exchangeCode(parsedCode.code, flowId))
-      : parsedCode;
+      ? this.exchangeCode(parsedCode.code, flowId)
+      : Effect.succeed(parsedCode);
   }
 
   /** Refresh session via Supabase native refresh, with concurrency protection. */
-  async refreshSession(
+  refreshSession(
     session: SupabaseSession,
     expectedVersion = this.sessionMutationVersion,
-  ): Promise<SupabaseSession | null> {
-    return runAuthProgram(this.refresh(session, expectedVersion));
+  ): Effect.Effect<SupabaseSession | null> {
+    return this.refresh(session, expectedVersion);
   }
 
   /** Read and parse the stored session. */

--- a/src/auth/TokenProvider.ts
+++ b/src/auth/TokenProvider.ts
@@ -1,3 +1,7 @@
+import type { Effect } from 'effect';
+
+import type { AuthPortError } from './authProgram';
+
 export interface SessionTokens {
   accessToken: string;
   refreshToken: string;
@@ -18,18 +22,22 @@ export function classifyAuthFailureStatus(
   return status === 400 || status === 401 ? 'invalid' : 'transient';
 }
 
-/** Host-neutral source for authenticated Supabase session tokens. */
+/**
+ * Host-neutral source for authenticated Supabase session tokens. Effect-typed
+ * (PRD R1): the one Promise rendering is `SupabaseClient`'s facade, settled
+ * through `runAuthProgram` for the consumers its own comment names.
+ */
 export interface AuthTokenProvider {
-  whenReady(): Promise<void>;
-  ensureFreshToken(): Promise<string | null>;
+  whenReady(): Effect.Effect<void, AuthPortError>;
+  ensureFreshToken(): Effect.Effect<string | null>;
   /** Classify the stored session while guarding against replacement races. */
-  getStoredSessionState(): Promise<StoredSessionState>;
+  getStoredSessionState(): Effect.Effect<StoredSessionState>;
   /**
    * The account label (email) from the stored session, without attempting a
-   * token refresh. Returns null when no session is stored or the stored data
-   * is unreadable.
+   * token refresh. Returns null when no session is stored; fails with
+   * {@link AuthPortError} when the stored data is unreadable.
    */
-  getStoredAccountLabel(): Promise<string | null>;
+  getStoredAccountLabel(): Effect.Effect<string | null, AuthPortError>;
   /**
    * Classification of the most recent refresh failure. `invalid` means the
    * credential was authoritatively rejected; `transient` covers transport and

--- a/src/auth/authProgram.ts
+++ b/src/auth/authProgram.ts
@@ -1,11 +1,12 @@
 /**
  * The Promise edge of the auth subsystem's Effect programs (Effect 4 runtime
- * PRD, R1 and R7): one run boundary behind each Promise-facing method, and
- * one typed failure for the host ports those programs call.
+ * PRD, R1 and R7): one typed failure for the host ports those programs call,
+ * and the settle-fold every Promise-facing auth surface shares. The run edge
+ * itself is installed by the host entry ({@link installAuthProgramEdge}), so
+ * the only `Effect.run*` site in the subsystem lives in host code at the
+ * sanctioned boundary, not here.
  */
 import { Cause, Data, Deferred, Effect, Exit, Option, Semaphore } from 'effect';
-
-import { effectRuntime } from '@platform/processRuntime';
 
 /**
  * A host port (secret storage), an SDK call, or a provider policy rejected.
@@ -103,7 +104,25 @@ function rethrowPortCause(error: unknown): never {
 }
 
 /**
- * Run one auth program on the process runtime and settle it as a Promise.
+ * Settles an auth program as an `Exit`, for the Promise-facing surfaces that
+ * settle through {@link runAuthProgram}. Installed like the process roots:
+ * exactly once per process, by the host entry, as
+ * `(program) => effectRuntime().runPromiseExit(program)` — which keeps the
+ * `Effect.run*` call itself in boundary code (PRD R1).
+ */
+export type AuthProgramEdge = <A, E>(
+  program: Effect.Effect<A, E>,
+) => Promise<Exit.Exit<A, E>>;
+
+let authProgramEdge: AuthProgramEdge | null = null;
+
+/** Install the process-wide run edge for auth programs. */
+export function installAuthProgramEdge(edge: AuthProgramEdge): void {
+  authProgramEdge = edge;
+}
+
+/**
+ * Run one auth program on the installed edge and settle it as a Promise.
  * An expected failure reaches `rethrow`, which re-mints it as the error the
  * caller matches on — by default the port's own error, unwrapped. Defects
  * and interruption propagate as they are.
@@ -112,7 +131,12 @@ export async function runAuthProgram<A, E>(
   program: Effect.Effect<A, E>,
   rethrow: (error: E) => never = rethrowPortCause,
 ): Promise<A> {
-  const exit = await effectRuntime().runPromiseExit(program);
+  if (!authProgramEdge) {
+    throw new Error(
+      'Auth program edge not installed: the host entry installs it beside the process runtime.',
+    );
+  }
+  const exit = await authProgramEdge(program);
   if (Exit.isSuccess(exit)) return exit.value;
   const failure = Cause.findErrorOption(exit.cause);
   if (Option.isSome(failure)) return rethrow(failure.value);

--- a/src/auth/oauth/deviceAuthorization.ts
+++ b/src/auth/oauth/deviceAuthorization.ts
@@ -100,12 +100,12 @@ export const pollDeviceAuthorization = Effect.fn(
 });
 
 /**
- * Persist the approved token as a session through the coordinator's Promise
- * method: the one foreign-boundary wrap over the session coordinators until
- * they are Effect programs themselves. An interruption already pending is
- * honored before the store starts; once it has started, an interruption
- * waits for it, so the persisted session and the caller's view of it never
- * diverge.
+ * Persist the approved token as a session through the coordinator's settled
+ * store: the Supabase coordinator's store program settled by `runAuthProgram`,
+ * or a subscription coordinator's Promise method while that surface settles
+ * its own callers. An interruption already pending is honored before the
+ * store starts; once it has started, an interruption waits for it, so the
+ * persisted session and the caller's view of it never diverge.
  */
 export const completeDeviceSession = Effect.fn(
   'deviceAuthorization.completeDeviceSession',

--- a/src/auth/pkcePermit.ts
+++ b/src/auth/pkcePermit.ts
@@ -1,0 +1,18 @@
+/**
+ * The shared PKCE permit, formerly `SupabaseClient.runPkceOperation`'s
+ * semaphore. Auth-js keeps each verifier in a flow-specific slot, while this
+ * single permit prevents an older callback exchange from racing OAuth
+ * initialization in the same extension host. The host composes its exchange
+ * or sign-in program under the permit and runs it at its own edge, so the
+ * operation's own failure reaches the caller unchanged.
+ */
+import { type Effect, Semaphore } from 'effect';
+
+const pkceOperations = Semaphore.makeUnsafe(1);
+
+/** Run `operation` under the shared PKCE permit. */
+export function withPkcePermit<A, E>(
+  operation: Effect.Effect<A, E>,
+): Effect.Effect<A, E> {
+  return pkceOperations.withPermits(1)(operation);
+}

--- a/src/controllers/session/Database.ts
+++ b/src/controllers/session/Database.ts
@@ -1,6 +1,6 @@
 /**
  * The persistence substrate
- * (`docs/proposals/2026-09-03-persistence-substrate-decision.md`): the C1
+ * (`.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md`): the C1
  * schema, the connection that owns it, and the C6 write path. One database
  * per session root, parameterized by `WorkspaceRoots` (section 7) and never a
  * process singleton; Effect code reads its root from `Context`, never from

--- a/src/test-kernel/architecture/persistenceWriteBoundary.vitest.ts
+++ b/src/test-kernel/architecture/persistenceWriteBoundary.vitest.ts
@@ -15,7 +15,7 @@ import {
 
 /**
  * Architecture ratchet for the persistence cutover
- * (`docs/proposals/2026-09-03-persistence-substrate-decision.md`, stage 1):
+ * (`.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md`, stage 1):
  * the substrate has exactly one writer. The rule is one sentence, and section
  * 9 rules out adding a second mechanism to state it: all app-owned durable
  * state lives in the database, and the database is written in one place.

--- a/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
+++ b/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const providerMocks = vi.hoisted(() => ({
@@ -7,13 +8,15 @@ const providerMocks = vi.hoisted(() => ({
   getUser: vi.fn(),
   invalidateRemoteAgentsAfterSignOut: vi.fn(async () => {}),
   openExternal: vi.fn(async () => true),
-  runPkceOperation: vi.fn((operation: () => Promise<unknown>) => {
-    const result = testDoubles.pkceTail.then(operation);
+  withPkcePermit: vi.fn((operation: unknown) => {
+    const result = testDoubles.pkceTail.then(() =>
+      testDoubles.runEffect(operation),
+    );
     testDoubles.pkceTail = result.then(
       () => undefined,
       () => undefined,
     );
-    return result;
+    return testDoubles.effectFrom(result);
   }),
   secretDelete: vi.fn(async (key: string) => {
     testDoubles.secrets.delete(key);
@@ -32,6 +35,11 @@ const testDoubles = vi.hoisted(() => ({
   emitters: [] as Array<{ fire: ReturnType<typeof vi.fn> }>,
   pkceTail: Promise.resolve<unknown>(undefined),
   secrets: new Map<string, string>(),
+  // Assigned at module scope (after the `effect` import): the `withPkcePermit`
+  // double turns its program into a Promise chained on the shared tail, and
+  // wraps that chain back into an Effect for `runAuthProgram` to settle.
+  runEffect: null as unknown as (operation: unknown) => Promise<unknown>,
+  effectFrom: null as unknown as (promise: Promise<unknown>) => unknown,
 }));
 
 vi.mock('vscode', () => ({
@@ -93,9 +101,12 @@ vi.mock('@auth/SupabaseAuthCoordinator', () => ({
   createHostAuthCoordinator: () => testDoubles.coordinator,
 }));
 
+vi.mock('@auth/pkcePermit', () => ({
+  withPkcePermit: providerMocks.withPkcePermit,
+}));
+
 vi.mock('@auth/SupabaseClient', () => ({
   SupabaseClient: {
-    runPkceOperation: providerMocks.runPkceOperation,
     getClient: () => ({
       auth: {
         getUser: providerMocks.getUser,
@@ -121,6 +132,10 @@ import type { SupabaseUriHandler } from '@frontend/auth/UriHandler';
 const PENDING_STATE_PREFIX = 'texra.extension.pendingOAuthState.';
 const TEST_NONCE = '0123456789abcdef0123456789abcdef';
 const TEST_FLOW_ID = 'abcdef0123456789abcdef0123456789';
+
+testDoubles.runEffect = (operation) =>
+  Effect.runPromise(operation as Effect.Effect<unknown, unknown>);
+testDoubles.effectFrom = (promise) => Effect.promise(() => promise);
 
 function seedPendingOAuthAttempt(
   nonce = TEST_NONCE,
@@ -152,9 +167,9 @@ function createProvider(options: {
   showError: ReturnType<typeof vi.fn>;
   showSignInPrompt: ReturnType<typeof vi.fn>;
 } {
-  const clearSessionIfCurrent = vi.fn(async () => true);
-  const getStoredSessionState = vi.fn<() => Promise<StoredSessionState>>(
-    async () => 'invalid',
+  const clearSessionIfCurrent = vi.fn(() => Effect.succeed(true));
+  const getStoredSessionState = vi.fn(() =>
+    Effect.succeed<StoredSessionState>('invalid'),
   );
   const showError = vi.fn();
   const showSignInPrompt = vi.fn();
@@ -166,10 +181,10 @@ function createProvider(options: {
     expiresAt: options.expiresAt,
   };
   const coordinator = {
-    loadSession: vi.fn(async () => session),
-    refreshSession: vi.fn(async () => null),
-    storeSession: vi.fn(async () => {}),
-    clearSession: vi.fn(async () => {}),
+    loadSession: vi.fn(() => Effect.succeed(session)),
+    refreshSession: vi.fn(() => Effect.succeed(null)),
+    storeSession: vi.fn(() => Effect.void),
+    clearSession: vi.fn(() => Effect.void),
     getStoredSessionState,
     getLastRefreshFailure: vi.fn(() => options.failure ?? null),
     clearSessionIfCurrent,
@@ -305,7 +320,7 @@ describe('SupabaseAuthProvider expired-session refresh', () => {
     });
     const { provider, clearSessionIfCurrent, showSignInPrompt } =
       createUnexpiredProvider();
-    clearSessionIfCurrent.mockResolvedValueOnce(false);
+    clearSessionIfCurrent.mockReturnValueOnce(Effect.succeed(false));
 
     await expect(provider.getSessions()).resolves.toEqual([]);
 
@@ -317,7 +332,7 @@ describe('SupabaseAuthProvider expired-session refresh', () => {
   it('does not clear a session that revalidates as authenticated', async () => {
     const { provider, clearSessionIfCurrent, getStoredSessionState } =
       createUnexpiredProvider();
-    getStoredSessionState.mockResolvedValueOnce('authenticated');
+    getStoredSessionState.mockReturnValueOnce(Effect.succeed('authenticated'));
 
     await expect(provider.clearStoredSession()).resolves.toBe(false);
 
@@ -347,7 +362,7 @@ describe('SupabaseAuthProvider model availability', () => {
     const { provider, coordinator } = createUnexpiredProvider();
     const uriHandler = createUriHandlerHarness();
     provider.setUriHandler(uriHandler.handler);
-    coordinator.loadSession.mockResolvedValue(null);
+    coordinator.loadSession.mockReturnValue(Effect.succeed(null));
     let redirectTo = '';
     providerMocks.signInWithOAuth.mockImplementation(async (input) => {
       redirectTo = input.options.redirectTo;
@@ -389,10 +404,12 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     const { provider, session, coordinator } = createUnexpiredProvider();
     const uriHandler = createUriHandlerHarness();
     provider.setUriHandler(uriHandler.handler);
-    coordinator.createSessionFromCallback.mockResolvedValue({
-      success: true,
-      session,
-    });
+    coordinator.createSessionFromCallback.mockReturnValue(
+      Effect.succeed({
+        success: true,
+        session,
+      }),
+    );
     providerMocks.getUser.mockResolvedValue({
       data: { user: { id: session.id } },
       error: null,
@@ -453,10 +470,12 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     const { provider, session, coordinator } = createUnexpiredProvider();
     const uriHandler = createUriHandlerHarness();
     provider.setUriHandler(uriHandler.handler);
-    coordinator.createSessionFromCallback.mockResolvedValue({
-      success: true,
-      session,
-    });
+    coordinator.createSessionFromCallback.mockReturnValue(
+      Effect.succeed({
+        success: true,
+        session,
+      }),
+    );
     providerMocks.getUser.mockResolvedValue({
       data: { user: { id: session.id } },
       error: null,
@@ -498,11 +517,13 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     const secondHandler = createUriHandlerHarness();
     first.provider.setUriHandler(firstHandler.handler);
     second.provider.setUriHandler(secondHandler.handler);
-    second.coordinator.loadSession.mockResolvedValue(null);
-    second.coordinator.createSessionFromCallback.mockResolvedValue({
-      success: true,
-      session: second.session,
-    });
+    second.coordinator.loadSession.mockReturnValue(Effect.succeed(null));
+    second.coordinator.createSessionFromCallback.mockReturnValue(
+      Effect.succeed({
+        success: true,
+        session: second.session,
+      }),
+    );
 
     const redirects: string[] = [];
     providerMocks.signInWithOAuth.mockImplementation(async (input) => {
@@ -559,7 +580,7 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     const first = createUnexpiredProvider();
     const firstHandler = createUriHandlerHarness();
     first.provider.setUriHandler(firstHandler.handler);
-    first.coordinator.loadSession.mockResolvedValue(null);
+    first.coordinator.loadSession.mockReturnValue(Effect.succeed(null));
 
     let exchangeStarted!: () => void;
     const started = new Promise<void>((resolve) => {
@@ -569,11 +590,13 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     const exchangeGate = new Promise<void>((resolve) => {
       finishExchange = resolve;
     });
-    first.coordinator.createSessionFromCallback.mockImplementation(async () => {
-      exchangeStarted();
-      await exchangeGate;
-      throw new Error('first exchange failed');
-    });
+    first.coordinator.createSessionFromCallback.mockImplementation(() =>
+      Effect.promise(async () => {
+        exchangeStarted();
+        await exchangeGate;
+        throw new Error('first exchange failed');
+      }),
+    );
 
     const firstCallback = firstHandler.fire({
       path: '/auth-callback',
@@ -584,10 +607,12 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     const second = createUnexpiredProvider();
     const secondHandler = createUriHandlerHarness();
     second.provider.setUriHandler(secondHandler.handler);
-    second.coordinator.createSessionFromCallback.mockResolvedValue({
-      success: true,
-      session: second.session,
-    });
+    second.coordinator.createSessionFromCallback.mockReturnValue(
+      Effect.succeed({
+        success: true,
+        session: second.session,
+      }),
+    );
     providerMocks.getUser.mockResolvedValue({
       data: { user: { id: second.session.id } },
       error: null,
@@ -615,7 +640,7 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
 
     const secondSignIn = second.provider.createSession([]);
     await vi.waitFor(() =>
-      expect(providerMocks.runPkceOperation).toHaveBeenCalledTimes(2),
+      expect(providerMocks.withPkcePermit).toHaveBeenCalledTimes(2),
     );
     expect(providerMocks.signInWithOAuth).not.toHaveBeenCalled();
 
@@ -645,10 +670,12 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     const { provider, session, coordinator } = createUnexpiredProvider();
     const uriHandler = createUriHandlerHarness();
     provider.setUriHandler(uriHandler.handler);
-    coordinator.createSessionFromCallback.mockResolvedValue({
-      success: true,
-      session,
-    });
+    coordinator.createSessionFromCallback.mockReturnValue(
+      Effect.succeed({
+        success: true,
+        session,
+      }),
+    );
     providerMocks.getUser.mockResolvedValue({
       data: { user: { id: session.id } },
       error: null,
@@ -709,11 +736,13 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     const { provider, session, coordinator } = createUnexpiredProvider();
     const uriHandler = createUriHandlerHarness();
     provider.setUriHandler(uriHandler.handler);
-    coordinator.loadSession.mockResolvedValue(null);
-    coordinator.createSessionFromCallback.mockResolvedValue({
-      success: true,
-      session,
-    });
+    coordinator.loadSession.mockReturnValue(Effect.succeed(null));
+    coordinator.createSessionFromCallback.mockReturnValue(
+      Effect.succeed({
+        success: true,
+        session,
+      }),
+    );
     providerMocks.signInWithOAuth.mockResolvedValue({
       data: {
         url: 'https://provider.example/authorize',
@@ -763,11 +792,13 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
         createUnexpiredProvider();
       const uriHandler = createUriHandlerHarness();
       provider.setUriHandler(uriHandler.handler);
-      coordinator.loadSession.mockResolvedValue(null);
-      coordinator.createSessionFromCallback.mockResolvedValue({
-        success: true,
-        session,
-      });
+      coordinator.loadSession.mockReturnValue(Effect.succeed(null));
+      coordinator.createSessionFromCallback.mockReturnValue(
+        Effect.succeed({
+          success: true,
+          session,
+        }),
+      );
       const failure = new Error('secret backend unavailable: private detail');
       if (operation === 'read') {
         providerMocks.secretGetStored.mockRejectedValueOnce(failure);
@@ -852,11 +883,13 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     const { provider, coordinator } = createUnexpiredProvider();
     const uriHandler = createUriHandlerHarness();
     provider.setUriHandler(uriHandler.handler);
-    coordinator.createSessionFromCallback.mockResolvedValue({
-      success: false,
-      error: 'exchange failed',
-      isAuthError: true,
-    });
+    coordinator.createSessionFromCallback.mockReturnValue(
+      Effect.succeed({
+        success: false,
+        error: 'exchange failed',
+        isAuthError: true,
+      }),
+    );
     providerMocks.signInWithOAuth.mockResolvedValue({
       data: {
         url: 'https://provider.example/authorize',
@@ -897,11 +930,13 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     const { provider, session, coordinator } = createUnexpiredProvider();
     const uriHandler = createUriHandlerHarness();
     provider.setUriHandler(uriHandler.handler);
-    coordinator.loadSession.mockResolvedValue(null);
-    coordinator.createSessionFromCallback.mockResolvedValue({
-      success: true,
-      session,
-    });
+    coordinator.loadSession.mockReturnValue(Effect.succeed(null));
+    coordinator.createSessionFromCallback.mockReturnValue(
+      Effect.succeed({
+        success: true,
+        session,
+      }),
+    );
 
     for (const query of [
       'code=test',

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -1,8 +1,10 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
+import { Effect } from 'effect';
 import { describe, it, afterEach, expect, vi } from 'vitest';
 
 // Local imports - auth
+import { AuthPortError } from '@auth/authProgram';
 import { SUPABASE_GOTRUE_STORAGE_KEY } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { AuthTokenProvider } from '@auth/TokenProvider';
@@ -22,10 +24,10 @@ function createTokenProvider(
   overrides: Partial<AuthTokenProvider> = {},
 ): AuthTokenProvider {
   return {
-    whenReady: async () => {},
-    ensureFreshToken: async () => 'access-token',
-    getStoredSessionState: async () => 'none',
-    getStoredAccountLabel: async () => null,
+    whenReady: () => Effect.void,
+    ensureFreshToken: () => Effect.succeed('access-token'),
+    getStoredSessionState: () => Effect.succeed('none'),
+    getStoredAccountLabel: () => Effect.succeed(null),
     getLastRefreshFailure: () => null,
     ...overrides,
   };
@@ -40,7 +42,7 @@ describe('SupabaseClient', () => {
   it('waits for token provider readiness', async () => {
     const readiness = createDeferred();
     const provider = createTokenProvider({
-      whenReady: () => readiness.promise,
+      whenReady: () => Effect.promise(() => readiness.promise),
     });
 
     initializeSupabase(new FakeSecrets());
@@ -62,9 +64,10 @@ describe('SupabaseClient', () => {
 
   it('reports not ready when token provider readiness fails', async () => {
     const provider = createTokenProvider({
-      whenReady: async () => {
-        throw new Error('host auth unavailable');
-      },
+      whenReady: () =>
+        Effect.fail(
+          new AuthPortError({ cause: new Error('host auth unavailable') }),
+        ),
     });
 
     initializeSupabase(new FakeSecrets());
@@ -80,9 +83,12 @@ describe('SupabaseClient', () => {
   it('warns and reports no label when the stored label read throws', async () => {
     SupabaseClient.setAuthProvider(
       createTokenProvider({
-        getStoredAccountLabel: async () => {
-          throw new Error('secret storage unavailable');
-        },
+        getStoredAccountLabel: () =>
+          Effect.fail(
+            new AuthPortError({
+              cause: new Error('secret storage unavailable'),
+            }),
+          ),
       }),
     );
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});

--- a/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
+++ b/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
@@ -5,6 +5,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
 // Local imports - auth
+import { runAuthProgram } from '@auth/authProgram';
 import {
   DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
   parseStoredSupabaseSession,
@@ -316,10 +317,10 @@ describe('SupabaseSession', () => {
       const { coordinator, read, getReadCount } = createCoordinator();
       const session = makeSession();
 
-      await coordinator.storeSession(session);
+      await runAuthProgram(coordinator.storeSession(session));
 
       assert.deepEqual(read(), session);
-      assert.deepEqual(await coordinator.getSessionTokens(), {
+      assert.deepEqual(await runAuthProgram(coordinator.getSessionTokens()), {
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
       });
@@ -332,7 +333,10 @@ describe('SupabaseSession', () => {
         initialSession,
       });
 
-      assert.equal(await coordinator.ensureFreshToken(), 'access-token');
+      assert.equal(
+        await runAuthProgram(coordinator.ensureFreshToken()),
+        'access-token',
+      );
       assert.equal(getReadCount(), 1);
     });
 
@@ -354,10 +358,12 @@ describe('SupabaseSession', () => {
       } as unknown as Client;
       const { coordinator } = createCoordinator({ client });
 
-      const result = await coordinator.createSessionFromCallback({
-        path: '/auth-callback',
-        query: 'code=pkce-code',
-      });
+      const result = await runAuthProgram(
+        coordinator.createSessionFromCallback({
+          path: '/auth-callback',
+          query: 'code=pkce-code',
+        }),
+      );
 
       assert.equal(result.success, true);
       if (!result.success) return;
@@ -381,10 +387,12 @@ describe('SupabaseSession', () => {
       } as unknown as Client;
       const { coordinator } = createCoordinator({ client });
 
-      const result = await coordinator.createSessionFromCallback({
-        path: '/auth-callback',
-        query: 'code=bad-code',
-      });
+      const result = await runAuthProgram(
+        coordinator.createSessionFromCallback({
+          path: '/auth-callback',
+          query: 'code=bad-code',
+        }),
+      );
 
       assert.equal(result.success, false);
       if (result.success) return;
@@ -407,10 +415,12 @@ describe('SupabaseSession', () => {
       } as unknown as Client;
       const { coordinator } = createCoordinator({ client });
 
-      const result = await coordinator.createSessionFromCallback({
-        path: '/auth-callback',
-        query: 'code=stale-code',
-      });
+      const result = await runAuthProgram(
+        coordinator.createSessionFromCallback({
+          path: '/auth-callback',
+          query: 'code=stale-code',
+        }),
+      );
 
       assert.equal(result.success, false);
       if (result.success) return;
@@ -422,13 +432,15 @@ describe('SupabaseSession', () => {
     it('rejects retired implicit-token callbacks', async () => {
       const { coordinator } = createCoordinator();
 
-      const result = await coordinator.createSessionFromCallback({
-        path: '/auth-callback',
-        query: new URLSearchParams({
-          access_token: 'access-token',
-          refresh_token: 'refresh-token',
-        }).toString(),
-      });
+      const result = await runAuthProgram(
+        coordinator.createSessionFromCallback({
+          path: '/auth-callback',
+          query: new URLSearchParams({
+            access_token: 'access-token',
+            refresh_token: 'refresh-token',
+          }).toString(),
+        }),
+      );
 
       assert.deepEqual(result, {
         success: false,
@@ -440,7 +452,7 @@ describe('SupabaseSession', () => {
       const { coordinator, getReadCount } = createCoordinator({
         initialSession: expiredSession(),
       });
-      assert.deepEqual(await coordinator.getSessionTokens(), {
+      assert.deepEqual(await runAuthProgram(coordinator.getSessionTokens()), {
         accessToken: 'refreshed-access',
         refreshToken: 'refreshed-refresh',
       });
@@ -450,10 +462,10 @@ describe('SupabaseSession', () => {
     it('does not return tokens cleared while loading the session', async () => {
       const { coordinator, getReadCount } = createClearingStorageCoordinator({
         initialSession: makeSession(),
-        onFirstRead: (c) => c.clearSession(),
+        onFirstRead: (c) => runAuthProgram(c.clearSession()),
       });
 
-      assert.equal(await coordinator.getSessionTokens(), null);
+      assert.equal(await runAuthProgram(coordinator.getSessionTokens()), null);
       assert.equal(getReadCount(), 2);
     });
 
@@ -463,7 +475,7 @@ describe('SupabaseSession', () => {
       const { coordinator, getReadCount } = createClearingStorageCoordinator({
         initialSession: makeSession(),
         onFirstRead: (c) => {
-          void c.clearSession();
+          void runAuthProgram(c.clearSession());
         },
         onDelete: async () => {
           deleteStarted.resolve();
@@ -471,7 +483,7 @@ describe('SupabaseSession', () => {
         },
       });
 
-      const tokensPromise = coordinator.getSessionTokens();
+      const tokensPromise = runAuthProgram(coordinator.getSessionTokens());
       await deleteStarted.promise;
       allowDelete.resolve();
 
@@ -504,9 +516,9 @@ describe('SupabaseSession', () => {
         client,
       });
 
-      const tokenPromise = coordinator.ensureFreshToken();
+      const tokenPromise = runAuthProgram(coordinator.ensureFreshToken());
       await refreshStarted.promise;
-      await coordinator.clearSession();
+      await runAuthProgram(coordinator.clearSession());
       allowRefresh.resolve();
 
       assert.equal(await tokenPromise, null);
@@ -534,10 +546,10 @@ describe('SupabaseSession', () => {
         getClient: () => createClient(),
       });
 
-      const tokenPromise = coordinator.ensureFreshToken();
+      const tokenPromise = runAuthProgram(coordinator.ensureFreshToken());
       await storeStarted.promise;
       // The refresh's store is blocked mid-write; the clear queues behind it.
-      const clearPromise = coordinator.clearSession();
+      const clearPromise = runAuthProgram(coordinator.clearSession());
       await delay(0);
       allowStore.resolve();
 
@@ -561,10 +573,10 @@ describe('SupabaseSession', () => {
         client,
       });
 
-      const statePromise = coordinator.getStoredSessionState();
+      const statePromise = runAuthProgram(coordinator.getStoredSessionState());
       await refreshStarted.promise;
       const replacement = replacementSession();
-      await coordinator.storeSession(replacement);
+      await runAuthProgram(coordinator.storeSession(replacement));
       allowRefreshFailure.resolve();
 
       assert.equal(await statePromise, 'authenticated');
@@ -579,14 +591,17 @@ describe('SupabaseSession', () => {
       const { coordinator, read } = createCoordinator({ initialSession });
       const replacement = replacementSession();
 
-      await coordinator.storeSession(replacement);
+      await runAuthProgram(coordinator.storeSession(replacement));
 
       assert.equal(
-        await coordinator.clearSessionIfCurrent(initialSession),
+        await runAuthProgram(coordinator.clearSessionIfCurrent(initialSession)),
         false,
       );
       assert.deepEqual(read(), replacement);
-      assert.equal(await coordinator.clearSessionIfCurrent(replacement), true);
+      assert.equal(
+        await runAuthProgram(coordinator.clearSessionIfCurrent(replacement)),
+        true,
+      );
       assert.equal(read(), null);
     });
 
@@ -595,13 +610,13 @@ describe('SupabaseSession', () => {
         status: 401,
         failure: 'invalid',
         request: (coordinator: SupabaseSessionCoordinator) =>
-          coordinator.getSessionTokens(),
+          runAuthProgram(coordinator.getSessionTokens()),
       },
       {
         status: 503,
         failure: 'transient',
         request: (coordinator: SupabaseSessionCoordinator) =>
-          coordinator.ensureFreshToken(),
+          runAuthProgram(coordinator.ensureFreshToken()),
       },
     ])(
       'classifies refresh HTTP $status as $failure and returns no token',

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 const mocks = vi.hoisted(() => {
   const authCoordinator = {
     clearSession: vi.fn(),
-    storeSession: vi.fn(async () => undefined),
+    storeSession: vi.fn(),
   };
   return {
     authCoordinator,
@@ -71,6 +71,13 @@ vi.mock('@cli/runtime/supabaseAuthDeviceCode', () => ({
 
 async function loadSupabaseAuth() {
   vi.resetModules();
+  // `vi.resetModules()` gives the module graph a fresh `@platform/processRuntime`
+  // whose runtime the shared fake-host install never reached; the module's own
+  // `initializeCliSupabaseAuth` installs the auth run edge from it.
+  const [{ initProcessRuntime }, { Layer, ManagedRuntime }] = await Promise.all(
+    [import('@platform/processRuntime'), import('effect')],
+  );
+  initProcessRuntime(ManagedRuntime.make(Layer.empty));
   return import('@cli/runtime/supabaseAuth');
 }
 
@@ -122,6 +129,8 @@ function stubSuccessfulSignIns(session: {
 describe('CLI Supabase auth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.authCoordinator.clearSession.mockReturnValue(Effect.void);
+    mocks.authCoordinator.storeSession.mockReturnValue(Effect.void);
     mocks.platform.mockReturnValue({ secrets: { kind: 'platform-secrets' } });
     mocks.invalidateRemoteAgentsAfterSignOut.mockResolvedValue(undefined);
   });

--- a/src/test-kernel/cli/SupabaseAuthCallbackServer.vitest.ts
+++ b/src/test-kernel/cli/SupabaseAuthCallbackServer.vitest.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
 
 import { type SupabaseSessionCoordinator } from '@auth/SupabaseSession';
 import {
@@ -14,7 +15,7 @@ function stubCoordinator(
 ): SupabaseSessionCoordinator {
   return {
     createSessionFromCallback: vi.fn(),
-    storeSession: vi.fn(),
+    storeSession: vi.fn(() => Effect.void),
     ...overrides,
   } as unknown as SupabaseSessionCoordinator;
 }
@@ -63,11 +64,13 @@ describe('CLI Supabase authentication callback server', () => {
 
   it('does not store a callback that finishes after cancellation', async () => {
     let finishCallback!: (result: unknown) => void;
-    const createSessionFromCallback = vi.fn(
-      () =>
-        new Promise((resolve) => {
-          finishCallback = resolve;
-        }),
+    const createSessionFromCallback = vi.fn(() =>
+      Effect.promise(
+        () =>
+          new Promise((resolve) => {
+            finishCallback = resolve;
+          }),
+      ),
     );
     const storeSession = vi.fn();
     const coordinator = stubCoordinator({
@@ -101,16 +104,18 @@ describe('CLI Supabase authentication callback server', () => {
   it('finishes a callback whose storage commit began before cancellation', async () => {
     let finishStorage!: () => void;
     const session = { account: { label: 'person@example.edu' } };
-    const storeSession = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          finishStorage = resolve;
-        }),
+    const storeSession = vi.fn(() =>
+      Effect.promise(
+        () =>
+          new Promise<void>((resolve) => {
+            finishStorage = resolve;
+          }),
+      ),
     );
     const coordinator = stubCoordinator({
       createSessionFromCallback: vi
         .fn()
-        .mockResolvedValue({ success: true, session }),
+        .mockReturnValue(Effect.succeed({ success: true, session })),
       storeSession,
     });
     const server = await startLoopbackCallbackServer(coordinator);

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
 
 import * as agentRegistry from '@agent/index/agentRegistry';
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -189,18 +190,20 @@ function routeMatchingCallback(
 }
 
 function installAuthenticatedSupabaseProvider() {
-  const ensureFreshToken = vi.fn(async () => 'fresh-access-token');
-  const getStoredSessionState = vi.fn(async () => 'authenticated' as const);
+  const ensureFreshToken = vi.fn(() => Effect.succeed('fresh-access-token'));
+  const getStoredSessionState = vi.fn(() =>
+    Effect.succeed('authenticated' as const),
+  );
   SupabaseClient.initialize(
     'https://example.supabase.co',
     'public-key',
     new FakeSecrets(),
   );
   SupabaseClient.setAuthProvider({
-    whenReady: vi.fn(async () => {}),
+    whenReady: vi.fn(() => Effect.void),
     ensureFreshToken,
     getStoredSessionState,
-    getStoredAccountLabel: vi.fn(async () => null),
+    getStoredAccountLabel: vi.fn(() => Effect.succeed(null)),
     getLastRefreshFailure: vi.fn(() => null),
   });
   vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue({

--- a/src/test-kernel/support/setupPlatform.ts
+++ b/src/test-kernel/support/setupPlatform.ts
@@ -57,11 +57,13 @@ export async function installFakeHost(host: FakeHost): Promise<void> {
     { initPlatform },
     { initProcessWorkspaceRoots },
     { effectRuntime, initProcessRuntime },
+    { installAuthProgramEdge },
     { Layer, ManagedRuntime },
   ] = await Promise.all([
     import('@platform/platform'),
     import('@platform/workspaceRoots'),
     import('@platform/processRuntime'),
+    import('@auth/authProgram'),
     import('effect'),
   ]);
   initPlatform(host.platform);
@@ -77,6 +79,9 @@ export async function installFakeHost(host: FakeHost): Promise<void> {
   } catch {
     initProcessRuntime(ManagedRuntime.make(Layer.empty));
   }
+  // The auth run edge, unconditionally: a suite that reset modules gets a
+  // fresh `@auth/authProgram` instance, and this install must land on it.
+  installAuthProgramEdge((program) => effectRuntime().runPromiseExit(program));
 }
 
 /** Installs a fake host built from `options`/`overrides` right now. */


### PR DESCRIPTION
## Summary

`main` fails `npm run check:effect-migration-ratchet` on four grown counts plus one `@adapter-until` marker, so every open PR fails `static checks` through no fault of its own. Neither in-flight lane PR can land alone: #11981 still leaves the two desktop catch rows, #11982 still leaves the three auth rows. This PR is those two conversions on current `origin/main`, plus the knip baseline for the intentional stage-1 `Database.ts` file that has been failing the same job since #11972.

Effect rows cleared:

- `[Effect.run*] src/auth/authProgram.ts: 0 -> 1` — `AuthTokenProvider` and `SupabaseSessionCoordinator` become Effect-typed; the only `runPromiseExit` moves to the host entries via `installAuthProgramEdge` (extension `SupabaseAuthProvider`, desktop `createDesktopAuthCoordinator`, CLI `initializeCliSupabaseAuth`, test `installFakeHost`). `runAuthProgram` no longer runs anything itself, so the file leaves the below-boundary row and `debtLanes`.
- `[catch:effect-importer] src/auth/SupabaseClient.ts: 0 -> 5` and `src/auth/SupabaseClient.ts:168: @adapter-until` — `runPkceOperation` is retired (R10); the extension host composes exchange/sign-in under `withPkcePermit`. `SupabaseClient` drops its runtime `effect` import, so its remaining Promise-facade catches leave the R7 row. The marker is gone.
- `[catch:effect-importer] packages/desktop/src/main/desktopPapers.ts: 0 -> 4` — all four raw catches converted (`Effect.try` / `Effect.tryPromise` + `Effect.catch` / `Effect.onError`), file back to 0.
- `[catch:effect-importer] packages/desktop/src/main/index.ts: 15 -> 16` — three sites converted (setup kickoff, window-closed disposal, paper reopen); file now 13, baseline locked.

`SupabaseClient`'s query methods stay Promise-typed for consumers owned by other lanes (wave-1 controllers/telemetry, agent-index-remote, Phase 5 tools). `SubscriptionOAuthCoordinator` is unchanged. Remaining 13 baselined catches in `index.ts` shrink in later lanes.

## Issue acceptance gates

- #11962: the SupabaseClient `@adapter-until` marker is gone; `authProgram.ts` is no longer a below-boundary `Effect.run*` site.
- #11949: the remaining four grown counts on current `main` (the leftover of the original 52) are converted, not allowlisted. `--update` was run; `authProgram.ts` is dropped from `debtLanes`.
- `node scripts/check-effect-migration-ratchet.mjs` exits 0; `@adapter-until` reports none present.
- `npm run check:dead-code-ratchet` exits 0 (`Database.ts` is the intentional stage-1 substrate file, now baselined).

## Single source of truth

`SupabaseSessionCoordinator` owns session storage/freshness/refresh as Effect programs; `AuthTokenProvider` is the Effect-typed port; `src/auth/authProgram.ts` owns the typed port failure and the settle-fold every Promise-facing auth surface shares; the host entry owns the run edge. `DesktopPaperRegistry` still owns open papers and their sessions.

## Duplication and abstraction budget

Removed: the per-method `runAuthProgram` wrappers in `SupabaseSessionCoordinator` (10), `SupabaseClient.runPkceOperation` and its semaphore field. `withPkcePermit` is the relocated semaphore; `installAuthProgramEdge` mirrors `initProcessRuntime`. Desktop sites convert in place with the same combinators #11977 established. No adapters, no new `@adapter-until` markers.

## Net elements (R6)

- Files: 23 changed, +1 (`src/auth/pkcePermit.ts`).
- Exported symbols: +3 / −0 (`withPkcePermit`, `AuthProgramEdge`, `installAuthProgramEdge`). `runPkceOperation` was a static class method.
- Classes/interfaces/enums: 0 added, 0 deleted — `AuthTokenProvider` retyped in place (Promise → Effect).
- Net LoC: +640 / −418.

## Consumer counts (R8)

- `SupabaseClient.runPkceOperation`: 3 production consumers (all in `SupabaseAuthProvider.ts`) + 1 test double; all converted to `withPkcePermit`; 0 references remain.
- `runAuthProgram(` call sites moved to host edges (extension, desktop, CLI) and the remaining Promise facades; the `Effect.run*` itself is only at those host installs.
- `AuthTokenProvider` implementors: 1 production (`SupabaseSessionCoordinator`), 3 test doubles — all updated.
- `installAuthProgramEdge` installers: 3 host entries + the shared test-harness install.
- Desktop paper/index conversions: no export deleted; signatures unchanged.

## Host impact

Extension: `SupabaseAuthProvider` installs the run edge at construction and settles coordinator programs at its method edges; PKCE serialization is the same semaphore, now `withPkcePermit`.

Desktop: `createDesktopAuthCoordinator` installs the run edge and renders the existing Promise interface over the Effect-typed coordinator. Paper open/close/flush, setup kickoff, window disposal, and paper reopen recover through typed Effect on the process runtime; same messages and ordering.

CLI: `initializeCliSupabaseAuth` installs the run edge at platform init; sign-in/sign-out/profile flows settle through `runAuthProgram`.

## Scheduled refactoring

As wave-1 (controllers/telemetry), agent-index-remote, and Phase-5 tools convert their callers, `SupabaseClient`'s Promise facade methods delete one by one. `runAuthProgram` and the installed edge delete with the last Promise facade. Remaining 13 baselined catches in `desktop/src/main/index.ts` shrink in later lanes.

Supersedes #11981 and #11982 (their commits are cherry-picked here so one PR can pass `static checks`).

## Validation

- `npx prettier --check` on all changed files: pass.
- `npm run typecheck` (all six projects): pass.
- `npm run lint`: pass.
- `node scripts/check-effect-migration-ratchet.mjs`: pass (no growth, no stale headroom, no `@adapter-until` markers).
- `npm run check:dead-code-ratchet`: pass.
- Targeted vitest (`src/test-kernel/auth`, CLI supabase, `src/test-kernel/desktop`, architecture `dependencyDirection` / `approvalPolicyAuthorityRatchet` / `persistenceWriteBoundary`): 613 passed; one `DesktopPreviewHost` openFile timeout while lint was also running, passed in isolation (19/19).

Fixes #11962
Fixes #11949