### PR TITLE
refactor: publish host snapshots directly to the session bridge

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -736,6 +736,13 @@ function createWindow(options: {
       workspacePath: paper.root,
       showOpenFileDialog: openFileDialog,
     });
+    // Install the recipient before host requests publish the recorder's state.
+    const bridge = new SessionBridge({
+      session: paper.session,
+      handleHostRequest: (request, portId) =>
+        hostRequests.handle(request, portId),
+      onPortClosed: (portId) => hostRequests.closePort(portId),
+    });
     const snapshot = createHostSnapshotSource({
       paper: paperDisplayOf(paper.key, paper.root),
       globalState: platform().globalState,
@@ -743,6 +750,7 @@ function createWindow(options: {
       readRecentCommits: () => recentCommitsOf(paper.root),
       isAuthenticated: () => SupabaseClient.isAuthenticated(),
       onError: reportBackgroundError,
+      publish: (next) => bridge.setHost(next),
     });
     const funnel = onboardingIpcRef.current?.funnelState();
     if (funnel) snapshot.setOnboarding(funnel);
@@ -785,16 +793,6 @@ function createWindow(options: {
       },
       logger: console,
     });
-    // The paper's bridge and this window's port on it: the framer cuts
-    // frames from the paper's session graph, and the host snapshot rides
-    // them (PRD 8.1).
-    const bridge = new SessionBridge({
-      session: paper.session,
-      handleHostRequest: (request, portId) =>
-        hostRequests.handle(request, portId),
-      onPortClosed: hostRequests.closePort,
-    });
-    const detachSnapshot = snapshot.onChange((next) => bridge.setHost(next));
     const port = bridge.attach({
       id: `window:${window.id}`,
       send: (message) => {
@@ -813,7 +811,6 @@ function createWindow(options: {
       dispose() {
         workspace.disposeRendererResources();
         workspace.dispose();
-        detachSnapshot();
         bridge.dispose();
         hostRequests.dispose();
         execution.dispose();

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -143,6 +143,12 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       'progressView',
     );
 
+    // Install the recipient before host requests publish the recorder's state.
+    this.bridge = new SessionBridge({
+      session,
+      handleHostRequest: (request, port) => hostRequests.handle(request, port),
+      onPortClosed: (port) => hostRequests.closePort(port),
+    });
     const roots = workspaceRoots();
     this.snapshot = createHostSnapshotSource({
       paper: paperDisplayOf(session.roots.storage, roots.workspace),
@@ -184,6 +190,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       onError: (error) => {
         this.logger.error('Host snapshot refresh failed', { data: error });
       },
+      publish: (snapshot) => this.bridge.setHost(snapshot),
     });
     const storageRoot = context.storageUri ?? context.globalStorageUri;
     // The tool-edit preview: staged copies of the original and proposed
@@ -232,19 +239,6 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       refreshOnboardingFunnel: () => this.refreshOnboardingFunnel(),
     });
     this.disposables.push({ dispose: () => hostRequests.dispose() });
-    this.bridge = new SessionBridge({
-      session,
-      handleHostRequest: (request, port) => hostRequests.handle(request, port),
-      onPortClosed: hostRequests.closePort,
-    });
-    // After the bridge: creating the host requests already published a
-    // snapshot (the recorder's first observation), and `initialize` refreshes
-    // the full one once the provider stands.
-    this.disposables.push({
-      dispose: this.snapshot.onChange((snapshot) =>
-        this.bridge.setHost(snapshot),
-      ),
-    });
 
     // Attached for the window's life: the runtime parks a request until a
     // host is attached, so the presentation must be there before the first

--- a/src/controllers/session/hostSnapshotSource.ts
+++ b/src/controllers/session/hostSnapshotSource.ts
@@ -39,12 +39,12 @@ export interface HostSnapshotSourceOptions {
    *  never shown. */
   apiKeyBanner?: () => Promise<Banners['apiKey']>;
   dependencyBanner?: () => Promise<Banners['dependency']>;
+  /** Write directly to the bridge's host snapshot, which its streams replay. */
+  publish(snapshot: HostSnapshot): void;
   onError(error: unknown): void;
 }
 
 export interface HostSnapshotSource {
-  /** The snapshot as last assembled; null until the first `refresh`. */
-  current(): HostSnapshot | null;
   /** Reassemble every catalog and publish the result. */
   refresh(): Promise<void>;
   /** The agent, team, and model catalogs changed (a roster edit, a
@@ -67,16 +67,12 @@ export interface HostSnapshotSource {
   /** The user dismissed one of the dismissable banners. */
   dismissBanner(banner: 'login' | 'gettingStarted' | 'dependency'): void;
   setOnboarding(state: HostSnapshot['onboarding']): void;
-  /** Fires with every published snapshot. */
-  onChange(listener: (snapshot: HostSnapshot) => void): () => void;
 }
 
 /** The paper's display record and the catalogs, assembled per session. */
 export function createHostSnapshotSource(
   options: HostSnapshotSourceOptions,
 ): HostSnapshotSource {
-  const listeners = new Set<(snapshot: HostSnapshot) => void>();
-  let snapshot: HostSnapshot | null = null;
   let catalogs: Pick<
     HostSnapshot,
     'agentOptions' | 'modelOptions' | 'teamOptions'
@@ -106,7 +102,7 @@ export function createHostSnapshotSource(
   const dismissed = new Set<'gettingStarted' | 'dependency'>();
 
   function publish(): void {
-    snapshot = {
+    options.publish({
       paper: options.paper,
       ...catalogs,
       workspaceRoots: options.workspaceRoots?.() ?? [],
@@ -131,8 +127,7 @@ export function createHostSnapshotSource(
           ),
       },
       onboarding,
-    };
-    for (const listener of [...listeners]) listener(snapshot);
+    });
   }
 
   async function loadAgents(): Promise<void> {
@@ -193,7 +188,6 @@ export function createHostSnapshotSource(
   const catalogLoads = [loadAgents, loadTeams, loadModels];
 
   return {
-    current: () => snapshot,
     refresh: guarded(
       ...catalogLoads,
       loadFiles,
@@ -234,12 +228,6 @@ export function createHostSnapshotSource(
       if (state === onboarding) return;
       onboarding = state;
       publish();
-    },
-    onChange(listener) {
-      listeners.add(listener);
-      return () => {
-        listeners.delete(listener);
-      };
     },
   };
 }

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
@@ -158,6 +158,7 @@ describe('desktop preview host', () => {
           fileOptions: () => files.fileOptions(),
           readRecentCommits: async () => ({ commits: [], isGitRepo: false }),
           isAuthenticated: async () => false,
+          publish: () => {},
           onError: () => {},
         }),
         draftRequests,


### PR DESCRIPTION
## Summary

Publish each assembled host snapshot directly to `SessionBridge`, whose existing Effect `SubscriptionRef` retains the latest value and supplies every attached view.

Remove the second completed-snapshot cache, `current()`, the listener set, `onChange()`, and both hosts' subscription relays. Construct the bridge before binding host requests so the recorder's initial state already has a recipient.

## Issue acceptance gates

This is an independently reviewable deletion from the native-Effect simplification campaign; it does not close a separate issue.

- Both production subscribers of the retired publication surface use the existing bridge.
- No compatibility alias, replacement event bus, or additional runtime boundary is introduced.
- Existing bridge disposal remains authoritative for rejecting late publication.

## Single source of truth

`SessionBridge` owns the completed host snapshot and its replay. `HostSnapshotSource` retains only the constituent values needed to assemble a snapshot.

## Duplication and abstraction budget

The duplicate cache and callback subscription mechanism are deleted. A constructor-supplied publication callback connects the assembler to its existing recipient; no new service or wrapper is introduced.

## Net elements (R6)

- Production files: 0 added, 0 deleted; 3 changed.
- Exported top-level symbols, classes, interfaces, and enums: 0 added, 0 deleted.
- Interface methods: `current` and `onChange` removed; one `publish` callback added to the existing options.
- State and wiring removed: one completed-snapshot variable, one listener set, and two subscription/disposal relays.
- Production lines: 19 added, 40 removed, net **−21**.
- Total, including the adjusted existing fixture: 20 added, 40 removed, net **−20**.
- No new tests or test files.

## Consumer counts (R8)

`HostSnapshotSource.onChange` had exactly **2 production subscribers**: `ProgressViewProvider` and the desktop composition root. Both now provide `publish: snapshot => bridge.setHost(snapshot)`. No subscriber is removed without a replacement connection.

The retired `current()` method had **0 consumers**. The completed snapshot is read and replayed through the existing bridge.

## Host impact

Extension: catalogs, banners, onboarding, and recorder state continue to reach the sidebar and editor through the same bridge.

Desktop: each paper's snapshot continues to reach its window through the same bridge.

CLI: unchanged.

## Scheduled refactoring

None for this deletion. It does not change the lifetime or error policy of catalog loading and does not claim that the remaining Promise-based host producers have been converted.

## Validation

All checks below ran in the isolated PR worktree against commit `1fac550d865143a6f5192395cbccf2fa3ccb8bec`, based on `3e171c15758df9e113c9fc140c56edd19c9e492b`.

- `corepack pnpm install --frozen-lockfile`
- `npm run format` — no unrelated changes.
- `npm run typecheck` — all workspace, test-kernel, agent, CLI, trace-viewer, and desktop checks passed.
- `npm run lint`
- `npm run compile:fast`
- `npm test -- --maxWorkers=4` — 765 suites passed, 1 skipped; 9,088 tests passed, 6 skipped.
- `npm run check:effect-migration-ratchet`
- `npm run check:dead-code-ratchet`
- `git diff --check` and the repository commit/push hooks.

## Verified

Reviewed initialization and disposal in both hosts, the recorder's immediate subscription notification, and `SessionBridge.setHost`. Request callbacks are not invoked by bridge construction; both hosts finish creating their handlers before attaching ports. Bridge disposal rejects late snapshot updates.
