### PR TITLE
refactor: normalize provider usage from plain values

### DIFF
--- a/src/agent/modelHandlers/anthropic/anthropicUsage.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicUsage.ts
@@ -73,12 +73,9 @@ function getAnthropicUsageTokenTotals(
 
 /** Calculates API usage cost based on input/output tokens and cache usage if supported. */
 function computeAnthropicPrice(
-  responseUsage: BetaUsage,
+  usageTotals: AnthropicUsageTokenTotals,
   config: AnthropicPricingConfig,
 ): number {
-  // Note: Anthropic doesn't provide tool_use_tokens in their API response
-  const usageTotals = getAnthropicUsageTokenTotals(responseUsage);
-
   // Standard pricing applies across the full context window (no long-context premium).
   const inputPrice = config.inputPrice;
   const outputPrice = config.outputPrice;
@@ -136,37 +133,29 @@ export function normalizeAnthropicUsage(
   responseTimeMs: number,
   config: AnthropicPricingConfig,
 ): NormalizedUsage {
-  return normalizeUsage(
-    {
-      provider: 'anthropic',
-      computePrice: (usage) => computeAnthropicPrice(usage, config),
-      extract: (usage) => {
-        const usageTotals = getAnthropicUsageTokenTotals(usage);
-        // Anthropic bills cache-read and cache-creation tokens separately, so
-        // total input is base + read + creation (matches percentageCached).
-        const totalInput =
-          usageTotals.baseInputTokens +
-          usageTotals.cacheReadTokens +
-          usageTotals.cacheCreationTokens;
+  if (!rawUsage) return normalizeUsage('anthropic', responseTimeMs, null);
 
-        return {
-          inputTokens: totalInput,
-          outputTokens: usageTotals.outputTokens,
-          cachedTokens: usageTotals.cacheReadTokens,
-          cacheCreationTokens: usageTotals.cacheCreationTokens,
-          cachePercentageBasis:
-            usageTotals.cacheReadTokens + usageTotals.cacheCreationTokens,
-          // SDK 0.100.0 reports the thinking-token breakdown of output_tokens,
-          // so Anthropic surfaces reasoning tokens like OpenAI/Google/xAI. This
-          // is a subset of outputTokens (already billed), not an extra charge.
-          reasoningTokens: usage.output_tokens_details?.thinking_tokens ?? 0,
-          serverToolRequests:
-            (usage.server_tool_use?.web_search_requests ?? 0) +
-            (usage.server_tool_use?.web_fetch_requests ?? 0),
-        };
-      },
-    },
+  const usageTotals = getAnthropicUsageTokenTotals(rawUsage);
+  // Anthropic bills cache-read and cache-creation tokens separately, so
+  // total input is base + read + creation (matches percentageCached).
+  const totalInput =
+    usageTotals.baseInputTokens +
+    usageTotals.cacheReadTokens +
+    usageTotals.cacheCreationTokens;
+
+  return normalizeUsage('anthropic', responseTimeMs, {
     rawUsage,
-    responseTimeMs,
-  );
+    inputTokens: totalInput,
+    outputTokens: usageTotals.outputTokens,
+    cachedTokens: usageTotals.cacheReadTokens,
+    cacheCreationTokens: usageTotals.cacheCreationTokens,
+    cachePercentageBasis:
+      usageTotals.cacheReadTokens + usageTotals.cacheCreationTokens,
+    // Thinking tokens are a subset of outputTokens, not an extra charge.
+    reasoningTokens: rawUsage.output_tokens_details?.thinking_tokens ?? 0,
+    serverToolRequests:
+      (rawUsage.server_tool_use?.web_search_requests ?? 0) +
+      (rawUsage.server_tool_use?.web_fetch_requests ?? 0),
+    cost: computeAnthropicPrice(usageTotals, config),
+  });
 }

--- a/src/agent/modelHandlers/google/googleInteractionsUsage.ts
+++ b/src/agent/modelHandlers/google/googleInteractionsUsage.ts
@@ -19,11 +19,7 @@ interface GoogleTokenCounts {
 }
 
 /** Map Interactions totals onto TeXRA's unified token model. */
-function tokenCounts(usage: InteractionsUsage | null): GoogleTokenCounts {
-  if (!usage) {
-    return { inputTokens: 0, outputTokens: 0, reasoningTokens: 0 };
-  }
-
+function tokenCounts(usage: InteractionsUsage): GoogleTokenCounts {
   const inputTokens =
     (usage.total_input_tokens ?? 0) + (usage.total_tool_use_tokens ?? 0);
   const reasoningTokens = usage.total_thought_tokens ?? 0;
@@ -43,45 +39,26 @@ function tokenCounts(usage: InteractionsUsage | null): GoogleTokenCounts {
   };
 }
 
-/** Compute Google cost from Interactions token totals. */
-function computeGoogleInteractionsPrice(
-  usage: InteractionsUsage | null,
-  config: StandardPricingConfig,
-): number {
-  const { inputTokens, outputTokens } = tokenCounts(usage);
-  return computeStandardPrice(
-    {
-      inputTokens,
-      outputTokens,
-      cachedTokens: usage?.total_cached_tokens ?? 0,
-    },
-    config,
-  );
-}
-
 /** Normalize Google Interactions usage into TeXRA's provider-neutral shape. */
 export function normalizeGoogleInteractionsUsage(
   usage: InteractionsUsage | null,
   responseTimeMs: number,
   config: StandardPricingConfig,
 ): NormalizedUsage {
-  return normalizeUsage(
-    {
-      provider: 'google',
-      computePrice: (value) => computeGoogleInteractionsPrice(value, config),
-      extract: (value) => {
-        const { inputTokens, outputTokens, reasoningTokens } =
-          tokenCounts(value);
-        return {
-          inputTokens,
-          outputTokens,
-          cachedTokens: value.total_cached_tokens ?? 0,
-          reasoningTokens,
-          toolUsePromptTokens: value.total_tool_use_tokens ?? 0,
-        };
-      },
-    },
-    usage,
-    responseTimeMs,
-  );
+  if (!usage) return normalizeUsage('google', responseTimeMs, null);
+
+  const { inputTokens, outputTokens, reasoningTokens } = tokenCounts(usage);
+  const tokens = {
+    inputTokens,
+    outputTokens,
+    cachedTokens: usage.total_cached_tokens ?? 0,
+  };
+  return normalizeUsage('google', responseTimeMs, {
+    ...tokens,
+    rawUsage: usage,
+    reasoningTokens,
+    toolUsePromptTokens: usage.total_tool_use_tokens ?? 0,
+    // Output already includes thought tokens; do not add a reasoning surcharge.
+    cost: computeStandardPrice(tokens, config),
+  });
 }

--- a/src/agent/modelHandlers/openai/openAIUsage.ts
+++ b/src/agent/modelHandlers/openai/openAIUsage.ts
@@ -18,45 +18,8 @@ import { normalizeUsage } from '../support/UsageNormalizer';
 import type { ResponseUsage } from 'openai/resources/responses/responses';
 
 /**
- * Cached prompt tokens. OpenAI reports them under
- * `prompt_tokens_details.cached_tokens`; DeepSeek uses `prompt_cache_hit_tokens`.
- */
-function getCachedTokens(usage: ExtendedCompletionUsage): number {
-  return (
-    usage.prompt_tokens_details?.cached_tokens ??
-    usage.prompt_cache_hit_tokens ??
-    0
-  );
-}
-
-/** Computes cost based on token usage and model pricing. */
-function computeOpenAIPrice(
-  responseUsage: ExtendedCompletionUsage | null,
-  config: StandardPricingConfig,
-): number {
-  if (!responseUsage) return 0;
-
-  const cachedTokens = getCachedTokens(responseUsage);
-  const promptTokens =
-    responseUsage.prompt_tokens ??
-    cachedTokens + (responseUsage.prompt_cache_miss_tokens ?? 0);
-  // Note: OpenAI doesn't provide tool_use_tokens in their API response
-
-  return computeStandardPrice(
-    {
-      inputTokens: promptTokens,
-      outputTokens: responseUsage.completion_tokens ?? 0,
-      cachedTokens,
-      reasoningTokens:
-        responseUsage.completion_tokens_details?.reasoning_tokens ?? 0,
-    },
-    config,
-  );
-}
-
-/**
  * Cost for the Responses API. Same inclusive-cache formula as
- * {@link computeOpenAIPrice}; only the token field names differ
+ * {@link normalizeOpenAIUsage}; only the token field names differ
  * (`input_tokens`/`output_tokens` vs `prompt_tokens`/`completion_tokens`).
  */
 export function computeOpenAIResponsePrice(
@@ -88,22 +51,17 @@ export function normalizeOpenAIResponseUsage(
   provider: NormalizedUsage['provider'],
   computePrice: (usage: ResponseUsage) => number,
 ): NormalizedUsage {
-  return normalizeUsage(
-    {
-      provider,
-      computePrice,
-      extract: (usage) => ({
-        inputTokens: usage.input_tokens ?? 0,
-        outputTokens: usage.output_tokens ?? 0,
-        cachedTokens: usage.input_tokens_details?.cached_tokens ?? 0,
-        cacheCreationTokens:
-          usage.input_tokens_details?.cache_write_tokens ?? 0,
-        reasoningTokens: usage.output_tokens_details?.reasoning_tokens ?? 0,
-      }),
-    },
+  if (!rawUsage) return normalizeUsage(provider, responseTimeMs, null);
+
+  return normalizeUsage(provider, responseTimeMs, {
     rawUsage,
-    responseTimeMs,
-  );
+    inputTokens: rawUsage.input_tokens ?? 0,
+    outputTokens: rawUsage.output_tokens ?? 0,
+    cachedTokens: rawUsage.input_tokens_details?.cached_tokens ?? 0,
+    cacheCreationTokens: rawUsage.input_tokens_details?.cache_write_tokens ?? 0,
+    reasoningTokens: rawUsage.output_tokens_details?.reasoning_tokens ?? 0,
+    cost: computePrice(rawUsage),
+  });
 }
 
 /** Normalizes OpenAI usage data into a unified format. */
@@ -113,36 +71,40 @@ export function normalizeOpenAIUsage(
   provider: NormalizedUsage['provider'],
   config: StandardPricingConfig,
 ): NormalizedUsage {
-  return normalizeUsage(
-    {
-      provider,
-      computePrice: (usage) => computeOpenAIPrice(usage, config),
-      extract: (usage) => {
-        const cachedTokens = getCachedTokens(usage);
-        const cacheMissTokens = usage.prompt_cache_miss_tokens ?? 0;
+  if (!rawUsage) return normalizeUsage(provider, responseTimeMs, null);
 
-        // OpenAI's prompt_tokens is the TOTAL (includes cached tokens). DeepSeek
-        // also exposes cache hit/miss fields; use their sum as a fallback if
-        // prompt_tokens is absent from an OpenAI-compatible response.
-        const inputTokens =
-          usage.prompt_tokens ??
-          (cachedTokens > 0 || cacheMissTokens > 0
-            ? cachedTokens + cacheMissTokens
-            : 0);
-
-        return {
-          inputTokens,
-          outputTokens: usage.completion_tokens ?? 0,
-          cachedTokens,
-          cacheMissTokens,
-          cacheCreationTokens:
-            usage.prompt_tokens_details?.cache_write_tokens ?? 0,
-          reasoningTokens:
-            usage.completion_tokens_details?.reasoning_tokens ?? 0,
-        };
-      },
-    },
+  // OpenAI and DeepSeek expose cached prompt counts under different fields.
+  const cachedTokens =
+    rawUsage.prompt_tokens_details?.cached_tokens ??
+    rawUsage.prompt_cache_hit_tokens ??
+    0;
+  const cacheMissTokens = rawUsage.prompt_cache_miss_tokens ?? 0;
+  // OpenAI's prompt_tokens includes cached tokens. For compatible providers
+  // without that total, reporting uses the cache buckets only if one is positive.
+  const inputTokens =
+    rawUsage.prompt_tokens ??
+    (cachedTokens > 0 || cacheMissTokens > 0
+      ? cachedTokens + cacheMissTokens
+      : 0);
+  const tokens = {
+    inputTokens,
+    outputTokens: rawUsage.completion_tokens ?? 0,
+    cachedTokens,
+    cacheMissTokens,
+    cacheCreationTokens:
+      rawUsage.prompt_tokens_details?.cache_write_tokens ?? 0,
+    reasoningTokens: rawUsage.completion_tokens_details?.reasoning_tokens ?? 0,
+  };
+  return normalizeUsage(provider, responseTimeMs, {
+    ...tokens,
     rawUsage,
-    responseTimeMs,
-  );
+    cost: computeStandardPrice(
+      {
+        ...tokens,
+        // Pricing retains the raw bucket sum even when neither is positive.
+        inputTokens: rawUsage.prompt_tokens ?? cachedTokens + cacheMissTokens,
+      },
+      config,
+    ),
+  });
 }

--- a/src/agent/modelHandlers/openrouter/openRouterUsage.ts
+++ b/src/agent/modelHandlers/openrouter/openRouterUsage.ts
@@ -17,32 +17,6 @@ import {
 import { normalizeUsage } from '../support/UsageNormalizer';
 import type { ChatUsage } from '@openrouter/sdk/models';
 
-function toStandardTokens(usage: ChatUsage) {
-  return {
-    inputTokens: usage.promptTokens ?? 0,
-    outputTokens: usage.completionTokens ?? 0,
-    cachedTokens: usage.promptTokensDetails?.cachedTokens ?? 0,
-    reasoningTokens: usage.completionTokensDetails?.reasoningTokens ?? 0,
-  };
-}
-
-/**
- * Prefer OpenRouter's billed cost for credit-backed requests. BYOK cost is
- * split between OpenRouter credits and the upstream provider account, so keep
- * the existing static full-inference estimate for that route.
- */
-function computeOpenRouterPrice(
-  responseUsage: ChatUsage | null,
-  config: StandardPricingConfig,
-): number {
-  if (!responseUsage) return 0;
-  if (responseUsage.isByok !== true && responseUsage.cost != null) {
-    return responseUsage.cost;
-  }
-
-  return computeStandardPrice(toStandardTokens(responseUsage), config);
-}
-
 /** Normalizes OpenRouter usage data into a unified format. */
 export function normalizeOpenRouterUsage(
   rawUsage: ChatUsage | null,
@@ -50,13 +24,23 @@ export function normalizeOpenRouterUsage(
   provider: NormalizedUsage['provider'],
   config: StandardPricingConfig,
 ): NormalizedUsage {
-  return normalizeUsage(
-    {
-      provider,
-      computePrice: (usage) => computeOpenRouterPrice(usage, config),
-      extract: (usage) => toStandardTokens(usage),
-    },
+  if (!rawUsage) return normalizeUsage(provider, responseTimeMs, null);
+
+  const tokens = {
+    inputTokens: rawUsage.promptTokens ?? 0,
+    outputTokens: rawUsage.completionTokens ?? 0,
+    cachedTokens: rawUsage.promptTokensDetails?.cachedTokens ?? 0,
+    reasoningTokens: rawUsage.completionTokensDetails?.reasoningTokens ?? 0,
+  };
+  // BYOK splits billing across accounts; retain the full-inference estimate.
+  // Credit-backed requests use the provider's billed cost, including zero.
+  const cost =
+    rawUsage.isByok !== true && rawUsage.cost != null
+      ? rawUsage.cost
+      : computeStandardPrice(tokens, config);
+  return normalizeUsage(provider, responseTimeMs, {
+    ...tokens,
     rawUsage,
-    responseTimeMs,
-  );
+    cost,
+  });
 }

--- a/src/agent/modelHandlers/support/UsageNormalizer.ts
+++ b/src/agent/modelHandlers/support/UsageNormalizer.ts
@@ -1,45 +1,19 @@
-/**
- * Generic, config-driven token-usage normalization shared by model handlers.
- *
- * Every provider's `normalizeUsage()` follows the same shape: null-check the
- * raw usage object, extract input/output/cache/reasoning token counts from
- * provider-specific fields, compute the cache percentage, compute price, and
- * assemble a {@link NormalizedUsage}. The only thing that differs between
- * providers is *where* those values live in the raw usage object (and a few
- * provider-only extras such as Anthropic's cache-creation/server-tool fields or
- * Google's tool-use prompt tokens).
- *
- * {@link normalizeUsage} captures that common assembly once; each handler
- * supplies a small {@link UsageNormalizerConfig} describing how to read the
- * fields. Behavior is intentionally byte-identical to the previous per-handler
- * implementations — see the field mappings in each handler for details.
- */
+/** Assemble provider-neutral usage from counts and cost already computed by the provider. */
 
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 
 /**
- * Calculate cache percentage from cached and total input tokens. Returns
- * undefined when no caching occurred (so a 0 is never stored).
- */
-function computeCachePercentage(
-  cachedTokens: number,
-  totalInputTokens: number,
-): number | undefined {
-  if (totalInputTokens <= 0 || cachedTokens <= 0) return undefined;
-  return (cachedTokens / totalInputTokens) * 100;
-}
-
-/**
- * Token counts extracted from a provider's raw usage object.
+ * Counts and cost derived from one provider usage object.
  *
- * `cachePercentageBasis` is the numerator passed to
- * {@link computeCachePercentage}; for most providers it equals `cachedTokens`,
- * but Anthropic counts both cache-read and cache-creation tokens.
+ * `cachePercentageBasis` usually equals `cachedTokens`, but Anthropic counts
+ * both cache-read and cache-creation tokens.
  *
  * `inputTokens` is the denominator for the cache percentage and the value
  * surfaced as `NormalizedUsage.inputTokens`.
  */
-interface ExtractedUsageTokens {
+interface UsageValues {
+  rawUsage: unknown;
+  cost: number;
   inputTokens: number;
   outputTokens: number;
   /** Tokens served from cache. Surfaced as `cachedInputTokens` when > 0. */
@@ -58,54 +32,40 @@ interface ExtractedUsageTokens {
   serverToolRequests?: number;
 }
 
-/**
- * Per-provider configuration for {@link normalizeUsage}.
- *
- * `T` is the provider's raw usage type (nullable for providers whose extractor
- * already tolerates a null payload).
- */
-interface UsageNormalizerConfig<T> {
-  /** Usage-tracking provider identifier. */
-  provider: NormalizedUsage['provider'];
-  /** Reads provider-specific token counts from the raw usage object. */
-  extract: (rawUsage: NonNullable<T>) => ExtractedUsageTokens;
-  /** Computes API cost for the raw usage object. */
-  computePrice: (rawUsage: NonNullable<T>) => number;
-}
-
-/** Builds a {@link NormalizedUsage} from a provider config and raw usage. */
-export function normalizeUsage<T>(
-  config: UsageNormalizerConfig<T>,
-  rawUsage: T,
+/** Builds a {@link NormalizedUsage}; absent usage has no optional metadata. */
+export function normalizeUsage(
+  provider: NormalizedUsage['provider'],
   responseTimeMs: number,
+  values: UsageValues | null,
 ): NormalizedUsage {
-  if (!rawUsage) {
+  if (!values) {
     return {
       inputTokens: 0,
       outputTokens: 0,
       cost: 0,
       responseTimeMs,
-      provider: config.provider,
+      provider,
     };
   }
 
-  const raw = rawUsage as NonNullable<T>;
-  const tokens = config.extract(raw);
-  const cacheBasis = tokens.cachePercentageBasis ?? tokens.cachedTokens;
+  const cacheBasis = values.cachePercentageBasis ?? values.cachedTokens;
 
   return {
-    inputTokens: tokens.inputTokens,
-    outputTokens: tokens.outputTokens,
-    cost: config.computePrice(raw),
+    inputTokens: values.inputTokens,
+    outputTokens: values.outputTokens,
+    cost: values.cost,
     responseTimeMs,
-    provider: config.provider,
-    cachedInputTokens: tokens.cachedTokens || undefined,
-    cacheMissInputTokens: tokens.cacheMissTokens || undefined,
-    cacheCreationTokens: tokens.cacheCreationTokens || undefined,
-    percentageCached: computeCachePercentage(cacheBasis, tokens.inputTokens),
-    reasoningTokens: tokens.reasoningTokens || undefined,
-    toolUsePromptTokens: tokens.toolUsePromptTokens || undefined,
-    serverToolRequests: tokens.serverToolRequests || undefined,
-    _native: raw,
+    provider,
+    cachedInputTokens: values.cachedTokens || undefined,
+    cacheMissInputTokens: values.cacheMissTokens || undefined,
+    cacheCreationTokens: values.cacheCreationTokens || undefined,
+    percentageCached:
+      values.inputTokens <= 0 || cacheBasis <= 0
+        ? undefined
+        : (cacheBasis / values.inputTokens) * 100,
+    reasoningTokens: values.reasoningTokens || undefined,
+    toolUsePromptTokens: values.toolUsePromptTokens || undefined,
+    serverToolRequests: values.serverToolRequests || undefined,
+    _native: values.rawUsage,
   };
 }


### PR DESCRIPTION
## Summary

Replace the callback configuration used to normalize provider usage with a shared formatter that accepts counts and cost as plain values. Provider-specific extraction and pricing remain in their existing modules.

Anthropic, Google, and OpenRouter no longer extract the same usage totals separately for reporting and pricing. OpenAI shares its extracted cache counts while retaining the distinct reporting and pricing formulas. This removes an unnecessary intermediate layer without introducing Effect into pure arithmetic.

## Issue acceptance gates

No issue is closed by this change.

- Remove `UsageNormalizerConfig`, five extraction callbacks, and four price-adapter callbacks.
- Compute Anthropic iteration totals, Google totals, and OpenRouter token counts once per normalization.
- Preserve absent-usage output shape, zero-to-undefined optional fields, and the identity of the raw `_native` value.
- Preserve all provider pricing rules and the externally supplied OpenAI Responses price function.
- Change no provider-handler API, schema, runtime, or persistence module; add no tests or dependencies.

## Single source of truth

The four provider usage modules own the interpretation and pricing of their raw provider data. `support/UsageNormalizer.ts` owns only the common output shape and cache-percentage calculation.

Anthropic pricing consumes the same iteration totals used for reporting. Google's output includes thought tokens once; those tokens are not passed as a second pricing surcharge. OpenRouter retains billed cost, including zero, except for BYOK requests, which retain the full-inference estimate. OpenAI keeps its reporting fallback conditional on a positive cache bucket and its pricing fallback as the raw bucket sum. The Responses price callback still runs after token fields are captured.

## Duplication and abstraction budget

Five callback-configuration objects are removed. The existing token-values record becomes a plain values record carrying the already-computed cost and raw usage reference. No new service, adapter, or runtime boundary is introduced. Six private helper functions become unnecessary and are deleted.

## Net elements (R6)

- Files: 0 added, 0 deleted, 5 modified.
- Exported symbols: 0 added, 0 deleted; the common formatter signature changes and all consumers are updated together.
- Classes/interfaces/enums: the private token-values interface is renamed and extended; the callback-configuration interface is deleted. Declaration accounting: 1 interface added, 2 deleted; net **−1**. No class or enum changes.
- Named functions: 0 added, 6 private helpers deleted. Five extraction callbacks and four price-adapter callbacks are also removed.
- Configuration objects: 0 added, 5 deleted.
- Production and total lines: 134 added, 262 deleted; net **−128**.

## Consumer counts (R8)

The common formatter has five production consumer functions: Anthropic, Google Interactions, OpenRouter, OpenAI Chat Completions, and OpenAI Responses normalization. Each now has an explicit absent-usage branch and a populated-usage branch, for ten direct calls. All five retain their existing caller-facing signatures.

The six deleted private helpers have no remaining references: `computeCachePercentage`, `computeGoogleInteractionsPrice`, `computeOpenRouterPrice`, `toStandardTokens`, `computeOpenAIPrice`, and `getCachedTokens`. No emission or subscription path changes.

## Host impact

Extension: No intended change to token statistics, pricing, or usage display.

Desktop: No intended change to token statistics, pricing, or usage display.

CLI: No intended change to token statistics, pricing, or usage display.

## Scheduled refactoring

None is required to complete this change. Native LLM/runtime conversion remains separate; this PR changes only pure usage calculation and formatting.

## Validation

Validation uses an isolated worktree based on `914173c95303b8d968b767e417aa33f5ec5aa127`.

- `corepack pnpm install --frozen-lockfile`
- `npm run format -- --log-level warn`
- `npm run typecheck` (all six checks)
- `npm run lint`
- `npm run compile:fast`
- `npm run check:effect-migration-ratchet`
- `npm run check:guidance-refs`
- `npm run check:dead-code-ratchet`
- Focused ESLint, Prettier, and `git diff --check`
- Existing model-handler suites: **765 tests passed, 4 skipped**.

`TMPDIR=<dedicated temporary directory> npm test -- --maxWorkers=4` passed: **9,088 tests passed, 6 skipped** across 765 passing suites and one skipped suite (319.51s). The dedicated temporary directory keeps independent worktree tests from observing each other's temporary files.
