### PR TITLE
refactor(model): keep stop policy in reflection

### DIFF
--- a/src/agent/implementations/flows/reflection/ResponseCycleFlow.ts
+++ b/src/agent/implementations/flows/reflection/ResponseCycleFlow.ts
@@ -13,8 +13,11 @@ import {
   type SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
 import {
+  ANTHROPIC_STOP,
+  GOOGLE_FINISH,
   isContextWindowExceededStopReason,
   isTokenLimitStopReason,
+  OPENAI_CHAT_FINISH,
   type ProviderStopReason,
 } from '@agent/types/StopReasonTypes';
 import { K_SLICE } from '@agent/core/constants';
@@ -30,6 +33,17 @@ import {
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { extractScratchpad } from '@utils/text/xmlExtraction';
+
+// Reflection owns conversation limits and document completion, not the provider.
+const CONTINUE_LIMIT = 10;
+const INPUT_TOKEN_LIMIT = 1500000;
+const OUTPUT_TOKEN_LIMIT_FACTOR = 2.5;
+const END_TURN_REASONS: ProviderStopReason[] = [
+  ANTHROPIC_STOP.END_TURN,
+  ANTHROPIC_STOP.STOP_SEQUENCE,
+  OPENAI_CHAT_FINISH.STOP,
+  GOOGLE_FINISH.STOP,
+];
 
 // ============================================================================
 // Cycle Fields
@@ -426,7 +440,7 @@ class ResponseContinuationNode extends BaseNode<
   override async exec(
     prepRes: ContinuationPrepResult,
   ): Promise<ContinuationNodeResult> {
-    const { round, run, setting } = this.services;
+    const { round, run, setting, logger } = this.services;
     const modelHandler = this.services.modelCell.handler;
 
     if (prepRes.kind === 'skipped') {
@@ -447,14 +461,45 @@ class ResponseContinuationNode extends BaseNode<
       };
     }
 
-    const { endTurn: shouldEndTurn, shouldStop } =
-      modelHandler.checkStopConditions(
-        stopReason,
-        processedResponse,
-        round,
-        run,
-        setting,
-      );
+    const totals = run.usageAccumulator.totals;
+    const maxOutputTokens =
+      totals.firstInputTokens > 0
+        ? OUTPUT_TOKEN_LIMIT_FACTOR * totals.firstInputTokens
+        : Number.POSITIVE_INFINITY;
+    const continuationLimitExceeded = round.continuationCount > CONTINUE_LIMIT;
+    const inputTokenLimitExceeded = totals.totalInputTokens > INPUT_TOKEN_LIMIT;
+    const maxOutputTokensExceeded = totals.totalOutputTokens > maxOutputTokens;
+    const shouldEndTurn = END_TURN_REASONS.includes(stopReason ?? '');
+    const encounterDocumentTag = processedResponse.includes(OUTPUT_END_TAG);
+
+    // Warn-only by design: this multiplier has never fed `shouldStop`, it just
+    // flags a run whose output has run away relative to its first input.
+    if (maxOutputTokensExceeded) {
+      logger.warn('Output tokens exceed input token multiplier', {
+        data: {
+          maxOutputTokensFactor: OUTPUT_TOKEN_LIMIT_FACTOR,
+          totalOutputTokens: totals.totalOutputTokens,
+          firstInputTokens: totals.firstInputTokens,
+        },
+      });
+    }
+
+    const shouldStop =
+      encounterDocumentTag ||
+      continuationLimitExceeded ||
+      inputTokenLimitExceeded;
+
+    if (shouldStop) {
+      logger.debug('StopFlags', {
+        data: {
+          endTurn: shouldEndTurn,
+          encounterDocumentTag,
+          continuationLimitExceeded,
+          inputTokenLimitExceeded,
+          maxOutputTokensExceeded,
+        },
+      });
+    }
 
     const shouldContinue = modelHandler.shouldContinue(
       stopReason,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -17,21 +17,12 @@ import {
 } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentSetting } from '@agent/core/definition/AgentDataclass';
-import type {
-  ConversationRoundStateSnapshot,
-  AgentRunStateSnapshot,
-} from '@agent/core/state/AgentState';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { MediaEntry } from '@agent/types/mediaTypes';
 import type { StandardPricingConfig } from '@agent/modelHandlers/support/priceUtils';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { K_SLICE } from '@agent/core/constants';
-import {
-  ANTHROPIC_STOP,
-  GOOGLE_FINISH,
-  isTokenLimitStopReason,
-  OPENAI_CHAT_FINISH,
-} from '@agent/types/StopReasonTypes';
+import { isTokenLimitStopReason } from '@agent/types/StopReasonTypes';
 import type { ProviderStopReason } from '@agent/types/StopReasonTypes';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import type {
@@ -43,7 +34,6 @@ import type {
   ModelCredentialSelection,
   ResolvedClientCredential,
   SdkToolCall,
-  StopConditionsResult,
   TokenCountOptions,
   TokenValidationResult,
 } from '@agent/types/ModelHandlerContracts';
@@ -131,12 +121,6 @@ interface ClientCompactionResult<M> {
   didCompact: boolean;
 }
 
-// Conversation stop limits. Fixed for every handler: nothing overrides them
-// per instance, so they are read straight from `checkStopConditions`.
-const CONTINUE_LIMIT = 10;
-const INPUT_TOKEN_LIMIT = 1500000;
-const OUTPUT_TOKEN_LIMIT_FACTOR = 2.5;
-
 /**
  * A round's media content plus the entries behind it — what the transcript's
  * attachment chips are derived from. Returned together so the two can't drift.
@@ -162,14 +146,6 @@ export interface AssistantTextAppendOptions {
   /** Provider fallback when converting an existing assistant message shape. */
   readonly fallbackText?: string;
 }
-
-// Stop markers that signal a completed turn across providers.
-const END_TURN_REASONS: ProviderStopReason[] = [
-  ANTHROPIC_STOP.END_TURN,
-  ANTHROPIC_STOP.STOP_SEQUENCE,
-  OPENAI_CHAT_FINISH.STOP,
-  GOOGLE_FINISH.STOP,
-];
 
 function mediaAttachmentKindsFromEntries(
   entries: readonly MediaEntry[],
@@ -952,64 +928,6 @@ export abstract class ModelHandler<
       reportMediaAttachmentFailure(this.logger, context, err);
       return [];
     }
-  }
-
-  /**
-   * Evaluates conversation stop conditions based on model response and state.
-   * @returns Object with endTurn (should end current turn) and shouldStop (should stop conversation)
-   */
-  public checkStopConditions(
-    stopReason: ProviderStopReason,
-    newResponse: string,
-    stateRound: ConversationRoundStateSnapshot,
-    stateGlobal: AgentRunStateSnapshot,
-    agentSetting: AgentSetting,
-  ): StopConditionsResult {
-    // Compute token-based stop flags
-    const totals = stateGlobal.usageAccumulator.totals;
-    const maxOutputTokens =
-      totals.firstInputTokens > 0
-        ? OUTPUT_TOKEN_LIMIT_FACTOR * totals.firstInputTokens
-        : Number.POSITIVE_INFINITY;
-    const continuationLimitExceeded =
-      stateRound.continuationCount > CONTINUE_LIMIT;
-    const inputTokenLimitExceeded = totals.totalInputTokens > INPUT_TOKEN_LIMIT;
-    const maxOutputTokensExceeded = totals.totalOutputTokens > maxOutputTokens;
-
-    // Detect stop markers in model output
-    const endTurn = END_TURN_REASONS.includes(stopReason ?? '');
-    const encounterDocumentTag = newResponse.includes(OUTPUT_END_TAG);
-
-    // Warn-only by design: this multiplier has never fed `shouldStop`, it just
-    // flags a run whose output has run away relative to its first input.
-    if (maxOutputTokensExceeded) {
-      this.logger.warn('Output tokens exceed input token multiplier', {
-        data: {
-          maxOutputTokensFactor: OUTPUT_TOKEN_LIMIT_FACTOR,
-          totalOutputTokens: totals.totalOutputTokens,
-          firstInputTokens: totals.firstInputTokens,
-        },
-      });
-    }
-
-    const shouldStop =
-      encounterDocumentTag ||
-      continuationLimitExceeded ||
-      inputTokenLimitExceeded;
-
-    if (shouldStop) {
-      this.logger.debug('StopFlags', {
-        data: {
-          endTurn,
-          encounterDocumentTag,
-          continuationLimitExceeded,
-          inputTokenLimitExceeded,
-          maxOutputTokensExceeded,
-        },
-      });
-    }
-
-    return { endTurn, shouldStop };
   }
 
   /**

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1162,7 +1162,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     const usage = responseObject.usage;
     // Map the Interactions terminal *status* to the canonical Google chat
     // FinishReason the shared stop/continue logic understands (mirrors the
-    // OpenAI Responses handler at extractResponse). `checkStopConditions` keys
+    // OpenAI Responses handler at extractResponse). Reflection keys
     // `endTurn` on GOOGLE_FINISH.STOP and `shouldContinue` /
     // `isTokenLimitStopReason` key truncation on GOOGLE_FINISH.MAX_TOKENS; the
     // raw 'completed' / 'incomplete' status strings match neither, so a clean

--- a/src/agent/types/IModelHandler.ts
+++ b/src/agent/types/IModelHandler.ts
@@ -63,7 +63,6 @@ export type IModelHandler<
   | 'getCredentialRouteForClient'
   | 'updateMessageContent'
   | 'shouldContinue'
-  | 'checkStopConditions'
   | 'processThinkingBlock'
   | 'extractToolUse'
   | 'extractServerToolData'

--- a/src/agent/types/ModelHandlerContracts.ts
+++ b/src/agent/types/ModelHandlerContracts.ts
@@ -139,16 +139,6 @@ export type ExtractNormalizedResponseResult = ExtractResponseBase<
 >;
 
 /**
- * Result from checking stop conditions.
- */
-export interface StopConditionsResult {
-  /** Whether the turn should end */
-  endTurn: boolean;
-  /** Whether generation should stop */
-  shouldStop: boolean;
-}
-
-/**
  * Shared tool-call base. Members of {@link SdkToolCall} specialize this with
  * their provider literal, input, and raw wire type. Provider-specific extras
  * (e.g. Google `thoughtSignature`) are intersected at the alias, not via a

--- a/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
@@ -113,10 +113,6 @@ async function processEmptyResponse(stopReason: ProviderStopReason) {
 
 function createServices(interrupted = false, supportsManualCompaction = false) {
   const round = { continuationCount: 0 };
-  const checkStopConditions = vi.fn(() => ({
-    endTurn: false,
-    shouldStop: false,
-  }));
   const shouldContinue = vi.fn(() => false);
   const requestCompaction = vi.fn(() => 7);
   const addContinueMessage = vi.fn();
@@ -125,14 +121,21 @@ function createServices(interrupted = false, supportsManualCompaction = false) {
       signal: interrupted ? AbortSignal.abort() : undefined,
     }),
     round,
-    run: {},
+    run: {
+      usageAccumulator: {
+        totals: {
+          firstInputTokens: 100,
+          totalInputTokens: 100,
+          totalOutputTokens: 50,
+        },
+      },
+    },
     setting: {},
     config: {},
     workspace: {},
-    logger: { info: vi.fn(), warn: vi.fn() },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
     modelCell: testModelCell({
       supportsManualCompaction,
-      checkStopConditions,
       shouldContinue,
       requestCompaction,
       addContinueMessage,
@@ -142,7 +145,6 @@ function createServices(interrupted = false, supportsManualCompaction = false) {
   return {
     services,
     round,
-    checkStopConditions,
     shouldContinue,
     requestCompaction,
     addContinueMessage,
@@ -191,13 +193,6 @@ describe('response cycle continuation phases', () => {
         processedResponse: 'partial response',
       },
     });
-    expect(harness.checkStopConditions).toHaveBeenCalledWith(
-      'length',
-      'partial response',
-      harness.round,
-      {},
-      {},
-    );
     expect(harness.shouldContinue).toHaveBeenCalledWith(
       'length',
       'partial response',
@@ -338,7 +333,6 @@ describe('response cycle continuation phases', () => {
 
     const { action } = await runContinuationNode(shared, harness.services);
 
-    expect(harness.checkStopConditions).not.toHaveBeenCalled();
     expect(harness.shouldContinue).not.toHaveBeenCalled();
     expect(shared).toMatchObject({ shouldStop: true, endTurn: false });
     expect(harness.addContinueMessage).not.toHaveBeenCalled();

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { noopTrace } from '@agent/trace';
+import { createResponseCycleFlow } from '@agent/implementations/flows/reflection/ResponseCycleFlow';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
 import type { CreatedMedia } from '@agent/modelHandlers/ModelHandler';
 import type { MediaAttachmentContext } from '@agent/modelHandlers/support/mediaAttachmentPolicy';
@@ -541,10 +542,10 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     expect(extracted.stopReason).toBe(GOOGLE_FINISH.STOP);
   });
 
-  it('maps a completed interaction to endTurn (not a spurious cancellation)', () => {
+  it('maps a completed interaction to endTurn (not a spurious cancellation)', async () => {
     // Regression: a background/non-streaming Interactions response that finished
     // cleanly on the document end tag was returning the raw 'completed' status,
-    // which is not in `endTurnReasons` — so checkStopConditions yielded
+    // which is not a reflection end-turn reason — so the cycle yielded
     // endTurn=false while encounterDocumentTag forced shouldStop=true. The
     // ResponseCycle then read `shouldStop && !endTurn` as a user cancellation
     // and discarded the already-generated output. The status must normalize to
@@ -577,14 +578,25 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
       },
     } as never;
 
-    const { endTurn, shouldStop } = handler.checkStopConditions(
-      stopReason,
-      text,
+    const continuationNode = createResponseCycleFlow()
+      .start.getNextNode()
+      ?.getNextNode()
+      ?.getNextNode();
+    if (!continuationNode) throw new Error('Missing continuation node');
+    continuationNode.setServices({
+      modelCell: { handler },
       round,
-      global,
+      run: global,
       setting,
-    );
-    expect(shouldStop).toBe(true);
-    expect(endTurn).toBe(true);
+      logger: noopTrace,
+    });
+    const result = await continuationNode.exec({
+      kind: 'success',
+      value: { interrupted: false, stopReason, processedResponse: text },
+    });
+    expect(result).toMatchObject({
+      kind: 'success',
+      value: { shouldStop: true, shouldEndTurn: true },
+    });
   });
 });


### PR DESCRIPTION
## Summary

Reflection now evaluates its stopping policy directly in the existing response-continuation stage. The provider base class no longer receives run and round state to decide document completion, continuation limits or total-input limits.

This removes `ModelHandler.checkStopConditions`, its `IModelHandler` member and the `StopConditionsResult` interface. No helper, public API or alternative execution path replaces them.

## Issue acceptance gates

This implements a bounded part of the runtime/LLM ownership division in `2026-09-04-agent-runtime-on-effect.md` §0.1: reflection owns continuation and document-output policy; the provider layer does not own run-wide stopping decisions.

It does not complete the native Effect runtime or LLM package extraction, change a Promise boundary, introduce ledger records or close the broader migration issues. The existing provider-specific `shouldContinue` behavior remains unchanged.

## Single source of truth

`ResponseCycleFlow` owns the reflection stopping decision beside the code that applies it. The policy is evaluated after the same skipped/interrupted guards and before the same provider-continuation check.

The strict continuation and input-token comparisons, document end marker and complete end-turn-reason vocabulary are unchanged. The output-token multiplier still produces a warning only. Diagnostics use the same run trace supplied to the handler at launch and to a replacement handler during fallback.

## Duplication and abstraction budget

The sole production caller absorbs the policy directly. The provider class loses both its `AgentRunStateSnapshot` and `ConversationRoundStateSnapshot` imports, the five-argument method and its result object. The caller no longer passes its own state through the provider to recover two booleans. No new helper, service, facade or factory is added.

The existing Google Interactions regression still verifies that a completed response ending on the document tag ends the turn instead of appearing cancelled; it now exercises the actual reflection continuation decision. The existing continuation tests supply real usage totals instead of mocking the deleted method. No test or test file is added or deleted.

## Net elements (R6)

- Files: 0 added, 0 deleted; 7 modified.
- Exported declarations: 0 added, 1 deleted (`StopConditionsResult`).
- Classes/interfaces/enums: 0 added, 1 interface deleted.
- Public methods: 1 deleted (`ModelHandler.checkStopConditions`), including its `IModelHandler` member; no replacement method or helper.
- Production: +56 / −104 lines, net −48.
- Tests: +31 / −25 lines, net +6.
- Total: +87 / −129 lines, net −42.
- No dependency, runtime-entry or ratchet-baseline additions.

## Consumer counts (R8)

`checkStopConditions` had exactly one production caller, in `ResponseCycleFlow`, and no subclass overrides. Its result interface had one production consumer, the deleted method signature. The method was also named by the curated `IModelHandler` member list. All three uses are removed together.

Two existing test suites referenced the retired method; both are adapted. The warning and debug diagnostics each retain one emission site, moved to the reflection stage without changing their payloads. No subscription or event interface changes.

## Host impact

Extension: reflection uses the same stopping and logging behavior.

Desktop: the same shared reflection path is updated; no host-specific change.

CLI: the same shared reflection path is updated; no host-specific change.

## Scheduled refactoring

None required for this deletion. The existing runtime/LLM migration remains separate; this change introduces no temporary adapter or additional removal obligation.

## Validation

Checks run in this isolated worktree, based on freshly fetched main `96b1bbe2b6b720381a95eb9684c3886d3f0a5c5b`:

- Focused continuation and Google Interactions suites: 31 tests passed.
- `npm run format`: passed.
- `npm run typecheck`: all six checks passed (workspace, test-kernel, agent, CLI, trace-viewer and desktop).
- `npm run lint`: passed.
- `npm run compile:fast`: passed.
- `TMPDIR=<private temporary directory> npm test -- --maxWorkers=4`: 763 suites and 9,084 tests passed; one suite and six tests skipped. A private temporary directory isolates filesystem-cleanup tests from concurrent worktrees.
- `npm run check:effect-migration-ratchet`: passed, with no allowance additions.
- `npm run check:dead-code-ratchet`: passed, with no allowance additions.
- `git diff --cached --check`: passed.

## Verified

Independent review confirmed unchanged thresholds, warning-only accounting policy, end-turn vocabulary, guard ordering, provider-continuation call and diagnostic trace ownership. The provider result interface and its sole production method consumer are removed. Historical source-census documents retain their pinned descriptions rather than being rewritten as current code.
