### PR TITLE
refactor(telemetry): remove unused flush outcome API

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -171,7 +171,7 @@
       "src/controllers/session/sessionLayer.ts": 3,
       "src/platform/defaults/jsonStore.ts": 1,
       "src/shared/signals.ts": 2,
-      "src/telemetry/UsageLogService.ts": 5,
+      "src/telemetry/UsageLogService.ts": 4,
       "src/tools/agentCliSessionRegistry.ts": 2,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/lean/direct/directLspAdapter.ts": 3

--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1538,12 +1538,6 @@
       "name": "isUnsupported"
     },
     {
-      "file": "src/telemetry/UsageLogService.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "USAGE_LOG_FLUSH_OUTCOME"
-    },
-    {
       "file": "src/tools/DiagnosticsTool.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -1,14 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import {
-  Clock,
-  Data,
-  Deferred,
-  Duration,
-  Effect,
-  Fiber,
-  Semaphore,
-} from 'effect';
+import { Clock, Data, Duration, Effect, Fiber, Semaphore } from 'effect';
 import ky from 'ky';
 
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -39,15 +31,6 @@ const USAGE_LOG_ENDPOINT = `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/log-u
 const MAX_QUEUE_SIZE = 1000;
 const REQUEST_TIMEOUT_MS = 10000;
 const DISPOSE_WARNING_TIMEOUT_MS = 5000;
-
-export const USAGE_LOG_FLUSH_OUTCOME = {
-  ACCEPTED: 'accepted',
-  PENDING: 'pending',
-  REJECTED: 'rejected',
-} as const;
-
-type UsageLogFlushOutcome =
-  (typeof USAGE_LOG_FLUSH_OUTCOME)[keyof typeof USAGE_LOG_FLUSH_OUTCOME];
 
 interface UsageLogConfig {
   batchSize: number;
@@ -233,13 +216,11 @@ class UsageLogServiceImpl {
    *  and interrupted by `dispose`. It only schedules: each flush runs on a
    *  fiber of its own, so interrupting the ticker never touches a send. */
   private flushTimer: Fiber.Fiber<never> | null = null;
-  /** One permit: a flush holds it while it drains, so batches leave in order
-   *  and a second caller (or `dispose`) waits behind the one in flight. */
+  /** One permit: batches leave in order, and disposal joins an active drain. */
   private readonly flushLane = Semaphore.makeUnsafe(1);
-  /** The drain in flight, if any: a `flush()` arriving while it runs joins
-   *  its outcome, so a rejection the drain hit is not hidden behind the
-   *  ACCEPTED an empty queue would report. */
-  private inFlightDrain: Deferred.Deferred<UsageLogFlushOutcome> | null = null;
+  /** Coalesce triggers before they wait for the lane; failed sends wait for
+   *  a later trigger instead of being retried by already waiting callers. */
+  private backgroundFlushActive = false;
   // Copied, never aliased: `dispose()` writes `config.enabled`, so a
   // dispose-before-initialize would otherwise flip DEFAULT_CONFIG for good.
   private config: UsageLogConfig = { ...DEFAULT_CONFIG };
@@ -298,46 +279,27 @@ class UsageLogServiceImpl {
     }
   }
 
-  flush(): Promise<UsageLogFlushOutcome> {
-    return effectRuntime().runPromise(this.sharedDrain());
-  }
-
-  /** One drain under the lane, its outcome shared with every caller that
-   *  arrives while it is in flight. The lane still orders it behind a
-   *  running dispose or an earlier drain. */
-  private readonly sharedDrain = Effect.fn('UsageLogService.flush')(function* (
-    this: UsageLogServiceImpl,
-  ) {
-    if (this.inFlightDrain) return yield* Deferred.await(this.inFlightDrain);
-    const outcome = yield* Deferred.make<UsageLogFlushOutcome>();
-    this.inFlightDrain = outcome;
-    return yield* this.flushLane.withPermit(this.drain()).pipe(
-      Effect.onExit((exit) => {
-        this.inFlightDrain = null;
-        return Deferred.done(outcome, exit);
-      }),
-    );
-  });
-
   /** Send every batch that is due, one after another, under the lane. */
   private readonly drain = Effect.fn('UsageLogService.drain')(function* (
     this: UsageLogServiceImpl,
   ) {
-    let finalOutcome: UsageLogFlushOutcome = USAGE_LOG_FLUSH_OUTCOME.ACCEPTED;
-
     while (this.retryBatch || this.queue.length > 0) {
-      const batchOutcome = yield* this.flushQueuedBatch();
-      if (batchOutcome === USAGE_LOG_FLUSH_OUTCOME.PENDING) {
-        return finalOutcome === USAGE_LOG_FLUSH_OUTCOME.REJECTED
-          ? finalOutcome
-          : batchOutcome;
-      }
-      if (batchOutcome === USAGE_LOG_FLUSH_OUTCOME.REJECTED) {
-        finalOutcome = batchOutcome;
-      }
+      const batchSettled = yield* this.sendNextBatch().pipe(
+        Effect.catchTag('UsageBatchUndelivered', (error) =>
+          Effect.sync(() => {
+            const requeued = error.requeue?.entries.length ?? 0;
+            if (error.requeue) this.retryBatch = error.requeue;
+            const requeuedMessage =
+              requeued > 0 ? `; requeued ${requeued} entries` : '';
+            log.warn(
+              `Failed to send usage batch${requeuedMessage}: ${error.reason}`,
+            );
+            return false;
+          }),
+        ),
+      );
+      if (!batchSettled) return;
     }
-
-    return finalOutcome;
   });
 
   /**
@@ -345,106 +307,95 @@ class UsageLogServiceImpl {
    * drain cannot fail, so only a defect reaches here, and it is reported by
    * its owner instead of ending a fiber nobody observes.
    */
-  private backgroundFlush(): Effect.Effect<void> {
-    return this.sharedDrain().pipe(
-      Effect.asVoid,
-      Effect.catchDefect((defect) =>
-        Effect.sync(() => {
-          log.error(`Usage flush failed: ${toErrorMessage(defect)}`);
-        }),
-      ),
-    );
-  }
+  private readonly backgroundFlush = Effect.fn('UsageLogService.flush')(
+    function* (this: UsageLogServiceImpl) {
+      if (this.backgroundFlushActive) return;
+      this.backgroundFlushActive = true;
+      yield* this.flushLane.withPermit(this.drain()).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            this.backgroundFlushActive = false;
+          }),
+        ),
+      );
+    },
+    Effect.catchDefect((defect) =>
+      Effect.sync(() => {
+        log.error(`Usage flush failed: ${toErrorMessage(defect)}`);
+      }),
+    ),
+  );
 
-  /** One batch: keep it for retry (PENDING) when it cannot be delivered. */
-  private flushQueuedBatch(): Effect.Effect<UsageLogFlushOutcome> {
-    return this.sendNextBatch().pipe(
-      Effect.catchTag('UsageBatchUndelivered', (error) =>
-        Effect.sync(() => {
-          const requeued = error.requeue?.entries.length ?? 0;
-          if (error.requeue) this.retryBatch = error.requeue;
-          const requeuedMessage =
-            requeued > 0 ? `; requeued ${requeued} entries` : '';
-          log.warn(
-            `Failed to send usage batch${requeuedMessage}: ${error.reason}`,
-          );
-          return USAGE_LOG_FLUSH_OUTCOME.PENDING;
-        }),
-      ),
-    );
-  }
+  /** True means this batch is settled; false pauses draining until a later trigger. */
+  private readonly sendNextBatch = Effect.fn('UsageLogService.sendNextBatch')(
+    function* (this: UsageLogServiceImpl) {
+      const token = yield* Effect.tryPromise({
+        try: () => SupabaseClient.getAccessToken(),
+        catch: (error) =>
+          new UsageBatchUndelivered({
+            reason: toErrorMessage(error),
+            requeue: null,
+          }),
+      });
+      if (!token) {
+        log.debug('Skipping flush - user not authenticated');
+        return false;
+      }
 
-  private readonly sendNextBatch = Effect.fn(
-    'UsageLogService.flushQueuedBatch',
-  )(function* (this: UsageLogServiceImpl) {
-    const token = yield* Effect.tryPromise({
-      try: () => SupabaseClient.getAccessToken(),
-      catch: (error) =>
-        new UsageBatchUndelivered({
-          reason: toErrorMessage(error),
-          requeue: null,
-        }),
-    });
-    if (!token) {
-      log.debug('Skipping flush - user not authenticated');
-      return USAGE_LOG_FLUSH_OUTCOME.PENDING;
-    }
+      let batch = this.retryBatch;
+      if (batch) {
+        this.retryBatch = null;
+      } else {
+        const entries = this.queue;
+        this.queue = [];
+        if (entries.length === 0) return false;
 
-    let batch = this.retryBatch;
-    if (batch) {
-      this.retryBatch = null;
-    } else {
-      const entries = this.queue;
-      this.queue = [];
-      if (entries.length === 0) return USAGE_LOG_FLUSH_OUTCOME.PENDING;
+        batch = {
+          entries,
+          batchId: randomUUID(),
+        };
+      }
 
-      batch = {
-        entries,
-        batchId: randomUUID(),
-      };
-    }
+      // Re-read each entry's consent here rather than on entry: the token
+      // lookup above is asynchronous, so a user who opts out while it is in
+      // flight would otherwise have this continuation ship the batch anyway.
+      // Applied after the batch is taken so it also drops optional rounds
+      // queued before the opt-out instead of leaving the timer to send them,
+      // and read from the workspace each entry was recorded in, since this
+      // flush runs outside any run.
+      const kept = batch.entries.filter(
+        ({ entry, config }) =>
+          isPlanAccounting(entry) || isTelemetryEnabledBySetting(config),
+      );
+      const dropped = batch.entries.length - kept.length;
+      if (dropped > 0) {
+        log.debug(
+          `Usage logging is disabled; dropped ${dropped} optional ${dropped === 1 ? 'entry' : 'entries'} without sending`,
+        );
+      }
+      if (kept.length === 0) {
+        return true;
+      }
+      batch = { ...batch, entries: kept };
 
-    // Re-read each entry's consent here rather than on entry: the token
-    // lookup above is asynchronous, so a user who opts out while it is in
-    // flight would otherwise have this continuation ship the batch anyway.
-    // Applied after the batch is taken so it also drops optional rounds
-    // queued before the opt-out instead of leaving the timer to send them,
-    // and read from the workspace each entry was recorded in, since this
-    // flush runs outside any run.
-    const kept = batch.entries.filter(
-      ({ entry, config }) =>
-        isPlanAccounting(entry) || isTelemetryEnabledBySetting(config),
-    );
-    const dropped = batch.entries.length - kept.length;
-    if (dropped > 0) {
       log.debug(
-        `Usage logging is disabled; dropped ${dropped} optional ${dropped === 1 ? 'entry' : 'entries'} without sending`,
+        `Flushing ${batch.entries.length} entries (batch: ${batch.batchId})`,
       );
-    }
-    if (kept.length === 0) {
-      // ACCEPTED, not PENDING: these entries are gone for good, and PENDING
-      // means "kept for a later retry" to every caller that inspects it.
-      return USAGE_LOG_FLUSH_OUTCOME.ACCEPTED;
-    }
-    batch = { ...batch, entries: kept };
 
-    log.debug(
-      `Flushing ${batch.entries.length} entries (batch: ${batch.batchId})`,
-    );
-
-    const response = yield* this.sendBatch(batch, token);
-    if (!response.success) {
-      this.reportPermanentRejection(
-        batch,
-        response.error ?? 'Usage batch was rejected',
+      const response = yield* this.sendBatch(batch, token);
+      if (!response.success) {
+        this.reportPermanentRejection(
+          batch,
+          response.error ?? 'Usage batch was rejected',
+        );
+        return true;
+      }
+      log.debug(
+        `Batch ${batch.batchId} sent successfully (${response.accepted} entries)`,
       );
-      return USAGE_LOG_FLUSH_OUTCOME.REJECTED;
-    }
-    log.debug(
-      `Batch ${batch.batchId} sent successfully (${response.accepted} entries)`,
-    );
-    return USAGE_LOG_FLUSH_OUTCOME.ACCEPTED;
-  });
+      return true;
+    },
+  );
 
   private reportPermanentRejection(batch: RetryBatch, reason: string): void {
     log.error(
@@ -565,7 +516,7 @@ class UsageLogServiceImpl {
     }
     this.config.enabled = false;
 
-    // An in-flight flush — a caller's or the timer's — is waited for without
+    // An in-flight background flush is waited for without
     // bound; past the deadline the wait is reported, not abandoned. The
     // warning is withdrawn the moment the lane is ours.
     const warning = yield* Effect.forkChild(

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -12,10 +12,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import * as logger from '@logger/logUtils';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import { AgentCategory, TELEMETRY_ENABLED_KEY } from '@shared/schemas';
-import {
-  USAGE_LOG_FLUSH_OUTCOME,
-  UsageLogService,
-} from '@telemetry/UsageLogService';
+import { UsageLogService } from '@telemetry/UsageLogService';
 import { createDeferred } from '@test/support/asyncTestUtils';
 import {
   createFakePlatform,
@@ -77,8 +74,9 @@ function stubBatchFetch(
 
 describe('UsageLogService', () => {
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
     UsageLogService.initialize({
-      batchSize: 100,
+      batchSize: 1,
       flushIntervalMs: 60_000,
       enabled: true,
     });
@@ -86,6 +84,7 @@ describe('UsageLogService', () => {
 
   afterEach(async () => {
     await UsageLogService.dispose();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
@@ -103,51 +102,16 @@ describe('UsageLogService', () => {
     });
 
     UsageLogService.log(usageEntry('first'));
-    const firstFlush = UsageLogService.flush();
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     UsageLogService.log(usageEntry('second'));
-    const secondFlush = UsageLogService.flush();
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     releaseFirstFetch();
-    await expect(Promise.all([firstFlush, secondFlush])).resolves.toEqual([
-      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-    ]);
-
+    await vi.waitFor(() =>
+      expect(batches.map(batchModels)).toEqual([['first'], ['second']]),
+    );
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(batches.map(batchModels)).toEqual([['first'], ['second']]);
-  });
-
-  it('shares a rejection with a flush that arrives while it is in flight', async () => {
-    stubAccessToken();
-
-    const { promise: rejectionReleased, resolve: releaseRejection } =
-      createDeferred();
-    const { fetchMock } = stubBatchFetch(async (callCount) => {
-      if (callCount !== 1) return;
-      await rejectionReleased;
-      return jsonResponse({
-        success: false,
-        accepted: 0,
-        error: 'invalid batch',
-        retryable: false,
-      });
-    });
-
-    UsageLogService.log(usageEntry('invalid'));
-    const firstFlush = UsageLogService.flush();
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-
-    UsageLogService.log(usageEntry('valid'));
-    const secondFlush = UsageLogService.flush();
-
-    releaseRejection();
-    await expect(Promise.all([firstFlush, secondFlush])).resolves.toEqual([
-      USAGE_LOG_FLUSH_OUTCOME.REJECTED,
-      USAGE_LOG_FLUSH_OUTCOME.REJECTED,
-    ]);
   });
 
   it('waits for successive active batches during disposal', async () => {
@@ -163,11 +127,9 @@ describe('UsageLogService', () => {
     });
 
     UsageLogService.log(usageEntry('first'));
-    const firstFlush = UsageLogService.flush();
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     UsageLogService.log(usageEntry('second'));
-    const secondFlush = UsageLogService.flush();
     const disposal = UsageLogService.dispose();
 
     releaseFirstFetch();
@@ -181,10 +143,6 @@ describe('UsageLogService', () => {
     expect(disposed).toBe(false);
 
     releaseSecondFetch();
-    await expect(Promise.all([firstFlush, secondFlush])).resolves.toEqual([
-      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-    ]);
     await expect(disposal).resolves.toBeUndefined();
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -218,7 +176,7 @@ describe('UsageLogService', () => {
       disposed = true;
     });
     // Long enough for a dispose that abandons the send to have resolved.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await vi.advanceTimersByTimeAsync(50);
     expect(request.signal.aborted).toBe(false);
     expect(disposed).toBe(false);
 
@@ -233,6 +191,7 @@ describe('UsageLogService', () => {
   // empty loop, so the ticker's timer is unref'd while the request a flush
   // sends holds the loop on its own.
   it('schedules the ticker on a timer that does not hold the event loop', () => {
+    vi.useRealTimers();
     const timers = vi.spyOn(globalThis, 'setTimeout');
     UsageLogService.initialize({
       batchSize: 100,
@@ -256,10 +215,8 @@ describe('UsageLogService', () => {
     });
 
     UsageLogService.log(usageEntry('slow'));
-    const flush = UsageLogService.flush();
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
     const disposal = UsageLogService.dispose();
     let disposed = false;
     void disposal.then(() => {
@@ -280,10 +237,8 @@ describe('UsageLogService', () => {
     expect(disposed).toBe(false);
 
     releaseFetch();
-    await expect(flush).resolves.toBe(USAGE_LOG_FLUSH_OUTCOME.ACCEPTED);
     await expect(disposal).resolves.toBeUndefined();
     expect(batches.map(batchModels)).toEqual([['slow']]);
-    vi.useRealTimers();
   });
 
   it('keeps queued entries when setup fails before dequeue', async () => {
@@ -294,15 +249,11 @@ describe('UsageLogService', () => {
     const { batches, fetchMock } = stubBatchFetch();
 
     UsageLogService.log(usageEntry('first'));
-    await expect(UsageLogService.flush()).resolves.toBe(
-      USAGE_LOG_FLUSH_OUTCOME.PENDING,
-    );
+    await vi.advanceTimersByTimeAsync(0);
 
     expect(fetchMock).not.toHaveBeenCalled();
 
-    await expect(UsageLogService.flush()).resolves.toBe(
-      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-    );
+    await vi.advanceTimersByTimeAsync(60_000);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(batches.map(batchModels)).toEqual([['first']]);
@@ -326,12 +277,9 @@ describe('UsageLogService', () => {
     });
 
     UsageLogService.log(usageEntry('first'));
-    await expect(UsageLogService.flush()).resolves.toBe(
-      USAGE_LOG_FLUSH_OUTCOME.PENDING,
-    );
-    await expect(UsageLogService.flush()).resolves.toBe(
-      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(60_000);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(batches.map(batchModels)).toEqual([['first'], ['first']]);
@@ -356,20 +304,17 @@ describe('UsageLogService', () => {
     });
 
     UsageLogService.log(usageEntry('invalid'));
-    const flush = UsageLogService.flush();
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     UsageLogService.log(usageEntry('valid'));
     releaseRejection();
 
-    await expect(flush).resolves.toBe(USAGE_LOG_FLUSH_OUTCOME.REJECTED);
+    await vi.advanceTimersByTimeAsync(0);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(batches.map(batchModels)).toEqual([['invalid'], ['valid']]);
     expect(batchId(batches[1])).not.toBe(batchId(batches[0]));
 
-    await expect(UsageLogService.flush()).resolves.toBe(
-      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-    );
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(batches.map(batchModels)).toEqual([
       ['invalid'],
       ['valid'],
@@ -388,14 +333,10 @@ describe('UsageLogService', () => {
     });
 
     UsageLogService.log(usageEntry('first'));
-    await expect(UsageLogService.flush()).resolves.toBe(
-      USAGE_LOG_FLUSH_OUTCOME.PENDING,
-    );
+    await vi.advanceTimersByTimeAsync(0);
 
     UsageLogService.log(usageEntry('second'));
-    await expect(UsageLogService.flush()).resolves.toBe(
-      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-    );
+    await vi.advanceTimersByTimeAsync(0);
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(batches.map(batchModels)).toEqual([
@@ -414,16 +355,12 @@ describe('UsageLogService', () => {
     // every suite that runs afterwards.
     setupPlatform({}, { config: new FakeScopedConfigProvider() });
 
-    // Shared tail of every opt-out case: an optional entry must vanish without
-    // a single fetch, and the flush still reports ACCEPTED — the entry is
-    // gone, not kept for retry (that would be PENDING).
-    async function expectOptedOutFlush(): Promise<void> {
+    // Optional entries must be discarded without a request.
+    async function expectNoOptionalUsageSent(): Promise<void> {
       const { batches, fetchMock } = stubBatchFetch();
 
       UsageLogService.log(usageEntry('optional'));
-      await expect(UsageLogService.flush()).resolves.toBe(
-        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-      );
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(fetchMock).not.toHaveBeenCalled();
       expect(batches).toEqual([]);
@@ -437,7 +374,7 @@ describe('UsageLogService', () => {
         'global',
       );
 
-      await expectOptedOutFlush();
+      await expectNoOptionalUsageSent();
     });
 
     it('honours a workspace-scoped telemetry opt-out', async () => {
@@ -448,7 +385,7 @@ describe('UsageLogService', () => {
         'workspace',
       );
 
-      await expectOptedOutFlush();
+      await expectNoOptionalUsageSent();
     });
 
     it('does not let a project opt in over a user-wide opt-out', async () => {
@@ -464,13 +401,14 @@ describe('UsageLogService', () => {
         'workspace',
       );
 
-      await expectOptedOutFlush();
+      await expectNoOptionalUsageSent();
     });
 
     // The setting is read live, so turning it off has to drop rounds already
     // queued under the old value rather than letting the next flush ship them.
     it('discards entries queued before the setting was turned off', async () => {
       stubAccessToken();
+      UsageLogService.initialize({ batchSize: 100, flushIntervalMs: 60_000 });
 
       const { batches, fetchMock } = stubBatchFetch();
 
@@ -481,11 +419,7 @@ describe('UsageLogService', () => {
         'global',
       );
 
-      // ACCEPTED, not PENDING: the entry is gone, and PENDING means "kept for a
-      // later retry" everywhere else in this service.
-      await expect(UsageLogService.flush()).resolves.toBe(
-        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-      );
+      await vi.advanceTimersByTimeAsync(60_000);
 
       expect(fetchMock).not.toHaveBeenCalled();
       expect(batches).toEqual([]);
@@ -502,7 +436,7 @@ describe('UsageLogService', () => {
       const { batches, fetchMock } = stubBatchFetch();
 
       UsageLogService.log(usageEntry('dropped'));
-      await UsageLogService.flush();
+      await vi.advanceTimersByTimeAsync(0);
       expect(fetchMock).not.toHaveBeenCalled();
 
       await workspaceRoots().config.update(
@@ -511,9 +445,7 @@ describe('UsageLogService', () => {
         'global',
       );
       UsageLogService.log(usageEntry('sent'));
-      await expect(UsageLogService.flush()).resolves.toBe(
-        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-      );
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(batches.map(batchModels)).toEqual([['sent']]);
@@ -540,9 +472,7 @@ describe('UsageLogService', () => {
         const { batches, fetchMock } = stubBatchFetch();
 
         UsageLogService.log({ ...usageEntry('hosted'), usageRoute });
-        await expect(UsageLogService.flush()).resolves.toBe(
-          USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-        );
+        await vi.advanceTimersByTimeAsync(0);
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(batches.map(batchModels)).toEqual([['hosted']]);
@@ -551,6 +481,7 @@ describe('UsageLogService', () => {
 
     it('drops optional entries from a batch but keeps the accounted ones', async () => {
       stubAccessToken();
+      UsageLogService.initialize({ batchSize: 100, flushIntervalMs: 60_000 });
 
       const { batches, fetchMock } = stubBatchFetch();
 
@@ -565,9 +496,7 @@ describe('UsageLogService', () => {
         'global',
       );
 
-      await expect(UsageLogService.flush()).resolves.toBe(
-        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-      );
+      await vi.advanceTimersByTimeAsync(60_000);
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(batches.map(batchModels)).toEqual([['hosted']]);
@@ -588,7 +517,6 @@ describe('UsageLogService', () => {
       const { batches, fetchMock } = stubBatchFetch();
 
       UsageLogService.log(usageEntry('optional'));
-      const flush = UsageLogService.flush();
 
       await workspaceRoots().config.update(
         TELEMETRY_ENABLED_KEY,
@@ -597,7 +525,7 @@ describe('UsageLogService', () => {
       );
       releaseToken();
 
-      await expect(flush).resolves.toBe(USAGE_LOG_FLUSH_OUTCOME.ACCEPTED);
+      await vi.advanceTimersByTimeAsync(0);
       expect(fetchMock).not.toHaveBeenCalled();
       expect(batches).toEqual([]);
     });
@@ -618,7 +546,7 @@ describe('UsageLogService', () => {
       );
       vi.stubEnv(name, value);
 
-      await expectOptedOutFlush();
+      await expectNoOptionalUsageSent();
     });
 
     it.each(['0', 'false', ''])(
@@ -635,9 +563,7 @@ describe('UsageLogService', () => {
         const { batches, fetchMock } = stubBatchFetch();
 
         UsageLogService.log(usageEntry('optional'));
-        await expect(UsageLogService.flush()).resolves.toBe(
-          USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-        );
+        await vi.advanceTimersByTimeAsync(0);
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(batches.map(batchModels)).toEqual([['optional']]);
@@ -656,9 +582,7 @@ describe('UsageLogService', () => {
         ...usageEntry('hosted'),
         usageRoute: 'chatgpt-subscription',
       });
-      await expect(UsageLogService.flush()).resolves.toBe(
-        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
-      );
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(batches.map(batchModels)).toEqual([['hosted']]);
@@ -679,7 +603,7 @@ describe('UsageLogService', () => {
         const { batches, fetchMock } = stubBatchFetch();
 
         UsageLogService.log(usageEntry('optional'));
-        await UsageLogService.flush();
+        await vi.advanceTimersByTimeAsync(0);
 
         expect(fetchMock).not.toHaveBeenCalled();
         expect(batches).toEqual([]);
@@ -702,7 +626,7 @@ describe('UsageLogService', () => {
       const { batches, fetchMock } = stubBatchFetch();
 
       UsageLogService.log(usageEntry('optional'));
-      await UsageLogService.flush();
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(fetchMock).not.toHaveBeenCalled();
       expect(batches).toEqual([]);


### PR DESCRIPTION
## Summary

Remove the unused public `UsageLogService.flush()` method and the machinery that shared its aggregate result. Production requests delivery through the existing batch-size trigger, periodic timer and disposal path; no production caller uses `flush()`.

The service no longer creates a Deferred for each drain, exposes an outcome constant, accumulates a final outcome or routes draining through `sharedDrain` and `flushQueuedBatch`. The remaining per-batch decision answers only whether processing may continue or must pause for a later retry.

## Issue acceptance gates

This is a bounded deletion from the native Effect campaign, not the complete conversion of usage logging. It removes one internal runtime entry and its unused public result contract. The existing producer, authentication interface, process ownership and four remaining internal runtime entries are unchanged; no broader migration issue is closed.

The consequential delivery behavior remains: background triggers coalesce before waiting for the serialization permit, pending batches retry only on a later trigger, permanent rejections are reported and discarded without blocking subsequent entries, and disposal joins an active sender.

## Single source of truth

`UsageLogService` remains the sole owner of queued entries, retained batch identity and delivery order. Its existing semaphore continues to serialize background delivery and disposal. `backgroundFlushActive` only combines concurrent background triggers; it is set before permit acquisition and reset by Effect finalization on every exit.

Consent is still checked when an entry is accepted and immediately before sending, using the originating workspace's configuration. Plan-accounting routes retain their existing exemption from optional telemetry consent. Authentication and HTTP acknowledgement classification are not changed.

## Duplication and abstraction budget

The public Promise `flush()` entry, shared-outcome Deferred, `sharedDrain`, aggregate-outcome bookkeeping, `flushQueuedBatch`, and obsolete outcome constant/type are removed. The drain handles its existing typed undelivered-batch error directly. No service, forwarding API or test-only production entry replaces the deleted API.

An active flag remains necessary: merely queuing every timer or batch-size trigger behind the semaphore would immediately retry a failed batch when an already waiting duplicate drain acquired the permit. The flag preserves the existing trigger-combining behavior without constructing or publishing an outcome.

## Net elements (R6)

- Files: 0 added, 0 deleted; 4 modified.
- Exported symbols: 0 added, 1 deleted (`USAGE_LOG_FLUSH_OUTCOME`).
- Classes, interfaces and enums: 0 added, 0 deleted; 1 private type alias deleted (`UsageLogFlushOutcome`).
- Methods/helpers: public `flush` and private `sharedDrain`/`flushQueuedBatch` deleted; no new method or helper.
- Production: +102 / −151 lines, net −49.
- Tests: +37 / −113 lines, net −76. One test solely preserving shared public outcomes is deleted; no tests or test files are added.
- Ratchets: +1 / −7 lines, net −6. The service's internal runtime count drops from 5 to 4, and the obsolete exported-outcome finding is removed from the dead-code baseline.
- Total: +140 / −271 lines, net −131. No dependency changes.

## Consumer counts (R8)

The retired public `flush()` method has zero production callers. The removed outcome export has zero production consumers outside its defining module; its only external consumer was the existing usage-log test suite. Production still has one `log()` caller and three host initialization/disposal pairs. No event emission or subscription interface changes.

Existing behavioral tests now trigger delivery through batch size, timer ticks and disposal. Their assertions continue to protect batch identities, order, retry timing, rejection handling, consent and shutdown rather than the retired return values.

## Host impact

Extension: initialization, round-usage recording and shutdown registration are unchanged.

Desktop: initialization and shutdown registration are unchanged; each entry retains its originating workspace's consent source.

CLI: the ticker remains unreferenced so it does not keep an idle process alive; shutdown still joins active delivery. The five-second disposal warning remains a warning, not a new abandonment deadline.

## Scheduled refactoring

None required to complete this deletion. A fully native usage-log service still requires its producer callbacks and process ownership to change together; that separate migration is not implemented or emulated here.

## Validation

The isolated worktree starts from freshly fetched main `914173c95303b8d968b767e417aa33f5ec5aa127`. Full tests use a private temporary directory so concurrent worktrees cannot interfere with each other's temporary-file assertions.

- Focused usage-log and CLI initialization tests: 49 passed across 2 suites.
- Independent concurrency review and rerun of the usage-log suite: 35 passed.
- Targeted workspace/test-kernel type checks and ESLint: passed.
- `npm run format -- --log-level warn`: passed.
- `npm run typecheck`: passed (all six constituent checks).
- `npm run lint`: passed.
- `npm run compile:fast`: passed.
- `npm test -- --maxWorkers=4` with private `TMPDIR`: 765 suites passed, 1 skipped; 9,087 tests passed, 6 skipped.
- Effect migration, dead-code and browser-safe-utils checks: passed.
- `git diff --check`: passed.

## Verified

Independent review covered the complete production diff and adapted existing tests. In particular, the permanent-rejection/later-entry case triggers a second background request while a drain is active, then requires exactly two sends before the later timer retry; this detects a duplicate drain incorrectly queued behind the semaphore. Existing tests also verify active-send shutdown joining, the five-second warning without abandonment, preserved retry identities and order, post-token consent checks, and plan-accounting delivery.
