### PR TITLE
refactor(controllers): move the last controller and telemetry runs out to the host entries

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -163,15 +163,11 @@
     "Effect.run*": {
       "packages/extension/src/progressView/frontend/sessionTransport.ts": 4,
       "src/agent/runtime/SessionHandle.ts": 3,
-      "src/controllers/onboarding/OnboardingRefreshQueue.ts": 1,
-      "src/controllers/progressView/ProgressApiKeyRetryController.ts": 3,
       "src/controllers/session/SessionBridge.ts": 6,
-      "src/controllers/session/hostDraftRequests.ts": 1,
       "src/controllers/session/hostRunActions.ts": 1,
       "src/controllers/session/sessionLayer.ts": 3,
       "src/platform/defaults/jsonStore.ts": 1,
       "src/shared/signals.ts": 2,
-      "src/telemetry/UsageLogService.ts": 4,
       "src/tools/agentCliSessionRegistry.ts": 2,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/lean/direct/directLspAdapter.ts": 3
@@ -210,15 +206,11 @@
   "debtLanes": {
     "packages/extension/src/progressView/frontend/sessionTransport.ts": "webview frontends — the progress view subscribes through an Effect-typed session plane instead of running fibers in the view",
     "src/agent/runtime/SessionHandle.ts": "Phase 3 — run lifecycle and cancellation",
-    "src/controllers/onboarding/OnboardingRefreshQueue.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
-    "src/controllers/progressView/ProgressApiKeyRetryController.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/controllers/session/SessionBridge.ts": "lane D — host composition root and session graph",
-    "src/controllers/session/hostDraftRequests.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/controllers/session/hostRunActions.ts": "lane D — host composition root and session graph",
     "src/controllers/session/sessionLayer.ts": "lane D — host composition root and session graph",
     "src/platform/defaults/jsonStore.ts": "lane D — Platform ports become Effect-typed",
     "src/shared/signals.ts": "lane D — host composition root and session graph",
-    "src/telemetry/UsageLogService.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/tools/agentCliSessionRegistry.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/github/PollingSourceBase.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — the port is Effect-typed and the tool-facing runs moved to the tools' execute(); what remains is pool construction/disposal (the platform-lifetime seam) and the run-end hook's Promise seam, both owned by lane D"

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -385,7 +385,9 @@ export async function initCliPlatform(
       // The default session is installed later by whichever entry point opens
       // transcripts, so its shutdown lookup remains lazy.
       flushArtifacts: () => tryDefaultSession()?.flushArtifacts(),
-      afterFlushArtifacts: [() => UsageLogService.dispose()],
+      afterFlushArtifacts: [
+        () => effectRuntime().runPromise(UsageLogService.dispose()),
+      ],
       afterExecutionSettlement: [
         () => teardownDefaultSession(),
         () => flushNdjsonStdout(),
@@ -398,7 +400,9 @@ export async function initCliPlatform(
     // dispose() flushes any queued entries; it
     // runs on normal exit (bin/texra.ts finally) and on signals, both of
     // which call lifecycle.runShutdown().
-    UsageLogService.initialize({}, context.version, 'cli');
+    await effectRuntime().runPromise(
+      UsageLogService.initialize({}, context.version, 'cli'),
+    );
   }
 
   if (!supabaseAuthInitialized) {

--- a/packages/desktop/src/main/desktopHostRequests.ts
+++ b/packages/desktop/src/main/desktopHostRequests.ts
@@ -39,6 +39,7 @@ import {
 import { runCleanRunDir, runPackRunDir } from '@housekeeping/runDirOps';
 import { LaTeXdiffService } from '@latex/latexdiff';
 import { computeModelOptionsData } from '@model/computeModelOptions';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   cloneRoundIndexed,
   type ExecutionId,
@@ -595,7 +596,7 @@ export function createDesktopHostRequests(
         await runActions.runCompileFixer(request.streamId);
         return done;
       case 'useOwnApiKey':
-        await runActions.useOwnApiKey(request);
+        await effectRuntime().runPromise(runActions.useOwnApiKey(request));
         return done;
       case 'latexdiff':
         await workflowRunActions.diffStream(request.streamId);
@@ -613,7 +614,7 @@ export function createDesktopHostRequests(
       case 'record':
       case 'polish':
       case 'savePastedImage':
-        return draftRequests.handle(request, port);
+        return effectRuntime().runPromise(draftRequests.handle(request, port));
       case 'popOut':
       case 'popBack':
         throw notOnDesktop('Pop-out to editor');

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -2,6 +2,7 @@ import { planOnboardingFunnelTransition } from '@controllers/onboarding/onboardi
 import { OnboardingRefreshQueue } from '@controllers/onboarding/OnboardingRefreshQueue';
 import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
+import { effectRuntime } from '@platform/processRuntime';
 import type { StateStore } from '@platform/interfaces';
 import type { OnboardingFunnelState } from '@shared/schemas';
 import {
@@ -158,7 +159,7 @@ export function createDesktopOnboardingIpc(
   }
 
   function refreshOnboardingFunnel(): Promise<void> {
-    return funnelRefreshQueue.run();
+    return effectRuntime().runPromise(funnelRefreshQueue.run());
   }
 
   async function dismiss(): Promise<void> {

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -157,8 +157,12 @@ export async function initializeElectronPlatform(
   // carries an undefined host/version, so a queue shorter than one batch is
   // lost at quit — including plan accounting. `dispose()` drains it, from the
   // same BEFORE phase the other two hosts use.
-  UsageLogService.initialize({}, app.getVersion(), 'desktop');
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => UsageLogService.dispose());
+  await effectRuntime().runPromise(
+    UsageLogService.initialize({}, app.getVersion(), 'desktop'),
+  );
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+    effectRuntime().runPromise(UsageLogService.dispose()),
+  );
 
   // Reconcile the persisted enabled-models list against the current curated
   // defaults, as the extension and CLI hosts do at startup. Preferred defaults

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -513,7 +513,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
   registerRuntimeShutdownHandlers(lifecycle, {
     afterAgentShutdown: [
       () => killActiveRecording(),
-      () => UsageLogService.dispose(),
+      () => effectRuntime().runPromise(UsageLogService.dispose()),
     ],
     flushArtifacts: () => runtimeSession.flushArtifacts(),
     afterExecutionSettlement: [
@@ -632,10 +632,12 @@ async function activateExtension(context: vscode.ExtensionContext) {
       ? context.extension.packageJSON.version
       : undefined;
   try {
-    UsageLogService.initialize(
-      {},
-      extensionVersion,
-      vscode.env.appName || undefined,
+    await effectRuntime().runPromise(
+      UsageLogService.initialize(
+        {},
+        extensionVersion,
+        vscode.env.appName || undefined,
+      ),
     );
   } catch (error) {
     log.warn(`Failed to initialize usage logging: ${toErrorMessage(error)}`);

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -389,7 +389,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
    * auto-starts setup; the user launches it from the setup card.
    */
   public refreshOnboardingFunnel(): Promise<void> {
-    return this.onboardingFunnelRefreshQueue.run();
+    return effectRuntime().runPromise(this.onboardingFunnelRefreshQueue.run());
   }
 
   private async refreshOnboardingFunnelSerially(): Promise<void> {

--- a/packages/extension/src/progressView/extensionHostRequests.ts
+++ b/packages/extension/src/progressView/extensionHostRequests.ts
@@ -53,6 +53,7 @@ import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { parseVersionControlDiffFilename } from '@latex/latexdiff/diffFileNameManager';
 import { createLog } from '@logger/logUtils';
 import { computeModelOptionsData } from '@model/computeModelOptions';
+import { effectRuntime } from '@platform/processRuntime';
 import latexPreamble from '@resources/templates/chatExport.tex';
 import {
   GETTING_STARTED_COMMANDS,
@@ -646,7 +647,7 @@ export function createExtensionHostRequests(
         await runActions.runCompileFixer(request.streamId);
         return done;
       case 'useOwnApiKey':
-        await runActions.useOwnApiKey(request);
+        await effectRuntime().runPromise(runActions.useOwnApiKey(request));
         return done;
       case 'latexdiff':
         await workflowRunActions.diffStream(request.streamId);
@@ -664,7 +665,7 @@ export function createExtensionHostRequests(
       case 'record':
       case 'polish':
       case 'savePastedImage':
-        return draftRequests.handle(request, port);
+        return effectRuntime().runPromise(draftRequests.handle(request, port));
       case 'popOut':
         await options.popOutToEditor();
         return done;

--- a/src/controllers/effectPort.ts
+++ b/src/controllers/effectPort.ts
@@ -1,0 +1,19 @@
+import { Effect } from 'effect';
+
+/**
+ * Call a host port from an Effect program.
+ *
+ * A port's rejection is the host's own error — a `vscode` API failure, an
+ * Electron IPC error, a store's own throw — and the controllers that call one
+ * match on that identity. `Effect.tryPromise`'s default catch would wrap it,
+ * so every caller wants the identity catch this applies once.
+ *
+ * The callback may be synchronous or return a promise; a synchronous throw is
+ * caught the same way as a rejection. It takes no `AbortSignal`, which is
+ * deliberate: a host port has no cancellation to hand it, and
+ * `Effect.tryPromise` only creates a signal for a callback that declares one.
+ */
+export const hostPort = <A>(
+  call: () => A | PromiseLike<A>,
+): Effect.Effect<A, unknown> =>
+  Effect.tryPromise({ try: async () => call(), catch: (error) => error });

--- a/src/controllers/onboarding/OnboardingRefreshQueue.ts
+++ b/src/controllers/onboarding/OnboardingRefreshQueue.ts
@@ -1,7 +1,5 @@
 import { Effect, Semaphore } from 'effect';
 
-import { effectRuntime } from '@platform/processRuntime';
-
 /** Serialize funnel refreshes and collapse an in-flight burst to one rerun. */
 export class OnboardingRefreshQueue {
   /** One permit: a refresh holds it while it runs; callers that arrive
@@ -10,6 +8,9 @@ export class OnboardingRefreshQueue {
   private readonly lane = Semaphore.makeUnsafe(1);
   private rerunRequested = false;
 
+  /** The latch and the program it reruns are one pair: the refresh is
+   *  captured here, with the latch that records a request for it, so one
+   *  consumer's `run` can only ever be answered by its own refresh. */
   constructor(private readonly refresh: () => Promise<void>) {}
 
   private readonly drain = Effect.fn('OnboardingRefreshQueue.run')(function* (
@@ -24,8 +25,19 @@ export class OnboardingRefreshQueue {
     }
   });
 
-  run(): Promise<void> {
-    this.rerunRequested = true;
-    return effectRuntime().runPromise(this.lane.withPermit(this.drain()));
+  /**
+   * Ask for a refresh: the caller that finds the lane free runs it, callers
+   * that arrive while it runs are collapsed into the single rerun it performs
+   * afterwards, and every caller returns once the rerun it asked for has
+   * landed. A refresh that fails keeps the host's own error identity.
+   *
+   * The request is latched when the program starts, not when it is built, so
+   * an unrun `run` leaves no rerun owed to nobody.
+   */
+  run(): Effect.Effect<void, unknown> {
+    return Effect.suspend(() => {
+      this.rerunRequested = true;
+      return this.lane.withPermit(this.drain());
+    });
   }
 }

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -10,7 +10,6 @@ import {
   quotaFallbackRuntimes,
   type QuotaFallbackRuntime,
 } from '@model/quotaFallbackRoutes';
-import { effectRuntime } from '@platform/processRuntime';
 import type { ExhaustionReason, StreamTabId } from '@shared/schemas';
 import {
   isKimiCodeExclusiveModel,
@@ -115,11 +114,9 @@ export class ProgressApiKeyRetryController {
     return this.deps.quotaFallbackRuntimes ?? quotaFallbackRuntimes;
   }
 
-  useOwnApiKey(request: ProgressApiKeyRetryRequest): Promise<void> {
-    return effectRuntime().runPromise(this.switchToOwnApiKey(request));
-  }
-
-  private readonly switchToOwnApiKey = Effect.fn(
+  /** Switch this retry onto the user's own key and relaunch it. The host
+   *  arm that took the request runs this where it stands. */
+  readonly useOwnApiKey = Effect.fn(
     'ProgressApiKeyRetryController.useOwnApiKey',
   )(function* (
     this: ProgressApiKeyRetryController,
@@ -134,7 +131,7 @@ export class ProgressApiKeyRetryController {
       return;
     }
 
-    const proceeded = yield* this.ensureOwnApiKeyReady({
+    const proceeded = yield* this.ensureOwnApiKey({
       ...request,
       provider: this.credentialProviderFor(request),
     });
@@ -148,6 +145,39 @@ export class ProgressApiKeyRetryController {
     yield* this.commitOwnApiKeyRouting(request, () =>
       this.deps.triggerRetry(request.stream, request.requestId),
     );
+  });
+
+  /** Whether the user has (or has just entered) a usable key for this
+   *  retry's credential owner. */
+  readonly ensureOwnApiKey = Effect.fn(
+    'ProgressApiKeyRetryController.ensureOwnApiKey',
+  )(function* (
+    this: ProgressApiKeyRetryController,
+    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
+  ) {
+    const provider = this.resolveProvider(request);
+    const providersToCheck = provider ? [provider] : this.deps.providers;
+    const requireChange = request.exhaustionReason === 'upstream-credit';
+
+    // The gate depends on which credential failed:
+    // - Upstream credit depletion means the stored direct key is the broken
+    //   credential, so the user must provide a changed usable key.
+    // - Subscription quota limits do not imply a broken direct key, so any
+    //   usable direct key is enough consent to retry on it.
+    if (requireChange) {
+      const before = yield* this.readKeys(providersToCheck);
+      yield* port(() => this.deps.promptForApiKey(provider));
+      return yield* this.hasChangedUsableKey(providersToCheck, before);
+    }
+
+    // Subscription exhaustion does not break the stored direct key, so
+    // if a usable one already exists, switch to it and retry without
+    // re-prompting, since the user has already provided a key. Only prompt when
+    // none exists yet, and only re-check the keys after that prompt (so the
+    // common already-set path reads the secret store once, not twice).
+    if (yield* this.hasAnyUsableKey(providersToCheck)) return true;
+    yield* port(() => this.deps.promptForApiKey(provider));
+    return yield* this.hasAnyUsableKey(providersToCheck);
   });
 
   /**
@@ -227,43 +257,6 @@ export class ProgressApiKeyRetryController {
     return yield* port(action);
   });
 
-  ensureOwnApiKey(
-    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
-  ): Promise<boolean> {
-    return effectRuntime().runPromise(this.ensureOwnApiKeyReady(request));
-  }
-
-  private readonly ensureOwnApiKeyReady = Effect.fn(
-    'ProgressApiKeyRetryController.ensureOwnApiKey',
-  )(function* (
-    this: ProgressApiKeyRetryController,
-    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
-  ) {
-    const provider = this.resolveProvider(request);
-    const providersToCheck = provider ? [provider] : this.deps.providers;
-    const requireChange = request.exhaustionReason === 'upstream-credit';
-
-    // The gate depends on which credential failed:
-    // - Upstream credit depletion means the stored direct key is the broken
-    //   credential, so the user must provide a changed usable key.
-    // - Subscription quota limits do not imply a broken direct key, so any
-    //   usable direct key is enough consent to retry on it.
-    if (requireChange) {
-      const before = yield* this.readKeys(providersToCheck);
-      yield* port(() => this.deps.promptForApiKey(provider));
-      return yield* this.hasChangedUsableKey(providersToCheck, before);
-    }
-
-    // Subscription exhaustion does not break the stored direct key, so
-    // if a usable one already exists, switch to it and retry without
-    // re-prompting, since the user has already provided a key. Only prompt when
-    // none exists yet, and only re-check the keys after that prompt (so the
-    // common already-set path reads the secret store once, not twice).
-    if (yield* this.hasAnyUsableKey(providersToCheck)) return true;
-    yield* port(() => this.deps.promptForApiKey(provider));
-    return yield* this.hasAnyUsableKey(providersToCheck);
-  });
-
   // OAuth subscriptions pin the fallback key provider (ChatGPT → openai,
   // Grok → xai) so a mislabeled SDK provider cannot prompt for the wrong key.
   private resolveProvider(
@@ -320,13 +313,11 @@ export class ProgressApiKeyRetryController {
   runCopilotFallbackWithRouting(
     request: ProgressApiKeyRetryRequest,
     start: (copilotRouteOverride: CopilotRouteOverride) => Promise<boolean>,
-  ): Promise<boolean> {
+  ): Effect.Effect<boolean, unknown> {
     // The user chose "use own API key" for this retry. The direct-route
     // override travels only with the replacement launch; the standing
     // preference remains visible to concurrent and future runs.
-    return effectRuntime().runPromise(
-      this.commitOwnApiKeyRouting(request, () => start('direct')),
-    );
+    return this.commitOwnApiKeyRouting(request, () => start('direct'));
   }
 
   private routingSnapshot(): ProgressApiRoutingSnapshot {

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -2,6 +2,7 @@ import { Effect, Exit, Semaphore } from 'effect';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports
+import { hostPort } from '@controllers/effectPort';
 import { createLog } from '@logger/logUtils';
 import type { ApiProvider } from '@model/apiProviders';
 import type { CopilotRouteOverride } from '@model/copilotRouting';
@@ -37,16 +38,6 @@ interface ProgressApiKeyRetryRequest {
 
 interface ProgressApiRoutingSnapshot {
   readonly quotaRoutes: ReadonlyMap<ExhaustionReason, boolean>;
-}
-
-/** A host port call (credentials, prompts, toggles, the retry launch). Its
- *  rejection is the host's own error and reaches the caller with the same
- *  identity from the Promise edge. */
-function port<A>(call: () => A | PromiseLike<A>): Effect.Effect<A, unknown> {
-  return Effect.tryPromise({
-    try: async () => call(),
-    catch: (error) => error,
-  });
 }
 
 export interface ProgressApiKeyRetryControllerDeps {
@@ -166,7 +157,7 @@ export class ProgressApiKeyRetryController {
     //   usable direct key is enough consent to retry on it.
     if (requireChange) {
       const before = yield* this.readKeys(providersToCheck);
-      yield* port(() => this.deps.promptForApiKey(provider));
+      yield* hostPort(() => this.deps.promptForApiKey(provider));
       return yield* this.hasChangedUsableKey(providersToCheck, before);
     }
 
@@ -176,7 +167,7 @@ export class ProgressApiKeyRetryController {
     // none exists yet, and only re-check the keys after that prompt (so the
     // common already-set path reads the secret store once, not twice).
     if (yield* this.hasAnyUsableKey(providersToCheck)) return true;
-    yield* port(() => this.deps.promptForApiKey(provider));
+    yield* hostPort(() => this.deps.promptForApiKey(provider));
     return yield* this.hasAnyUsableKey(providersToCheck);
   });
 
@@ -236,11 +227,9 @@ export class ProgressApiKeyRetryController {
       yield* Effect.addFinalizer((exit) =>
         Exit.isSuccess(exit) && exit.value === true
           ? Effect.void
-          : Effect.tryPromise({
-              try: () =>
-                runtime.restoreEnabled(before.quotaRoutes.get(reason) ?? false),
-              catch: (error) => error,
-            }).pipe(
+          : hostPort(() =>
+              runtime.restoreEnabled(before.quotaRoutes.get(reason) ?? false),
+            ).pipe(
               Effect.tapError((error) =>
                 Effect.sync(() => {
                   log.warn(
@@ -251,10 +240,10 @@ export class ProgressApiKeyRetryController {
               Effect.orDie,
             ),
       );
-      yield* port(() => runtime.setEnabled(false));
+      yield* hostPort(() => runtime.setEnabled(false));
     }
 
-    return yield* port(action);
+    return yield* hostPort(action);
   });
 
   // OAuth subscriptions pin the fallback key provider (ChatGPT → openai,
@@ -337,7 +326,7 @@ export class ProgressApiKeyRetryController {
     return Effect.map(
       Effect.forEach(
         providers,
-        (provider) => port(() => this.deps.hasUsableKey(provider)),
+        (provider) => hostPort(() => this.deps.hasUsableKey(provider)),
         { concurrency: 'unbounded' },
       ),
       (checks) => checks.some(Boolean),
@@ -364,7 +353,7 @@ export class ProgressApiKeyRetryController {
         providers,
         (provider) =>
           Effect.map(
-            port(() => this.deps.readKey(provider)),
+            hostPort(() => this.deps.readKey(provider)),
             (key) => [provider, key] as const,
           ),
         { concurrency: 'unbounded' },

--- a/src/controllers/session/hostDraftRequests.ts
+++ b/src/controllers/session/hostDraftRequests.ts
@@ -4,6 +4,7 @@ import { Deferred, Effect } from 'effect';
 import { runInSession } from '@agent/runtime/RunContext';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { polishTextWithAI } from '@agent/runtime/textEnhancement';
+import { hostPort } from '@controllers/effectPort';
 import type { HostRequest } from '@shared/session/hostRequest';
 import type { HostSnapshot } from '@shared/session/hostSnapshot';
 import { Cancelled, Rejected } from '@shared/session/requestErrors';
@@ -33,11 +34,6 @@ interface Take {
   stopping: boolean;
   cancelled: boolean;
 }
-
-/** `Effect.tryPromise` with the identity catch every call below wants: the
- *  rejection value flows through unchanged as the error. */
-const tryPromise = <A>(run: () => Promise<A>): Effect.Effect<A, unknown> =>
-  Effect.tryPromise({ try: run, catch: (error) => error });
 
 /** One instance per host process, shared by its session request handlers. */
 export class HostDraftRequests {
@@ -78,7 +74,7 @@ export class HostDraftRequests {
   ): Effect.fn.Return<HostOutcome, unknown> {
     switch (request.kind) {
       case 'polish': {
-        const result = yield* tryPromise(() =>
+        const result = yield* hostPort(() =>
           polishTextWithAI(request.text, undefined, session),
         );
         if (!result.success) {
@@ -91,7 +87,7 @@ export class HostDraftRequests {
       case 'savePastedImage':
         return {
           kind: 'savedImage',
-          fileName: yield* tryPromise(() =>
+          fileName: yield* hostPort(() =>
             savePastedImageBase64(request.base64, request.fileName),
           ),
         };
@@ -157,7 +153,7 @@ export class HostDraftRequests {
   ) {
     const takeProgram: Effect.Effect<HostOutcome, unknown> = Effect.gen(
       function* () {
-        const started = yield* tryPromise(async () =>
+        const started = yield* hostPort(async () =>
           runInSession(take.session, startRecording),
         );
         if (!started.success) {
@@ -172,7 +168,7 @@ export class HostDraftRequests {
             reason: 'The recording was cancelled.',
           });
         }
-        const result = yield* tryPromise(async () =>
+        const result = yield* hostPort(async () =>
           runInSession(take.session, stopRecordingAndTranscribe),
         );
         if (!result.success) {

--- a/src/controllers/session/hostDraftRequests.ts
+++ b/src/controllers/session/hostDraftRequests.ts
@@ -4,7 +4,6 @@ import { Deferred, Effect } from 'effect';
 import { runInSession } from '@agent/runtime/RunContext';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { polishTextWithAI } from '@agent/runtime/textEnhancement';
-import { effectRuntime } from '@platform/processRuntime';
 import type { HostRequest } from '@shared/session/hostRequest';
 import type { HostSnapshot } from '@shared/session/hostSnapshot';
 import { Cancelled, Rejected } from '@shared/session/requestErrors';
@@ -69,15 +68,9 @@ export class HostDraftRequests {
     return () => this.listeners.delete(listener);
   }
 
-  handle(
-    session: SessionHandle,
-    request: DraftRequest,
-    port: string,
-  ): Promise<HostOutcome> {
-    return effectRuntime().runPromise(this.draft(session, request, port));
-  }
-
-  private readonly draft = Effect.fn('HostDraftRequests.handle')(function* (
+  /** Answer one draft request of `session`, arriving on `port`. The host
+   *  that took the request runs this where it stands. */
+  readonly handle = Effect.fn('HostDraftRequests.handle')(function* (
     this: HostDraftRequests,
     session: SessionHandle,
     request: DraftRequest,

--- a/src/controllers/session/hostRunActions.ts
+++ b/src/controllers/session/hostRunActions.ts
@@ -15,6 +15,7 @@ import {
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { hostPort } from '@controllers/effectPort';
 import { createLog } from '@logger/logUtils';
 import type { ApiProvider } from '@model/apiProviders';
 import {
@@ -199,11 +200,6 @@ export function createHostRunActions(
     return parsed.success ? parsed.data : undefined;
   };
 
-  /** A host port call. Its rejection is the host's own error and reaches the
-   *  caller with the same identity from the Promise edge. */
-  const port = <A>(call: () => A | PromiseLike<A>): Effect.Effect<A, unknown> =>
-    Effect.tryPromise({ try: async () => call(), catch: (error) => error });
-
   /** The Copilot subscription's fallback: a replacement run on the user's
    *  own key for the model Copilot served, then the pending retry is
    *  cancelled in its favor. */
@@ -216,7 +212,7 @@ export function createHostRunActions(
       const modelsChanged =
         'The available models changed while TeXRA was preparing the API key. Try again.';
       if (!request.model) {
-        yield* port(() =>
+        yield* hostPort(() =>
           ports.showInfo(
             `TeXRA did not record which Copilot model this retry used. ${chooseAnotherModel}`,
           ),
@@ -229,7 +225,7 @@ export function createHostRunActions(
         getUseOpenRouter(),
       );
       if (!fallback) {
-        yield* port(() =>
+        yield* hostPort(() =>
           ports.showInfo(
             `No model you can use with your own API key matches this Copilot model. ${chooseAnotherModel}`,
           ),
@@ -250,7 +246,7 @@ export function createHostRunActions(
         getUseOpenRouter(),
       );
       if (!currentFallback) {
-        yield* port(() => ports.showInfo(modelsChanged));
+        yield* hostPort(() => ports.showInfo(modelsChanged));
         return;
       }
       if (currentFallback.provider !== fallback.provider) {
@@ -265,14 +261,14 @@ export function createHostRunActions(
           getUseOpenRouter(),
         );
         if (!finalFallback || finalFallback.provider !== fallback.provider) {
-          yield* port(() => ports.showInfo(modelsChanged));
+          yield* hostPort(() => ports.showInfo(modelsChanged));
           return;
         }
       }
-      yield* port(() => snapshots.preload([streamId]));
+      yield* hostPort(() => snapshots.preload([streamId]));
       const { config } = snapshots.getRunMetadata(streamId);
       if (!config) {
-        yield* port(() =>
+        yield* hostPort(() =>
           ports.showInfo(
             `The settings for this run are no longer available. ${chooseAnotherModel}`,
           ),
@@ -304,7 +300,9 @@ export function createHostRunActions(
         },
       );
       if (!started) return;
-      yield* port(() => settleRetry(streamId, requestId, { action: 'cancel' }));
+      yield* hostPort(() =>
+        settleRetry(streamId, requestId, { action: 'cancel' }),
+      );
     },
   );
 

--- a/src/controllers/session/hostRunActions.ts
+++ b/src/controllers/session/hostRunActions.ts
@@ -6,7 +6,7 @@
  * catalog lookups, its key prompt, and its notifications, and both the VS
  * Code extension and the desktop answer the same arms through one body.
  */
-import { SubscriptionRef } from 'effect';
+import { Effect, SubscriptionRef } from 'effect';
 
 import { resolveAgentKey } from '@agent/index/agentRegistry';
 import type { ExecutionRequest } from '@agent/core/state/executionRequests';
@@ -74,9 +74,11 @@ export interface HostRunActions {
   resume(streamId: StreamTabId): Promise<void>;
   runNew(streamId: StreamTabId): Promise<void>;
   runCompileFixer(streamId: StreamTabId): Promise<void>;
+  /** The retry's switch onto the user's own key. The host arm that took the
+   *  request runs it where it stands. */
   useOwnApiKey(
     request: Extract<HostRequest, { kind: 'useOwnApiKey' }>,
-  ): Promise<void>;
+  ): Effect.Effect<void, unknown>;
   /** The launcher's form of a settled run's saved setup. */
   restoreState(streamId: StreamTabId): Promise<AgentConfig>;
   /** The shared sidecar readers used by the workflow controllers. */
@@ -197,103 +199,114 @@ export function createHostRunActions(
     return parsed.success ? parsed.data : undefined;
   };
 
+  /** A host port call. Its rejection is the host's own error and reaches the
+   *  caller with the same identity from the Promise edge. */
+  const port = <A>(call: () => A | PromiseLike<A>): Effect.Effect<A, unknown> =>
+    Effect.tryPromise({ try: async () => call(), catch: (error) => error });
+
   /** The Copilot subscription's fallback: a replacement run on the user's
    *  own key for the model Copilot served, then the pending retry is
    *  cancelled in its favor. */
-  async function copilotFallback(
-    request: Extract<HostRequest, { kind: 'useOwnApiKey' }>,
-  ): Promise<void> {
-    const { streamId, requestId } = request;
-    if (!isRetryPending(streamId, requestId)) return;
-    const chooseAnotherModel =
-      'Choose another model and start the agent again.';
-    const modelsChanged =
-      'The available models changed while TeXRA was preparing the API key. Try again.';
-    if (!request.model) {
-      await ports.showInfo(
-        `TeXRA did not record which Copilot model this retry used. ${chooseAnotherModel}`,
+  const copilotFallback = Effect.fn('HostRunActions.copilotFallback')(
+    function* (request: Extract<HostRequest, { kind: 'useOwnApiKey' }>) {
+      const { streamId, requestId } = request;
+      if (!isRetryPending(streamId, requestId)) return;
+      const chooseAnotherModel =
+        'Choose another model and start the agent again.';
+      const modelsChanged =
+        'The available models changed while TeXRA was preparing the API key. Try again.';
+      if (!request.model) {
+        yield* port(() =>
+          ports.showInfo(
+            `TeXRA did not record which Copilot model this retry used. ${chooseAnotherModel}`,
+          ),
+        );
+        return;
+      }
+      const exhaustionReason = exhaustionReasonOf(request);
+      let fallback = getRuntimeModelDirectFallback(
+        request.model,
+        getUseOpenRouter(),
       );
-      return;
-    }
-    const exhaustionReason = exhaustionReasonOf(request);
-    let fallback = getRuntimeModelDirectFallback(
-      request.model,
-      getUseOpenRouter(),
-    );
-    if (!fallback) {
-      await ports.showInfo(
-        `No model you can use with your own API key matches this Copilot model. ${chooseAnotherModel}`,
-      );
-      return;
-    }
-    // Key entry can outlive the retry panel, and the user can change the
-    // OpenRouter preference while that prompt is open. Revalidate both the
-    // exact retry identity and the effective credential owner after each
-    // prompt so an old action cannot launch or alter a replacement request.
-    let prepared = await apiKeyRetry.ensureOwnApiKey({
-      provider: fallback.provider,
-      exhaustionReason,
-    });
-    if (!prepared || !isRetryPending(streamId, requestId)) return;
-    const currentFallback = getRuntimeModelDirectFallback(
-      request.model,
-      getUseOpenRouter(),
-    );
-    if (!currentFallback) {
-      await ports.showInfo(modelsChanged);
-      return;
-    }
-    if (currentFallback.provider !== fallback.provider) {
-      fallback = currentFallback;
-      prepared = await apiKeyRetry.ensureOwnApiKey({
+      if (!fallback) {
+        yield* port(() =>
+          ports.showInfo(
+            `No model you can use with your own API key matches this Copilot model. ${chooseAnotherModel}`,
+          ),
+        );
+        return;
+      }
+      // Key entry can outlive the retry panel, and the user can change the
+      // OpenRouter preference while that prompt is open. Revalidate both the
+      // exact retry identity and the effective credential owner after each
+      // prompt so an old action cannot launch or alter a replacement request.
+      let prepared = yield* apiKeyRetry.ensureOwnApiKey({
         provider: fallback.provider,
         exhaustionReason,
       });
       if (!prepared || !isRetryPending(streamId, requestId)) return;
-      const finalFallback = getRuntimeModelDirectFallback(
+      const currentFallback = getRuntimeModelDirectFallback(
         request.model,
         getUseOpenRouter(),
       );
-      if (!finalFallback || finalFallback.provider !== fallback.provider) {
-        await ports.showInfo(modelsChanged);
+      if (!currentFallback) {
+        yield* port(() => ports.showInfo(modelsChanged));
         return;
       }
-    }
-    await snapshots.preload([streamId]);
-    const { config } = snapshots.getRunMetadata(streamId);
-    if (!config) {
-      await ports.showInfo(
-        `The settings for this run are no longer available. ${chooseAnotherModel}`,
-      );
-      return;
-    }
-    const model = fallback.model;
-    const started = await apiKeyRetry.runCopilotFallbackWithRouting(
-      {
-        stream: streamId,
-        requestId,
-        provider: fallback.provider,
-        model,
-        exhaustionReason,
-        chatGptSubscriptionEligible: fallback.chatGptSubscriptionEligible,
-      },
-      async (copilotRouteOverride) => {
-        if (!isRetryPending(streamId, requestId)) return false;
-        // Start acknowledges ownership of the replacement run. Settlement
-        // without an onRun callback means no replacement was launched.
-        return new Promise<boolean>((resolve, reject) => {
-          void ports
-            .runExecutionRequest(
-              { config: { ...config, model } },
-              { copilotRouteOverride, onRun: () => resolve(true) },
-            )
-            .then(() => resolve(false), reject);
+      if (currentFallback.provider !== fallback.provider) {
+        fallback = currentFallback;
+        prepared = yield* apiKeyRetry.ensureOwnApiKey({
+          provider: fallback.provider,
+          exhaustionReason,
         });
-      },
-    );
-    if (!started) return;
-    await settleRetry(streamId, requestId, { action: 'cancel' });
-  }
+        if (!prepared || !isRetryPending(streamId, requestId)) return;
+        const finalFallback = getRuntimeModelDirectFallback(
+          request.model,
+          getUseOpenRouter(),
+        );
+        if (!finalFallback || finalFallback.provider !== fallback.provider) {
+          yield* port(() => ports.showInfo(modelsChanged));
+          return;
+        }
+      }
+      yield* port(() => snapshots.preload([streamId]));
+      const { config } = snapshots.getRunMetadata(streamId);
+      if (!config) {
+        yield* port(() =>
+          ports.showInfo(
+            `The settings for this run are no longer available. ${chooseAnotherModel}`,
+          ),
+        );
+        return;
+      }
+      const model = fallback.model;
+      const started = yield* apiKeyRetry.runCopilotFallbackWithRouting(
+        {
+          stream: streamId,
+          requestId,
+          provider: fallback.provider,
+          model,
+          exhaustionReason,
+          chatGptSubscriptionEligible: fallback.chatGptSubscriptionEligible,
+        },
+        async (copilotRouteOverride) => {
+          if (!isRetryPending(streamId, requestId)) return false;
+          // Start acknowledges ownership of the replacement run. Settlement
+          // without an onRun callback means no replacement was launched.
+          return new Promise<boolean>((resolve, reject) => {
+            void ports
+              .runExecutionRequest(
+                { config: { ...config, model } },
+                { copilotRouteOverride, onRun: () => resolve(true) },
+              )
+              .then(() => resolve(false), reject);
+          });
+        },
+      );
+      if (!started) return;
+      yield* port(() => settleRetry(streamId, requestId, { action: 'cancel' }));
+    },
+  );
 
   return {
     snapshotPort,
@@ -359,16 +372,15 @@ export function createHostRunActions(
         },
       );
     },
-    async useOwnApiKey(request) {
+    useOwnApiKey(request) {
       if (request.exhaustionReason === 'copilot-subscription') {
-        await copilotFallback(request);
-        return;
+        return copilotFallback(request);
       }
       const provider =
         request.provider != null && isApiProvider(request.provider)
           ? request.provider
           : undefined;
-      await apiKeyRetry.useOwnApiKey({
+      return apiKeyRetry.useOwnApiKey({
         stream: request.streamId,
         requestId: request.requestId,
         model: request.model ?? undefined,

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -1,13 +1,21 @@
 import { randomUUID } from 'node:crypto';
 
-import { Clock, Data, Duration, Effect, Fiber, Semaphore } from 'effect';
+import {
+  Clock,
+  Data,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Scope,
+  Semaphore,
+} from 'effect';
 import ky from 'ky';
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';
 import { createLog } from '@logger/logUtils';
 import type { ConfigProvider } from '@platform/interfaces';
-import { effectRuntime } from '@platform/processRuntime';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import type { UsageRoute } from '@shared/schemas';
 import {
@@ -212,10 +220,12 @@ class UsageBatchUndelivered extends Data.TaggedError('UsageBatchUndelivered')<{
 class UsageLogServiceImpl {
   private queue: QueuedUsageEntry[] = [];
   private retryBatch: RetryBatch | null = null;
-  /** The ticker that schedules the periodic flush, forked by `initialize`
-   *  and interrupted by `dispose`. It only schedules: each flush runs on a
-   *  fiber of its own, so interrupting the ticker never touches a send. */
-  private flushTimer: Fiber.Fiber<never> | null = null;
+  /** The scope the two schedulers live in: the periodic ticker and the
+   *  batch-size watcher. `initialize` opens it and `dispose` closes it, and
+   *  closing it interrupts both. Neither ever sends: each forks its flush
+   *  onto a fiber of its own, so closing this scope cannot land inside a
+   *  request that has already taken a batch. */
+  private timers: Scope.Closeable | null = null;
   /** One permit: batches leave in order, and disposal joins an active drain. */
   private readonly flushLane = Semaphore.makeUnsafe(1);
   /** Coalesce triggers before they wait for the lane; failed sends wait for
@@ -226,16 +236,33 @@ class UsageLogServiceImpl {
   private config: UsageLogConfig = { ...DEFAULT_CONFIG };
   private extensionVersion: string | undefined;
   private editorType: string | undefined;
+  /** The batch-size watcher's resume, while it is parked. `log` is
+   *  synchronous — the recorder runs inside an agent round, not inside an
+   *  Effect program — so this callback slot is how a full batch reaches a
+   *  fiber without a run of its own. */
+  private wake: (() => void) | null = null;
+  /** A wake that arrived while the watcher was busy, delivered on its next
+   *  park instead of being dropped. */
+  private wakePending = false;
 
-  initialize(
+  /**
+   * Adopt the host's batching configuration and start the schedulers.
+   *
+   * Run by the host at its bootstrap: the ticker and the batch-size watcher
+   * are forked here, so the process's one runtime owns them for the whole of
+   * their lives instead of `log()` forking a fiber per full batch.
+   */
+  readonly initialize = Effect.fn('UsageLogService.initialize')(function* (
+    this: UsageLogServiceImpl,
     config?: Partial<UsageLogConfig>,
     extensionVersion?: string,
     editorType?: string,
-  ): void {
+  ) {
+    yield* this.stopTimers();
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.extensionVersion = extensionVersion;
     this.editorType = editorType;
-    this.startFlushTimer();
+    yield* this.startSchedulers();
 
     if (isTelemetryDisabledByEnv()) {
       log.info(
@@ -246,7 +273,37 @@ class UsageLogServiceImpl {
     log.debug(
       `UsageLogService initialized (batchSize=${this.config.batchSize}, flushIntervalMs=${this.config.flushIntervalMs}, enabled=${this.config.enabled})`,
     );
+  });
+
+  /**
+   * Wake the batch-size watcher, or record that it is owed a wake.
+   *
+   * A trigger that arrives while a background flush is running is dropped,
+   * not queued: that flush's drain empties the queue this entry just joined,
+   * and a failed send must wait for a later trigger rather than be retried by
+   * the caller that was already waiting behind it.
+   */
+  private signalWake(): void {
+    if (this.backgroundFlushActive) return;
+    if (this.wake) this.wake();
+    else this.wakePending = true;
   }
+
+  /** Park until the next full batch. */
+  private readonly awaitWake = Effect.callback<void>((resume) => {
+    if (this.wakePending) {
+      this.wakePending = false;
+      resume(Effect.void);
+      return;
+    }
+    this.wake = () => {
+      this.wake = null;
+      resume(Effect.void);
+    };
+    return Effect.sync(() => {
+      this.wake = null;
+    });
+  });
 
   log(
     entry: Omit<UsageLogEntry, 'timestamp' | 'extensionVersion' | 'editorType'>,
@@ -274,9 +331,7 @@ class UsageLogServiceImpl {
     });
     log.debug(`Queued usage entry (queue size: ${this.queue.length})`);
 
-    if (this.queue.length >= this.config.batchSize) {
-      effectRuntime().runFork(this.backgroundFlush());
-    }
+    if (this.queue.length >= this.config.batchSize) this.signalWake();
   }
 
   /** Send every batch that is due, one after another, under the lane. */
@@ -474,46 +529,69 @@ class UsageLogServiceImpl {
     },
   );
 
-  private startFlushTimer(): void {
-    const runtime = effectRuntime();
-    if (this.flushTimer) runtime.runFork(Fiber.interrupt(this.flushTimer));
-    // The ticker lives until dispose() interrupts it, and it must not keep a
-    // short-lived host (the CLI) alive on its own: an active run keeps the
-    // loop running so the tick still fires, but at exit dispose() flushes and
-    // interrupts it rather than the ticker pinning the process. Its sleep
-    // therefore runs on `unrefSleepClock`; a host that never disposes exits
-    // on an empty loop as before, with whatever the queue holds unsent.
-    //
-    // Detached on purpose: a flush belongs to the lane, not to the tick that
-    // scheduled it. `sendNextBatch` takes the batch before the request goes
-    // out, and an interrupt landing there would abort the request without
-    // failing it, so nothing would requeue what was taken. Running the flush
-    // on its own fiber keeps a dispose (or re-initialize) that lands mid-send
-    // from reaching it: dispose waits behind the send on the lane instead.
-    // The flush ends with its drain and is observed by nothing else.
+  /** Close the schedulers' scope, interrupting both of them. */
+  private readonly stopTimers = Effect.fn('UsageLogService.stopTimers')(
+    function* (this: UsageLogServiceImpl) {
+      const scope = this.timers;
+      if (!scope) return;
+      this.timers = null;
+      yield* Scope.close(scope, Exit.void);
+    },
+  );
+
+  /**
+   * Fork the periodic ticker and the batch-size watcher into a scope of their
+   * own.
+   *
+   * The schedulers live until dispose() closes that scope, and they must not
+   * keep a short-lived host (the CLI) alive on their own: an active run keeps
+   * the loop running so the tick still fires, but at exit dispose() flushes
+   * and closes the scope rather than the ticker pinning the process. The tick
+   * therefore sleeps on `unrefSleepClock`; a host that never disposes exits
+   * on an empty loop as before, with whatever the queue holds unsent.
+   *
+   * Each scheduler forks its flush detached, on purpose: a flush belongs to
+   * the lane, not to the tick that scheduled it. `sendNextBatch` takes the
+   * batch before the request goes out, and an interrupt landing there would
+   * abort the request without failing it, so nothing would requeue what was
+   * taken. Running the flush on its own fiber keeps a dispose (or a
+   * re-initialize) that lands mid-send from reaching it: dispose waits behind
+   * the send on the lane instead.
+   */
+  private readonly startSchedulers = Effect.fn(
+    'UsageLogService.startSchedulers',
+  )(function* (this: UsageLogServiceImpl) {
+    const scope = yield* Scope.make();
+    this.timers = scope;
     const tick = Clock.clockWith((clock) =>
       Effect.sleep(Duration.millis(this.config.flushIntervalMs)).pipe(
         Effect.provideService(Clock.Clock, unrefSleepClock(clock)),
       ),
     );
-    this.flushTimer = runtime.runFork(
+    yield* Effect.forkIn(
       Effect.forever(
         tick.pipe(Effect.andThen(Effect.forkDetach(this.backgroundFlush()))),
       ),
+      scope,
+      { startImmediately: true },
     );
-  }
+    yield* Effect.forkIn(
+      Effect.forever(
+        this.awaitWake.pipe(
+          Effect.andThen(Effect.forkDetach(this.backgroundFlush())),
+        ),
+      ),
+      scope,
+      { startImmediately: true },
+    );
+  });
 
-  dispose(): Promise<void> {
-    return effectRuntime().runPromise(this.shutdown());
-  }
-
-  private readonly shutdown = Effect.fn('UsageLogService.dispose')(function* (
+  /** Stop the schedulers, refuse new rounds, and drain what is queued. Run
+   *  by the host on its shutdown path. */
+  readonly dispose = Effect.fn('UsageLogService.dispose')(function* (
     this: UsageLogServiceImpl,
   ) {
-    if (this.flushTimer) {
-      yield* Fiber.interrupt(this.flushTimer);
-      this.flushTimer = null;
-    }
+    yield* this.stopTimers();
     this.config.enabled = false;
 
     // An in-flight background flush is waited for without

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -137,9 +137,17 @@ vi.mock('@platform/defaults/nodeAgentRuntime', () => ({
   initNodeAgentRuntime: mocks.initNodeAgentRuntime,
 }));
 
-vi.mock('@telemetry/UsageLogService', () => ({
-  UsageLogService: { initialize: vi.fn(), dispose: vi.fn() },
-}));
+// The two lifecycle arms are Effects the host runs, so the doubles answer
+// with one rather than `undefined`.
+vi.mock('@telemetry/UsageLogService', async () => {
+  const { Effect: effect } = await import('effect');
+  return {
+    UsageLogService: {
+      initialize: vi.fn(() => effect.void),
+      dispose: vi.fn(() => effect.void),
+    },
+  };
+});
 
 // First-init dependencies: only exercised when tryPlatform() returns undefined.
 // Most cases keep tryPlatform truthy and skip this block, so these stubs are

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import pDefer from 'p-defer';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -51,8 +52,40 @@ interface HarnessOptions {
   restoreChatGptSubscription?(enabled: boolean): Promise<void>;
 }
 
+/**
+ * The controller behind its host's run edge: the three arms are Effects the
+ * host arm that took the request runs, so the harness runs them here.
+ */
+interface RetryControllerAtRunEdge {
+  useOwnApiKey(
+    ...args: Parameters<ProgressApiKeyRetryController['useOwnApiKey']>
+  ): Promise<void>;
+  ensureOwnApiKey(
+    ...args: Parameters<ProgressApiKeyRetryController['ensureOwnApiKey']>
+  ): Promise<boolean>;
+  runCopilotFallbackWithRouting(
+    ...args: Parameters<
+      ProgressApiKeyRetryController['runCopilotFallbackWithRouting']
+    >
+  ): Promise<boolean>;
+}
+
+/** Run each arm where its host would: at the host's request edge. */
+function atRunEdge(
+  controller: ProgressApiKeyRetryController,
+): RetryControllerAtRunEdge {
+  return {
+    useOwnApiKey: (...args) =>
+      Effect.runPromise(controller.useOwnApiKey(...args)),
+    ensureOwnApiKey: (...args) =>
+      Effect.runPromise(controller.ensureOwnApiKey(...args)),
+    runCopilotFallbackWithRouting: (...args) =>
+      Effect.runPromise(controller.runCopilotFallbackWithRouting(...args)),
+  };
+}
+
 function createHarness(options: HarnessOptions = {}): {
-  controller: ProgressApiKeyRetryController;
+  controller: RetryControllerAtRunEdge;
   keys: Map<ApiProvider, string | undefined>;
   prompts: Array<ApiProvider | undefined>;
   chatGptSubscriptionValues: boolean[];
@@ -85,73 +118,75 @@ function createHarness(options: HarnessOptions = {}): {
     kimiCodeValues,
     grokSubscriptionValues,
     retries,
-    controller: new ProgressApiKeyRetryController({
-      providers: PROVIDERS,
-      readKey: async (provider) => keys.get(provider),
-      hasUsableKey: async (provider) =>
-        (keys.get(provider)?.trim().length ?? 0) > 0,
-      promptForApiKey: async (provider) => {
-        prompts.push(provider);
-        options.prompt?.(keys);
-      },
-      quotaFallbackRuntimes: [
-        testRuntime(
-          {
-            id: 'chatgpt',
-            exhaustionReason: 'chatgpt-subscription',
-            fallbackApiProvider: 'openai',
-          },
-          () => preferChatGptSubscription,
-          async (enabled) => {
-            preferChatGptSubscription = enabled;
-            chatGptSubscriptionValues.push(enabled);
-          },
-          options.restoreChatGptSubscription,
-        ),
-        testRuntime(
-          {
-            id: 'grok',
-            exhaustionReason: 'xai-subscription',
-            fallbackApiProvider: 'xai',
-          },
-          () => preferGrokSubscription,
-          async (enabled) => {
-            preferGrokSubscription = enabled;
-            grokSubscriptionValues.push(enabled);
-          },
-        ),
-        testRuntime(
-          {
-            id: 'glmCodingPlan',
-            exhaustionReason: 'glm-coding-plan',
-          },
-          () => glmCodingPlan,
-          async (enabled) => {
-            glmCodingPlan = enabled;
-            glmCodingPlanValues.push(enabled);
-          },
-        ),
-        testRuntime(
-          {
-            id: 'kimiCode',
-            exhaustionReason: 'kimi-code-subscription',
-          },
-          () => kimiCode,
-          async (enabled) => {
-            kimiCode = enabled;
-            kimiCodeValues.push(enabled);
-          },
-        ),
-      ],
-      isRetryPending:
-        options.isRetryPending ?? (() => options.retryPending ?? true),
-      triggerRetry:
-        options.triggerRetry ??
-        ((stream) => {
-          retries.push(stream);
-          return options.retryAvailable ?? true;
-        }),
-    }),
+    controller: atRunEdge(
+      new ProgressApiKeyRetryController({
+        providers: PROVIDERS,
+        readKey: async (provider) => keys.get(provider),
+        hasUsableKey: async (provider) =>
+          (keys.get(provider)?.trim().length ?? 0) > 0,
+        promptForApiKey: async (provider) => {
+          prompts.push(provider);
+          options.prompt?.(keys);
+        },
+        quotaFallbackRuntimes: [
+          testRuntime(
+            {
+              id: 'chatgpt',
+              exhaustionReason: 'chatgpt-subscription',
+              fallbackApiProvider: 'openai',
+            },
+            () => preferChatGptSubscription,
+            async (enabled) => {
+              preferChatGptSubscription = enabled;
+              chatGptSubscriptionValues.push(enabled);
+            },
+            options.restoreChatGptSubscription,
+          ),
+          testRuntime(
+            {
+              id: 'grok',
+              exhaustionReason: 'xai-subscription',
+              fallbackApiProvider: 'xai',
+            },
+            () => preferGrokSubscription,
+            async (enabled) => {
+              preferGrokSubscription = enabled;
+              grokSubscriptionValues.push(enabled);
+            },
+          ),
+          testRuntime(
+            {
+              id: 'glmCodingPlan',
+              exhaustionReason: 'glm-coding-plan',
+            },
+            () => glmCodingPlan,
+            async (enabled) => {
+              glmCodingPlan = enabled;
+              glmCodingPlanValues.push(enabled);
+            },
+          ),
+          testRuntime(
+            {
+              id: 'kimiCode',
+              exhaustionReason: 'kimi-code-subscription',
+            },
+            () => kimiCode,
+            async (enabled) => {
+              kimiCode = enabled;
+              kimiCodeValues.push(enabled);
+            },
+          ),
+        ],
+        isRetryPending:
+          options.isRetryPending ?? (() => options.retryPending ?? true),
+        triggerRetry:
+          options.triggerRetry ??
+          ((stream) => {
+            retries.push(stream);
+            return options.retryAvailable ?? true;
+          }),
+      }),
+    ),
   };
 }
 

--- a/src/test-kernel/controllers/session/hostDraftRequests.vitest.ts
+++ b/src/test-kernel/controllers/session/hostDraftRequests.vitest.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect } from 'effect';
 import pDefer from 'p-defer';
 import { expect, it, vi } from 'vitest';
 
@@ -28,12 +29,15 @@ it('returns transcription to Start when another paper stops the process recorder
     text: 'A conserved quantity.',
   });
   const requests = new HostDraftRequests();
+  /** The host's run edge: every arm answers where the host took the request. */
+  const handle = (...args: Parameters<HostDraftRequests['handle']>) =>
+    Effect.runPromise(requests.handle(...args));
   const first = { roots: { storage: '/papers/first' } } as SessionHandle;
   const second = { roots: { storage: '/papers/second' } } as SessionHandle;
   const snapshot = vi.fn();
   const unsubscribe = requests.subscribe(snapshot);
 
-  const started = requests.handle(
+  const started = handle(
     first,
     {
       kind: 'record',
@@ -42,7 +46,7 @@ it('returns transcription to Start when another paper stops the process recorder
     'origin',
   );
   await expect(
-    requests.handle(
+    handle(
       second,
       {
         kind: 'record',
@@ -57,11 +61,7 @@ it('returns transcription to Start when another paper stops the process recorder
   });
 
   await expect(
-    requests.handle(
-      second,
-      { kind: 'record', action: { kind: 'stop' } },
-      'other',
-    ),
+    handle(second, { kind: 'record', action: { kind: 'stop' } }, 'other'),
   ).resolves.toEqual({ kind: 'done' });
   expect(audio.stopRecordingAndTranscribe).not.toHaveBeenCalled();
   startup.resolve({ success: true });
@@ -75,7 +75,7 @@ it('returns transcription to Start when another paper stops the process recorder
 
   const nextStartup = pDefer<{ success: boolean }>();
   audio.startRecording.mockReturnValueOnce(nextStartup.promise);
-  const nextTake = requests.handle(
+  const nextTake = handle(
     first,
     {
       kind: 'record',

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
@@ -1,6 +1,7 @@
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { StreamTabId } from '@shared/schemas';
@@ -130,8 +131,8 @@ describe('desktop preview host', () => {
       shell.openExternal.mockRejectedValue(new Error('Browser unavailable'));
       const preview = createDesktopPreviewHost({ shell });
       const draftRequests = new HostDraftRequests();
-      vi.spyOn(draftRequests, 'handle').mockRejectedValue(
-        new Error('Text service unavailable'),
+      vi.spyOn(draftRequests, 'handle').mockReturnValue(
+        Effect.fail(new Error('Text service unavailable')),
       );
       const files = createDesktopFileSelection({
         workspacePath: undefined,

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -10,6 +10,7 @@ import {
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import * as logger from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import { AgentCategory, TELEMETRY_ENABLED_KEY } from '@shared/schemas';
 import { UsageLogService } from '@telemetry/UsageLogService';
@@ -72,10 +73,19 @@ function stubBatchFetch(
   return { batches, fetchMock: stubFetch(batches, beforeRespond) };
 }
 
+/** The host's run edge: the two lifecycle arms answer where the host runs. */
+const initialize = (
+  ...args: Parameters<typeof UsageLogService.initialize>
+): Promise<void> =>
+  effectRuntime().runPromise(UsageLogService.initialize(...args));
+
+const dispose = (): Promise<void> =>
+  effectRuntime().runPromise(UsageLogService.dispose());
+
 describe('UsageLogService', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-    UsageLogService.initialize({
+    await initialize({
       batchSize: 1,
       flushIntervalMs: 60_000,
       enabled: true,
@@ -83,7 +93,7 @@ describe('UsageLogService', () => {
   });
 
   afterEach(async () => {
-    await UsageLogService.dispose();
+    await dispose();
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
@@ -130,7 +140,7 @@ describe('UsageLogService', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     UsageLogService.log(usageEntry('second'));
-    const disposal = UsageLogService.dispose();
+    const disposal = dispose();
 
     releaseFirstFetch();
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
@@ -155,7 +165,7 @@ describe('UsageLogService', () => {
   // had already taken from the queue.
   it('waits for a timer-driven flush during disposal instead of aborting it', async () => {
     stubAccessToken();
-    UsageLogService.initialize({
+    await initialize({
       batchSize: 100,
       flushIntervalMs: 20,
       enabled: true,
@@ -170,7 +180,7 @@ describe('UsageLogService', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     const request = fetchMock.mock.calls[0]?.[0] as Request;
 
-    const disposal = UsageLogService.dispose();
+    const disposal = dispose();
     let disposed = false;
     void disposal.then(() => {
       disposed = true;
@@ -190,10 +200,10 @@ describe('UsageLogService', () => {
   // that reaches initialize() and exits without dispose() still exits on an
   // empty loop, so the ticker's timer is unref'd while the request a flush
   // sends holds the loop on its own.
-  it('schedules the ticker on a timer that does not hold the event loop', () => {
+  it('schedules the ticker on a timer that does not hold the event loop', async () => {
     vi.useRealTimers();
     const timers = vi.spyOn(globalThis, 'setTimeout');
-    UsageLogService.initialize({
+    await initialize({
       batchSize: 100,
       flushIntervalMs: 12_345,
       enabled: true,
@@ -217,7 +227,7 @@ describe('UsageLogService', () => {
     UsageLogService.log(usageEntry('slow'));
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
-    const disposal = UsageLogService.dispose();
+    const disposal = dispose();
     let disposed = false;
     void disposal.then(() => {
       disposed = true;
@@ -408,7 +418,7 @@ describe('UsageLogService', () => {
     // queued under the old value rather than letting the next flush ship them.
     it('discards entries queued before the setting was turned off', async () => {
       stubAccessToken();
-      UsageLogService.initialize({ batchSize: 100, flushIntervalMs: 60_000 });
+      await initialize({ batchSize: 100, flushIntervalMs: 60_000 });
 
       const { batches, fetchMock } = stubBatchFetch();
 
@@ -481,7 +491,7 @@ describe('UsageLogService', () => {
 
     it('drops optional entries from a batch but keeps the accounted ones', async () => {
       stubAccessToken();
-      UsageLogService.initialize({ batchSize: 100, flushIntervalMs: 60_000 });
+      await initialize({ batchSize: 100, flushIntervalMs: 60_000 });
 
       const { batches, fetchMock } = stubBatchFetch();
 


### PR DESCRIPTION
## Summary

Lane w7 of the Effect 4 migration, rebuilt on current `main` under the second ruling ("fully embrace Effect; no pass-throughs, no adapters"). Four files below the R1 boundary each held their own `effectRuntime()` call; all four are now **zero**, and the runs live at host entries where R1 puts them.

| File | `Effect.run*` before | after |
|---|---|---|
| `src/telemetry/UsageLogService.ts` | 4 | **0** |
| `src/controllers/progressView/ProgressApiKeyRetryController.ts` | 3 | **0** |
| `src/controllers/onboarding/OnboardingRefreshQueue.ts` | 1 | **0** |
| `src/controllers/session/hostDraftRequests.ts` | 1 | **0** |

The `Effect.run*` row drops **14 files / 35 sites → 10 files / 26 sites**, and the baseline diff is **deletion-only**: 8 lines removed, 0 added, across the row and its `debtLanes` register. No file was moved below the boundary to get there.

**`UsageLogService` is the substantive change.** Its per-batch `effectRuntime().runFork()` in `log()` is gone. `initialize` now opens a `Scope` and forks two long-lived schedulers into it — the existing periodic ticker, plus a batch-size watcher parked on `Effect.callback` — and `dispose` closes that scope, interrupting both. `log()` stays synchronous (the recorder runs inside an agent round, not inside an Effect program) and only signals the watcher through a callback slot. That is what lets a `src/telemetry` module reach a fiber without owning a run of its own.

Both the ticker and the watcher fork their flush **detached**, unchanged from before and for the same reason: `sendNextBatch` takes the batch before the request goes out, so an interrupt landing there would abort the request without failing it and nothing would requeue what was taken. `dispose` waits behind the send on the lane instead of interrupting it.

**`ProgressApiKeyRetryController` pulled one more file with it.** Its only production caller is `hostRunActions.ts`, which is itself below the boundary and is capped at 1 run (lane D's `settleRetry`). Converting the controller without converting `copilotFallback` and the `useOwnApiKey` arm would have parked a new run there — widening a row to shrink another. Both arms are Effect now, `HostRunActions.useOwnApiKey` returns an Effect, and `hostRunActions.ts` stays at **exactly 1** site.

**`OnboardingRefreshQueue`**'s `run()` returns an Effect, latched inside `Effect.suspend` so an unrun program owes no rerun. `main` already pairs that latch with a per-instance captured refresh; I kept and documented that pairing rather than reintroducing a module-level latch, which is what the pre-rebuild branch's design would have needed.

**`HostDraftRequests.handle`** is now the `Effect.fn` itself — the `runPromise` pass-through that wrapped it is deleted, not re-pointed.

## Issue acceptance gates

No issue is closed. **R1**: every new run is kind (a), a host entry — `extension.ts`, `desktop/main/platform/index.ts`, `cli/runtime/initPlatform.ts`, the two host request handlers, `ProgressViewProvider.ts`, `desktopOnboardingIpc.ts`. **R6 (Scope)**: the two schedulers are scope-owned; closing the scope interrupts both, which the nullable-`Fiber` field could only do for one. **R7**: no error identity changed. **R8**: no clock change — the ticker keeps `unrefSleepClock` so it still never pins a short-lived CLI. **R10**: the `runFork` in `log()`, the `flushTimer` field, and the `dispose`/`shutdown` `runPromise` wrapper are deleted, not kept beside their replacements.

## Single source of truth

`UsageLogService` owns its own scheduling for the first time: previously the *cadence* lived in the ticker but the *batch-size trigger* lived in `log()`'s call site, forking through a runtime the service reached for itself. Both now sit in `startSchedulers`. The hosts own when the service starts and stops, and nothing else.

`src/controllers/effectPort.ts` (added in `4084d04`, see below) owns the host-port identity catch, which three files in this subsystem previously defined for themselves.

## Duplication and abstraction budget

Removed: one nullable-`Fiber` lifecycle field hand-managed across three methods, one `runPromise` pass-through method (`dispose` → `shutdown`), four `effectRuntime()` reaches from below the boundary, and — after review — **three copies of the host-port identity-catch helper** plus a fourth written inline.

Added: `signalWake`/`awaitWake`, a two-member pair that exists because `log()` is synchronous by contract; it replaces the `runFork` that was doing the same job less safely, rather than layering over it. And one new module, `src/controllers/effectPort.ts`, whose whole purpose is to delete the duplication described next.

*This section originally read "Added: nothing new." That was wrong, and it is the kind of wrong the section exists to prevent — I had added a fourth copy of an existing two-line helper while claiming the abstraction budget was untouched. Corrected below.*

## Corrections after review

**The host-port helper was duplicated four ways** (`4084d04`). `claude[bot]` flagged that `hostRunActions.ts`'s `port` is a verbatim duplicate of `ProgressApiKeyRetryController.ts`'s. Grepping the pattern rather than the two named files found it is worse: `hostDraftRequests.ts:39` and `packages/cli/src/runtime/initPlatform.ts:95` carry the same body under the name `tryPromise`, and `ProgressApiKeyRetryController`'s restore finalizer had a fifth instance inline. Only the `hostRunActions.ts` copy is this branch's; the other three predate it, which does not make adding a fourth right.

`src/controllers/effectPort.ts` now holds the one definition, taking the more general of the two signatures that existed (the callback may be synchronous or return a promise, so it subsumes both and catches a synchronous throw the same way as a rejection). 19 call sites across the three `src/controllers/` files go through it.

**One copy stays, deliberately.** `packages/cli/src/runtime/initPlatform.ts` keeps its own: it is a host, not a controller, and having a host reach into `src/controllers/` for a two-line utility is a worse trade than the duplication it removes. `src/utils/` would have been the neutral home, but it is effectively closed — `check-browser-safe-utils.mjs` pins the module total against numbers documented in both AGENTS.md and CLAUDE.md, so adding a file there means editing three documents to land a two-line function.

## Net elements (R6)

Files: 19 changed (14 production, 5 test). Exports: **1 added** (`hostPort`, with 19 consumers in the same PR), 0 removed; three file-local helpers deleted. `UsageLog.initialize` and `.dispose` change from `void`/`Promise<void>` to Effects; `HostDraftRequests.handle`, `OnboardingRefreshQueue.run`, the three `ProgressApiKeyRetryController` arms and `HostRunActions.useOwnApiKey` likewise — all consumers converted in this PR. Dependencies: none added or removed. Knip: 283 combined vs 283 baselined, unchanged by the new export.

## Consumer counts (R8)

No emit path changes. `UsageLog.initialize`/`dispose`: 3 hosts, 6 call sites (bootstrap + shutdown each), all now run edges. `ProgressApiKeyRetryController`: 1 production caller (`hostRunActions.ts`). `HostRunActions.useOwnApiKey`: 2 production callers (`desktopHostRequests.ts`, `extensionHostRequests.ts`), both run edges. `HostDraftRequests.handle` and `OnboardingRefreshQueue.run`: the same two host handlers plus `ProgressViewProvider`/`desktopOnboardingIpc`. `hostPort`: 19 call sites across `hostRunActions.ts` (7), `ProgressApiKeyRetryController.ts` (8), `hostDraftRequests.ts` (4).

No `effect` import was added to a host file absent from the `catch:effect-importer` row — `extensionHostRequests.ts`, `desktopOnboardingIpc.ts`, `extension.ts` and `initPlatform.ts` reach the runtime through `effectRuntime()` only. That row is unchanged at 28 files / 74 sites.

## Host impact

All three hosts gain run edges at existing entry points; none gains a new entry point. **Extension**: `activate` and `afterAgentShutdown`. **Desktop**: bootstrap and `SHUTDOWN_PHASE.BEFORE`, plus `desktopHostRequests`/`desktopOnboardingIpc`. **CLI**: init and `afterFlushArtifacts`. Behaviour is unchanged with one narrowing: closing the scheduler scope now interrupts the batch-size watcher as well as the ticker, where before only the ticker was tracked.

## Scheduled refactoring

The ten files still on the `Effect.run*` row keep their named lanes; nothing here was deferred into a new one. `hostRunActions.ts`'s last site (`settleRetry`) and `sessionLayer`/`SessionBridge` remain lane D's. The CLI's remaining `tryPromise` copy is the one open thread from the consolidation above, left for whoever decides where a host-and-controller-shared Effect utility should live.

## Validation

Run by hand on the current head (`4084d04`), with `origin/main` at `1fd5932a29` (0 merge conflicts):

- `npm run typecheck` — all six projects, exit 0.
- `npm run lint` — exit 0. `npm run format:check` — clean.
- `npx vitest run src/test-kernel/{controllers,telemetry,desktop,cli}` — **215 files, 2893 passed, 1 pre-existing skip**, exit 0.
- `node scripts/check-effect-migration-ratchet.mjs` — exit 0, "no count grew, no baseline headroom"; no `@adapter-until` markers. `Effect.run*` at 10/26; every other row byte-identical.
- `npm run check:dead-code-ratchet` — 283 vs 283, no new findings.

The same set was run on `564812d` before the consolidation commit; CI on that head was green across static checks, kernel shard 1, build artifacts, webview smoke and guidance references.

One test needed a service-side fix rather than a test-side one, and it is worth naming. Replacing the per-batch `runFork` with a watcher fiber adds a scheduling hop, which broke `discards a permanent rejection and continues with later entries` (3 fetches, expected 2): a trigger arriving during an in-flight flush could land after that flush's drain ended and start a second. The fix is in `signalWake`, which drops a trigger while `backgroundFlushActive` — the same coalescing the old `runFork` path got for free from `backgroundFlush`'s own re-entry guard. The assertion passes unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyJjcnpYcFopcGbYdWayxp