### PR TITLE
feat: connect native Effect diagnostics to host logging

### DIFF
--- a/src/auth/authProgram.ts
+++ b/src/auth/authProgram.ts
@@ -7,6 +7,7 @@
  * sanctioned boundary, not here.
  */
 import { Cause, Data, Deferred, Effect, Exit, Option, Semaphore } from 'effect';
+import type { HttpClient } from 'effect/unstable/http';
 
 /**
  * A host port (secret storage), an SDK call, or a provider policy rejected.
@@ -111,7 +112,7 @@ function rethrowPortCause(error: unknown): never {
  * `Effect.run*` call itself in boundary code (PRD R1).
  */
 export type AuthProgramEdge = <A, E>(
-  program: Effect.Effect<A, E>,
+  program: Effect.Effect<A, E, HttpClient.HttpClient>,
 ) => Promise<Exit.Exit<A, E>>;
 
 let authProgramEdge: AuthProgramEdge | null = null;
@@ -128,7 +129,7 @@ export function installAuthProgramEdge(edge: AuthProgramEdge): void {
  * and interruption propagate as they are.
  */
 export async function runAuthProgram<A, E>(
-  program: Effect.Effect<A, E>,
+  program: Effect.Effect<A, E, HttpClient.HttpClient>,
   rethrow: (error: E) => never = rethrowPortCause,
 ): Promise<A> {
   if (!authProgramEdge) {

--- a/src/auth/codex/codexLoopbackLogin.ts
+++ b/src/auth/codex/codexLoopbackLogin.ts
@@ -14,6 +14,7 @@ import {
 } from './codexConstants';
 import { type CodexSession } from './codexSessionTypes';
 import type { Effect } from 'effect';
+import type { HttpClient } from 'effect/unstable/http';
 
 export interface CodexLoopbackLoginOptions {
   coordinator: LoopbackOAuthCoordinator<CodexSession>;
@@ -22,7 +23,7 @@ export interface CodexLoopbackLoginOptions {
 
 export function loginWithLoopback(
   options: CodexLoopbackLoginOptions,
-): Effect.Effect<CodexSession, unknown> {
+): Effect.Effect<CodexSession, unknown, HttpClient.HttpClient> {
   return loginWithOAuthLoopback({
     coordinator: options.coordinator,
     openBrowser: options.openBrowser,

--- a/src/auth/oauth/SubscriptionOAuthCoordinator.ts
+++ b/src/auth/oauth/SubscriptionOAuthCoordinator.ts
@@ -32,6 +32,7 @@ import {
   type ProviderAuthErrorCtor,
 } from './providerAuthBridge';
 import { SubscriptionOAuthError } from './subscriptionOAuthError';
+import type { HttpClient } from 'effect/unstable/http';
 import type { z } from 'zod';
 
 const log = createLog('SubscriptionOAuth');
@@ -74,10 +75,18 @@ export interface SubscriptionOAuthClient {
     code: string;
     verifier: string;
     redirectUri: string;
-  }): Effect.Effect<SubscriptionTokenResponse, SubscriptionOAuthError>;
+  }): Effect.Effect<
+    SubscriptionTokenResponse,
+    SubscriptionOAuthError,
+    HttpClient.HttpClient
+  >;
   refreshTokens(
     refreshToken: string,
-  ): Effect.Effect<SubscriptionTokenResponse, SubscriptionOAuthError>;
+  ): Effect.Effect<
+    SubscriptionTokenResponse,
+    SubscriptionOAuthError,
+    HttpClient.HttpClient
+  >;
 }
 
 export interface SubscriptionSessionStatus {
@@ -226,7 +235,7 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     code: string;
     verifier: string;
     redirectUri: string;
-  }): Effect.Effect<S, unknown> {
+  }): Effect.Effect<S, unknown, HttpClient.HttpClient> {
     return Effect.mapError(this.exchangeCode(params), this.toProviderError);
   }
 

--- a/src/auth/oauth/loopbackLogin.ts
+++ b/src/auth/oauth/loopbackLogin.ts
@@ -14,8 +14,9 @@
 import http from 'node:http';
 
 import { Deferred, Duration, Effect } from 'effect';
-
 import { AUTH_CALLBACK_TIMEOUT_MS } from '../config';
+import type { HttpClient } from 'effect/unstable/http';
+
 import type { SubscriptionAuthorizeRequest } from './SubscriptionOAuthCoordinator';
 
 /**
@@ -42,7 +43,7 @@ export interface LoopbackOAuthCoordinator<S> {
     code: string;
     verifier: string;
     redirectUri: string;
-  }): Effect.Effect<S, unknown>;
+  }): Effect.Effect<S, unknown, HttpClient.HttpClient>;
 }
 
 export interface OAuthLoopbackLoginOptions<S> {
@@ -130,7 +131,7 @@ function bindLoopbackServer(
  */
 export function loginWithOAuthLoopback<S>(
   options: OAuthLoopbackLoginOptions<S>,
-): Effect.Effect<S, unknown> {
+): Effect.Effect<S, unknown, HttpClient.HttpClient> {
   const { coordinator, openBrowser, ports, callbackPath, displayName } =
     options;
   // The setup prefix is uninterruptible to preserve the Promise

--- a/src/auth/oauth/oauthRequest.ts
+++ b/src/auth/oauth/oauthRequest.ts
@@ -4,13 +4,16 @@
  *
  * One request is one fiber: headers and body are read under one
  * `Effect.timeoutOrElse`, and fiber interruption reaches `fetch` and the body
- * stream through the `AbortSignal` that `Effect.tryPromise` hands the request.
+ * stream through the request scope owned by `HttpClient.withScope`.
  * Expected transport failures are yieldable tagged errors carrying the
  * user-facing message; the flows above pass them up unchanged and the hosts
  * render `message` at their run edge.
  */
+// Third-party imports
 import { Data, Duration, Effect } from 'effect';
+import { HttpBody, HttpClient, HttpClientRequest } from 'effect/unstable/http';
 
+// Local imports
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import type { z } from 'zod';
@@ -77,28 +80,30 @@ interface OAuthPostOptions {
 export const postOAuth = Effect.fn('oauthRequest.postOAuth')(function* (
   options: OAuthPostOptions,
 ) {
-  return yield* Effect.tryPromise({
-    // The body is read on the same signal so the deadline and interruption
-    // bound a server that sends headers and then stalls.
-    try: async (signal): Promise<OAuthResponse> => {
-      const response = await fetch(options.url, {
-        method: 'POST',
-        headers: options.headers,
-        body: options.body,
-        signal,
-      });
-      return {
-        status: response.status,
-        ok: response.ok,
-        text: await response.text(),
-      };
-    },
-    catch: (cause) =>
-      new OAuthNetworkError({
+  const client = yield* HttpClient.HttpClient;
+  return yield* Effect.gen(function* () {
+    const response = yield* HttpClient.withScope(client).execute(
+      HttpClientRequest.post(options.url, {
+        body: HttpBody.raw(options.body),
+      }).pipe(HttpClientRequest.setHeaders(options.headers)),
+    );
+    const text = yield* response.text;
+    return {
+      status: response.status,
+      ok: response.status >= 200 && response.status < 300,
+      text,
+    } satisfies OAuthResponse;
+  }).pipe(
+    Effect.scoped,
+    Effect.mapError((error) => {
+      // Keep the underlying transport error only: HTTP error wrappers also
+      // retain the request body, which contains OAuth credentials.
+      const cause = error.reason.cause;
+      return new OAuthNetworkError({
         message: `${options.networkErrorMessage}: ${toErrorMessage(cause)}`,
         cause,
-      }),
-  }).pipe(
+      });
+    }),
     Effect.timeoutOrElse({
       duration: Duration.millis(options.timeoutMs),
       orElse: () =>

--- a/src/auth/xai/xaiLoopbackLogin.ts
+++ b/src/auth/xai/xaiLoopbackLogin.ts
@@ -10,6 +10,7 @@ import {
 import { XAI_CALLBACK_PATH, XAI_CALLBACK_PORT } from './xaiConstants';
 import { type XaiSession } from './xaiSessionTypes';
 import type { Effect } from 'effect';
+import type { HttpClient } from 'effect/unstable/http';
 
 export interface XaiLoopbackLoginOptions {
   coordinator: LoopbackOAuthCoordinator<XaiSession>;
@@ -18,7 +19,7 @@ export interface XaiLoopbackLoginOptions {
 
 export function loginWithLoopback(
   options: XaiLoopbackLoginOptions,
-): Effect.Effect<XaiSession, unknown> {
+): Effect.Effect<XaiSession, unknown, HttpClient.HttpClient> {
   return loginWithOAuthLoopback({
     coordinator: options.coordinator,
     openBrowser: options.openBrowser,

--- a/src/controllers/modelAccess/subscriptionProviders.ts
+++ b/src/controllers/modelAccess/subscriptionProviders.ts
@@ -43,6 +43,7 @@ import {
   setPreferXaiSubscription,
 } from '@model/xai/xaiPreference';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import type { HttpClient } from 'effect/unstable/http';
 
 const log = createLog('subscriptionProviders');
 
@@ -114,7 +115,7 @@ export interface SubscriptionProvider {
    */
   signIn(
     options: SubscriptionSignInOptions,
-  ): Effect.Effect<SubscriptionAccount, unknown>;
+  ): Effect.Effect<SubscriptionAccount, unknown, HttpClient.HttpClient>;
   signOut(): Promise<void>;
   getStatus(): Promise<SubscriptionAccount>;
   isPreferSubscription(): boolean;
@@ -142,11 +143,11 @@ interface SubscriptionProviderBindings<Coordinator, Session> {
   readonly loginWithDeviceCode: (options: {
     coordinator: Coordinator;
     onPrompt: (prompt: SubscriptionDeviceCodePrompt) => void;
-  }) => Effect.Effect<Session, unknown>;
+  }) => Effect.Effect<Session, unknown, HttpClient.HttpClient>;
   readonly loginWithLoopback: (options: {
     coordinator: Coordinator;
     openBrowser: (url: string) => void | Promise<void>;
-  }) => Effect.Effect<Session, unknown>;
+  }) => Effect.Effect<Session, unknown, HttpClient.HttpClient>;
   readonly accountLabel: (
     account:
       | { readonly email?: string | null; readonly accountId?: string | null }

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -54,6 +54,7 @@ import {
   type SessionOpen,
 } from '@agent/runtime/sessionGraph';
 import { createLog } from '@logger/logUtils';
+import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
 import {
   clearProcessRuntime,
   initProcessRuntime,
@@ -596,16 +597,22 @@ export function installProcessRuntime(
   const release = (key: SessionKey): void => {
     runtime.runFork(Effect.flatMap(Sessions, (s) => s.invalidate(key)));
   };
-  const runtime = ManagedRuntime.make(Sessions.layer(release, identity));
+  const runtime = ManagedRuntime.make(
+    Sessions.layer(release, identity).pipe(
+      Layer.provideMerge(effectDiagnosticsLayer),
+    ),
+  );
   initProcessRuntime(runtime);
   // The map's services on the caller's own fiber: an Effect-native opener
   // (the SDK) runs these where it stands, so the owner adds no run site of
-  // its own. `openSync` and `current` stay synchronous for the three hosts.
+  // its own. Supply only the owned session family: the caller retains its
+  // tracer, logger, and other independently provided services. `openSync`
+  // and `current` stay synchronous for the three hosts.
   const onThisRuntime = <A, E>(
     effect: Effect.Effect<A, E, Sessions>,
   ): Effect.Effect<A, E> =>
     Effect.flatMap(runtime.contextEffect, (context) =>
-      Effect.provideContext(effect, context),
+      Effect.provideService(effect, Sessions, Context.get(context, Sessions)),
     );
   initSessionOwner({
     openSync: (open) => runtime.runSync(openSession(open)),

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -37,6 +37,7 @@ import {
   SubscriptionRef,
   Fiber,
 } from 'effect';
+import { FetchHttpClient } from 'effect/unstable/http';
 
 import { proveOwnerLiveness } from '@agent/storage/leaseOwnerLiveness';
 import { runInSession } from '@agent/runtime/RunContext';
@@ -599,7 +600,9 @@ export function installProcessRuntime(
   };
   const runtime = ManagedRuntime.make(
     Sessions.layer(release, identity).pipe(
-      Layer.provideMerge(effectDiagnosticsLayer),
+      Layer.provideMerge(
+        Layer.mergeAll(effectDiagnosticsLayer, FetchHttpClient.layer),
+      ),
     ),
   );
   initProcessRuntime(runtime);

--- a/src/logger/effectDiagnostics.ts
+++ b/src/logger/effectDiagnostics.ts
@@ -1,0 +1,95 @@
+/** Effect diagnostics use the host's existing, secret-redacting output sink. */
+// Third-party imports
+import { Exit, Layer, Logger, Option, References, Tracer } from 'effect';
+import safeStringify from 'safe-stable-stringify';
+
+// Local imports
+import { createLog, isDebugModeEnabled } from '@logger/logUtils';
+
+const log = createLog('Effect');
+const MAX_SPAN_ATTRIBUTES = 32;
+const MAX_ATTRIBUTE_LENGTH = 512;
+
+/** Route native log levels and annotations through the shared host logger. */
+const diagnosticLogger = Logger.make<unknown, void>((options) => {
+  if (options.logLevel === 'None') return;
+  const verbose = options.logLevel === 'Debug' || options.logLevel === 'Trace';
+  if (verbose && !isDebugModeEnabled()) return;
+  const entry = Logger.formatStructured.log(options);
+  const message =
+    typeof entry.message === 'string'
+      ? entry.message
+      : (safeStringify(entry.message) ?? String(entry.message));
+  const data = { ...entry, message: undefined };
+  switch (options.logLevel) {
+    case 'Fatal':
+    case 'Error':
+      log.error(entry.cause ? `${message}\n${entry.cause}` : message, { data });
+      break;
+    case 'Warn':
+      log.warn(message, { data });
+      break;
+    case 'Debug':
+    case 'Trace':
+      log.debug(message, { data });
+      break;
+    default:
+      log.info(message, { data });
+  }
+});
+
+/**
+ * Retain only bounded scalar attributes while a span is live. Span events and
+ * links are deliberately omitted from local diagnostics. The output contains
+ * neither an operation's return value nor its error body.
+ */
+class DiagnosticSpan extends Tracer.NativeSpan {
+  override attribute(key: string, value: unknown): void {
+    if (!this.sampled || key.length > MAX_ATTRIBUTE_LENGTH) return;
+    if (
+      this.attributes.size >= MAX_SPAN_ATTRIBUTES &&
+      !this.attributes.has(key)
+    ) {
+      return;
+    }
+    if (typeof value === 'string') {
+      super.attribute(key, value.slice(0, MAX_ATTRIBUTE_LENGTH));
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      super.attribute(key, value);
+    }
+  }
+
+  override event(): void {}
+
+  override addLinks(): void {}
+
+  override end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {
+    if (this.status._tag === 'Ended') return;
+    super.end(endTime, exit);
+    if (!this.sampled || !isDebugModeEnabled()) return;
+    log.debug(`${this.name}: ${exit._tag}`, {
+      data: {
+        traceId: this.traceId,
+        spanId: this.spanId,
+        parentSpanId: Option.getOrUndefined(this.parent)?.spanId,
+        durationMs: Number(endTime - this.startTime) / 1_000_000,
+        attributes: Object.fromEntries(this.attributes),
+      },
+    });
+  }
+}
+
+/**
+ * Local diagnostics for the process runtime. Successful and failed spans are
+ * emitted only in debug mode; no exporter or retained collection is installed.
+ * Callers can still provide their own Tracer on an individual Effect.
+ */
+export const effectDiagnosticsLayer = Layer.mergeAll(
+  Logger.layer([diagnosticLogger]),
+  Layer.succeed(References.MinimumLogLevel)('Trace'),
+  Layer.succeed(Tracer.Tracer)(
+    Tracer.make({
+      span: (options) => new DiagnosticSpan({ ...options, links: [] }),
+    }),
+  ),
+);

--- a/src/platform/processRuntime.ts
+++ b/src/platform/processRuntime.ts
@@ -7,8 +7,12 @@
  * Installed like the process roots: exactly once, by the entry.
  */
 import type { ManagedRuntime } from 'effect';
+import type { HttpClient } from 'effect/unstable/http';
 
-export type ProcessRuntime = ManagedRuntime.ManagedRuntime<never, never>;
+export type ProcessRuntime = ManagedRuntime.ManagedRuntime<
+  HttpClient.HttpClient,
+  never
+>;
 
 let processRuntime: ProcessRuntime | null = null;
 

--- a/src/test-kernel/auth/CodexDeviceLogin.vitest.ts
+++ b/src/test-kernel/auth/CodexDeviceLogin.vitest.ts
@@ -1,5 +1,6 @@
 import { it } from '@effect/vitest';
 import { Cause, Effect, Exit, Fiber } from 'effect';
+import { FetchHttpClient } from 'effect/unstable/http';
 import { TestClock } from 'effect/testing';
 import { afterEach, describe, expect, vi } from 'vitest';
 
@@ -24,7 +25,10 @@ function stubDeviceEndpoints(
     'fetch',
     vi.fn<typeof fetch>(async (input, init) => {
       const url = String(input);
-      if (url === CODEX_DEVICE_USERCODE_URL) {
+      if (String(url) === CODEX_DEVICE_USERCODE_URL) {
+        expect(new Headers(init?.headers).get('content-type')).toBe(
+          'application/json',
+        );
         return jsonResponse({
           device_auth_id: 'device-auth-id',
           user_code: 'ABCD-EFGH',
@@ -32,7 +36,7 @@ function stubDeviceEndpoints(
           ...userCode,
         });
       }
-      if (url === CODEX_DEVICE_TOKEN_URL) return onPoll(init);
+      if (String(url) === CODEX_DEVICE_TOKEN_URL) return onPoll(init);
       throw new Error(`Unexpected fetch: ${url}`);
     }),
   );
@@ -67,7 +71,10 @@ describe('Codex device login', () => {
         const coordinator = coordinatorStub();
         const onPrompt = vi.fn();
         const fiber = yield* Effect.forkChild(
-          loginWithDeviceCode({ coordinator, onPrompt }),
+          loginWithDeviceCode({ coordinator, onPrompt }).pipe(
+            Effect.provide(FetchHttpClient.layer),
+            Effect.provideService(FetchHttpClient.Fetch, globalThis.fetch),
+          ),
         );
         yield* prompted(onPrompt);
         yield* TestClock.adjust('5 seconds');
@@ -106,7 +113,10 @@ describe('Codex device login', () => {
         );
         const onPrompt = vi.fn();
         const fiber = yield* Effect.forkChild(
-          loginWithDeviceCode({ coordinator, onPrompt }),
+          loginWithDeviceCode({ coordinator, onPrompt }).pipe(
+            Effect.provide(FetchHttpClient.layer),
+            Effect.provideService(FetchHttpClient.Fetch, globalThis.fetch),
+          ),
         );
         yield* prompted(onPrompt);
         yield* TestClock.adjust('5 seconds');
@@ -141,7 +151,13 @@ describe('Codex device login', () => {
         });
         const onPrompt = vi.fn();
         const fiber = yield* Effect.forkChild(
-          loginWithDeviceCode({ coordinator: coordinatorStub(), onPrompt }),
+          loginWithDeviceCode({
+            coordinator: coordinatorStub(),
+            onPrompt,
+          }).pipe(
+            Effect.provide(FetchHttpClient.layer),
+            Effect.provideService(FetchHttpClient.Fetch, globalThis.fetch),
+          ),
         );
         yield* prompted(onPrompt);
 

--- a/src/test-kernel/auth/CodexLoopbackLogin.vitest.ts
+++ b/src/test-kernel/auth/CodexLoopbackLogin.vitest.ts
@@ -1,4 +1,5 @@
 import { Effect } from 'effect';
+import { FetchHttpClient } from 'effect/unstable/http';
 import { describe, expect, it, vi } from 'vitest';
 
 import { loginWithLoopback } from '@auth/codex';
@@ -38,7 +39,10 @@ function runLogin(
   options: Parameters<typeof loginWithLoopback>[0],
   signal?: AbortSignal,
 ): Promise<CodexSession> {
-  return Effect.runPromise(loginWithLoopback(options), { signal });
+  return Effect.runPromise(
+    loginWithLoopback(options).pipe(Effect.provide(FetchHttpClient.layer)),
+    { signal },
+  );
 }
 
 describe('Codex loopback login', () => {

--- a/src/test-kernel/auth/FormTokenClient.vitest.ts
+++ b/src/test-kernel/auth/FormTokenClient.vitest.ts
@@ -1,4 +1,5 @@
 import { Effect } from 'effect';
+import { FetchHttpClient } from 'effect/unstable/http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
@@ -42,14 +43,20 @@ describe('form token endpoint (declarative)', () => {
         code: 'code-1',
         verifier: 'verifier-1',
         redirectUri: 'http://127.0.0.1/callback',
-      }),
+      }).pipe(
+        Effect.provide(FetchHttpClient.layer),
+        Effect.provideService(FetchHttpClient.Fetch, globalThis.fetch),
+      ),
     );
 
     expect(tokens.access_token).toBe('access');
     expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0]!;
-    expect(url).toBe('https://example.test/token');
+    expect(String(url)).toBe('https://example.test/token');
     expect(init?.method).toBe('POST');
+    expect(new Headers(init?.headers).get('content-type')).toBe(
+      'application/x-www-form-urlencoded',
+    );
     const body = new URLSearchParams(String(init?.body));
     expect(body.get('grant_type')).toBe('authorization_code');
     expect(body.get('client_id')).toBe('client-1');
@@ -65,7 +72,10 @@ describe('form token endpoint (declarative)', () => {
     });
 
     const tokens = await Effect.runPromise(
-      refreshOAuthTokens(ENDPOINT, 'old-refresh'),
+      refreshOAuthTokens(ENDPOINT, 'old-refresh').pipe(
+        Effect.provide(FetchHttpClient.layer),
+        Effect.provideService(FetchHttpClient.Fetch, globalThis.fetch),
+      ),
     );
     expect(tokens.access_token).toBe('new-access');
     const body = new URLSearchParams(String(fetchMock.mock.calls[0]![1]?.body));
@@ -80,7 +90,12 @@ describe('form token endpoint (declarative)', () => {
     );
 
     await expect(
-      Effect.runPromise(refreshOAuthTokens(ENDPOINT, 'bad')),
+      Effect.runPromise(
+        refreshOAuthTokens(ENDPOINT, 'bad').pipe(
+          Effect.provide(FetchHttpClient.layer),
+          Effect.provideService(FetchHttpClient.Fetch, globalThis.fetch),
+        ),
+      ),
     ).rejects.toMatchObject({
       _tag: 'OAuthHttpError',
       message: 'Token refresh failed (HTTP 401): nope',
@@ -111,7 +126,10 @@ describe('postOAuth', () => {
           body: '',
           timeoutMs: 20,
           networkErrorMessage: 'Network error contacting token',
-        }),
+        }).pipe(
+          Effect.provide(FetchHttpClient.layer),
+          Effect.provideService(FetchHttpClient.Fetch, globalThis.fetch),
+        ),
       ),
     ).rejects.toMatchObject({
       _tag: 'OAuthNetworkError',

--- a/src/test-kernel/cli/ChatgptLoginBrowser.vitest.ts
+++ b/src/test-kernel/cli/ChatgptLoginBrowser.vitest.ts
@@ -1,5 +1,6 @@
 import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { effectRuntime } from '@platform/processRuntime';
 
 const mocks = vi.hoisted(() => ({
   codexCoordinator: vi.fn(() => ({})),
@@ -28,7 +29,7 @@ const signInCliChatGpt = (
   options: { writeProgress: (message: string) => void },
   signal?: AbortSignal,
 ) =>
-  Effect.runPromise(signInCliSubscription('chatgpt', init, options), {
+  effectRuntime().runPromise(signInCliSubscription('chatgpt', init, options), {
     signal,
   });
 

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
@@ -1,5 +1,6 @@
 import { Effect, Exit } from 'effect';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { testHttpClientLayer } from '@test/support/fetchTestUtils';
 
 const mocks = vi.hoisted(() => {
   const authCoordinator = {
@@ -74,10 +75,11 @@ async function loadSupabaseAuth() {
   // `vi.resetModules()` gives the module graph a fresh `@platform/processRuntime`
   // whose runtime the shared fake-host install never reached; the module's own
   // `initializeCliSupabaseAuth` installs the auth run edge from it.
-  const [{ initProcessRuntime }, { Layer, ManagedRuntime }] = await Promise.all(
-    [import('@platform/processRuntime'), import('effect')],
-  );
-  initProcessRuntime(ManagedRuntime.make(Layer.empty));
+  const [{ initProcessRuntime }, { ManagedRuntime }] = await Promise.all([
+    import('@platform/processRuntime'),
+    import('effect'),
+  ]);
+  initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
   return import('@cli/runtime/supabaseAuth');
 }
 
@@ -165,9 +167,12 @@ describe('CLI Supabase auth', () => {
     );
     const { signInCliSupabaseDeviceCode } = await loadSupabaseAuth();
 
-    const exit = await Effect.runPromiseExit(signInCliSupabaseDeviceCode(), {
-      signal: controller.signal,
-    });
+    const exit = await Effect.runPromiseExit(
+      signInCliSupabaseDeviceCode().pipe(Effect.provide(testHttpClientLayer)),
+      {
+        signal: controller.signal,
+      },
+    );
 
     expect(Exit.isFailure(exit) && Exit.hasInterrupts(exit)).toBe(true);
     expect(mocks.authCoordinator.storeSession).not.toHaveBeenCalled();
@@ -192,9 +197,12 @@ describe('CLI Supabase auth', () => {
       openBrowser: false,
       signal: controller.signal,
     });
-    const deviceSignIn = Effect.runPromise(signInCliSupabaseDeviceCode(), {
-      signal: controller.signal,
-    });
+    const deviceSignIn = Effect.runPromise(
+      signInCliSupabaseDeviceCode().pipe(Effect.provide(testHttpClientLayer)),
+      {
+        signal: controller.signal,
+      },
+    );
     controller.abort();
     await expect(deviceSignIn).rejects.toThrow(/interrupted/);
 

--- a/src/test-kernel/cli/ClipboardText.vitest.ts
+++ b/src/test-kernel/cli/ClipboardText.vitest.ts
@@ -1,4 +1,4 @@
-import { Layer, ManagedRuntime } from 'effect';
+import { ManagedRuntime } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const writeMock = vi.hoisted(() => vi.fn());
@@ -24,6 +24,7 @@ vi.mock('node:child_process', async (importOriginal) => {
 import { writeClipboardText } from '@cli/runtime/clipboardText';
 import { disposeProcessRuntime } from '@controllers/session/sessionLayer';
 import { initProcessRuntime } from '@platform/processRuntime';
+import { testHttpClientLayer } from '@test/support/fetchTestUtils';
 
 describe('CLI clipboard text writer', () => {
   beforeEach(() => {
@@ -89,7 +90,7 @@ describe('CLI clipboard text writer', () => {
       expect(execFileMock).toHaveBeenCalled();
     } finally {
       await disposeProcessRuntime();
-      initProcessRuntime(ManagedRuntime.make(Layer.empty));
+      initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
     }
   });
 

--- a/src/test-kernel/cli/DeviceCodeAuth.vitest.ts
+++ b/src/test-kernel/cli/DeviceCodeAuth.vitest.ts
@@ -1,7 +1,7 @@
 import { it } from '@effect/vitest';
 import { Cause, Effect, Exit, Fiber } from 'effect';
 import { TestClock } from 'effect/testing';
-import { afterEach, describe, expect, vi } from 'vitest';
+import { afterEach, expect, vi } from 'vitest';
 
 import {
   CLI_DEVICE_AUTH_URL_PROMPT,
@@ -10,6 +10,7 @@ import {
   pollForDeviceSession,
   requestDeviceAuthorization,
 } from '@cli/runtime/supabaseAuthDeviceCode';
+import { testHttpClientLayer } from '@test/support/fetchTestUtils';
 
 import { jsonResponse } from '@test/support/fetchTestUtils';
 
@@ -74,181 +75,186 @@ const advancePolls = (
 const failureOf = (exit: Exit.Exit<unknown, unknown>): unknown =>
   Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined;
 
-describe('CLI device-code sign-in (texra login --device)', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it.effect('cancels a pending poll before its first network request', () =>
-    Effect.gen(function* () {
-      const calls = queuedFetch([jsonResponse(SESSION_PAYLOAD)]);
-      const fiber = yield* Effect.forkChild(
-        pollForDeviceSession(AUTHORIZATION),
-      );
-
-      yield* Fiber.interrupt(fiber);
-
-      const exit = yield* Fiber.await(fiber);
-      expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(
-        true,
-      );
-      expect(calls).toHaveLength(0);
-    }),
-  );
-
-  it('parses a device authorization and defaults a missing interval', () => {
-    const parsed = DeviceAuthorizationSchema.parse({
-      ...AUTHORIZATION,
-      interval: 'bogus',
+it.layer(testHttpClientLayer)(
+  'CLI device-code sign-in (texra login --device)',
+  (it) => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
     });
-    expect(parsed.interval).toBe(5);
-    expect(parsed.user_code).toBe('BCDF-GHJK');
-  });
 
-  it.effect('requests a device authorization from the auth server', () =>
-    Effect.gen(function* () {
-      const calls = queuedFetch([jsonResponse(AUTHORIZATION)]);
-      const authorization = yield* requestDeviceAuthorization();
-      expect(authorization.device_code).toBe('device-code-secret');
-      expect(calls[0].url).toMatch(/\/auth-device\/code$/);
-    }),
-  );
+    it.effect('cancels a pending poll before its first network request', () =>
+      Effect.gen(function* () {
+        const calls = queuedFetch([jsonResponse(SESSION_PAYLOAD)]);
+        const fiber = yield* Effect.forkChild(
+          pollForDeviceSession(AUTHORIZATION),
+        );
 
-  it.effect('reports an unavailable device endpoint with a recovery hint', () =>
-    Effect.gen(function* () {
-      queuedFetch([jsonResponse({ error: 'nope' }, 503)]);
-      const exit = yield* Effect.exit(requestDeviceAuthorization());
-      expect(failureOf(exit)).toMatchObject({
-        _tag: 'DeviceSignInError',
-        reason: 'request',
-        message: expect.stringMatching(/unavailable.*--no-browser/s),
+        yield* Fiber.interrupt(fiber);
+
+        const exit = yield* Fiber.await(fiber);
+        expect(
+          Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause),
+        ).toBe(true);
+        expect(calls).toHaveLength(0);
+      }),
+    );
+
+    it('parses a device authorization and defaults a missing interval', () => {
+      const parsed = DeviceAuthorizationSchema.parse({
+        ...AUTHORIZATION,
+        interval: 'bogus',
       });
-    }),
-  );
+      expect(parsed.interval).toBe(5);
+      expect(parsed.user_code).toBe('BCDF-GHJK');
+    });
 
-  it.effect(
-    'polls through pending and slow_down, honoring the growing interval',
-    () =>
+    it.effect('requests a device authorization from the auth server', () =>
+      Effect.gen(function* () {
+        const calls = queuedFetch([jsonResponse(AUTHORIZATION)]);
+        const authorization = yield* requestDeviceAuthorization();
+        expect(authorization.device_code).toBe('device-code-secret');
+        expect(calls[0].url).toMatch(/\/auth-device\/code$/);
+      }),
+    );
+
+    it.effect(
+      'reports an unavailable device endpoint with a recovery hint',
+      () =>
+        Effect.gen(function* () {
+          queuedFetch([jsonResponse({ error: 'nope' }, 503)]);
+          const exit = yield* Effect.exit(requestDeviceAuthorization());
+          expect(failureOf(exit)).toMatchObject({
+            _tag: 'DeviceSignInError',
+            reason: 'request',
+            message: expect.stringMatching(/unavailable.*--no-browser/s),
+          });
+        }),
+    );
+
+    it.effect(
+      'polls through pending and slow_down, honoring the growing interval',
+      () =>
+        Effect.gen(function* () {
+          const calls = queuedFetch([
+            jsonResponse({ error: 'authorization_pending' }, 400),
+            jsonResponse({ error: 'slow_down' }, 400),
+            jsonResponse(SESSION_PAYLOAD),
+          ]);
+          const fiber = yield* Effect.forkChild(
+            pollForDeviceSession(AUTHORIZATION),
+          );
+
+          // 5s, 5s, then 10s after the slow_down bump.
+          yield* advancePolls(2);
+          expect(calls).toHaveLength(2);
+          yield* advancePolls(1);
+          expect(calls).toHaveLength(2);
+          yield* advancePolls(1);
+
+          const exchange = yield* Fiber.join(fiber);
+          expect(exchange.access_token).toBe('access-token');
+          expect(exchange.user.email).toBe('user@example.edu');
+          expect(calls).toHaveLength(3);
+          expect(
+            calls.every((call) => call.url.endsWith('/auth-device/token')),
+          ).toBe(true);
+          expect(calls[0].body).toEqual({ device_code: 'device-code-secret' });
+        }),
+    );
+
+    it.effect('surfaces a denial from the browser as a clear error', () =>
+      Effect.gen(function* () {
+        queuedFetch([jsonResponse({ error: 'access_denied' }, 400)]);
+        const fiber = yield* Effect.forkChild(
+          pollForDeviceSession(AUTHORIZATION),
+        );
+        yield* advancePolls(1);
+        expect(failureOf(yield* Fiber.await(fiber))).toMatchObject({
+          reason: 'denied',
+          message: 'Sign-in was denied in the browser.',
+        });
+      }),
+    );
+
+    it.effect('maps expired_token to a fresh-code suggestion', () =>
+      Effect.gen(function* () {
+        queuedFetch([jsonResponse({ error: 'expired_token' }, 400)]);
+        const fiber = yield* Effect.forkChild(
+          pollForDeviceSession(AUTHORIZATION),
+        );
+        yield* advancePolls(1);
+        expect(failureOf(yield* Fiber.await(fiber))).toMatchObject({
+          reason: 'expired',
+          message: expect.stringMatching(/expired before it was approved/),
+        });
+      }),
+    );
+
+    it.effect('stops polling when the code expires locally', () =>
       Effect.gen(function* () {
         const calls = queuedFetch([
           jsonResponse({ error: 'authorization_pending' }, 400),
-          jsonResponse({ error: 'slow_down' }, 400),
+        ]);
+        const fiber = yield* Effect.forkChild(
+          pollForDeviceSession({ ...AUTHORIZATION, expires_in: 10 }),
+        );
+        yield* advancePolls(2);
+        expect(failureOf(yield* Fiber.await(fiber))).toMatchObject({
+          reason: 'expired',
+          message: expect.stringMatching(/expired before it was approved/),
+        });
+        expect(calls).toHaveLength(1);
+      }),
+    );
+
+    it.effect('tolerates transient poll failures but not persistent ones', () =>
+      Effect.gen(function* () {
+        queuedFetch([
+          new Error('socket hang up'),
+          new Error('socket hang up'),
+          jsonResponse(SESSION_PAYLOAD),
+        ]);
+        const tolerant = yield* Effect.forkChild(
+          pollForDeviceSession(AUTHORIZATION),
+        );
+        yield* advancePolls(3);
+        expect((yield* Fiber.join(tolerant)).access_token).toBe('access-token');
+
+        queuedFetch([
+          new Error('socket hang up'),
+          new Error('socket hang up'),
+          new Error('socket hang up'),
+        ]);
+        const persistent = yield* Effect.forkChild(
+          pollForDeviceSession(AUTHORIZATION),
+        );
+        yield* advancePolls(3);
+        expect(failureOf(yield* Fiber.await(persistent))).toMatchObject({
+          reason: 'poll',
+          message: 'Device sign-in poll failed: socket hang up',
+        });
+      }),
+    );
+
+    it.effect('treats rate-limited poll responses as transient', () =>
+      Effect.gen(function* () {
+        queuedFetch([
+          jsonResponse({ error: 'rate_limited' }, 429),
           jsonResponse(SESSION_PAYLOAD),
         ]);
         const fiber = yield* Effect.forkChild(
           pollForDeviceSession(AUTHORIZATION),
         );
-
-        // 5s, 5s, then 10s after the slow_down bump.
         yield* advancePolls(2);
-        expect(calls).toHaveLength(2);
-        yield* advancePolls(1);
-        expect(calls).toHaveLength(2);
-        yield* advancePolls(1);
-
-        const exchange = yield* Fiber.join(fiber);
-        expect(exchange.access_token).toBe('access-token');
-        expect(exchange.user.email).toBe('user@example.edu');
-        expect(calls).toHaveLength(3);
-        expect(
-          calls.every((call) => call.url.endsWith('/auth-device/token')),
-        ).toBe(true);
-        expect(calls[0].body).toEqual({ device_code: 'device-code-secret' });
+        expect((yield* Fiber.join(fiber)).access_token).toBe('access-token');
       }),
-  );
+    );
 
-  it.effect('surfaces a denial from the browser as a clear error', () =>
-    Effect.gen(function* () {
-      queuedFetch([jsonResponse({ error: 'access_denied' }, 400)]);
-      const fiber = yield* Effect.forkChild(
-        pollForDeviceSession(AUTHORIZATION),
-      );
-      yield* advancePolls(1);
-      expect(failureOf(yield* Fiber.await(fiber))).toMatchObject({
-        reason: 'denied',
-        message: 'Sign-in was denied in the browser.',
-      });
-    }),
-  );
-
-  it.effect('maps expired_token to a fresh-code suggestion', () =>
-    Effect.gen(function* () {
-      queuedFetch([jsonResponse({ error: 'expired_token' }, 400)]);
-      const fiber = yield* Effect.forkChild(
-        pollForDeviceSession(AUTHORIZATION),
-      );
-      yield* advancePolls(1);
-      expect(failureOf(yield* Fiber.await(fiber))).toMatchObject({
-        reason: 'expired',
-        message: expect.stringMatching(/expired before it was approved/),
-      });
-    }),
-  );
-
-  it.effect('stops polling when the code expires locally', () =>
-    Effect.gen(function* () {
-      const calls = queuedFetch([
-        jsonResponse({ error: 'authorization_pending' }, 400),
-      ]);
-      const fiber = yield* Effect.forkChild(
-        pollForDeviceSession({ ...AUTHORIZATION, expires_in: 10 }),
-      );
-      yield* advancePolls(2);
-      expect(failureOf(yield* Fiber.await(fiber))).toMatchObject({
-        reason: 'expired',
-        message: expect.stringMatching(/expired before it was approved/),
-      });
-      expect(calls).toHaveLength(1);
-    }),
-  );
-
-  it.effect('tolerates transient poll failures but not persistent ones', () =>
-    Effect.gen(function* () {
-      queuedFetch([
-        new Error('socket hang up'),
-        new Error('socket hang up'),
-        jsonResponse(SESSION_PAYLOAD),
-      ]);
-      const tolerant = yield* Effect.forkChild(
-        pollForDeviceSession(AUTHORIZATION),
-      );
-      yield* advancePolls(3);
-      expect((yield* Fiber.join(tolerant)).access_token).toBe('access-token');
-
-      queuedFetch([
-        new Error('socket hang up'),
-        new Error('socket hang up'),
-        new Error('socket hang up'),
-      ]);
-      const persistent = yield* Effect.forkChild(
-        pollForDeviceSession(AUTHORIZATION),
-      );
-      yield* advancePolls(3);
-      expect(failureOf(yield* Fiber.await(persistent))).toMatchObject({
-        reason: 'poll',
-        message: 'Device sign-in poll failed: socket hang up',
-      });
-    }),
-  );
-
-  it.effect('treats rate-limited poll responses as transient', () =>
-    Effect.gen(function* () {
-      queuedFetch([
-        jsonResponse({ error: 'rate_limited' }, 429),
-        jsonResponse(SESSION_PAYLOAD),
-      ]);
-      const fiber = yield* Effect.forkChild(
-        pollForDeviceSession(AUTHORIZATION),
-      );
-      yield* advancePolls(2);
-      expect((yield* Fiber.join(fiber)).access_token).toBe('access-token');
-    }),
-  );
-
-  it('describes device login as any-device auth with the code inline', () => {
-    const message = formatCliDeviceAuthMessage(AUTHORIZATION);
-    expect(message).toContain(CLI_DEVICE_AUTH_URL_PROMPT);
-    expect(message).toContain(AUTHORIZATION.verification_uri);
-    expect(message).toContain('BCDF-GHJK');
-  });
-});
+    it('describes device login as any-device auth with the code inline', () => {
+      const message = formatCliDeviceAuthMessage(AUTHORIZATION);
+      expect(message).toContain(CLI_DEVICE_AUTH_URL_PROMPT);
+      expect(message).toContain(AUTHORIZATION.verification_uri);
+      expect(message).toContain('BCDF-GHJK');
+    });
+  },
+);

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -13,6 +13,7 @@ import {
   resolveCliModelAccessRoute,
   shortCliModelAccessRoute,
 } from '@cli/runtime/modelAccessRoute';
+import { effectRuntime } from '@platform/processRuntime';
 import type { UsageRoute } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
@@ -316,7 +317,7 @@ describe('CLI model access routes', () => {
   it('enables Kimi Code routing on a personal fallback when a key exists', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
 
-    const result = await Effect.runPromise(
+    const result = await effectRuntime().runPromise(
       await updateCliModelAccess(
         context,
         subscriptionPreference('kimi-code', 'on'),
@@ -336,7 +337,7 @@ describe('CLI model access routes', () => {
   });
 
   it('guides to key entry when Kimi Code is selected without a key', async () => {
-    const result = await Effect.runPromise(
+    const result = await effectRuntime().runPromise(
       await updateCliModelAccess(
         context,
         subscriptionPreference('kimi-code', 'on'),
@@ -371,7 +372,7 @@ describe('CLI model access routes', () => {
   it('enables GLM Coding Plan routing on a personal fallback when a key exists', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
 
-    const result = await Effect.runPromise(
+    const result = await effectRuntime().runPromise(
       await updateCliModelAccess(
         context,
         subscriptionPreference('glm-code', 'on'),
@@ -391,7 +392,7 @@ describe('CLI model access routes', () => {
   });
 
   it('guides to key entry when GLM Coding Plan is selected without a key', async () => {
-    const result = await Effect.runPromise(
+    const result = await effectRuntime().runPromise(
       await updateCliModelAccess(
         context,
         subscriptionPreference('glm-code', 'on'),
@@ -405,7 +406,7 @@ describe('CLI model access routes', () => {
   });
 
   it('turns off GLM Coding Plan without requiring a key', async () => {
-    const result = await Effect.runPromise(
+    const result = await effectRuntime().runPromise(
       await updateCliModelAccess(
         context,
         subscriptionPreference('glm-code', 'off'),
@@ -436,7 +437,7 @@ describe('CLI model access routes', () => {
     });
     const writeProgress = vi.fn();
 
-    const result = await Effect.runPromise(
+    const result = await effectRuntime().runPromise(
       await updateCliModelAccess(
         context,
         subscriptionPreference('chatgpt', 'on'),
@@ -470,7 +471,7 @@ describe('CLI model access routes', () => {
       target: 'global',
     });
 
-    const result = await Effect.runPromise(
+    const result = await effectRuntime().runPromise(
       await updateCliModelAccess(
         context,
         subscriptionPreference('chatgpt', 'off'),
@@ -517,7 +518,7 @@ describe('CLI model access routes', () => {
       'glm-code': 'Off · key configured',
     });
 
-    await Effect.runPromise(
+    await effectRuntime().runPromise(
       await updateCliModelAccess(
         context,
         subscriptionPreference('kimi-code', 'off'),
@@ -541,7 +542,7 @@ describe('CLI model access routes', () => {
       effective: false,
       target: 'global',
     });
-    await Effect.runPromise(
+    await effectRuntime().runPromise(
       await updateCliModelAccess(
         context,
         subscriptionPreference('chatgpt', 'off'),
@@ -571,7 +572,7 @@ describe('CLI model access routes', () => {
     );
     expect(selection?.description).toBe('On · sign in required');
     if (!selection) throw new Error('Expected ChatGPT preference item');
-    await Effect.runPromise(
+    await effectRuntime().runPromise(
       await updateCliModelAccess(context, selection.value, {
         writeProgress: vi.fn(),
       }),
@@ -596,7 +597,7 @@ describe('CLI model access routes', () => {
     if (!selection) throw new Error('Expected Kimi preference item');
 
     vi.clearAllMocks();
-    await Effect.runPromise(
+    await effectRuntime().runPromise(
       await updateCliModelAccess(context, selection.value),
     );
 

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { setImmediate as nextTurn } from 'node:timers/promises';
 
-import { Effect, Layer, ManagedRuntime } from 'effect';
+import { Effect, ManagedRuntime } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { NO_TOOL_AVAILABILITY_HOST } from '@platform/interfaces';
@@ -19,6 +19,7 @@ import { nodeProcesses } from '@platform/defaults/nodeProcesses';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import { testHttpClientLayer } from '@test/support/fetchTestUtils';
 import { FakeConfigProvider, FakeSecrets } from '@test/support/FakePlatform';
 import { writeSkill } from '@test/support/skillFixtures';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
@@ -82,7 +83,7 @@ describe('desktop agent directory bootstrap', () => {
     try {
       effectRuntime();
     } catch {
-      initProcessRuntime(ManagedRuntime.make(Layer.empty));
+      initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
     }
     const storage = new WorkspaceStorageProvider(userDataPath, workspacePath);
     const [globalStateStore, workspaceStateStore] = await Effect.runPromise(

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -1,5 +1,7 @@
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
 import * as logger from '@logger/logUtils';
 import * as rootsAccess from '@platform/workspaceRoots';
 import type { WorkspaceRoots } from '@platform/workspaceRoots';
@@ -148,6 +150,41 @@ describe('logUtils', () => {
     expect(lines).toHaveLength(2);
     expect(output).toContain('[BoundChannel] with data');
     expect(output).toContain('"requestId": "visible-request-id"');
+  });
+
+  it('routes native Effect logs and nested spans through the redacting sink', () => {
+    enableDebugLogging();
+    const lines = captureLines();
+    const operation = Effect.fn('model.request')(function* () {
+      yield* Effect.annotateCurrentSpan('executionId', 'run-42');
+      yield* Effect.annotateCurrentSpan('authorization', `Bearer ${SECRET}`);
+      yield* Effect.logWarning('provider warning').pipe(
+        Effect.annotateLogs({ executionId: 'run-42', apiKey: SECRET }),
+      );
+    });
+
+    Effect.runSync(
+      operation().pipe(
+        Effect.withSpan('session.run'),
+        Effect.provide(effectDiagnosticsLayer),
+      ),
+    );
+
+    const output = lines.join('\n');
+    expect(output).toContain('WARN');
+    expect(output).toContain('provider warning');
+    expect(output).toContain('model.request: Success');
+    expect(output).toContain('session.run: Success');
+    expect(output).toContain('"executionId": "run-42"');
+    expect(output).toContain('"parentSpanId"');
+    expect(output).toContain('[redacted]');
+    expect(output).not.toContain(SECRET);
+
+    vi.spyOn(rootsAccess, 'tryWorkspaceRoots').mockReturnValue(undefined);
+    lines.length = 0;
+    Effect.runSync(operation().pipe(Effect.provide(effectDiagnosticsLayer)));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('provider warning');
   });
 
   it('disposes a shared underlying sink exactly once', () => {

--- a/src/test-kernel/support/fetchTestUtils.ts
+++ b/src/test-kernel/support/fetchTestUtils.ts
@@ -4,6 +4,8 @@
  */
 
 // Third-party imports
+import { Layer } from 'effect';
+import { FetchHttpClient } from 'effect/unstable/http';
 import { vi, type Mock } from 'vitest';
 
 /**
@@ -26,3 +28,12 @@ export function stubJsonFetch(payload: unknown): Mock<typeof fetch> {
   vi.stubGlobal('fetch', fetchMock);
   return fetchMock;
 }
+
+/** Use each test's current fetch stub even when the client layer is shared. */
+export const testHttpClientLayer = FetchHttpClient.layer.pipe(
+  Layer.provide(
+    Layer.succeed(FetchHttpClient.Fetch)((input, init) =>
+      globalThis.fetch(input, init),
+    ),
+  ),
+);

--- a/src/test-kernel/support/setupPlatform.ts
+++ b/src/test-kernel/support/setupPlatform.ts
@@ -58,13 +58,15 @@ export async function installFakeHost(host: FakeHost): Promise<void> {
     { initProcessWorkspaceRoots },
     { effectRuntime, initProcessRuntime },
     { installAuthProgramEdge },
-    { Layer, ManagedRuntime },
+    { ManagedRuntime },
+    { testHttpClientLayer },
   ] = await Promise.all([
     import('@platform/platform'),
     import('@platform/workspaceRoots'),
     import('@platform/processRuntime'),
     import('@auth/authProgram'),
     import('effect'),
+    import('@test/support/fetchTestUtils'),
   ]);
   initPlatform(host.platform);
   initProcessWorkspaceRoots(host.roots);
@@ -77,7 +79,7 @@ export async function installFakeHost(host: FakeHost): Promise<void> {
   try {
     effectRuntime();
   } catch {
-    initProcessRuntime(ManagedRuntime.make(Layer.empty));
+    initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
   }
   // The auth run edge, unconditionally: a suite that reset modules gets a
   // fresh `@auth/authProgram` instance, and this install must land on it.


### PR DESCRIPTION
## Summary

Native Effect logs and named spans now reach the existing host logger. Debug mode shows span duration, parent identity and bounded scalar attributes; ordinary logs retain their levels and secret redaction. No remote exporter or second execution history is introduced.

Session operations provide only their owned session service, preserving a caller-supplied tracer, logger and other services.

## Issue acceptance gates

Advances the diagnostic-context work in #11868. The process installs the diagnostic layer, and the existing logger suite verifies native logging, nested spans, redaction and debug-mode behaviour. This does not complete run-context propagation or the broader runtime migration.

## Single source of truth

`src/logger/effectDiagnostics.ts` defines the native logger and local tracer. `logUtils.ts` remains the output and redaction owner; `sessionLayer.ts` installs the layer at process construction. Durable `AgentTrace` events retain their existing owner.

## Duplication and abstraction budget

Adds one diagnostic layer and one bounded span implementation. It retains no span registry, span-event history or links, and introduces no new runtime entry or Promise facade.

## Net elements (R6)

Three files changed, including one new production file: **+142 / −3 lines (net +139)**. Exported declaration lines: +1 / −0 (`effectDiagnosticsLayer`). Classes: +1 / −0 (`DiagnosticSpan`); interfaces and enums: no change. One test is added to the existing logger suite to protect diagnostic output and secret redaction.

## Consumer counts (R8)

One production consumer installs `effectDiagnosticsLayer`. Four process initializers reach that composition: extension, desktop, CLI and agent SDK. No application event publisher or subscriber is replaced.

## Host impact

Extension: native logs use the existing output channel; span summaries require debug mode.

Desktop: the same diagnostic policy uses its existing host sink.

CLI: the same policy uses its existing logger. Effect SDK callers retain their supplied services.

## Scheduled refactoring

Broader run identity and lifetime conversion remains tracked in #11868; no temporary compatibility path is added.

## Validation

- `npm run format`
- `npm run typecheck` (all workspace packages)
- `npm run lint`
- `npm run compile:fast`
- `node scripts/check-effect-migration-ratchet.mjs`
- `git diff --check`
- Full suite on the combined diagnostics/HTTP tree: **9,089 passed, six skipped**.
- Diagnostics-only full suite: **9,087 passed, two failed, six skipped**. The two failures are `DesktopDiffHost` assertions at lines 341 and 495 comparing the shared temporary-directory list while concurrent suites added or removed matching directories. All **16 tests in that file passed** when rerun separately. No other failures occurred.

