### PR TITLE
refactor: remove unobserved API-key retry results

### DIFF
--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -36,26 +36,8 @@ interface ProgressApiKeyRetryRequest {
   chatGptSubscriptionEligible?: boolean;
 }
 
-interface ProgressApiKeyPreparationResult {
-  proceeded: boolean;
-  /** Exhaustion reasons whose quota-fallback toggle was turned off. */
-  disabledQuotaRoutes: readonly ExhaustionReason[];
-}
-
-interface ProgressApiKeyRetryResult extends ProgressApiKeyPreparationResult {
-  retried: boolean;
-}
-
 interface ProgressApiRoutingSnapshot {
   readonly quotaRoutes: ReadonlyMap<ExhaustionReason, boolean>;
-}
-
-function noRetryResult(): ProgressApiKeyRetryResult {
-  return {
-    proceeded: false,
-    retried: false,
-    disabledQuotaRoutes: [],
-  };
 }
 
 /** A host port call (credentials, prompts, toggles, the retry launch). Its
@@ -133,9 +115,7 @@ export class ProgressApiKeyRetryController {
     return this.deps.quotaFallbackRuntimes ?? quotaFallbackRuntimes;
   }
 
-  useOwnApiKey(
-    request: ProgressApiKeyRetryRequest,
-  ): Promise<ProgressApiKeyRetryResult> {
+  useOwnApiKey(request: ProgressApiKeyRetryRequest): Promise<void> {
     return effectRuntime().runPromise(this.switchToOwnApiKey(request));
   }
 
@@ -151,7 +131,7 @@ export class ProgressApiKeyRetryController {
         request.exhaustionReason,
       )
     ) {
-      return noRetryResult();
+      return;
     }
 
     const proceeded = yield* this.ensureOwnApiKeyReady({
@@ -162,20 +142,19 @@ export class ProgressApiKeyRetryController {
       !proceeded ||
       !this.deps.isRetryPending(request.stream, request.requestId)
     ) {
-      return noRetryResult();
+      return;
     }
 
-    const committed = yield* this.commitOwnApiKeyRouting(request, () =>
+    yield* this.commitOwnApiKeyRouting(request, () =>
       this.deps.triggerRetry(request.stream, request.requestId),
     );
-    return committed ? { ...committed, retried: true } : noRetryResult();
   });
 
   /**
    * Serialize one own-API-key routing commit: switch the routing for `action`
    * and restore it when `action` fails or reports it never used the
-   * switches. Resolves to the preparation (whose switches stay on for the
-   * retry) or undefined when the retry identity is no longer pending.
+   * switches. Returns whether the action used the routing, or false without
+   * running the action when the retry identity is no longer pending.
    *
    * The request may have been dismissed or replaced while this callback
    * waited behind another stream's routing commit. The pending identity is
@@ -185,7 +164,7 @@ export class ProgressApiKeyRetryController {
   private commitOwnApiKeyRouting(
     request: ProgressApiKeyRetryRequest,
     action: () => boolean | PromiseLike<boolean>,
-  ): Effect.Effect<ProgressApiKeyPreparationResult | undefined, unknown> {
+  ): Effect.Effect<boolean, unknown> {
     return this.routingLane.withPermit(
       Effect.scoped(this.routingTransaction(request, action)),
     );
@@ -199,13 +178,12 @@ export class ProgressApiKeyRetryController {
     action: () => boolean | PromiseLike<boolean>,
   ) {
     if (!this.deps.isRetryPending(request.stream, request.requestId)) {
-      return undefined;
+      return false;
     }
     const before = this.routingSnapshot();
     // One chain: turn off every matching quota-fallback preference so the
     // retry rebuilds onto the fallback credential. Remark: prefer-off sticks
     // after the quota resets — users may forget to re-enable it.
-    const disabledQuotaRoutes: ExhaustionReason[] = [];
     for (const runtime of this.fallbackRuntimes) {
       if (
         !runtime.getEnabled() ||
@@ -214,7 +192,6 @@ export class ProgressApiKeyRetryController {
         continue;
       }
       const reason = runtime.descriptor.exhaustionReason;
-      disabledQuotaRoutes.push(reason);
       // The compensation is registered before its setter runs: a setter can
       // mutate in memory and then reject on persistence, so a throw midway
       // must roll back every switch that may have landed instead of
@@ -227,7 +204,7 @@ export class ProgressApiKeyRetryController {
       // restore to fail (the last switch applied) reaches the caller as its
       // own error.
       yield* Effect.addFinalizer((exit) =>
-        Exit.isSuccess(exit) && exit.value !== undefined
+        Exit.isSuccess(exit) && exit.value === true
           ? Effect.void
           : Effect.tryPromise({
               try: () =>
@@ -247,10 +224,7 @@ export class ProgressApiKeyRetryController {
       yield* port(() => runtime.setEnabled(false));
     }
 
-    const actionSucceeded = yield* port(action);
-    return actionSucceeded
-      ? { proceeded: true, disabledQuotaRoutes }
-      : undefined;
+    return yield* port(action);
   });
 
   ensureOwnApiKey(
@@ -351,10 +325,7 @@ export class ProgressApiKeyRetryController {
     // override travels only with the replacement launch; the standing
     // preference remains visible to concurrent and future runs.
     return effectRuntime().runPromise(
-      Effect.map(
-        this.commitOwnApiKeyRouting(request, () => start('direct')),
-        (committed) => committed !== undefined,
-      ),
+      this.commitOwnApiKeyRouting(request, () => start('direct')),
     );
   }
 

--- a/src/controllers/session/hostRunActions.ts
+++ b/src/controllers/session/hostRunActions.ts
@@ -368,7 +368,7 @@ export function createHostRunActions(
         request.provider != null && isApiProvider(request.provider)
           ? request.provider
           : undefined;
-      const result = await apiKeyRetry.useOwnApiKey({
+      await apiKeyRetry.useOwnApiKey({
         stream: request.streamId,
         requestId: request.requestId,
         model: request.model ?? undefined,
@@ -376,11 +376,6 @@ export function createHostRunActions(
         exhaustionReason: exhaustionReasonOf(request),
         kimiCodeRoutedOnFailure: request.kimiCodeRoutedOnFailure ?? undefined,
       });
-      if (result.proceeded && !result.retried) {
-        await ports.showInfo(
-          'Switched to your own API key. There is no pending retry to resume, so run the agent again when you are ready.',
-        );
-      }
     },
     async restoreState(streamId) {
       const { config } = await nativeAgentRun(streamId, 'restored');

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -16,19 +16,6 @@ const PROVIDERS = [
   'anthropic',
 ] as const satisfies readonly ApiProvider[];
 
-// The two dominant outcomes: the controller refused to act, or it switched to
-// a stored key and triggered the retry.
-const IDLE_RESULT = {
-  proceeded: false,
-  retried: false,
-  disabledQuotaRoutes: [],
-};
-const RETRIED_WITH_OWN_KEY_RESULT = {
-  proceeded: true,
-  retried: true,
-  disabledQuotaRoutes: [],
-};
-
 function testRuntime(
   descriptor: Pick<
     QuotaFallbackRoute,
@@ -177,14 +164,13 @@ describe('ProgressApiKeyRetryController', () => {
       },
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-a',
       requestId: 'retry-a',
       provider: 'anthropic',
       exhaustionReason: 'upstream-credit',
     });
 
-    expect(result).toStrictEqual(RETRIED_WITH_OWN_KEY_RESULT);
     expect(harness.prompts).toStrictEqual(['anthropic']);
     expect(harness.retries).toStrictEqual(['stream-a']);
   });
@@ -197,14 +183,13 @@ describe('ProgressApiKeyRetryController', () => {
       },
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-a',
       requestId: 'retry-a',
       provider: 'anthropic',
       exhaustionReason: 'upstream-credit',
     });
 
-    expect(result).toStrictEqual(IDLE_RESULT);
     expect(harness.prompts).toStrictEqual(['anthropic']);
     expect(harness.retries).toStrictEqual([]);
   });
@@ -215,34 +200,14 @@ describe('ProgressApiKeyRetryController', () => {
       retryPending: false,
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-a',
       requestId: 'retry:stale',
       provider: 'anthropic',
       exhaustionReason: 'copilot-subscription',
     });
 
-    expect(result).toStrictEqual(IDLE_RESULT);
     expect(harness.retries).toStrictEqual([]);
-  });
-
-  it('returns a fresh result when no retry occurs', async () => {
-    const harness = createHarness({
-      keys: { anthropic: 'stored-key' },
-      retryPending: false,
-    });
-    const request = {
-      stream: 'stream-a' as const,
-      requestId: 'retry:stale',
-      provider: 'anthropic' as const,
-      exhaustionReason: 'copilot-subscription' as const,
-    };
-
-    const first = await harness.controller.useOwnApiKey(request);
-    const second = await harness.controller.useOwnApiKey(request);
-
-    expect(first).not.toBe(second);
-    expect(first).toStrictEqual(second);
   });
 
   it('accepts a changed key from any provider when depletion has no provider hint', async () => {
@@ -253,13 +218,12 @@ describe('ProgressApiKeyRetryController', () => {
       },
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-b',
       requestId: 'retry-b',
       exhaustionReason: 'upstream-credit',
     });
 
-    expect(result).toStrictEqual(RETRIED_WITH_OWN_KEY_RESULT);
     expect(harness.prompts).toStrictEqual([undefined]);
     expect(harness.retries).toStrictEqual(['stream-b']);
   });
@@ -270,14 +234,13 @@ describe('ProgressApiKeyRetryController', () => {
       retryAvailable: false,
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-race',
       requestId: 'retry-race',
       provider: 'openai',
       exhaustionReason: 'chatgpt-subscription',
     });
 
-    expect(result).toStrictEqual(IDLE_RESULT);
     expect(harness.chatGptSubscriptionValues).toStrictEqual([false, true]);
     expect(harness.retries).toStrictEqual(['stream-race']);
   });
@@ -287,18 +250,13 @@ describe('ProgressApiKeyRetryController', () => {
       keys: { openai: 'stored-openai' },
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-d',
       requestId: 'retry-d',
       provider: 'openai',
       exhaustionReason: 'chatgpt-subscription',
     });
 
-    expect(result).toStrictEqual({
-      proceeded: true,
-      retried: true,
-      disabledQuotaRoutes: ['chatgpt-subscription'],
-    });
     // The subscription quota failed, not the key — a stored key is already
     // usable, so "Use your own API key" must not jump to the key-input prompt.
     expect(harness.prompts).toStrictEqual([]);
@@ -311,18 +269,13 @@ describe('ProgressApiKeyRetryController', () => {
       keys: { xai: 'stored-xai' },
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-grok',
       requestId: 'retry-grok',
       provider: 'xai',
       exhaustionReason: 'xai-subscription',
     });
 
-    expect(result).toStrictEqual({
-      proceeded: true,
-      retried: true,
-      disabledQuotaRoutes: ['xai-subscription'],
-    });
     expect(harness.prompts).toStrictEqual([]);
     expect(harness.grokSubscriptionValues).toStrictEqual([false]);
     expect(harness.retries).toStrictEqual(['stream-grok']);
@@ -331,14 +284,13 @@ describe('ProgressApiKeyRetryController', () => {
   it('does not disable the subscription when no usable OpenAI key is available', async () => {
     const harness = createHarness({ keys: {} });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-e',
       requestId: 'retry-e',
       provider: 'openai',
       exhaustionReason: 'chatgpt-subscription',
     });
 
-    expect(result).toStrictEqual(IDLE_RESULT);
     // No usable key exists, so the prompt is still shown (then declined here).
     expect(harness.prompts).toStrictEqual(['openai']);
     expect(harness.chatGptSubscriptionValues).toStrictEqual([]);
@@ -350,18 +302,13 @@ describe('ProgressApiKeyRetryController', () => {
       keys: { glm: 'stored-glm' },
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-glm',
       requestId: 'retry-glm',
       provider: 'glm',
       exhaustionReason: 'glm-coding-plan',
     });
 
-    expect(result).toStrictEqual({
-      proceeded: true,
-      retried: true,
-      disabledQuotaRoutes: ['glm-coding-plan'],
-    });
     // The coding-plan quota failed, not the key — a stored key is already
     // usable, so "Use your own API key" must not jump to the key-input prompt.
     expect(harness.prompts).toStrictEqual([]);
@@ -375,19 +322,15 @@ describe('ProgressApiKeyRetryController', () => {
       glmCodingPlan: false,
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-glm2',
       requestId: 'retry-glm2',
       provider: 'glm',
       exhaustionReason: 'glm-coding-plan',
     });
 
-    expect(result).toStrictEqual({
-      proceeded: true,
-      retried: true,
-      disabledQuotaRoutes: [],
-    });
     expect(harness.glmCodingPlanValues).toStrictEqual([]);
+    expect(harness.retries).toStrictEqual(['stream-glm2']);
   });
 
   it('prepares an existing direct key for a fresh Copilot fallback without retrying in place', async () => {
@@ -560,12 +503,8 @@ describe('ProgressApiKeyRetryController', () => {
     expect(triggerOrder).toStrictEqual(['stream-a']);
 
     firstTrigger.resolve(false);
-    await expect(first).resolves.toStrictEqual(IDLE_RESULT);
-    await expect(second).resolves.toStrictEqual({
-      proceeded: true,
-      retried: true,
-      disabledQuotaRoutes: ['chatgpt-subscription'],
-    });
+    await first;
+    await second;
     expect(harness.chatGptSubscriptionValues).toStrictEqual([
       false,
       true,
@@ -577,14 +516,13 @@ describe('ProgressApiKeyRetryController', () => {
   it('refuses the API-key switch for a Kimi Code-exclusive model', async () => {
     const harness = createHarness({ keys: { openai: 'stored-openai' } });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-kimi-exclusive',
       requestId: 'retry-kimi-exclusive',
       model: 'kimiCoding',
       exhaustionReason: 'kimi-code-subscription',
     });
 
-    expect(result).toStrictEqual(IDLE_RESULT);
     expect(harness.prompts).toStrictEqual([]);
     expect(harness.retries).toStrictEqual([]);
   });
@@ -601,14 +539,13 @@ describe('ProgressApiKeyRetryController', () => {
       },
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-stale-queue',
       requestId: 'retry-stale-queue',
       provider: 'openai',
       exhaustionReason: 'chatgpt-subscription',
     });
 
-    expect(result).toStrictEqual(IDLE_RESULT);
     expect(harness.chatGptSubscriptionValues).toStrictEqual([]);
     expect(harness.retries).toStrictEqual([]);
     expect(pendingChecks).toBe(2);
@@ -623,7 +560,7 @@ describe('ProgressApiKeyRetryController', () => {
       kimiCode: true,
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-kimi-credit',
       requestId: 'retry-kimi-credit',
       model: 'kimiCoding',
@@ -632,11 +569,6 @@ describe('ProgressApiKeyRetryController', () => {
       kimiCodeRoutedOnFailure: true,
     });
 
-    expect(result).toStrictEqual({
-      proceeded: true,
-      retried: true,
-      disabledQuotaRoutes: [],
-    });
     // The SDK error identifies the open-platform Moonshot provider, but the
     // exclusive handler rebinds with `kimiCode`; the prompt and key check must
     // target the same credential or the retry repeats the same failure.
@@ -656,7 +588,7 @@ describe('ProgressApiKeyRetryController', () => {
       kimiCode: true,
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-kimi-dual',
       requestId: 'retry-kimi-dual',
       model: 'kimi3',
@@ -665,11 +597,6 @@ describe('ProgressApiKeyRetryController', () => {
       kimiCodeRoutedOnFailure: true,
     });
 
-    expect(result).toStrictEqual({
-      proceeded: true,
-      retried: true,
-      disabledQuotaRoutes: ['kimi-code-subscription'],
-    });
     // The forwarded SDK provider is `moonshot`, so that is the credential the
     // panel asks to replace; the routing step then turns off "Prefer Kimi
     // Code" so the rebuilt handler actually uses the new Moonshot key. The
@@ -693,7 +620,7 @@ describe('ProgressApiKeyRetryController', () => {
       kimiCode: true,
     });
 
-    const result = await harness.controller.useOwnApiKey({
+    await harness.controller.useOwnApiKey({
       stream: 'stream-kimi-moonshot',
       requestId: 'retry-kimi-moonshot',
       model: 'kimi3',
@@ -702,11 +629,6 @@ describe('ProgressApiKeyRetryController', () => {
       kimiCodeRoutedOnFailure: false,
     });
 
-    expect(result).toStrictEqual({
-      proceeded: true,
-      retried: true,
-      disabledQuotaRoutes: [],
-    });
     // A canonical `kimi3` can also fail through OpenRouter or Moonshot. Those
     // failed handlers were not dispatched onto the Kimi Code endpoint, so the
     // retry must not turn off the user's coding preference.


### PR DESCRIPTION
## Summary

Remove unobserved API-key retry results and the caller's unreachable notice. `useOwnApiKey` now completes without returning a result object. Previously it returned only `proceeded: false, retried: false` or `proceeded: true, retried: true`, so the sole caller's `proceeded && !retried` branch could never run.

The routing transaction retains a boolean: a successful `true` keeps the routing changes; a failure or `false` rolls them back. Copilot fallback still uses this boolean to acknowledge a replacement launch before cancelling the old retry. Credential preparation retains its independently observed boolean.

## Issue acceptance gates

- Remove both unused result interfaces, `noRetryResult`, and `disabledQuotaRoutes` accumulation.
- Remove the unreachable notice from the sole controller caller.
- Preserve credential-change requirements, pending-retry checks, routing serialization, rollback and error precedence, and Copilot launch acknowledgment.
- Add no tests or abstractions. Retire the one test concerned only with result-object identity.

This is an internal result cleanup, not a native Effect call-chain conversion. No issue is claimed closed.

## Single source of truth

`ProgressApiKeyRetryController` continues to own routing policy. The retry or launch action's boolean is the transaction's decision: only a successful `true` permits its routing changes to remain. Actual prompt calls, retry calls, and routing writes are the observable behavior; a second report of those operations is no longer constructed.

## Duplication and abstraction budget

Delete the result objects and route-name accumulation, the result-to-boolean mapping for Copilot, and the unreachable caller branch. Add no replacement layer. The existing semaphore, scoped compensation, host ports, and runtime entries remain unchanged.

## Net elements (R6)

- Files: 3 modified; 0 added, 0 deleted.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added; 2 private result interfaces deleted; no class or enum changes.
- Production functions: 0 added, 1 deleted (`noRetryResult`).
- Production lines: 12 added, 46 deleted; **net -34**.
- Test lines: 18 added, 96 deleted; **net -78**.
- Total lines: 30 added, 142 deleted; **net -112**.
- Tests: 0 added, 1 result-identity-only test deleted; 22 behavioral cases remain.

## Consumer counts (R8)

`useOwnApiKey` has exactly one production controller caller, in `hostRunActions.ts`; its only reads of `proceeded` and `retried` formed the unreachable branch removed here. `disabledQuotaRoutes` had zero production readers. `ensureOwnApiKey` has two production calls and `runCopilotFallbackWithRouting` has one, all in the same caller; their booleans remain observed. The shared host action continues to serve the extension and desktop request handlers. No event or subscription path is removed or redirected.

## Host impact

Extension: unchanged prompt, credential, retry, and routing behavior; remove only an unreachable notice.

Desktop: the same shared controller cleanup; replacement-launch acknowledgment and subsequent cancellation of the old Copilot retry remain ordered.

CLI: no direct consumer or code change.

## Scheduled refactoring

None required by this cleanup. Existing internal runtime entries and their larger native conversion remain outside this PR.

Integration note: [#11978](https://github.com/LionSR/TeXRA/pull/11978) also modifies `hostRunActions.ts`; integrating both changes may require resolving the small result-binding and notice-removal hunk.

## Validation

Validated against `origin/main` at `914173c95303b8d968b767e417aa33f5ec5aa127`:

- `corepack pnpm install --frozen-lockfile` — passed.
- `npm run format -- --log-level warn` — passed; no unrelated changes.
- `npm run typecheck` — passed, including all six constituent checks.
- `npm run lint` — passed.
- `npm run compile:fast` — passed.
- `corepack pnpm exec vitest run src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts --maxWorkers=4` — 22 passed.
- `TMPDIR=/tmp/texra-retry-results-tests.fFz5fk npm test -- --maxWorkers=4` — 765 suites passed, 1 skipped; 9,087 tests passed, 6 skipped. A private temporary directory isolates the existing filesystem tests from other worktrees.
- `npm run check:effect-migration-ratchet` — passed; runtime and other migration counts unchanged.
- `npm run check:dead-code-ratchet` — passed.
- `git diff --check` — passed.

## Verified

Reviewed every production return and caller, the transaction's success/rollback condition, and the existing credential, rollback, concurrency, and Copilot tests. The fresh-result identity test was deleted with the result object; meaningful assertions remain on actual prompts, retries, and routing writes.

Two independent reviews found no correctness issue; the second review independently ran the remaining 22 controller tests successfully.
