### PR TITLE
refactor(tools): keep request programs native to Effect

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -197,8 +197,6 @@
       "src/tools/arxiv/ArxivSearchTool.ts": 1,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/lean/direct/leanServer.ts": 1,
-      "src/tools/web/WebFetchTool.ts": 2,
-      "src/tools/zotero/bbtClient.ts": 1,
       "src/utils/files/relativeFS.ts": 2
     }
   },

--- a/src/test-kernel/tools/Cancellation.vitest.ts
+++ b/src/test-kernel/tools/Cancellation.vitest.ts
@@ -82,7 +82,7 @@ describe('rateLimitedApiCall cancellation', () => {
 /**
  * `callZoteroConnector` runs its non-idempotent `saveItems`/`saveSnapshot`
  * write under `Effect.uninterruptible` so cancelling a run cannot tear it
- * mid-request and lose the outcome. That rests on one non-obvious property of
+ * mid-request. That rests on one non-obvious property of
  * the effect runtime: the region defers the *caller's* interrupt but not the
  * deadline, because `timeoutOrElse` races through `raceAllFirst`, which forks
  * both racers interruptible regardless of the enclosing region. An effect
@@ -96,12 +96,16 @@ describe('withRequestTimeout under Effect.uninterruptible', () => {
       const fiber = yield* Effect.forkChild(
         Effect.flip(
           Effect.uninterruptible(
-            withRequestTimeout(1000, (signal) => {
-              signal.addEventListener('abort', () => {
-                aborted = true;
-              });
-              return new Promise<never>(() => {});
-            }),
+            withRequestTimeout(
+              1000,
+              Effect.gen(function* () {
+                const signal = yield* Effect.abortSignal;
+                signal.addEventListener('abort', () => {
+                  aborted = true;
+                });
+                return yield* Effect.never;
+              }),
+            ),
           ),
         ),
       );
@@ -115,47 +119,43 @@ describe('withRequestTimeout under Effect.uninterruptible', () => {
 
   it.effect('lets an interrupted request settle instead of tearing it', () =>
     Effect.gen(function* () {
-      let aborted = false;
+      let abortedBeforeSettlement = false;
       let settled = false;
       let finish: () => void = () => {};
       const fiber = yield* Effect.forkChild(
         Effect.uninterruptible(
-          withRequestTimeout(1000, (signal) => {
-            signal.addEventListener('abort', () => {
-              aborted = true;
-            });
-            return new Promise<string>((resolve) => {
-              finish = () => {
-                settled = true;
-                resolve('written');
-              };
-            });
-          }),
+          withRequestTimeout(
+            1000,
+            Effect.gen(function* () {
+              const signal = yield* Effect.abortSignal;
+              signal.addEventListener('abort', () => {
+                if (!settled) abortedBeforeSettlement = true;
+              });
+              return yield* Effect.promise(
+                () =>
+                  new Promise<string>((resolve) => {
+                    finish = () => {
+                      settled = true;
+                      resolve('written');
+                    };
+                  }),
+              );
+            }),
+          ),
         ),
       );
       yield* started;
       const interrupting = yield* Effect.forkChild(Fiber.interrupt(fiber));
       yield* started;
       // The interrupt is deferred: the write is untouched and still in flight.
-      expect(aborted).toBe(false);
+      expect(abortedBeforeSettlement).toBe(false);
       expect(settled).toBe(false);
       finish();
       yield* Fiber.join(interrupting);
       // The write ran to completion, and only then did the interrupt land.
       expect(settled).toBe(true);
-      expect(aborted).toBe(false);
+      expect(abortedBeforeSettlement).toBe(false);
       expect(Exit.hasInterrupts(yield* Fiber.await(fiber))).toBe(true);
-    }),
-  );
-});
-
-describe('withRequestTimeout misuse', () => {
-  it.effect('dies on a request that declares no AbortSignal parameter', () =>
-    Effect.gen(function* () {
-      const exit = yield* Effect.exit(
-        withRequestTimeout(1000, () => Promise.resolve('unabortable')),
-      );
-      expect(Exit.hasDies(exit)).toBe(true);
     }),
   );
 });

--- a/src/test-kernel/tools/Cancellation.vitest.ts
+++ b/src/test-kernel/tools/Cancellation.vitest.ts
@@ -93,16 +93,19 @@ describe('withRequestTimeout under Effect.uninterruptible', () => {
   it.effect('still ends the request at its deadline', () =>
     Effect.gen(function* () {
       let aborted = false;
+      const request = Effect.gen(function* () {
+        const signal = yield* Effect.abortSignal;
+        signal.addEventListener('abort', () => {
+          aborted = true;
+        });
+        return yield* Effect.tryPromise({
+          try: () => new Promise<never>(() => {}),
+          catch: (cause) => cause,
+        });
+      });
       const fiber = yield* Effect.forkChild(
         Effect.flip(
-          Effect.uninterruptible(
-            withRequestTimeout(1000, (signal) => {
-              signal.addEventListener('abort', () => {
-                aborted = true;
-              });
-              return new Promise<never>(() => {});
-            }),
-          ),
+          Effect.uninterruptible(withRequestTimeout(1000, request)),
         ),
       );
       yield* started;
@@ -118,20 +121,24 @@ describe('withRequestTimeout under Effect.uninterruptible', () => {
       let aborted = false;
       let settled = false;
       let finish: () => void = () => {};
-      const fiber = yield* Effect.forkChild(
-        Effect.uninterruptible(
-          withRequestTimeout(1000, (signal) => {
-            signal.addEventListener('abort', () => {
-              aborted = true;
-            });
-            return new Promise<string>((resolve) => {
+      const request = Effect.gen(function* () {
+        const signal = yield* Effect.abortSignal;
+        signal.addEventListener('abort', () => {
+          aborted = true;
+        });
+        return yield* Effect.tryPromise({
+          try: () =>
+            new Promise<string>((resolve) => {
               finish = () => {
                 settled = true;
                 resolve('written');
               };
-            });
-          }),
-        ),
+            }),
+          catch: (cause) => cause,
+        });
+      });
+      const fiber = yield* Effect.forkChild(
+        Effect.uninterruptible(withRequestTimeout(1000, request)),
       );
       yield* started;
       const interrupting = yield* Effect.forkChild(Fiber.interrupt(fiber));
@@ -141,21 +148,11 @@ describe('withRequestTimeout under Effect.uninterruptible', () => {
       expect(settled).toBe(false);
       finish();
       yield* Fiber.join(interrupting);
-      // The write ran to completion, and only then did the interrupt land.
+      // The write ran to completion before the deferred interrupt closed its
+      // request scope and aborted the now-settled transport signal.
       expect(settled).toBe(true);
-      expect(aborted).toBe(false);
+      expect(aborted).toBe(true);
       expect(Exit.hasInterrupts(yield* Fiber.await(fiber))).toBe(true);
-    }),
-  );
-});
-
-describe('withRequestTimeout misuse', () => {
-  it.effect('dies on a request that declares no AbortSignal parameter', () =>
-    Effect.gen(function* () {
-      const exit = yield* Effect.exit(
-        withRequestTimeout(1000, () => Promise.resolve('unabortable')),
-      );
-      expect(Exit.hasDies(exit)).toBe(true);
     }),
   );
 });

--- a/src/test-kernel/tools/FetchToolErrorClassification.vitest.ts
+++ b/src/test-kernel/tools/FetchToolErrorClassification.vitest.ts
@@ -13,19 +13,12 @@ const MESSAGES = {
   fallback: (message: string) => `Failed: ${message}`,
 } as const;
 
-/**
- * The failure `withRequestTimeout` raises for a request that threw `cause`.
- * The request takes `signal` because `withRequestTimeout` requires it: a
- * zero-parameter request gets no AbortSignal from `Effect.tryPromise` and
- * dies as a defect.
- */
+/** The failure `withRequestTimeout` raises for a request that failed with `cause`. */
 const failed = (cause: unknown) =>
-  Effect.flip(withRequestTimeout(1000, (_signal) => Promise.reject(cause)));
+  Effect.flip(withRequestTimeout(1000, Effect.fail(cause)));
 
 /** The failure `withRequestTimeout` raises when the deadline passes first. */
-const timedOut = Effect.flip(
-  withRequestTimeout(0, (_signal) => new Promise<never>(() => {})),
-);
+const timedOut = Effect.flip(withRequestTimeout(0, Effect.never));
 
 /**
  * Regression coverage for the retry/final-label predicate consolidation

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -100,28 +100,19 @@ describe('retryTransientFetch', () => {
         const retriesLeft: number[] = [];
         const fiber = yield* Effect.forkChild(
           Effect.flip(
-            retryTransientFetch(
-              (_signal) => Promise.reject(kyErrorWithStatus(503)),
-              {
-                retries: 3,
-                minTimeout: 1,
-                timeoutMs: 1000,
-                onFailedAttempt: (_error, left) =>
-                  Effect.sync(() => {
-                    retriesLeft.push(left);
-                  }),
-              },
-            ),
+            retryTransientFetch(Effect.fail(kyErrorWithStatus(503)), {
+              retries: 3,
+              minTimeout: 1,
+              timeoutMs: 1000,
+              onFailedAttempt: (_error, left) =>
+                Effect.sync(() => {
+                  retriesLeft.push(left);
+                }),
+            }),
           ),
         );
-        // Each backoff (at most 8 ms with jitter) sleeps on the test clock;
-        // let the rejected attempt settle before moving the clock past it.
-        for (let i = 0; i < 4; i++) {
-          yield* Effect.promise(
-            () => new Promise<void>((resolve) => setTimeout(resolve, 0)),
-          );
-          yield* TestClock.adjust('10 millis');
-        }
+        // The three backoff intervals together take less than 14 ms.
+        yield* TestClock.adjust('40 millis');
         const error = yield* Fiber.join(fiber);
         expect(error._tag).toBe('RequestFailed');
         expect(error.cause).toBeInstanceOf(HTTPError);

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -117,27 +117,33 @@ const LOOGLE_API_URL = 'https://loogle.lean-lang.org/json';
  */
 const fetchLoogle = Effect.fn('LoogleTool.fetchLoogle')((query: string) =>
   retryTransientFetch(
-    async (signal) => {
-      const raw = await ky
-        .get(LOOGLE_API_URL, {
-          searchParams: { q: query },
-          headers: { 'User-Agent': 'TeXRA-VSCode-Extension' },
-          timeout: false,
-          signal,
-          retry: 0,
-        })
-        .json<unknown>();
+    Effect.gen(function* () {
+      const raw = yield* Effect.tryPromise({
+        try: (signal) =>
+          ky
+            .get(LOOGLE_API_URL, {
+              searchParams: { q: query },
+              headers: { 'User-Agent': 'TeXRA-VSCode-Extension' },
+              timeout: false,
+              signal,
+              retry: 0,
+            })
+            .json<unknown>(),
+        catch: (cause) => cause,
+      });
       // Validate the body at the boundary. A malformed shape is not
       // transient, so it is not retried; searchOne surfaces it as a tool
       // error.
       const parsed = LoogleResponseSchema.safeParse(raw);
       if (!parsed.success) {
-        throw new Error(
-          `Unexpected Loogle response shape: ${z.prettifyError(parsed.error)}`,
+        return yield* Effect.fail(
+          new Error(
+            `Unexpected Loogle response shape: ${z.prettifyError(parsed.error)}`,
+          ),
         );
       }
       return parsed.data;
-    },
+    }),
     {
       retries: LOOGLE_RETRIES,
       minTimeout: 1000,

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -9,11 +9,11 @@
  *
  * A deadline is `Effect.timeoutOrElse`, the retry is an exponential
  * `Schedule` with the [1, 2) jitter window the tools were tuned to
- * ({@link transientBackoff}), and cancellation is fiber interruption:
- * `Effect.tryPromise` hands the attempt's own `AbortSignal` to the request,
- * so an interrupted run aborts the in-flight fetch instead of waiting out the
- * deadline or the next backoff. The caller's signal enters once, as the
- * `{ signal }` of the tool's run edge.
+ * ({@link transientBackoff}), and cancellation is fiber interruption. Each
+ * attempt owns a scope for the entire request, including the response body.
+ * The request can acquire `Effect.abortSignal` there for its foreign HTTP
+ * calls. The caller's signal enters once, as the `{ signal }` of the tool's
+ * run edge.
  */
 
 import { Data, Duration, Effect, Random, Schedule } from 'effect';
@@ -84,42 +84,19 @@ function isTransientRequestError(error: RequestError): boolean {
 /**
  * One request under a deadline of `timeoutMs` that spans the whole of
  * `request` — connection and body read — where a client's own `timeout`
- * option (e.g. ky's) only clears once headers arrive. The signal handed to
- * `request` aborts when the attempt is interrupted, by the deadline or by
- * the caller. Fails with {@link RequestTimedOut} on the deadline and with
- * {@link RequestFailed} carrying the request's own error otherwise.
- *
- * `request` must declare its `signal` parameter and hand it to the client;
- * one that does not gets no signal at all and dies as a defect rather than
- * quietly outliving its own cancellation.
+ * option (e.g. ky's) only clears once headers arrive. The attempt's scope
+ * stays open through the body read, so a signal acquired with
+ * `Effect.abortSignal` aborts when the whole attempt ends. Fails with
+ * {@link RequestTimedOut} on the deadline and with {@link RequestFailed}
+ * carrying the request's expected error otherwise. Defects and interruption
+ * are not converted into request failures.
  */
 export const withRequestTimeout = Effect.fn('timeouts.withRequestTimeout')(
-  function* <T>(
-    timeoutMs: number,
-    request: (signal: AbortSignal) => Promise<T>,
-  ) {
-    // `Effect.tryPromise` creates the AbortSignal only when its callback
-    // declares the parameter (`f.length !== 0`, effect's `tryPromise`). A
-    // request written `() => ky.get(url)` therefore gets no signal, and
-    // neither the deadline below nor the caller's interruption reaches the
-    // in-flight request: it is abandoned to settle unobserved while this
-    // program reports a timeout — a cancellation that silently does nothing.
-    // TypeScript cannot catch it (a zero-parameter function is assignable to
-    // a one-parameter type), so the misuse is a defect raised here.
-    if (request.length === 0) {
-      yield* Effect.die(
-        new Error(
-          'withRequestTimeout was given a request that declares no AbortSignal parameter, ' +
-            'so neither the deadline nor the caller can abort it. Take the signal and hand ' +
-            'it to the client: (signal) => ky.get(url, { signal }).',
-        ),
-      );
-    }
-    return yield* Effect.tryPromise({
-      try: request,
-      catch: (cause) =>
-        new RequestFailed({ message: toErrorMessage(cause), cause }),
-    }).pipe(
+  <T, E, R>(timeoutMs: number, request: Effect.Effect<T, E, R>) =>
+    Effect.scoped(request).pipe(
+      Effect.mapError(
+        (cause) => new RequestFailed({ message: toErrorMessage(cause), cause }),
+      ),
       Effect.timeoutOrElse({
         duration: Duration.millis(timeoutMs),
         orElse: () =>
@@ -130,8 +107,7 @@ export const withRequestTimeout = Effect.fn('timeouts.withRequestTimeout')(
             }),
           ),
       }),
-    );
-  },
+    ),
 );
 
 interface RetryTransientFetchOptions {
@@ -172,20 +148,20 @@ function transientBackoff(minTimeout: number) {
 }
 
 /**
- * Run `fetchOnce` under a per-attempt deadline, retrying only transient
+ * Run `request` under a per-attempt deadline, retrying only transient
  * failures (timeout, network error, 429, 5xx) with exponential backoff and
  * full jitter — the pattern every network-boundary tool (web fetch/search,
  * Loogle) repeats. Any other failure — a non-transient HTTP status, a
- * response-shape or size-limit check `fetchOnce` throws itself — ends the
+ * response-shape or size-limit failure reported by `request` — ends the
  * retry immediately and is the program's failure. Interruption stops both
  * the active attempt and the backoff sleep.
  */
 export const retryTransientFetch = Effect.fn('timeouts.retryTransientFetch')(
-  <T>(
-    fetchOnce: (signal: AbortSignal) => Promise<T>,
+  <T, E, R>(
+    request: Effect.Effect<T, E, R>,
     options: RetryTransientFetchOptions,
   ) =>
-    withRequestTimeout(options.timeoutMs, fetchOnce).pipe(
+    withRequestTimeout(options.timeoutMs, request).pipe(
       Effect.tapError((error) =>
         Effect.gen(function* () {
           if (!options.onFailedAttempt || !isTransientRequestError(error)) {

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -16,7 +16,7 @@
  * run edge.
  */
 
-import { Data, Duration, Effect, Random, Schedule } from 'effect';
+import { Data, Duration, Effect, Random, Schedule, Scope } from 'effect';
 import isNetworkError from 'is-network-error';
 import { HTTPError, TimeoutError } from 'ky';
 
@@ -92,7 +92,10 @@ function isTransientRequestError(error: RequestError): boolean {
  * are not converted into request failures.
  */
 export const withRequestTimeout = Effect.fn('timeouts.withRequestTimeout')(
-  <T, E, R>(timeoutMs: number, request: Effect.Effect<T, E, R>) =>
+  <T, E, R>(
+    timeoutMs: number,
+    request: Effect.Effect<T, E, R | Scope.Scope>,
+  ) =>
     Effect.scoped(request).pipe(
       Effect.mapError(
         (cause) => new RequestFailed({ message: toErrorMessage(cause), cause }),

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -2,7 +2,7 @@
 import { isIP } from 'node:net';
 
 // Third-party imports
-import { Effect } from 'effect';
+import { Effect, Stream } from 'effect';
 import ky from 'ky';
 import { z } from 'zod';
 
@@ -19,51 +19,6 @@ import { createHtmlToMarkdown } from '@utils/text/htmlToMarkdown';
 const WEB_FETCH_TIMEOUT_MS = 30_000; // 30 s
 const WEB_FETCH_RETRIES = 2;
 const MAX_CONTENT_BYTES = 10 * 1024 * 1024; // 10 MB
-
-/**
- * Read a response body into a string, failing once accumulated bytes exceed
- * `maxBytes` (a permanent failure: `retryTransientFetch` does not retry it).
- * Enforces the cap on received data rather than trusting the Content-Length
- * header (chunked responses omit it entirely). Respects the charset from the
- * Content-Type header (falls back to UTF-8).
- */
-async function readBodyWithLimit(
-  response: Response,
-  maxBytes: number,
-): Promise<string> {
-  const reader = response.body?.getReader();
-  if (!reader) {
-    return '';
-  }
-  const ct = response.headers.get('content-type') ?? '';
-  const charsetMatch = /charset=([^\s;]+)/i.exec(ct);
-  const charset = charsetMatch?.[1]?.replaceAll(/^["']|["']$/gu, '');
-  let decoder: TextDecoder;
-  try {
-    decoder = new TextDecoder(charset || 'utf-8');
-  } catch {
-    decoder = new TextDecoder();
-  }
-  const parts: string[] = [];
-  let total = 0;
-  try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      total += value.byteLength;
-      if (total > maxBytes) {
-        throw new Error(
-          `Response too large (exceeds ${maxBytes / (1024 * 1024)} MB maximum).`,
-        );
-      }
-      parts.push(decoder.decode(value, { stream: true }));
-    }
-    parts.push(decoder.decode());
-  } finally {
-    reader.releaseLock();
-  }
-  return parts.join('');
-}
 
 const WebFetchInputSchema = z.strictObject({
   url: z
@@ -94,25 +49,68 @@ const PRIVATE_IPV6_PREFIXES = ['fc', 'fd', 'fe80'];
 /** Fetch `url` with transient retries, as text plus its content type. */
 const fetchPage = Effect.fn('WebFetchTool.fetchPage')((url: string) =>
   retryTransientFetch(
-    async (signal): Promise<{ rawBody: string; contentType: string }> => {
-      const response = await ky.get(url, {
-        timeout: false,
-        signal,
-        retry: 0,
+    Effect.gen(function* () {
+      // One attempt owns headers and body together; its signal must remain
+      // live after ky resolves the response headers.
+      const signal = yield* Effect.abortSignal;
+      const response = yield* Effect.tryPromise({
+        try: () => ky.get(url, { timeout: false, signal, retry: 0 }),
+        catch: (error) => error,
       });
 
       const lengthHeader = response.headers.get('content-length');
       if (lengthHeader && Number(lengthHeader) > MAX_CONTENT_BYTES) {
         // Permanent: not retried.
-        throw new Error(
-          `Response too large (${lengthHeader} bytes); maximum is ${MAX_CONTENT_BYTES / (1024 * 1024)} MB.`,
+        return yield* Effect.fail(
+          new Error(
+            `Response too large (${lengthHeader} bytes); maximum is ${MAX_CONTENT_BYTES / (1024 * 1024)} MB.`,
+          ),
         );
       }
 
-      const ct = response.headers.get('content-type') ?? '';
-      const text = await readBodyWithLimit(response, MAX_CONTENT_BYTES);
-      return { rawBody: text, contentType: ct };
-    },
+      const contentType = response.headers.get('content-type') ?? '';
+      const body = response.body;
+      if (!body) return { rawBody: '', contentType };
+      const charset = /charset=([^\s;]+)/i
+        .exec(contentType)?.[1]
+        ?.replaceAll(/^["']|["']$/gu, '');
+      // Unsupported labels fall back to UTF-8, as for an absent charset.
+      const decoder = yield* Effect.try(
+        () => new TextDecoder(charset || 'utf-8'),
+      ).pipe(Effect.orElseSucceed(() => new TextDecoder()));
+      let total = 0;
+      const parts = yield* Stream.fromReadableStream({
+        evaluate: () => body,
+        onError: (error) => error,
+        releaseLockOnEnd: true,
+      }).pipe(
+        Stream.mapEffect((chunk) => {
+          // Count received bytes even when Content-Length is absent or wrong.
+          total += chunk.byteLength;
+          if (total > MAX_CONTENT_BYTES) {
+            return Effect.fail(
+              new Error(
+                `Response too large (exceeds ${MAX_CONTENT_BYTES / (1024 * 1024)} MB maximum).`,
+              ),
+            );
+          }
+          return Effect.try({
+            try: () => decoder.decode(chunk, { stream: true }),
+            catch: (error) => error,
+          });
+        }),
+        Stream.runCollect,
+      );
+      // Flush incomplete trailing code units too; streaming decode alone
+      // would silently omit their replacement characters.
+      parts.push(
+        yield* Effect.try({
+          try: () => decoder.decode(),
+          catch: (error) => error,
+        }),
+      );
+      return { rawBody: parts.join(''), contentType };
+    }),
     {
       retries: WEB_FETCH_RETRIES,
       minTimeout: 500,
@@ -180,15 +178,13 @@ export class WebFetchTool extends defineTool({
 
       let markdown: string;
       if (isMarkupContent) {
-        try {
-          markdown = this.turndown.turndown(rawBody);
-        } catch (error) {
-          return yield* Effect.fail(
+        markdown = yield* Effect.try({
+          try: () => this.turndown.turndown(rawBody),
+          catch: (error) =>
             new ToolError(
               `Failed to convert HTML to Markdown: ${toErrorMessage(error)}`,
             ),
-          );
-        }
+        });
       } else {
         markdown = rawBody;
       }

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -74,30 +74,40 @@ type DuckDuckGoResponse = z.infer<typeof DuckDuckGoResponseSchema>;
 const searchDuckDuckGo = Effect.fn('WebSearchTool.searchDuckDuckGo')(
   (query: string) =>
     retryTransientFetch(
-      async (signal) => {
-        const response = await ky.get('https://api.duckduckgo.com/', {
-          searchParams: {
-            q: query,
-            format: 'json',
-            no_redirect: 1,
-            no_html: 1,
-          },
-          timeout: false,
-          signal,
-          retry: 0,
+      Effect.gen(function* () {
+        const signal = yield* Effect.abortSignal;
+        const response = yield* Effect.tryPromise({
+          try: () =>
+            ky.get('https://api.duckduckgo.com/', {
+              searchParams: {
+                q: query,
+                format: 'json',
+                no_redirect: 1,
+                no_html: 1,
+              },
+              timeout: false,
+              signal,
+              retry: 0,
+            }),
+          catch: (cause) => cause,
         });
-        const raw = await response.json();
+        const raw = yield* Effect.tryPromise({
+          try: () => response.json(),
+          catch: (cause) => cause,
+        });
         // Validate the body at the boundary. A malformed shape is not
         // transient, so it is not retried; the classification below surfaces
         // it as a tool error.
         const parsed = DuckDuckGoResponseSchema.safeParse(raw);
         if (!parsed.success) {
-          throw new Error(
-            `Unexpected DuckDuckGo response shape: ${z.prettifyError(parsed.error)}`,
+          return yield* Effect.fail(
+            new Error(
+              `Unexpected DuckDuckGo response shape: ${z.prettifyError(parsed.error)}`,
+            ),
           );
         }
         return parsed.data;
-      },
+      }),
       {
         retries: DDG_RETRIES,
         minTimeout: 500,

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -75,24 +75,21 @@ const searchDuckDuckGo = Effect.fn('WebSearchTool.searchDuckDuckGo')(
   (query: string) =>
     retryTransientFetch(
       Effect.gen(function* () {
-        const signal = yield* Effect.abortSignal;
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            ky.get('https://api.duckduckgo.com/', {
-              searchParams: {
-                q: query,
-                format: 'json',
-                no_redirect: 1,
-                no_html: 1,
-              },
-              timeout: false,
-              signal,
-              retry: 0,
-            }),
-          catch: (cause) => cause,
-        });
         const raw = yield* Effect.tryPromise({
-          try: () => response.json(),
+          try: (signal) =>
+            ky
+              .get('https://api.duckduckgo.com/', {
+                searchParams: {
+                  q: query,
+                  format: 'json',
+                  no_redirect: 1,
+                  no_html: 1,
+                },
+                timeout: false,
+                signal,
+                retry: 0,
+              })
+              .json<unknown>(),
           catch: (cause) => cause,
         });
         // Validate the body at the boundary. A malformed shape is not

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -203,15 +203,20 @@ export const callBetterBibTeX = Effect.fn('bbtClient.callBetterBibTeX')(
   ) {
     const url = zoteroUrl(port, '/better-bibtex/json-rpc');
 
-    const raw = yield* withRequestTimeout(timeout, (signal) =>
-      ky
-        .post(url, {
-          json: { jsonrpc: '2.0', method, params, id: 1 },
-          timeout: false,
-          signal,
-          retry: 0,
-        })
-        .json<unknown>(),
+    const raw = yield* withRequestTimeout(
+      timeout,
+      Effect.tryPromise({
+        try: (signal) =>
+          ky
+            .post(url, {
+              json: { jsonrpc: '2.0', method, params, id: 1 },
+              timeout: false,
+              signal,
+              retry: 0,
+            })
+            .json<unknown>(),
+        catch: (cause) => cause,
+      }),
     ).pipe(Effect.mapError((error) => bbtRequestError(error, port, timeout)));
 
     const responseSchema = z.object({
@@ -258,11 +263,16 @@ export type ConnectorResult =
  */
 export const checkZoteroRunning = Effect.fn('bbtClient.checkZoteroRunning')(
   (port: number) =>
-    withRequestTimeout(ZOTERO_PING_TIMEOUT_MS, (signal) =>
-      ky.get(zoteroUrl(port, '/connector/ping'), {
-        timeout: false,
-        signal,
-        retry: 0,
+    withRequestTimeout(
+      ZOTERO_PING_TIMEOUT_MS,
+      Effect.tryPromise({
+        try: (signal) =>
+          ky.get(zoteroUrl(port, '/connector/ping'), {
+            timeout: false,
+            signal,
+            retry: 0,
+          }),
+        catch: (cause) => cause,
       }),
     ).pipe(
       Effect.mapError(() => zoteroUnreachableError(port)),
@@ -324,34 +334,43 @@ export const callZoteroConnector = Effect.fn('bbtClient.callZoteroConnector')(
   (endpoint: string, body: object, port: number) =>
     withRequestTimeout(
       ZOTERO_CONNECTOR_TIMEOUT_MS,
-      async (signal): Promise<ConnectorResult> => {
-        const response = await ky.post(
-          zoteroUrl(port, `/connector/${endpoint}`),
-          {
-            json: body,
-            timeout: false,
-            signal,
-            retry: 0,
-            throwHttpErrors: false,
-          },
-        );
+      Effect.gen(function* () {
+        // The request scope keeps this signal live through the body read,
+        // after the header request has already settled.
+        const signal = yield* Effect.abortSignal;
+        const response = yield* Effect.tryPromise({
+          try: () =>
+            ky.post(zoteroUrl(port, `/connector/${endpoint}`), {
+              json: body,
+              timeout: false,
+              signal,
+              retry: 0,
+              throwHttpErrors: false,
+            }),
+          catch: (cause) => cause,
+        });
         if (
           response.status === StatusCodes.OK ||
           response.status === StatusCodes.CREATED
         ) {
-          return { status: 'success' };
+          return { status: 'success' } satisfies ConnectorResult;
         }
         // Try to extract a machine-readable error message from the response
         // body; it is read under the same deadline as the headers.
-        let errorMessage = `Unexpected response status: ${response.status}`;
-        try {
-          const data = (await response.json()) as { error?: string };
-          if (data?.error) errorMessage = String(data.error);
-        } catch {
+        const data = yield* Effect.tryPromise({
+          try: () => response.json<{ error?: string }>(),
+          catch: (cause) => cause,
+        }).pipe(
           // Body is not JSON or is empty; use the generic status message.
-        }
-        return { status: 'error', message: errorMessage };
-      },
+          Effect.catch(() => Effect.succeed(undefined)),
+        );
+        return {
+          status: 'error',
+          message: data?.error
+            ? String(data.error)
+            : `Unexpected response status: ${response.status}`,
+        } satisfies ConnectorResult;
+      }),
     ).pipe(
       Effect.uninterruptible,
       Effect.catch((error) =>

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -311,15 +311,15 @@ function connectorRequestFailure(
  * The request is **uninterruptible**: `saveItems`/`saveSnapshot` write to the
  * user's library, so aborting one mid-flight would leave Zotero having
  * possibly stored the item with no way to tell whether it landed. Cancelling
- * the run instead lets this one write settle deterministically.
+ * the run instead lets this one write finish under its existing deadline.
  *
  * The interrupt is deferred, not absorbed. When the region ends it is
  * delivered as the continuation of the write's completion, and the
  * `Effect.catch` below recovers `Fail` reasons only (`findError` matches
  * `_tag === 'Fail'`), so this item's `ConnectorResult` is discarded and
  * `addItems`' `Effect.forEach` stops before the next item. The guarantee is
- * that Zotero's state is knowable afterwards — not that the result is
- * reported.
+ * that cancellation alone does not abandon this write — not that its
+ * remote outcome is durably known or its result is reported.
  *
  * The deadline is separate and unaffected by the region: `Effect.timeoutOrElse`
  * races the request in a fiber that `raceAllFirst` forks interruptible
@@ -356,7 +356,9 @@ export const callZoteroConnector = Effect.fn('bbtClient.callZoteroConnector')(
           return { status: 'success' } satisfies ConnectorResult;
         }
         // Try to extract a machine-readable error message from the response
-        // body; it is read under the same deadline as the headers.
+        // body; it is read under the same deadline as the headers. Keep this
+        // body-only recovery separate so request failures retain their own
+        // reachability/timeout classification.
         const data = yield* Effect.tryPromise({
           try: () => response.json<{ error?: string }>(),
           catch: (cause) => cause,


### PR DESCRIPTION
## Summary

Request timeout and retry operations now accept Effect programs. All six callers in web fetch, web search, Loogle and Zotero use that contract; the Promise-only callback and its arity guard are removed together.

Web fetch reads response bodies with Effect Stream, preserving byte limits, charset fallback and the final decoder flush. Each attempt owns the complete response lifetime. Web search combines headers and JSON decoding at one foreign HTTP boundary; Zotero keeps body-only error recovery separate from request failure classification. The existing tool `execute()` Promise boundary remains; converting the full tool dispatcher is outside this request-interface change.

## Issue acceptance gates

The request-program portion of R1, R5 and R6 is complete: every production caller is converted, interruption reaches foreign I/O, and each attempt owns its resources. Expected failures, defects and interruption remain distinct. Retry policy and output behavior are preserved. Zotero writes retain the incoming cancellation fence and deadline; this does not promise a durably known remote outcome after interruption.

## Single source of truth

`src/tools/timeouts.ts` owns deadlines, transient retries and request-error classification. Callers own the foreign HTTP operations and response validation.

## Duplication and abstraction budget

The callback contract and manual `readBodyWithLimit` loop are deleted. No overload, adapter, service or new runtime entry is added. Stream reading and release use the existing Effect implementation.

## Net elements (R6)

- Files: 9 modified; none added or deleted. Total +224 / −234 lines, net −10.
- Production: +178 / −170 lines, net +8. Tests: +46 / −62 lines, net −16. Ratchet: 2 lines deleted.
- Exported symbols, classes, interfaces and enums: none added or deleted. The two existing request functions accept Effects in place of callbacks.
- Private helpers: `readBodyWithLimit` deleted. No dependency changes or baseline widening.

## Consumer counts (R8)

Six production request sites in four modules are converted: one each in WebFetchTool, WebSearchTool and LoogleTool, and three in bbtClient. The shared retry operation also calls the timeout operation internally. The deleted body reader had one caller. No event emission or subscription interface changes.

## Host impact

Extension, desktop and CLI retain the existing shared tool execution boundary and cancellation input. No host-specific behavior changes.

## Scheduled refactoring

None for this request-interface conversion. The larger native runtime and tool migration remains incomplete and is not claimed by this PR.

## Validation

Current head `8579a90003983f982d39d4fa59d6a7552b42456a` includes current main `7ee6c20382`, preserving both sets of Effect ratchet decreases.

- Formatting, all six typechecks, safe build, full lint, and Effect/browser/guidance/dead-code guards pass.
- Full suite on this source: **9,089 tests passed, 5 skipped; 763 files passed, 1 skipped**, with four workers.
- The existing cancellation cases prove both the independent deadline and deferred caller interruption. The retained assertion distinguishes an abort before completion from scope cleanup after completion.
- All three review threads are resolved after a fresh check. Current-head CI passes every applicable job (run 34096433772), including static checks, both kernel shards, build artifacts and macOS smoke. The PR is mergeable against current main.

Review verification: pinned Effect 4.0.0-rc.112 `Stream.runCollect` returns a mutable `Array<A>` (`node_modules/effect/src/Stream.ts:18584`), so appending the decoder flush is valid. Zotero intentionally preserves separate status/body handling so only body parse failures recover to a status message; transport failures retain their existing classification.
