### PR TITLE
refactor(telemetry): own delivery in the process scope

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -171,7 +171,6 @@
       "src/controllers/session/sessionLayer.ts": 3,
       "src/platform/defaults/jsonStore.ts": 1,
       "src/shared/signals.ts": 2,
-      "src/telemetry/UsageLogService.ts": 4,
       "src/tools/agentCliSessionRegistry.ts": 2,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/lean/direct/directLspAdapter.ts": 3
@@ -218,7 +217,6 @@
     "src/controllers/session/sessionLayer.ts": "lane D — host composition root and session graph",
     "src/platform/defaults/jsonStore.ts": "lane D — Platform ports become Effect-typed",
     "src/shared/signals.ts": "lane D — host composition root and session graph",
-    "src/telemetry/UsageLogService.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/tools/agentCliSessionRegistry.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/github/PollingSourceBase.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — the port is Effect-typed and the tool-facing runs moved to the tools' execute(); what remains is pool construction/disposal (the platform-lifetime seam) and the run-end hook's Promise seam, both owned by lane D"

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -385,7 +385,9 @@ export async function initCliPlatform(
       // The default session is installed later by whichever entry point opens
       // transcripts, so its shutdown lookup remains lazy.
       flushArtifacts: () => tryDefaultSession()?.flushArtifacts(),
-      afterFlushArtifacts: [() => UsageLogService.dispose()],
+      afterFlushArtifacts: [
+        () => effectRuntime().runPromise(UsageLogService.dispose()),
+      ],
       afterExecutionSettlement: [
         () => teardownDefaultSession(),
         () => flushNdjsonStdout(),
@@ -398,7 +400,14 @@ export async function initCliPlatform(
     // dispose() flushes any queued entries; it
     // runs on normal exit (bin/texra.ts finally) and on signals, both of
     // which call lifecycle.runShutdown().
-    UsageLogService.initialize({}, context.version, 'cli');
+    await effectRuntime().runPromise(
+      UsageLogService.initialize(
+        effectRuntime().scope,
+        {},
+        context.version,
+        'cli',
+      ),
+    );
   }
 
   if (!supabaseAuthInitialized) {

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -401,7 +401,12 @@ export async function initCliPlatform(
     // runs on normal exit (bin/texra.ts finally) and on signals, both of
     // which call lifecycle.runShutdown().
     await effectRuntime().runPromise(
-      UsageLogService.initialize({}, context.version, 'cli'),
+      UsageLogService.initialize(
+        effectRuntime().scope,
+        {},
+        context.version,
+        'cli',
+      ),
     );
   }
 

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -157,8 +157,17 @@ export async function initializeElectronPlatform(
   // carries an undefined host/version, so a queue shorter than one batch is
   // lost at quit — including plan accounting. `dispose()` drains it, from the
   // same BEFORE phase the other two hosts use.
-  UsageLogService.initialize({}, app.getVersion(), 'desktop');
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => UsageLogService.dispose());
+  await effectRuntime().runPromise(
+    UsageLogService.initialize(
+      effectRuntime().scope,
+      {},
+      app.getVersion(),
+      'desktop',
+    ),
+  );
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+    effectRuntime().runPromise(UsageLogService.dispose()),
+  );
 
   // Reconcile the persisted enabled-models list against the current curated
   // defaults, as the extension and CLI hosts do at startup. Preferred defaults

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -158,7 +158,12 @@ export async function initializeElectronPlatform(
   // lost at quit — including plan accounting. `dispose()` drains it, from the
   // same BEFORE phase the other two hosts use.
   await effectRuntime().runPromise(
-    UsageLogService.initialize({}, app.getVersion(), 'desktop'),
+    UsageLogService.initialize(
+      effectRuntime().scope,
+      {},
+      app.getVersion(),
+      'desktop',
+    ),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
     effectRuntime().runPromise(UsageLogService.dispose()),

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -513,7 +513,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
   registerRuntimeShutdownHandlers(lifecycle, {
     afterAgentShutdown: [
       () => killActiveRecording(),
-      () => UsageLogService.dispose(),
+      () => effectRuntime().runPromise(UsageLogService.dispose()),
     ],
     flushArtifacts: () => runtimeSession.flushArtifacts(),
     afterExecutionSettlement: [
@@ -632,10 +632,13 @@ async function activateExtension(context: vscode.ExtensionContext) {
       ? context.extension.packageJSON.version
       : undefined;
   try {
-    UsageLogService.initialize(
-      {},
-      extensionVersion,
-      vscode.env.appName || undefined,
+    await effectRuntime().runPromise(
+      UsageLogService.initialize(
+        effectRuntime().scope,
+        {},
+        extensionVersion,
+        vscode.env.appName || undefined,
+      ),
     );
   } catch (error) {
     log.warn(`Failed to initialize usage logging: ${toErrorMessage(error)}`);

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -634,6 +634,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
   try {
     await effectRuntime().runPromise(
       UsageLogService.initialize(
+        effectRuntime().scope,
         {},
         extensionVersion,
         vscode.env.appName || undefined,

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -1,13 +1,21 @@
 import { randomUUID } from 'node:crypto';
 
-import { Clock, Data, Duration, Effect, Fiber, Semaphore } from 'effect';
+import {
+  Clock,
+  Data,
+  Duration,
+  Effect,
+  Fiber,
+  Queue,
+  Scope,
+  Semaphore,
+} from 'effect';
 import ky from 'ky';
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';
 import { createLog } from '@logger/logUtils';
 import type { ConfigProvider } from '@platform/interfaces';
-import { effectRuntime } from '@platform/processRuntime';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import type { UsageRoute } from '@shared/schemas';
 import {
@@ -216,6 +224,9 @@ class UsageLogServiceImpl {
    *  and interrupted by `dispose`. It only schedules: each flush runs on a
    *  fiber of its own, so interrupting the ticker never touches a send. */
   private flushTimer: Fiber.Fiber<never> | null = null;
+  private sender: Fiber.Fiber<never> | null = null;
+  private triggers: Queue.Queue<void> | null = null;
+  private owner: Scope.Scope | undefined;
   /** One permit: batches leave in order, and disposal joins an active drain. */
   private readonly flushLane = Semaphore.makeUnsafe(1);
   /** Coalesce triggers before they wait for the lane; failed sends wait for
@@ -227,15 +238,53 @@ class UsageLogServiceImpl {
   private extensionVersion: string | undefined;
   private editorType: string | undefined;
 
-  initialize(
+  readonly initialize = Effect.fn('UsageLogService.initialize')(function* (
+    this: UsageLogServiceImpl,
+    owner: Scope.Scope,
     config?: Partial<UsageLogConfig>,
     extensionVersion?: string,
     editorType?: string,
-  ): void {
+  ) {
+    if (this.owner && this.owner !== owner) yield* this.dispose();
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.extensionVersion = extensionVersion;
     this.editorType = editorType;
-    this.startFlushTimer();
+    if (this.flushTimer) yield* Fiber.interrupt(this.flushTimer);
+    if (!this.sender) {
+      this.triggers = yield* Queue.make<void>({
+        capacity: 1,
+        strategy: 'dropping',
+      });
+      const triggers = this.triggers;
+      this.sender = yield* Effect.forkIn(
+        Effect.forever(
+          Queue.take(triggers).pipe(Effect.andThen(this.backgroundFlush())),
+        ),
+        owner,
+      );
+    }
+    const tick = Clock.clockWith((clock) =>
+      Effect.sleep(Duration.millis(this.config.flushIntervalMs)).pipe(
+        Effect.provideService(Clock.Clock, unrefSleepClock(clock)),
+      ),
+    );
+    this.flushTimer = yield* Effect.forkIn(
+      Effect.forever(
+        tick.pipe(Effect.andThen(Effect.sync(() => this.requestFlush()))),
+      ),
+      owner,
+      { startImmediately: true },
+    );
+    if (this.owner !== owner) {
+      this.owner = owner;
+      // Registered after the fibers: drain before scope closure interrupts them.
+      yield* Scope.addFinalizer(
+        owner,
+        Effect.suspend(() =>
+          this.owner === owner ? this.dispose() : Effect.void,
+        ),
+      );
+    }
 
     if (isTelemetryDisabledByEnv()) {
       log.info(
@@ -246,7 +295,7 @@ class UsageLogServiceImpl {
     log.debug(
       `UsageLogService initialized (batchSize=${this.config.batchSize}, flushIntervalMs=${this.config.flushIntervalMs}, enabled=${this.config.enabled})`,
     );
-  }
+  });
 
   log(
     entry: Omit<UsageLogEntry, 'timestamp' | 'extensionVersion' | 'editorType'>,
@@ -275,8 +324,16 @@ class UsageLogServiceImpl {
     log.debug(`Queued usage entry (queue size: ${this.queue.length})`);
 
     if (this.queue.length >= this.config.batchSize) {
-      effectRuntime().runFork(this.backgroundFlush());
+      this.requestFlush();
     }
+  }
+
+  /** Synchronous producer admission; the process-owned sender does the I/O. */
+  private requestFlush(): void {
+    if (!this.config.enabled || !this.triggers || this.backgroundFlushActive)
+      return;
+    this.backgroundFlushActive = true;
+    Queue.offerUnsafe(this.triggers, undefined);
   }
 
   /** Send every batch that is due, one after another, under the lane. */
@@ -307,10 +364,10 @@ class UsageLogServiceImpl {
    * drain cannot fail, so only a defect reaches here, and it is reported by
    * its owner instead of ending a fiber nobody observes.
    */
-  private readonly backgroundFlush = Effect.fn('UsageLogService.flush')(
+  private readonly backgroundFlush = Effect.fn(
+    'UsageLogService.backgroundFlush',
+  )(
     function* (this: UsageLogServiceImpl) {
-      if (this.backgroundFlushActive) return;
-      this.backgroundFlushActive = true;
       yield* this.flushLane.withPermit(this.drain()).pipe(
         Effect.ensuring(
           Effect.sync(() => {
@@ -474,40 +531,7 @@ class UsageLogServiceImpl {
     },
   );
 
-  private startFlushTimer(): void {
-    const runtime = effectRuntime();
-    if (this.flushTimer) runtime.runFork(Fiber.interrupt(this.flushTimer));
-    // The ticker lives until dispose() interrupts it, and it must not keep a
-    // short-lived host (the CLI) alive on its own: an active run keeps the
-    // loop running so the tick still fires, but at exit dispose() flushes and
-    // interrupts it rather than the ticker pinning the process. Its sleep
-    // therefore runs on `unrefSleepClock`; a host that never disposes exits
-    // on an empty loop as before, with whatever the queue holds unsent.
-    //
-    // Detached on purpose: a flush belongs to the lane, not to the tick that
-    // scheduled it. `sendNextBatch` takes the batch before the request goes
-    // out, and an interrupt landing there would abort the request without
-    // failing it, so nothing would requeue what was taken. Running the flush
-    // on its own fiber keeps a dispose (or re-initialize) that lands mid-send
-    // from reaching it: dispose waits behind the send on the lane instead.
-    // The flush ends with its drain and is observed by nothing else.
-    const tick = Clock.clockWith((clock) =>
-      Effect.sleep(Duration.millis(this.config.flushIntervalMs)).pipe(
-        Effect.provideService(Clock.Clock, unrefSleepClock(clock)),
-      ),
-    );
-    this.flushTimer = runtime.runFork(
-      Effect.forever(
-        tick.pipe(Effect.andThen(Effect.forkDetach(this.backgroundFlush()))),
-      ),
-    );
-  }
-
-  dispose(): Promise<void> {
-    return effectRuntime().runPromise(this.shutdown());
-  }
-
-  private readonly shutdown = Effect.fn('UsageLogService.dispose')(function* (
+  readonly dispose = Effect.fn('UsageLogService.dispose')(function* (
     this: UsageLogServiceImpl,
   ) {
     if (this.flushTimer) {
@@ -532,6 +556,13 @@ class UsageLogServiceImpl {
       Fiber.interrupt(warning).pipe(Effect.andThen(this.drain())),
     );
 
+    if (this.sender) {
+      yield* Fiber.interrupt(this.sender);
+      this.sender = null;
+    }
+    this.triggers = null;
+    this.backgroundFlushActive = false;
+    this.owner = undefined;
     log.debug('UsageLogService disposed');
   });
 }

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -221,8 +221,8 @@ class UsageLogServiceImpl {
   private queue: QueuedUsageEntry[] = [];
   private retryBatch: RetryBatch | null = null;
   /** The ticker that schedules the periodic flush, forked by `initialize`
-   *  and interrupted by `dispose`. It only schedules: each flush runs on a
-   *  fiber of its own, so interrupting the ticker never touches a send. */
+   *  and interrupted by `dispose`. It only signals the sender, so interrupting
+   *  the ticker never touches a send. */
   private flushTimer: Fiber.Fiber<never> | null = null;
   private sender: Fiber.Fiber<never> | null = null;
   private triggers: Queue.Queue<void> | null = null;

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -7,6 +7,7 @@ import {
   Effect,
   Exit,
   Fiber,
+  Queue,
   Scope,
   Semaphore,
 } from 'effect';
@@ -220,12 +221,14 @@ class UsageBatchUndelivered extends Data.TaggedError('UsageBatchUndelivered')<{
 class UsageLogServiceImpl {
   private queue: QueuedUsageEntry[] = [];
   private retryBatch: RetryBatch | null = null;
-  /** The scope the two schedulers live in: the periodic ticker and the
-   *  batch-size watcher. `initialize` opens it and `dispose` closes it, and
-   *  closing it interrupts both. Neither ever sends: each forks its flush
-   *  onto a fiber of its own, so closing this scope cannot land inside a
-   *  request that has already taken a batch. */
-  private timers: Scope.Closeable | null = null;
+  /** The ticker that schedules the periodic flush, forked by `initialize`
+   *  and interrupted by `dispose`. It only signals the sender, so interrupting
+   *  the ticker never touches a send. */
+  private flushTimer: Fiber.Fiber<never> | null = null;
+  private sender: Fiber.Fiber<never> | null = null;
+  private triggers: Queue.Queue<void> | null = null;
+  private owner: Scope.Scope | undefined;
+  private lifetime: Scope.Closeable | undefined;
   /** One permit: batches leave in order, and disposal joins an active drain. */
   private readonly flushLane = Semaphore.makeUnsafe(1);
   /** Coalesce triggers before they wait for the lane; failed sends wait for
@@ -236,33 +239,54 @@ class UsageLogServiceImpl {
   private config: UsageLogConfig = { ...DEFAULT_CONFIG };
   private extensionVersion: string | undefined;
   private editorType: string | undefined;
-  /** The batch-size watcher's resume, while it is parked. `log` is
-   *  synchronous — the recorder runs inside an agent round, not inside an
-   *  Effect program — so this callback slot is how a full batch reaches a
-   *  fiber without a run of its own. */
-  private wake: (() => void) | null = null;
-  /** A wake that arrived while the watcher was busy, delivered on its next
-   *  park instead of being dropped. */
-  private wakePending = false;
 
-  /**
-   * Adopt the host's batching configuration and start the schedulers.
-   *
-   * Run by the host at its bootstrap: the ticker and the batch-size watcher
-   * are forked here, so the process's one runtime owns them for the whole of
-   * their lives instead of `log()` forking a fiber per full batch.
-   */
   readonly initialize = Effect.fn('UsageLogService.initialize')(function* (
     this: UsageLogServiceImpl,
+    owner: Scope.Scope,
     config?: Partial<UsageLogConfig>,
     extensionVersion?: string,
     editorType?: string,
   ) {
-    yield* this.stopTimers();
+    if (this.owner && this.owner !== owner) yield* this.dispose();
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.extensionVersion = extensionVersion;
     this.editorType = editorType;
-    yield* this.startSchedulers();
+    if (this.flushTimer) yield* Fiber.interrupt(this.flushTimer);
+    const freshLifetime = !this.lifetime;
+    const lifetime = this.lifetime ?? (yield* Scope.fork(owner));
+    this.lifetime = lifetime;
+    this.owner = owner;
+    if (!this.sender) {
+      this.triggers = yield* Queue.make<void>({
+        capacity: 1,
+        strategy: 'dropping',
+      });
+      const triggers = this.triggers;
+      this.sender = yield* Effect.forkIn(
+        Effect.forever(
+          Queue.take(triggers).pipe(Effect.andThen(this.backgroundFlush())),
+        ),
+        lifetime,
+      );
+    }
+    const tick = Clock.clockWith((clock) =>
+      Effect.sleep(Duration.millis(this.config.flushIntervalMs)).pipe(
+        Effect.provideService(Clock.Clock, unrefSleepClock(clock)),
+      ),
+    );
+    this.flushTimer = yield* Effect.forkIn(
+      Effect.forever(
+        tick.pipe(Effect.andThen(Effect.sync(() => this.requestFlush()))),
+      ),
+      lifetime,
+      { startImmediately: true },
+    );
+    if (freshLifetime) {
+      // Run before the sender's interruption finalizer. Closing this child on
+      // dispose also removes its parent finalizer, so reinitialization neither
+      // retains old shutdown callbacks nor changes the drain-before-stop order.
+      yield* Scope.addFinalizer(lifetime, this.shutdown());
+    }
 
     if (isTelemetryDisabledByEnv()) {
       log.info(
@@ -273,36 +297,6 @@ class UsageLogServiceImpl {
     log.debug(
       `UsageLogService initialized (batchSize=${this.config.batchSize}, flushIntervalMs=${this.config.flushIntervalMs}, enabled=${this.config.enabled})`,
     );
-  });
-
-  /**
-   * Wake the batch-size watcher, or record that it is owed a wake.
-   *
-   * A trigger that arrives while a background flush is running is dropped,
-   * not queued: that flush's drain empties the queue this entry just joined,
-   * and a failed send must wait for a later trigger rather than be retried by
-   * the caller that was already waiting behind it.
-   */
-  private signalWake(): void {
-    if (this.backgroundFlushActive) return;
-    if (this.wake) this.wake();
-    else this.wakePending = true;
-  }
-
-  /** Park until the next full batch. */
-  private readonly awaitWake = Effect.callback<void>((resume) => {
-    if (this.wakePending) {
-      this.wakePending = false;
-      resume(Effect.void);
-      return;
-    }
-    this.wake = () => {
-      this.wake = null;
-      resume(Effect.void);
-    };
-    return Effect.sync(() => {
-      this.wake = null;
-    });
   });
 
   log(
@@ -331,7 +325,17 @@ class UsageLogServiceImpl {
     });
     log.debug(`Queued usage entry (queue size: ${this.queue.length})`);
 
-    if (this.queue.length >= this.config.batchSize) this.signalWake();
+    if (this.queue.length >= this.config.batchSize) {
+      this.requestFlush();
+    }
+  }
+
+  /** Synchronous producer admission; the process-owned sender does the I/O. */
+  private requestFlush(): void {
+    if (!this.config.enabled || !this.triggers || this.backgroundFlushActive)
+      return;
+    this.backgroundFlushActive = true;
+    Queue.offerUnsafe(this.triggers, undefined);
   }
 
   /** Send every batch that is due, one after another, under the lane. */
@@ -362,10 +366,10 @@ class UsageLogServiceImpl {
    * drain cannot fail, so only a defect reaches here, and it is reported by
    * its owner instead of ending a fiber nobody observes.
    */
-  private readonly backgroundFlush = Effect.fn('UsageLogService.flush')(
+  private readonly backgroundFlush = Effect.fn(
+    'UsageLogService.backgroundFlush',
+  )(
     function* (this: UsageLogServiceImpl) {
-      if (this.backgroundFlushActive) return;
-      this.backgroundFlushActive = true;
       yield* this.flushLane.withPermit(this.drain()).pipe(
         Effect.ensuring(
           Effect.sync(() => {
@@ -529,69 +533,20 @@ class UsageLogServiceImpl {
     },
   );
 
-  /** Close the schedulers' scope, interrupting both of them. */
-  private readonly stopTimers = Effect.fn('UsageLogService.stopTimers')(
-    function* (this: UsageLogServiceImpl) {
-      const scope = this.timers;
-      if (!scope) return;
-      this.timers = null;
-      yield* Scope.close(scope, Exit.void);
-    },
-  );
+  /** Close the active process child, draining its sender before interruption. */
+  dispose(): Effect.Effect<void> {
+    return Effect.suspend(() =>
+      this.lifetime ? Scope.close(this.lifetime, Exit.void) : this.shutdown(),
+    );
+  }
 
-  /**
-   * Fork the periodic ticker and the batch-size watcher into a scope of their
-   * own.
-   *
-   * The schedulers live until dispose() closes that scope, and they must not
-   * keep a short-lived host (the CLI) alive on their own: an active run keeps
-   * the loop running so the tick still fires, but at exit dispose() flushes
-   * and closes the scope rather than the ticker pinning the process. The tick
-   * therefore sleeps on `unrefSleepClock`; a host that never disposes exits
-   * on an empty loop as before, with whatever the queue holds unsent.
-   *
-   * Each scheduler forks its flush detached, on purpose: a flush belongs to
-   * the lane, not to the tick that scheduled it. `sendNextBatch` takes the
-   * batch before the request goes out, and an interrupt landing there would
-   * abort the request without failing it, so nothing would requeue what was
-   * taken. Running the flush on its own fiber keeps a dispose (or a
-   * re-initialize) that lands mid-send from reaching it: dispose waits behind
-   * the send on the lane instead.
-   */
-  private readonly startSchedulers = Effect.fn(
-    'UsageLogService.startSchedulers',
-  )(function* (this: UsageLogServiceImpl) {
-    const scope = yield* Scope.make();
-    this.timers = scope;
-    const tick = Clock.clockWith((clock) =>
-      Effect.sleep(Duration.millis(this.config.flushIntervalMs)).pipe(
-        Effect.provideService(Clock.Clock, unrefSleepClock(clock)),
-      ),
-    );
-    yield* Effect.forkIn(
-      Effect.forever(
-        tick.pipe(Effect.andThen(Effect.forkDetach(this.backgroundFlush()))),
-      ),
-      scope,
-      { startImmediately: true },
-    );
-    yield* Effect.forkIn(
-      Effect.forever(
-        this.awaitWake.pipe(
-          Effect.andThen(Effect.forkDetach(this.backgroundFlush())),
-        ),
-      ),
-      scope,
-      { startImmediately: true },
-    );
-  });
-
-  /** Stop the schedulers, refuse new rounds, and drain what is queued. Run
-   *  by the host on its shutdown path. */
-  readonly dispose = Effect.fn('UsageLogService.dispose')(function* (
+  private readonly shutdown = Effect.fn('UsageLogService.dispose')(function* (
     this: UsageLogServiceImpl,
   ) {
-    yield* this.stopTimers();
+    if (this.flushTimer) {
+      yield* Fiber.interrupt(this.flushTimer);
+      this.flushTimer = null;
+    }
     this.config.enabled = false;
 
     // An in-flight background flush is waited for without
@@ -610,6 +565,14 @@ class UsageLogServiceImpl {
       Fiber.interrupt(warning).pipe(Effect.andThen(this.drain())),
     );
 
+    if (this.sender) {
+      yield* Fiber.interrupt(this.sender);
+      this.sender = null;
+    }
+    this.triggers = null;
+    this.backgroundFlushActive = false;
+    this.owner = undefined;
+    this.lifetime = undefined;
     log.debug('UsageLogService disposed');
   });
 }

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -138,7 +138,10 @@ vi.mock('@platform/defaults/nodeAgentRuntime', () => ({
 }));
 
 vi.mock('@telemetry/UsageLogService', () => ({
-  UsageLogService: { initialize: vi.fn(), dispose: vi.fn() },
+  UsageLogService: {
+    initialize: vi.fn(() => Effect.void),
+    dispose: vi.fn(() => Effect.void),
+  },
 }));
 
 // First-init dependencies: only exercised when tryPlatform() returns undefined.
@@ -296,6 +299,7 @@ describe('CLI platform init', () => {
     );
 
     expect(vi.mocked(UsageLogService.initialize)).toHaveBeenCalledWith(
+      expect.anything(),
       {},
       '1.2.3',
       'cli',

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -304,6 +304,7 @@ describe('CLI platform init', () => {
     );
 
     expect(vi.mocked(UsageLogService.initialize)).toHaveBeenCalledWith(
+      expect.anything(),
       {},
       '1.2.3',
       'cli',

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -1,3 +1,5 @@
+import { effectRuntime } from '@platform/processRuntime';
+import { Exit, Scope } from 'effect';
 import {
   afterEach,
   beforeEach,
@@ -73,17 +75,19 @@ function stubBatchFetch(
 }
 
 describe('UsageLogService', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-    UsageLogService.initialize({
-      batchSize: 1,
-      flushIntervalMs: 60_000,
-      enabled: true,
-    });
+    await effectRuntime().runPromise(
+      UsageLogService.initialize(effectRuntime().scope, {
+        batchSize: 1,
+        flushIntervalMs: 60_000,
+        enabled: true,
+      }),
+    );
   });
 
   afterEach(async () => {
-    await UsageLogService.dispose();
+    await effectRuntime().runPromise(UsageLogService.dispose());
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
@@ -130,7 +134,7 @@ describe('UsageLogService', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     UsageLogService.log(usageEntry('second'));
-    const disposal = UsageLogService.dispose();
+    const disposal = effectRuntime().runPromise(UsageLogService.dispose());
 
     releaseFirstFetch();
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
@@ -149,17 +153,20 @@ describe('UsageLogService', () => {
     expect(batches.map(batchModels)).toEqual([['first'], ['second']]);
   });
 
-  // The ticker only schedules; each flush runs on a fiber of its own.
+  // The ticker only schedules; the process owns the sender independently.
   // Interrupting the ticker on dispose must leave a send already in flight
   // alone and wait behind it, not abort the request and lose the batch it
   // had already taken from the queue.
-  it('waits for a timer-driven flush during disposal instead of aborting it', async () => {
+  it('process scope closure joins a timer-driven send before stopping admission', async () => {
     stubAccessToken();
-    UsageLogService.initialize({
-      batchSize: 100,
-      flushIntervalMs: 20,
-      enabled: true,
-    });
+    const owner = Scope.makeUnsafe();
+    await effectRuntime().runPromise(
+      UsageLogService.initialize(owner, {
+        batchSize: 100,
+        flushIntervalMs: 20,
+        enabled: true,
+      }),
+    );
 
     const { promise: fetchReleased, resolve: releaseFetch } = createDeferred();
     const { batches, fetchMock } = stubBatchFetch(async () => {
@@ -170,7 +177,7 @@ describe('UsageLogService', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     const request = fetchMock.mock.calls[0]?.[0] as Request;
 
-    const disposal = UsageLogService.dispose();
+    const disposal = effectRuntime().runPromise(Scope.close(owner, Exit.void));
     let disposed = false;
     void disposal.then(() => {
       disposed = true;
@@ -184,20 +191,25 @@ describe('UsageLogService', () => {
     await expect(disposal).resolves.toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(batches.map(batchModels)).toEqual([['timer']]);
+    UsageLogService.log(usageEntry('after-close'));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   // The ticker must not keep a short-lived host alive by itself: a process
   // that reaches initialize() and exits without dispose() still exits on an
   // empty loop, so the ticker's timer is unref'd while the request a flush
   // sends holds the loop on its own.
-  it('schedules the ticker on a timer that does not hold the event loop', () => {
+  it('schedules the ticker on a timer that does not hold the event loop', async () => {
     vi.useRealTimers();
     const timers = vi.spyOn(globalThis, 'setTimeout');
-    UsageLogService.initialize({
-      batchSize: 100,
-      flushIntervalMs: 12_345,
-      enabled: true,
-    });
+    await effectRuntime().runPromise(
+      UsageLogService.initialize(effectRuntime().scope, {
+        batchSize: 100,
+        flushIntervalMs: 12_345,
+        enabled: true,
+      }),
+    );
 
     const tick = timers.mock.calls.findIndex(([, delay]) => delay === 12_345);
     expect(tick).toBeGreaterThanOrEqual(0);
@@ -217,7 +229,7 @@ describe('UsageLogService', () => {
     UsageLogService.log(usageEntry('slow'));
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
-    const disposal = UsageLogService.dispose();
+    const disposal = effectRuntime().runPromise(UsageLogService.dispose());
     let disposed = false;
     void disposal.then(() => {
       disposed = true;
@@ -408,7 +420,12 @@ describe('UsageLogService', () => {
     // queued under the old value rather than letting the next flush ship them.
     it('discards entries queued before the setting was turned off', async () => {
       stubAccessToken();
-      UsageLogService.initialize({ batchSize: 100, flushIntervalMs: 60_000 });
+      await effectRuntime().runPromise(
+        UsageLogService.initialize(effectRuntime().scope, {
+          batchSize: 100,
+          flushIntervalMs: 60_000,
+        }),
+      );
 
       const { batches, fetchMock } = stubBatchFetch();
 
@@ -481,7 +498,12 @@ describe('UsageLogService', () => {
 
     it('drops optional entries from a batch but keeps the accounted ones', async () => {
       stubAccessToken();
-      UsageLogService.initialize({ batchSize: 100, flushIntervalMs: 60_000 });
+      await effectRuntime().runPromise(
+        UsageLogService.initialize(effectRuntime().scope, {
+          batchSize: 100,
+          flushIntervalMs: 60_000,
+        }),
+      );
 
       const { batches, fetchMock } = stubBatchFetch();
 

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -1,4 +1,3 @@
-import { effectRuntime } from '@platform/processRuntime';
 import { Exit, Scope } from 'effect';
 import {
   afterEach,
@@ -12,6 +11,7 @@ import {
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import * as logger from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import { AgentCategory, TELEMETRY_ENABLED_KEY } from '@shared/schemas';
 import { UsageLogService } from '@telemetry/UsageLogService';

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -1,3 +1,4 @@
+import { Exit, Scope } from 'effect';
 import {
   afterEach,
   beforeEach,
@@ -73,27 +74,20 @@ function stubBatchFetch(
   return { batches, fetchMock: stubFetch(batches, beforeRespond) };
 }
 
-/** The host's run edge: the two lifecycle arms answer where the host runs. */
-const initialize = (
-  ...args: Parameters<typeof UsageLogService.initialize>
-): Promise<void> =>
-  effectRuntime().runPromise(UsageLogService.initialize(...args));
-
-const dispose = (): Promise<void> =>
-  effectRuntime().runPromise(UsageLogService.dispose());
-
 describe('UsageLogService', () => {
   beforeEach(async () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-    await initialize({
-      batchSize: 1,
-      flushIntervalMs: 60_000,
-      enabled: true,
-    });
+    await effectRuntime().runPromise(
+      UsageLogService.initialize(effectRuntime().scope, {
+        batchSize: 1,
+        flushIntervalMs: 60_000,
+        enabled: true,
+      }),
+    );
   });
 
   afterEach(async () => {
-    await dispose();
+    await effectRuntime().runPromise(UsageLogService.dispose());
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
@@ -140,7 +134,7 @@ describe('UsageLogService', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     UsageLogService.log(usageEntry('second'));
-    const disposal = dispose();
+    const disposal = effectRuntime().runPromise(UsageLogService.dispose());
 
     releaseFirstFetch();
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
@@ -159,17 +153,32 @@ describe('UsageLogService', () => {
     expect(batches.map(batchModels)).toEqual([['first'], ['second']]);
   });
 
-  // The ticker only schedules; each flush runs on a fiber of its own.
+  // The ticker only schedules; the process owns the sender independently.
   // Interrupting the ticker on dispose must leave a send already in flight
   // alone and wait behind it, not abort the request and lose the batch it
   // had already taken from the queue.
-  it('waits for a timer-driven flush during disposal instead of aborting it', async () => {
+  it('process scope closure joins a timer-driven send before stopping admission', async () => {
     stubAccessToken();
-    await initialize({
-      batchSize: 100,
-      flushIntervalMs: 20,
-      enabled: true,
-    });
+    const owner = Scope.makeUnsafe();
+    // Reusing a process after explicit disposal must release its old child
+    // finalizers and preserve shutdown ordering for the next in-flight send.
+    for (let cycle = 0; cycle < 3; cycle++) {
+      await effectRuntime().runPromise(
+        UsageLogService.initialize(owner, { enabled: true }),
+      );
+      await effectRuntime().runPromise(UsageLogService.dispose());
+      if (owner.state._tag === 'Open') {
+        expect(owner.state.finalizer).toBeUndefined();
+        expect(owner.state.finalizers?.size ?? 0).toBe(0);
+      }
+    }
+    await effectRuntime().runPromise(
+      UsageLogService.initialize(owner, {
+        batchSize: 100,
+        flushIntervalMs: 20,
+        enabled: true,
+      }),
+    );
 
     const { promise: fetchReleased, resolve: releaseFetch } = createDeferred();
     const { batches, fetchMock } = stubBatchFetch(async () => {
@@ -180,7 +189,7 @@ describe('UsageLogService', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     const request = fetchMock.mock.calls[0]?.[0] as Request;
 
-    const disposal = dispose();
+    const disposal = effectRuntime().runPromise(Scope.close(owner, Exit.void));
     let disposed = false;
     void disposal.then(() => {
       disposed = true;
@@ -194,6 +203,9 @@ describe('UsageLogService', () => {
     await expect(disposal).resolves.toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(batches.map(batchModels)).toEqual([['timer']]);
+    UsageLogService.log(usageEntry('after-close'));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   // The ticker must not keep a short-lived host alive by itself: a process
@@ -203,11 +215,13 @@ describe('UsageLogService', () => {
   it('schedules the ticker on a timer that does not hold the event loop', async () => {
     vi.useRealTimers();
     const timers = vi.spyOn(globalThis, 'setTimeout');
-    await initialize({
-      batchSize: 100,
-      flushIntervalMs: 12_345,
-      enabled: true,
-    });
+    await effectRuntime().runPromise(
+      UsageLogService.initialize(effectRuntime().scope, {
+        batchSize: 100,
+        flushIntervalMs: 12_345,
+        enabled: true,
+      }),
+    );
 
     const tick = timers.mock.calls.findIndex(([, delay]) => delay === 12_345);
     expect(tick).toBeGreaterThanOrEqual(0);
@@ -227,7 +241,7 @@ describe('UsageLogService', () => {
     UsageLogService.log(usageEntry('slow'));
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
-    const disposal = dispose();
+    const disposal = effectRuntime().runPromise(UsageLogService.dispose());
     let disposed = false;
     void disposal.then(() => {
       disposed = true;
@@ -418,7 +432,12 @@ describe('UsageLogService', () => {
     // queued under the old value rather than letting the next flush ship them.
     it('discards entries queued before the setting was turned off', async () => {
       stubAccessToken();
-      await initialize({ batchSize: 100, flushIntervalMs: 60_000 });
+      await effectRuntime().runPromise(
+        UsageLogService.initialize(effectRuntime().scope, {
+          batchSize: 100,
+          flushIntervalMs: 60_000,
+        }),
+      );
 
       const { batches, fetchMock } = stubBatchFetch();
 
@@ -491,7 +510,12 @@ describe('UsageLogService', () => {
 
     it('drops optional entries from a batch but keeps the accounted ones', async () => {
       stubAccessToken();
-      await initialize({ batchSize: 100, flushIntervalMs: 60_000 });
+      await effectRuntime().runPromise(
+        UsageLogService.initialize(effectRuntime().scope, {
+          batchSize: 100,
+          flushIntervalMs: 60_000,
+        }),
+      );
 
       const { batches, fetchMock } = stubBatchFetch();
 


### PR DESCRIPTION
## Summary

Usage delivery now has one sender owned by the host process. Full batches and the periodic timer signal that sender; stopping or reinitializing the service waits for an in-flight request instead of abandoning a batch already taken from the queue.

The extension, CLI and desktop pass their existing process scope at initialization. Each active service lifetime uses a child scope. Explicit disposal closes that child and removes its parent registration, so repeated initialization on the same process does not accumulate shutdown callbacks. Closing the process drains the sender before interrupting it. Batching, retry order, account selection and telemetry opt-out behavior remain unchanged.

This branch includes current main, preserving the Effect-native controller and telemetry host entry changes delivered by #12001.

## Issue acceptance gates

The existing process-scope test covers repeated initialize/dispose cycles, removal of old finalizers, an in-flight timer-driven send during process closure, and refusal of new records after closure. Its retained-finalizer assertion fails against the previous PR head and passes with this change.

## Single source of truth

`UsageLogService` owns the queue, retry batch, sender and active child lifetime. The three hosts supply their existing process scope and execute lifecycle Effects at their host boundaries.

## Duplication and abstraction budget

One sender replaces detached per-trigger delivery fibers. The timer only signals the sender. No Promise facade, additional runtime or compatibility writer is introduced.

## Net elements (R6)

Six existing files change against current main: 149 insertions and 150 deletions (net −1). No files, exported symbols, classes, interfaces or enums are added. The initialization signature gains the process scope; the disposal signature remains Effect-native.

## Consumer counts (R8)

`initialize` has three production callers: extension activation, CLI initialization and desktop platform initialization. All pass the process scope. The existing three shutdown callers still await `dispose`. Synchronous `log` retains its existing agent usage-monitor caller and signature.

## Host impact

The extension, desktop and CLI each own delivery through their existing process lifetime. No host UI behavior changes.

## Scheduled refactoring

None introduced by this change.

## Validation

- Full formatting, all six typechecks, safe build and full lint: pass.
- Full Vitest: 763 suites and 9,089 tests pass; five tests intentionally skipped.
- Effect migration, dead-code, guidance-reference and browser-safety checks: pass.
- Focused telemetry and CLI initialization suites: 49 tests pass. The existing repeated-scope regression fails on the old service with one retained finalizer, then passes on the repaired service.
- The committed source tree is byte-identical to the full validation snapshot.
