### PR TITLE
refactor(tools): convert raw catches in web/arxiv/lean tools to typed recovery

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -194,10 +194,8 @@
       "src/auth/oauth/loopbackLogin.ts": 2,
       "src/common/errors/sdkError/errorInspection.ts": 1,
       "src/common/errors/sdkError/providerErrorFormat.ts": 2,
-      "src/tools/arxiv/ArxivSearchTool.ts": 1,
       "src/tools/github/PollingSourceBase.ts": 1,
-      "src/tools/lean/direct/leanServer.ts": 1,
-      "src/tools/web/WebFetchTool.ts": 2,
+      "src/tools/web/WebFetchTool.ts": 1,
       "src/tools/zotero/bbtClient.ts": 1,
       "src/utils/files/relativeFS.ts": 2
     }

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -87,20 +87,27 @@ const searchArxiv = Effect.fn('ArxivSearchTool.execute')(function* (
   for (const cat of input.categories ?? []) {
     const trimmed = cat.trim();
     if (!trimmed) continue;
-    try {
-      // catQuery expects a strict Category union ("cs.AI", "math.CO", ...).
-      // User input is unconstrained string — cast to the expected type
-      // and rely on the library's runtime validation (caught below).
-      categoryFilters.push(catQuery(trimmed as Category));
-    } catch (error) {
+    // catQuery expects a strict Category union ("cs.AI", "math.CO", ...).
+    // User input is unconstrained string — cast to the expected type
+    // and rely on the library's runtime validation (recovered below).
+    const filter = yield* Effect.try({
+      try: () => catQuery(trimmed as Category),
+      catch: (error) => error,
+    }).pipe(
       // Skip invalid categories — log so a silently-dropped filter is
       // traceable rather than mysteriously absent from the query.
-      warn(
-        'arxiv.search',
-        `Ignoring invalid arxiv category filter "${trimmed}"`,
-        { data: error },
-      );
-    }
+      Effect.catch((error) =>
+        Effect.sync(() => {
+          warn(
+            'arxiv.search',
+            `Ignoring invalid arxiv category filter "${trimmed}"`,
+            { data: error },
+          );
+          return null;
+        }),
+      ),
+    );
+    if (filter != null) categoryFilters.push(filter);
   }
 
   if (categoryFilters.length > 0) {

--- a/src/tools/lean/direct/leanServer.ts
+++ b/src/tools/lean/direct/leanServer.ts
@@ -277,7 +277,7 @@ const make = ({
 
     const handlePublishDiagnostics = (params: LspPublishDiagnosticsParams) =>
       Effect.gen(function* () {
-        const absolute = fileUriToPath(params.uri);
+        const absolute = yield* fileUriToPath(params.uri);
         if (!absolute) return;
         const state = openFiles.get(absolute);
         if (!state) return;
@@ -590,17 +590,24 @@ function pathToUri(absolute: string): string {
   return pathToFileURL(absolute).toString();
 }
 
-function fileUriToPath(uri: string): string | null {
-  if (!uri.startsWith('file://')) return null;
-  try {
-    return fileURLToPath(uri);
-  } catch (err) {
-    // Malformed or non-local file URIs from an external Lean LSP server
-    // (e.g. `file://host/path`, bad percent-encoding) make fileURLToPath
-    // throw. This runs on the JSON-RPC notification path, so map to null
-    // (an untracked URI the caller skips) rather than letting the exception
-    // escape and break diagnostics handling.
-    debug(LOG_CHANNEL, `Ignoring unmappable file URI ${uri}`, { data: err });
-    return null;
-  }
+function fileUriToPath(uri: string): Effect.Effect<string | null> {
+  if (!uri.startsWith('file://')) return Effect.succeed(null);
+  // Malformed or non-local file URIs from an external Lean LSP server
+  // (e.g. `file://host/path`, bad percent-encoding) make fileURLToPath
+  // throw. This runs on the JSON-RPC notification path, so map to null
+  // (an untracked URI the caller skips) rather than letting the exception
+  // escape and break diagnostics handling.
+  return Effect.try({
+    try: () => fileURLToPath(uri),
+    catch: (error) => error,
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.sync(() => {
+        debug(LOG_CHANNEL, `Ignoring unmappable file URI ${uri}`, {
+          data: error,
+        });
+        return null;
+      }),
+    ),
+  );
 }

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -180,15 +180,13 @@ export class WebFetchTool extends defineTool({
 
       let markdown: string;
       if (isMarkupContent) {
-        try {
-          markdown = this.turndown.turndown(rawBody);
-        } catch (error) {
-          return yield* Effect.fail(
+        markdown = yield* Effect.try({
+          try: () => this.turndown.turndown(rawBody),
+          catch: (error) =>
             new ToolError(
               `Failed to convert HTML to Markdown: ${toErrorMessage(error)}`,
             ),
-          );
-        }
+        });
       } else {
         markdown = rawBody;
       }


### PR DESCRIPTION
## Summary

One lane of the Effect 4 runtime migration (PRD
`.agents/docs/proposed/architecture/2026-08-26-effect-4-runtime-migration.md`,
rule R7 typed errors; ratchet row `catch:effect-importer`). This PR converts the
raw catch sites in three `src/tools/` modules that already import `effect` at
runtime to native Effect typed recovery, with byte-identical behavior (same log
messages, same fallbacks, same error text):

- `src/tools/web/WebFetchTool.ts` — the turndown HTML→Markdown conversion inside
  the `Effect.gen` execute path becomes `Effect.try({ try, catch })` failing
  with the same `ToolError` message as the previous `try/catch` + `Effect.fail`.
- `src/tools/arxiv/ArxivSearchTool.ts` — the category-filter loop's `try/catch`
  around `catQuery(...)` becomes `Effect.try` + `Effect.catch`, logging the same
  `arxiv.search` warning and skipping invalid entries.
- `src/tools/lean/direct/leanServer.ts` — the module-private `fileUriToPath`
  helper now returns `Effect<string | null>`: `Effect.try` around
  `fileURLToPath` with `Effect.catch` recovery that keeps the same
  `lean.direct` debug log and `null` fallback. Its only caller
  (`handlePublishDiagnostics`, itself an `Effect.gen`) gains a `yield*`. This
  touches only catch recovery — it is NOT the `directLspAdapter.ts` lane-D seam
  work; the pool lifecycle is unchanged.

Two catalogued sites are deliberately left raw (baseline keeps both files in
the row at 1 site each):

- `WebFetchTool.ts` — the `TextDecoder` charset fallback lives in the plain
  async helper `readBodyWithLimit`, which runs inside the Promise thunk handed
  to the shared `retryTransientFetch`. There is no Effect context, no run call
  is permitted below the boundary, and converting the helper would force a
  signature change on a shared helper used by other tools.
- `src/tools/zotero/bbtClient.ts` — the `response.json()` fallback lives in the
  Promise thunk handed to the shared `withRequestTimeout`, whose deadline
  deliberately spans the body read (documented in the code). Lifting the parse
  into the Effect pipeline would move it outside the deadline; any in-thunk
  conversion would require a forbidden below-boundary run.

The migration baseline is regenerated in the same commit: the
`catch:effect-importer` row drops `ArxivSearchTool.ts` and `leanServer.ts` and
shrinks `WebFetchTool.ts` from 2 to 1 (28→26 files, 74→71 sites).

## Issue acceptance gates

n/a — migration lane PR, no linked issue. Ratchet gate: `catch:effect-importer`
shrinks only; no other row grows; no below-boundary `Effect.run*` added.

## Single source of truth

Each recovery lives at the catch site itself via `Effect.try`'s typed `catch`
channel; no new owner module. The ratchet baseline
(`config/ratchets/effect-migration-baseline.json`) remains the single record of
the remaining raw-catch debt.

## Duplication and abstraction budget

No new abstractions, helpers, exports, or wrapper layers. Recovery reuses the
file-local idioms already present (`Effect.try` + `Effect.catch` with an
`Effect.sync` logging handler, matching `leanServer.ts`'s existing handlers).

## Net elements (R6)

`git diff --stat origin/main...HEAD`: 4 files changed, 45 insertions, 35
deletions (net +10 LoC, of which 4 are the regenerated baseline JSON; the three
source files net +12 because each `try/catch` becomes an `Effect.try({try,
catch})` + `Effect.catch` pipeline).

- Files: 0 added, 0 deleted, 4 modified.
- Exported symbols: `^[+-]export` over the diff = 0 (no export added, removed,
  or re-signed).
- Classes/interfaces/enums: 0 added, 0 deleted.

## Consumer counts (R8)

- `WebFetchTool` / `ArxivSearchTool` (exported tool classes): registered in
  `src/tools/registry.ts`; public signatures unchanged — consumer count
  unchanged.
- `fileUriToPath` (`leanServer.ts`): module-private, exactly 1 consumer
  (`handlePublishDiagnostics`, same file), updated in this PR; no external
  consumers.
- `callZoteroConnector` (`bbtClient.ts`): untouched; its 3 zotero-tool
  consumers unchanged.

## Host impact

Extension: none (no `packages/extension` changes).

Desktop: none.

CLI: none.

## Scheduled refactoring

Package-level `catch:effect-importer` zeroing waits for the other catch lanes
(26 files remain in the row repo-wide). The two sites left raw here convert
when the `retryTransientFetch` / `withRequestTimeout` thunks become
Effect-native (the shared-helper seam, not this lane).

## Validation

- `npx prettier --write` on the three touched source files — all unchanged.
- `npm run typecheck:workspace` — exit 0.
- `npm run typecheck:test-kernel` — exit 0.
- `npx eslint src/tools/web/WebFetchTool.ts src/tools/arxiv/ArxivSearchTool.ts src/tools/lean/direct/leanServer.ts` — clean.
- `npx vitest run src/test-kernel/tools/ArxivSearchTool.vitest.ts src/test-kernel/tools/lean/LeanTools.vitest.ts src/test-kernel/tools/lean/LeanServerRegistry.vitest.ts src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts src/test-kernel/agent/AgentPromptContracts.vitest.ts src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts --maxWorkers=4` — 6 files, 828 tests, all pass.
- `node scripts/check-effect-migration-ratchet.mjs` — OK after `--update`
  (baseline regenerated in this commit); no count grew, no headroom.
- `npm run check:dead-code-ratchet` — OK, no new findings.
- `npm test -- --maxWorkers=4` (full suite) — 763 files passed / 1 skipped, 9085 tests passed / 5 skipped, exit 0; neither of the known pre-existing flakes appeared.
