### PR TITLE
fix(tools): protect the Zotero Connector write from cancellation and make a signal-less request loud

### DIFF
--- a/src/test-kernel/tools/Cancellation.vitest.ts
+++ b/src/test-kernel/tools/Cancellation.vitest.ts
@@ -1,10 +1,12 @@
 // Third-party imports
 import { it } from '@effect/vitest';
 import { Effect, Exit, Fiber } from 'effect';
+import { TestClock } from 'effect/testing';
 import { describe, expect } from 'vitest';
 
 // Local imports
 import { ToolError } from '@shared/schemas';
+import { withRequestTimeout } from '@tools/timeouts';
 import { rateLimitedApiCall } from '@tools/support/rateLimiter';
 
 /** The rate-limited lookup of `operation` as a tool program runs it. */
@@ -73,6 +75,87 @@ describe('rateLimitedApiCall cancellation', () => {
       const thrown = new ToolError('No such record', { summary: 'Missing' });
       const error = yield* Effect.flip(lookup(() => Promise.reject(thrown)));
       expect(error).toBe(thrown);
+    }),
+  );
+});
+
+/**
+ * `callZoteroConnector` runs its non-idempotent `saveItems`/`saveSnapshot`
+ * write under `Effect.uninterruptible` so cancelling a run cannot tear it
+ * mid-request and lose the outcome. That rests on one non-obvious property of
+ * the effect runtime: the region defers the *caller's* interrupt but not the
+ * deadline, because `timeoutOrElse` races through `raceAllFirst`, which forks
+ * both racers interruptible regardless of the enclosing region. An effect
+ * upgrade that changed either half would turn an unresponsive Zotero into a
+ * hang, or bring the torn write back — silently in both directions.
+ */
+describe('withRequestTimeout under Effect.uninterruptible', () => {
+  it.effect('still ends the request at its deadline', () =>
+    Effect.gen(function* () {
+      let aborted = false;
+      const fiber = yield* Effect.forkChild(
+        Effect.flip(
+          Effect.uninterruptible(
+            withRequestTimeout(1000, (signal) => {
+              signal.addEventListener('abort', () => {
+                aborted = true;
+              });
+              return new Promise<never>(() => {});
+            }),
+          ),
+        ),
+      );
+      yield* started;
+      yield* TestClock.adjust('1000 millis');
+      const error = yield* Fiber.join(fiber);
+      expect(error._tag).toBe('RequestTimedOut');
+      expect(aborted).toBe(true);
+    }),
+  );
+
+  it.effect('lets an interrupted request settle instead of tearing it', () =>
+    Effect.gen(function* () {
+      let aborted = false;
+      let settled = false;
+      let finish: () => void = () => {};
+      const fiber = yield* Effect.forkChild(
+        Effect.uninterruptible(
+          withRequestTimeout(1000, (signal) => {
+            signal.addEventListener('abort', () => {
+              aborted = true;
+            });
+            return new Promise<string>((resolve) => {
+              finish = () => {
+                settled = true;
+                resolve('written');
+              };
+            });
+          }),
+        ),
+      );
+      yield* started;
+      const interrupting = yield* Effect.forkChild(Fiber.interrupt(fiber));
+      yield* started;
+      // The interrupt is deferred: the write is untouched and still in flight.
+      expect(aborted).toBe(false);
+      expect(settled).toBe(false);
+      finish();
+      yield* Fiber.join(interrupting);
+      // The write ran to completion, and only then did the interrupt land.
+      expect(settled).toBe(true);
+      expect(aborted).toBe(false);
+      expect(Exit.hasInterrupts(yield* Fiber.await(fiber))).toBe(true);
+    }),
+  );
+});
+
+describe('withRequestTimeout misuse', () => {
+  it.effect('dies on a request that declares no AbortSignal parameter', () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        withRequestTimeout(1000, () => Promise.resolve('unabortable')),
+      );
+      expect(Exit.hasDies(exit)).toBe(true);
     }),
   );
 });

--- a/src/test-kernel/tools/FetchToolErrorClassification.vitest.ts
+++ b/src/test-kernel/tools/FetchToolErrorClassification.vitest.ts
@@ -13,13 +13,18 @@ const MESSAGES = {
   fallback: (message: string) => `Failed: ${message}`,
 } as const;
 
-/** The failure `withRequestTimeout` raises for a request that threw `cause`. */
+/**
+ * The failure `withRequestTimeout` raises for a request that threw `cause`.
+ * The request takes `signal` because `withRequestTimeout` requires it: a
+ * zero-parameter request gets no AbortSignal from `Effect.tryPromise` and
+ * dies as a defect.
+ */
 const failed = (cause: unknown) =>
-  Effect.flip(withRequestTimeout(1000, () => Promise.reject(cause)));
+  Effect.flip(withRequestTimeout(1000, (_signal) => Promise.reject(cause)));
 
 /** The failure `withRequestTimeout` raises when the deadline passes first. */
 const timedOut = Effect.flip(
-  withRequestTimeout(0, () => new Promise<never>(() => {})),
+  withRequestTimeout(0, (_signal) => new Promise<never>(() => {})),
 );
 
 /**

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -100,15 +100,18 @@ describe('retryTransientFetch', () => {
         const retriesLeft: number[] = [];
         const fiber = yield* Effect.forkChild(
           Effect.flip(
-            retryTransientFetch(() => Promise.reject(kyErrorWithStatus(503)), {
-              retries: 3,
-              minTimeout: 1,
-              timeoutMs: 1000,
-              onFailedAttempt: (_error, left) =>
-                Effect.sync(() => {
-                  retriesLeft.push(left);
-                }),
-            }),
+            retryTransientFetch(
+              (_signal) => Promise.reject(kyErrorWithStatus(503)),
+              {
+                retries: 3,
+                minTimeout: 1,
+                timeoutMs: 1000,
+                onFailedAttempt: (_error, left) =>
+                  Effect.sync(() => {
+                    retriesLeft.push(left);
+                  }),
+              },
+            ),
           ),
         );
         // Each backoff (at most 8 ms with jitter) sleeps on the test clock;

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -88,10 +88,34 @@ function isTransientRequestError(error: RequestError): boolean {
  * `request` aborts when the attempt is interrupted, by the deadline or by
  * the caller. Fails with {@link RequestTimedOut} on the deadline and with
  * {@link RequestFailed} carrying the request's own error otherwise.
+ *
+ * `request` must declare its `signal` parameter and hand it to the client;
+ * one that does not gets no signal at all and dies as a defect rather than
+ * quietly outliving its own cancellation.
  */
 export const withRequestTimeout = Effect.fn('timeouts.withRequestTimeout')(
-  <T>(timeoutMs: number, request: (signal: AbortSignal) => Promise<T>) =>
-    Effect.tryPromise({
+  function* <T>(
+    timeoutMs: number,
+    request: (signal: AbortSignal) => Promise<T>,
+  ) {
+    // `Effect.tryPromise` creates the AbortSignal only when its callback
+    // declares the parameter (`f.length !== 0`, effect's `tryPromise`). A
+    // request written `() => ky.get(url)` therefore gets no signal, and
+    // neither the deadline below nor the caller's interruption reaches the
+    // in-flight request: it is abandoned to settle unobserved while this
+    // program reports a timeout — a cancellation that silently does nothing.
+    // TypeScript cannot catch it (a zero-parameter function is assignable to
+    // a one-parameter type), so the misuse is a defect raised here.
+    if (request.length === 0) {
+      yield* Effect.die(
+        new Error(
+          'withRequestTimeout was given a request that declares no AbortSignal parameter, ' +
+            'so neither the deadline nor the caller can abort it. Take the signal and hand ' +
+            'it to the client: (signal) => ky.get(url, { signal }).',
+        ),
+      );
+    }
+    return yield* Effect.tryPromise({
       try: request,
       catch: (cause) =>
         new RequestFailed({ message: toErrorMessage(cause), cause }),
@@ -106,7 +130,8 @@ export const withRequestTimeout = Effect.fn('timeouts.withRequestTimeout')(
             }),
           ),
       }),
-    ),
+    );
+  },
 );
 
 interface RetryTransientFetchOptions {

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -296,6 +296,16 @@ function connectorRequestFailure(
 /**
  * Call a Zotero Connector endpoint. Never fails: every outcome, the
  * transport's included, is a `ConnectorResult` the tool reports per item.
+ *
+ * The request is **uninterruptible**: `saveItems`/`saveSnapshot` write to the
+ * user's library, so aborting one mid-flight would leave Zotero having
+ * possibly stored the item while the tool reports nothing at all. Cancelling
+ * the run instead waits for this one write to settle and to yield its
+ * `ConnectorResult`; the interrupt then takes effect at the caller's next
+ * item. The deadline is unaffected — `Effect.timeoutOrElse` races the request
+ * in a fiber that `raceAllFirst` forks interruptible regardless of the
+ * enclosing region (`forkUnsafe(..., uninterruptible: false)` in effect
+ * rc.112), so `ZOTERO_CONNECTOR_TIMEOUT_MS` still bounds a wedged Zotero.
  */
 export const callZoteroConnector = Effect.fn('bbtClient.callZoteroConnector')(
   (endpoint: string, body: object, port: number) =>
@@ -330,6 +340,7 @@ export const callZoteroConnector = Effect.fn('bbtClient.callZoteroConnector')(
         return { status: 'error', message: errorMessage };
       },
     ).pipe(
+      Effect.uninterruptible,
       Effect.catch((error) =>
         Effect.succeed(connectorRequestFailure(error, port)),
       ),

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -294,18 +294,31 @@ function connectorRequestFailure(
 }
 
 /**
- * Call a Zotero Connector endpoint. Never fails: every outcome, the
- * transport's included, is a `ConnectorResult` the tool reports per item.
+ * Call a Zotero Connector endpoint. Never *fails*: every outcome the typed
+ * channel can carry, the transport's included, is a `ConnectorResult` the
+ * tool reports per item. It can still exit interrupted — see below.
  *
  * The request is **uninterruptible**: `saveItems`/`saveSnapshot` write to the
  * user's library, so aborting one mid-flight would leave Zotero having
- * possibly stored the item while the tool reports nothing at all. Cancelling
- * the run instead waits for this one write to settle and to yield its
- * `ConnectorResult`; the interrupt then takes effect at the caller's next
- * item. The deadline is unaffected — `Effect.timeoutOrElse` races the request
- * in a fiber that `raceAllFirst` forks interruptible regardless of the
- * enclosing region (`forkUnsafe(..., uninterruptible: false)` in effect
- * rc.112), so `ZOTERO_CONNECTOR_TIMEOUT_MS` still bounds a wedged Zotero.
+ * possibly stored the item with no way to tell whether it landed. Cancelling
+ * the run instead lets this one write settle deterministically.
+ *
+ * The interrupt is deferred, not absorbed. When the region ends it is
+ * delivered as the continuation of the write's completion, and the
+ * `Effect.catch` below recovers `Fail` reasons only (`findError` matches
+ * `_tag === 'Fail'`), so this item's `ConnectorResult` is discarded and
+ * `addItems`' `Effect.forEach` stops before the next item. The guarantee is
+ * that Zotero's state is knowable afterwards — not that the result is
+ * reported.
+ *
+ * The deadline is separate and unaffected by the region: `Effect.timeoutOrElse`
+ * races the request in a fiber that `raceAllFirst` forks interruptible
+ * regardless of the enclosing region (`forkUnsafe(..., uninterruptible: false)`
+ * in effect rc.112), so `ZOTERO_CONNECTOR_TIMEOUT_MS` still bounds a wedged
+ * Zotero. That cuts both ways: a *timeout* still aborts the write mid-flight,
+ * so the torn write this guards against remains possible on the deadline path.
+ * That is the deliberate trade — an unbounded write against a wedged Zotero is
+ * the worse failure.
  */
 export const callZoteroConnector = Effect.fn('bbtClient.callZoteroConnector')(
   (endpoint: string, body: object, port: number) =>


### PR DESCRIPTION
## Summary

Lane w3 of the Effect 4 migration: **interruption correctness at the tool network boundary** (PRD R5). Two defects, both of which type-check clean today and fail only at runtime, under cancellation.

**1. The Zotero Connector write was interruptible mid-flight.** `callZoteroConnector` backs `saveItems`/`saveSnapshot` — writes into the user's Zotero library. Interrupting one between "request sent" and "response observed" leaves Zotero having possibly stored the item with no way to tell whether it landed. `Effect.uninterruptible` on that one program makes cancelling the run let the in-flight write **settle deterministically** instead of tearing it.

What that does *not* buy is the item's result. The interrupt is deferred, not absorbed: when the region ends it is delivered as the continuation of the write's completion, and `Effect.catch` recovers `Fail` reasons only (`findError` matches `_tag === 'Fail'`), so the `ConnectorResult` is discarded and `addItems`' `Effect.forEach` stops before the next item. The guarantee is that Zotero's state is knowable afterwards, not that the write is reported. *(Corrected after review — see below.)*

The deadline is unaffected, and that is not an assumption — `Effect.timeoutOrElse` → `raceFirst` → `raceAllFirst` forks its racers with `forkUnsafe(parent, effect, true, true, false)` in rc.112, i.e. **interruptible unconditionally**, regardless of the enclosing region. `ZOTERO_CONNECTOR_TIMEOUT_MS` still bounds a wedged Zotero. That cuts both ways and the docstring now says so: a *timeout* still aborts the write mid-flight, so the torn write remains possible on the deadline path. That is the deliberate trade — an unbounded write against a wedged Zotero is the worse failure. `callBetterBibTeX` and `checkZoteroRunning` stay interruptible: they are reads, and there is nothing to tear.

**2. `withRequestTimeout` accepted requests it could not abort — silently.** `Effect.tryPromise` creates an `AbortSignal` **only when its callback declares the parameter** (`f.length !== 0` in effect's own `tryPromise`). A request written `() => ky.get(url)` therefore gets no signal, and neither the deadline nor the caller's interruption reaches the in-flight request: it is abandoned to settle unobserved while the program reports a timeout. TypeScript cannot catch this — a zero-parameter function is assignable to `(signal: AbortSignal) => Promise<T>` — so the misuse is now a **defect** (`Effect.die`) with a message naming the fix.

**The check immediately found two real instances, both in the existing suite** — and one of them was a *timeout* test (`withRequestTimeout(0, () => new Promise(() => {}))`) asserting that a deadline fires against a promise it had no way to abort. It passed for the wrong reason. Every production caller already declares `signal`: `bbtClient` (3 sites) and, through `retryTransientFetch`, `LoogleTool`, `WebFetchTool`, `WebSearchTool`. Verified by grep across the tree, not by sampling.

## Issue acceptance gates

No issue is closed. **R5 (interruption)** is the whole lane: a write that must not tear is now uninterruptible, and a request that cannot be aborted is now loud instead of silent. **R1**: no run boundary added or moved. **R7**: `RequestTimedOut`/`RequestFailed` identities unchanged; the arity misuse is a defect, not a typed failure, because it is a programming error with no recovery. **R8**: no clock change. **R10**: nothing to delete — this lane adds a guard rather than replacing a mechanism.

## Single source of truth

`timeouts.ts` already owned the request deadline and the retry policy; it now also owns the *precondition* those depend on, instead of each of the call sites being trusted to remember it. `bbtClient.ts` owns the connector's interruption region — its callers pass items, not cancellation policy.

## Duplication and abstraction budget

Nothing added. No new helper, no new module, no new export. One `if` in `withRequestTimeout` and one `Effect.uninterruptible` in a pipe.

## Net elements (R6)

Files: 5 changed (2 production, 3 test). Exports: **0 added, 0 removed**. Dependencies: none added. `withRequestTimeout` becomes an `Effect.fn` over a generator rather than an expression body — same signature, same call sites, no consumer change.

## Consumer counts (R8)

`callZoteroConnector`: 1 definition, **2 call sites** in `ZoteroAddTool.ts` (`:355` `saveSnapshot`, `:366` `saveItems`), both through the same tool. `withRequestTimeout`: 3 production call sites in `bbtClient.ts` plus `retryTransientFetch`; `retryTransientFetch` has 3 production callers (`LoogleTool`, `WebFetchTool`, `WebSearchTool`), each already signal-declaring. No emit path changes.

## Corrections after review

Two, both mine, both worth naming rather than editing away:

1. **R8 count.** This section first read "3 call sites" for `callZoteroConnector`. I counted `grep -c` matching lines, which included the import on `:38`, and reported them as call sites — a measurement error, not a typo. Caught by @claude.
2. **What the uninterruptible region guarantees** (`18a3a52`). The docstring and this summary claimed cancelling "waits for this one write to settle **and to yield its `ConnectorResult`**; the interrupt then takes effect at the caller's next item." That overstates the runtime, for the reason above. Caught by `texra-ai[bot]`, verified against `findError` in `dist/internal/effect.js` (matches `_tag === "Fail"` only) and against `Effect.forEach` at `ZoteroAddTool.ts:392`. The branch's own second test already asserted the correct behaviour — `Exit.hasInterrupts` is true after `settled` — so the code was right and the prose describing it was not. The pushed commit is comment-only; no behaviour changed.

## Host impact

None. Both files are host-agnostic `src/tools/`, VS Code-free, and no host entry point changes. The user-visible difference is behavioural and narrow: cancelling a run during a Zotero save now lets that write finish cleanly rather than abandoning it half-written.

## Scheduled refactoring

None scheduled by this lane. The arity guard is a runtime check because the language cannot express "callback must declare its parameter"; if effect ever gates signal creation on something type-visible, the guard becomes deletable.

## Validation

Run on this branch, with `origin/main` at `1fd5932a29` (0 merge conflicts; `main` untouched in all five files since the base commit):

- `npx tsc --noEmit -p tsconfig.json` — 0 errors. `-p tsconfig.test-kernel.json` — 0 errors. `npx tsc -p tsconfig.build.json` (SDK declaration emit) — 0 errors.
- `npx vitest run src/test-kernel/tools` — **96 files, 775 tests, all passing.**
- `node scripts/check-effect-migration-ratchet.mjs` — exit 0: no count grew, no baseline headroom, no `@adapter-until` markers present.
- CI on `af93b47` was green across validate, both kernel shards, static checks, build artifacts and webview smoke. `18a3a52` re-ran `prettier`, `eslint`, `tsc -p tsconfig.json` and `Cancellation.vitest.ts` (8 passing) before pushing.

Three cases were added to `Cancellation.vitest.ts` — the deadline firing inside the uninterruptible region, an interrupted write settling untorn, and the arity defect — and two existing tests were corrected to declare the signal they were always assumed to have. That is one behavioural test per defect plus the guard's own case, at the durable `src/tools` boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyJjcnpYcFopcGbYdWayxp