### PR TITLE
refactor(goal): make the goal-change subscription an Effect stream

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -177,7 +177,6 @@
       "src/telemetry/UsageLogService.ts": 5,
       "src/tools/agentCliSessionRegistry.ts": 2,
       "src/tools/github/PollingSourceBase.ts": 1,
-      "src/tools/goal/goalStore.ts": 2,
       "src/tools/lean/direct/directLspAdapter.ts": 3
     },
     "catch:effect-importer": {
@@ -225,7 +224,6 @@
     "src/telemetry/UsageLogService.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/tools/agentCliSessionRegistry.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/github/PollingSourceBase.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
-    "src/tools/goal/goalStore.ts": "Phase 5 — tools subsystem",
     "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — the port is Effect-typed and the tool-facing runs moved to the tools' execute(); what remains is pool construction/disposal (the platform-lifetime seam) and the run-end hook's Promise seam, both owned by lane D"
   }
 }

--- a/packages/desktop/src/main/desktopGoalSubscription.ts
+++ b/packages/desktop/src/main/desktopGoalSubscription.ts
@@ -1,0 +1,26 @@
+/**
+ * The desktop host's run edge for goal-change subscriptions (PRD R1: the
+ * fork lives at the host entry, not in the store). Mirrors the extension's
+ * `runFactSubscriptions`: one fiber draining the session's goal stream, an
+ * unsubscribe that interrupts it, and no other runtime contact.
+ */
+import { Effect, Fiber, Stream } from 'effect';
+
+import type { SessionHandle } from '@agent/runtime';
+import { effectRuntime } from '@platform/processRuntime';
+import { goalStateChanges, type GoalStateChange } from '@tools/goal';
+
+/** Read a session's goal-state changes from now on. */
+export function subscribeDesktopGoalChanges(
+  session: Pick<SessionHandle, 'events' | 'now'>,
+  listener: (change: GoalStateChange) => void,
+): () => void {
+  const fiber = effectRuntime().runFork(
+    Stream.runForEach(goalStateChanges(session), (change) =>
+      Effect.sync(() => listener(change)),
+    ),
+  );
+  return () => {
+    effectRuntime().runFork(Fiber.interrupt(fiber));
+  };
+}

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -29,7 +29,7 @@ import { unsupported, unsupportedCommands } from '@shared/utils/dispatcher';
 import { buildSettingsSnapshotMessage } from '@shared/settingsView/handlers/settingsSnapshot';
 import type { SettingsStores } from '@shared/config/settingsAccess';
 import { loadRuntimeSkillDisplay } from '@skills/runtimeSkills';
-import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
+import { GoalStore } from '@tools/goal';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import {
   GITHUB_TOKEN_CREATE_URL,
@@ -46,6 +46,7 @@ import {
   type DesktopCommandMessage,
   type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
+import { subscribeDesktopGoalChanges } from './desktopGoalSubscription.js';
 import type { DesktopAgentSettingsController } from './desktopAgentSettingsController.js';
 import type { DesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import type { DesktopToolingSettingsController } from './desktopToolingSettingsController.js';
@@ -303,7 +304,9 @@ export function createDesktopSettingsIpc(
   // needs the push. The session outlives the window, so the subscription is
   // window-scoped and released in `dispose` below.
   const subscriptions = [
-    subscribeGoalStateChanges(options.session, () => runAsync(postGoalList())),
+    subscribeDesktopGoalChanges(options.session, () =>
+      runAsync(postGoalList()),
+    ),
   ];
 
   // ── GitHub token + PR/repo/issue subscriptions (Git tab) ──

--- a/packages/extension/src/frontend/events/runFactSubscriptions.ts
+++ b/packages/extension/src/frontend/events/runFactSubscriptions.ts
@@ -4,6 +4,7 @@ import { Effect, Fiber, Stream } from 'effect';
 import type { SessionHandle } from '@agent/runtime';
 import { effectRuntime } from '@platform/processRuntime';
 import { aggregateTarget, type AddOutputFilesPayload } from '@shared/schemas';
+import { goalStateChanges, type GoalStateChange } from '@tools/goal';
 
 /** Read a session's `addOutputFiles` facts from now on. */
 export function subscribeAddOutputFilesRunFact(
@@ -19,6 +20,21 @@ export function subscribeAddOutputFilesRunFact(
           filesByRound: event.filesByRound,
         });
       }),
+    ),
+  );
+  return () => {
+    effectRuntime().runFork(Fiber.interrupt(fiber));
+  };
+}
+
+/** Read a session's goal-state changes from now on. */
+export function subscribeGoalStateChanges(
+  session: Pick<SessionHandle, 'events' | 'now'>,
+  listener: (change: GoalStateChange) => void,
+): () => void {
+  const fiber = effectRuntime().runFork(
+    Stream.runForEach(goalStateChanges(session), (change) =>
+      Effect.sync(() => listener(change)),
     ),
   );
   return () => {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -38,6 +38,7 @@ import {
   showLoggedErrorMessage,
   showLoggedInfoMessage,
 } from '@frontend/ui/errorHandlingUtils';
+import { subscribeGoalStateChanges } from '@frontend/events/runFactSubscriptions';
 import {
   invalidateApiKeyCache,
   loadApiKeyStatusMap,
@@ -84,7 +85,7 @@ import {
   getLastCheckResults,
   refreshToolAvailability,
 } from '@tools/toolAvailability';
-import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
+import { GoalStore } from '@tools/goal';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { getConfig } from '@utils/config/configUtils';
 import { getProviderKeyUrl } from '@utils/config/providerConfig';

--- a/src/test-kernel/tools/goal/goalStore.vitest.ts
+++ b/src/test-kernel/tools/goal/goalStore.vitest.ts
@@ -1,5 +1,6 @@
 import '@test/support/defaultSessionTestSetup';
 
+import { Effect, Fiber, Stream } from 'effect';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
@@ -8,6 +9,7 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import type { StateStore } from '@platform/interfaces';
+import { effectRuntime } from '@platform/processRuntime';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import {
   aggregateId as qualifyAggregateId,
@@ -18,7 +20,7 @@ import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { settleSessionEvents } from '@test/agent/progressTestUtils';
-import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
+import { GoalStore, goalStateChanges } from '@tools/goal';
 
 const STREAM_A = 'stream:forget-a' as StreamTabId;
 const STREAM_B = 'stream:forget-b' as StreamTabId;
@@ -100,15 +102,21 @@ function collectGoalChanges(session: SessionHandle): {
   detach: () => void;
 } {
   const seen: unknown[] = [];
-  const detach = subscribeGoalStateChanges(session, (change) => {
-    seen.push(change);
-  });
+  const fiber = effectRuntime().runFork(
+    Stream.runForEach(goalStateChanges(session), (change) =>
+      Effect.sync(() => {
+        seen.push(change);
+      }),
+    ),
+  );
   return {
     seen,
     clear: () => {
       seen.length = 0;
     },
-    detach,
+    detach: () => {
+      effectRuntime().runFork(Fiber.interrupt(fiber));
+    },
   };
 }
 
@@ -266,7 +274,7 @@ describe('GoalStore.forget (abandon-on-delete contract)', () => {
   });
 });
 
-describe('subscribeGoalStateChanges', () => {
+describe('goalStateChanges', () => {
   setupPlatform();
 
   it('delivers only goal changes from the supplied session', async () => {

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -1,5 +1,5 @@
 import { Mutex } from 'async-mutex';
-import { Effect, Fiber, Stream } from 'effect';
+import { Stream } from 'effect';
 
 import {
   getRunContextSession,
@@ -9,7 +9,6 @@ import {
   tryDefaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import { effectRuntime } from '@platform/processRuntime';
 import { tryWorkspaceRoots, workspaceRoots } from '@platform/workspaceRoots';
 import {
   aggregateId as qualifyAggregateId,
@@ -31,11 +30,10 @@ const INDEX_KEY = 'goals:index';
 // without calling `forget()` leave dangling entries until next manual cleanup.
 const indexMutex = new Mutex();
 
-interface GoalStateChange {
+/** One goal mutation as observed on a session's event plane. */
+export interface GoalStateChange {
   readonly streamId: StreamTabId;
 }
-
-type GoalStateChangeListener = (change: GoalStateChange) => void;
 
 function streamKey(streamId: StreamTabId): string {
   return `${STREAM_KEY_PREFIX}${streamId}`;
@@ -176,26 +174,22 @@ function requireNonEmpty(value: string, label: string): string {
 }
 
 /**
- * Subscribe to goal mutations in one explicitly-owned session, from now on.
- * Goal state is session-scoped: consumers must pass the session they render,
- * rather than listening on a process-wide compatibility event.
+ * Goal mutations in one explicitly-owned session, from now on. Goal state is
+ * session-scoped: consumers must pass the session they render, rather than
+ * listening on a process-wide compatibility event. The stream is the whole
+ * surface — the subscriber's host forks it at its own R1 boundary and
+ * interrupts that fork when the view it renders closes, so this module owns
+ * no fiber and no runtime.
  */
-export function subscribeGoalStateChanges(
+export function goalStateChanges(
   session: Pick<SessionHandle, 'events' | 'now'>,
-  listener: GoalStateChangeListener,
-): () => void {
-  const fiber = effectRuntime().runFork(
-    Stream.runForEach(session.events.all(session.now()), (event) =>
-      Effect.sync(() => {
-        if (event.type === 'goalStateChanged') {
-          listener({ streamId: aggregateTarget(event.aggregateId).id });
-        }
-      }),
-    ),
+): Stream.Stream<GoalStateChange> {
+  return session.events.all(session.now()).pipe(
+    Stream.filter((event) => event.type === 'goalStateChanged'),
+    Stream.map((event) => ({
+      streamId: aggregateTarget(event.aggregateId).id,
+    })),
   );
-  return () => {
-    effectRuntime().runFork(Fiber.interrupt(fiber));
-  };
 }
 
 export const GoalStore = Object.freeze({

--- a/src/tools/goal/index.ts
+++ b/src/tools/goal/index.ts
@@ -8,7 +8,7 @@
  * future internal split does not create a second public surface accidentally.
  */
 export { isGoalEnabled } from './goalFeatureFlag';
-export { GoalStore, subscribeGoalStateChanges } from './goalStore';
+export { GoalStore, goalStateChanges, type GoalStateChange } from './goalStore';
 export {
   setGoalSessionAutoApproval,
   type GoalAutoApprovalScope,


### PR DESCRIPTION
## Summary

Converts the goal-change subscription to an Effect `Stream` — the `goalStore.ts` entry in the effect-migration ratchet's `debtLanes` register ("Phase 5 — tools subsystem"). `subscribeGoalStateChanges` used to fork a stream drain on the process runtime and hand back an interrupt thunk: two below-boundary `Effect.run*` sites inside the store. The store now exposes `goalStateChanges(session): Stream<GoalStateChange>` and owns no fiber and no runtime; each host forks the stream at its own R1 boundary and interrupts that fork when the view it renders closes.

## Issue acceptance gates

No issue; the lane is registered in `config/ratchets/effect-migration-baseline.json` (`debtLanes`: `src/tools/goal/goalStore.ts`).

- `goalStore.ts` leaves the `Effect.run*` row (2 sites) and its `debtLanes` entry is dropped: done.
- No count grows in any row: done — the forks land in host-entry files (R1 boundary kinds), which the run row does not count, and neither fat host file gains a runtime `effect` import (so the catch row is untouched).

## Single source of truth

`goalStateChanges(session)` in `src/tools/goal/goalStore.ts` is the one definition of "goal mutations on a session's event plane" (filter + map over the session events). The two host edge modules own only their fork-and-interrupt lifecycle.

## Duplication and abstraction budget

Deleted: the store's fork/interrupt pair and its `effectRuntime` import. The extension reuses the existing `frontend/events/runFactSubscriptions.ts` idiom (goal changes are session facts, the module's existing subject). Desktop gets one thin edge module (`desktopGoalSubscription.ts`) because `desktopSettingsIpc.ts` must stay Promise-native — importing `effect` there would pull its existing recovery catches under R7's one-pass rule, which belongs to desktop's own catch-row lane, not this one. The two 10-line edge functions are per-host edges, not a shared helper: R1 assigns each host its own run edge.

## Net elements (R6)

- Files: 8 changed (+80/−34): 4 production source, 2 host edge modules (1 modified, 1 new), 1 test, 1 ratchet baseline.
- Exported symbols: −1 (`subscribeGoalStateChanges` from `@tools/goal`), +4 (`goalStateChanges`, `GoalStateChange`, and the two host-edge subscribe functions).
- Classes/interfaces/enums: +1 exported type (`GoalStateChange`, previously module-private).
- Net LoC: +46.

## Consumer counts (R8)

- `subscribeGoalStateChanges` (`@tools/goal`): 3 consumers — `SettingsViewMessageHandler.ts` (extension), `desktopSettingsIpc.ts` (desktop), `goalStore.vitest.ts`. Re-routed: extension → the sibling in `runFactSubscriptions.ts`, desktop → `desktopGoalSubscription.ts`, test → consumes the `goalStateChanges` stream directly.
- `goalStateChanges` (new): 3 consumers (two host edge modules + the updated test).

## Host impact

Extension: none beyond the import — the same fork/interrupt lifecycle now comes from `runFactSubscriptions.ts`, the module that already provides it for run facts.
Desktop: same lifecycle from the new `desktopGoalSubscription.ts`; `desktopSettingsIpc.ts` stays Promise-native.
CLI: no impact (it never subscribed; its `GoalStore` reads are untouched).

## Scheduled refactoring

None for this lane — the `debtLanes` entry is dropped. The store's `async-mutex` index serializer is a separate ratchet row (`import:async-mutex`, 3 files) owned by the wider Phase 5 conversion; converting it cascades into lane-D files (`ToolUseWaitNode`), so it is deliberately out of scope here.

## Validation

- `npm run typecheck:workspace` and `npm run typecheck:test-kernel` — clean.
- `npx eslint` on all changed files — clean.
- `prettier --check` on all changed files — clean.
- Affected suites: `goalStore` (13), `SettingsGoalList` (4) — 17 tests passed.
- Full Vitest suite (`npm test -- --maxWorkers=4`): 764 files / 9,092 tests passed.
- Ratchets: `check-effect-migration-ratchet` — OK after `--update` (goalStore entry dropped, no growth). `check:dead-code-ratchet` — no new findings expected (all new exports have consumers).
- Note: `DesktopPreviewHost`/`DesktopProgressFileActions` have pre-existing 10s-timeout flakes under full-directory parallel load; they fail at the same rate on a clean base (verified by stash A/B) and pass standalone with this change.
