### PR TITLE
fix: reject incomplete dead-code analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "check:desktop-build-artifacts": "node scripts/verify-desktop-build-artifacts.mjs",
     "check:initial-build-artifacts": "corepack pnpm run check:vsix-contents && corepack pnpm run check:desktop-build-artifacts",
     "check:desktop-package": "node scripts/verify-desktop-package.mjs",
-    "check:dead-code": "VITE_WEBVIEW=webview knip --no-progress --include files,exports,types,duplicates",
+    "check:dead-code": "VITE_WEBVIEW=progressView knip --no-progress --include files,exports,types,duplicates",
     "check:dead-code-ratchet": "node scripts/check-dead-code-ratchet.mjs",
     "check:effect-migration-ratchet": "node scripts/check-effect-migration-ratchet.mjs",
     "check:guidance-refs": "node scripts/check-guidance-refs.mjs",

--- a/scripts/check-dead-code-ratchet-core.mjs
+++ b/scripts/check-dead-code-ratchet-core.mjs
@@ -1,3 +1,6 @@
+// Node.js imports
+import { stripVTControlCharacters } from 'node:util';
+
 const EMPTY_COUNTS = { files: 0, exports: 0, types: 0, duplicates: 0 };
 const KNIP_KINDS = new Set(Object.keys(EMPTY_COUNTS));
 
@@ -113,6 +116,10 @@ export function countByCategory(findings) {
 // Split out from runKnip() so the parsing/validation logic is unit-testable
 // without spawning the real knip binary.
 export function parseKnipIssues(stdout, stderr) {
+  const diagnostics = stripVTControlCharacters(stderr);
+  if (/^ERROR:/m.test(diagnostics)) {
+    throw new Error(`knip reported an analysis error:\n${diagnostics}`);
+  }
   let parsed;
   try {
     parsed = JSON.parse(stdout);

--- a/scripts/check-dead-code-ratchet.mjs
+++ b/scripts/check-dead-code-ratchet.mjs
@@ -53,16 +53,14 @@ function runKnip({ production = false } = {}) {
     maxBuffer: 32 * 1024 * 1024,
     // Knip's vite plugin loads packages/extension/vite.config.mts for entry
     // detection, and that config throws unless VITE_WEBVIEW names a webview.
-    // Without this the analyzer swallowed a permanent config-load ERROR on
-    // every green run, hiding any real config failure behind it. Build callers
-    // set the variable themselves, so the per-webview build guard is untouched.
-    env: { ...process.env, VITE_WEBVIEW: 'webview' },
+    // Both frontend entry points are also listed explicitly in knip.json.
+    env: { ...process.env, VITE_WEBVIEW: 'progressView' },
   });
   if (result.error) {
     throw result.error;
   }
-  // Knip exits 1 whenever it finds any issue at all, which is expected here.
-  // A non-zero status is only a real failure if it did not produce JSON.
+  // Findings and configuration errors can both exit 1 with parseable JSON;
+  // the parser must inspect diagnostics before accepting the findings.
   return parseKnipIssues(result.stdout, result.stderr);
 }
 

--- a/src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.ts
+++ b/src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.ts
@@ -170,6 +170,15 @@ describe('check-dead-code-ratchet parseKnipIssues', () => {
     );
   });
 
+  it('rejects partial JSON findings when Knip reports a configuration error', () => {
+    const stderr =
+      '\u001b[31mERROR\u001b[39m: Error loading packages/extension/vite.config.mts (VITE_WEBVIEW must name a webview (progressView, settingsView), got: webview)';
+
+    expect(() => parseKnipIssues('{"issues":[]}', stderr)).toThrow(
+      'knip reported an analysis error',
+    );
+  });
+
   // Each of these must throw the contextual error (never a raw TypeError or a
   // silent default of zero issues) when the `issues` array is unusable.
   it.each([


### PR DESCRIPTION
## Summary

The dead-code check selected a retired extension webview. Knip reported a
configuration-loading error but still returned JSON findings and exit code 1,
which the checker accepted as an ordinary report. Incomplete analysis could
therefore pass the deletion check.

Both commands now select the current progress view. The existing report parser
rejects Knip's error diagnostics, including terminal-colored messages, before
accepting JSON findings. Normal unused-code findings remain valid input.

## Issue acceptance gates

- A regression test failed before the correction because valid JSON accompanied
  by a configuration error was accepted; the same test now passes.
- Knip loads the current Vite configuration without the retired-selector error.
- Normal and production findings remain unchanged: 13 normal, 283 production,
  and 283 combined findings against the existing 283-entry baseline.
- No baseline is widened or rewritten.

## Single source of truth

The existing `parseKnipIssues` function accepts or rejects the complete Knip
report. The checker still owns comparison with the checked-in baseline.
`knip.json` continues to identify both frontend entry points explicitly.

## Duplication and abstraction budget

No helper, layer, export or dependency is added. The existing boundary parser
uses Node's terminal-control stripping function to recognize the diagnostic
prefix emitted by the installed Knip implementation.

## Net elements (R6)

Four files modified; none added or deleted. Net +14 lines: +5 in validation
scripts and +9 in the existing regression suite. Production TypeScript is
unchanged. No exported symbol, class, interface or enum is added or deleted.
The additional check prevents partial analysis from being reported as success.

## Consumer counts (R8)

No event or production export is removed or rerouted. `parseKnipIssues` has one
script caller, used for normal and production analysis, and one existing test
module. CI continues to invoke `check:dead-code-ratchet`.

## Host impact

Extension: no runtime change; validation loads a current webview configuration.

Desktop: no runtime change.

CLI: no runtime change.

## Scheduled refactoring

None for this correction. This repairs validation used during the native
Effect migration; it is not itself a runtime migration or a code deletion.

## Validation

Base: `1fd5932a29c1e569084385d318b81928e4338b9f` from current main.

- Full formatting, all six typecheck commands, lint and `compile:fast` passed.
- The existing checker suite passed all 18 tests, including the one new
  regression; an independent reviewer repeated the focused suite successfully.
- Dead-code and Effect migration checks, guidance references, browser-safe
  checks and `git diff --check` passed.
- The full-suite rerun passed: 763 test files, 9,085 tests, and 6 skipped tests
  (306.79 seconds). The initial run passed 9,084 tests and failed one unchanged
  subprocess-timeout test because its PID file was read before its numeric
  contents were available. That suite then passed all 23 tests in isolation,
  followed by the successful full rerun. No change to that test is included.

## Verified

Independent review read all four changed files, the Vite selector and Knip
6.34.0's configuration-error and diagnostic-emission paths. It found no issue
with the correction. Successful JSON parsing or Knip's exit code alone cannot
distinguish the reproduced error from ordinary findings.
