### PR TITLE
refactor(github): run the subscription poll plane on an Effect-typed subscribe path

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -173,7 +173,6 @@
       "src/shared/signals.ts": 2,
       "src/telemetry/UsageLogService.ts": 4,
       "src/tools/agentCliSessionRegistry.ts": 2,
-      "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/lean/direct/directLspAdapter.ts": 3
     },
     "catch:effect-importer": {
@@ -200,7 +199,7 @@
       "src/common/errors/sdkError/errorInspection.ts": 1,
       "src/common/errors/sdkError/providerErrorFormat.ts": 2,
       "src/tools/arxiv/ArxivSearchTool.ts": 1,
-      "src/tools/github/PollingSourceBase.ts": 2,
+      "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/lean/direct/leanServer.ts": 1,
       "src/tools/web/WebFetchTool.ts": 2,
       "src/tools/zotero/bbtClient.ts": 1,
@@ -220,7 +219,6 @@
     "src/shared/signals.ts": "lane D — host composition root and session graph",
     "src/telemetry/UsageLogService.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/tools/agentCliSessionRegistry.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
-    "src/tools/github/PollingSourceBase.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — the port is Effect-typed and the tool-facing runs moved to the tools' execute(); what remains is pool construction/disposal (the platform-lifetime seam) and the run-end hook's Promise seam, both owned by lane D"
   }
 }

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -4,8 +4,9 @@
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 const submitFollowUpMock = vi.hoisted(() =>
   vi.fn(async () => ({ status: 'sent' as const })),
@@ -18,6 +19,7 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 // Local imports
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { appSignals, type AppSignalPayloads } from '@eventBus/AppSignals';
+import { effectRuntime } from '@platform/processRuntime';
 import type { StreamTabId } from '@shared/schemas';
 
 // Test support imports
@@ -26,6 +28,7 @@ import { GitHubAuthError } from '@tools/github/githubClient';
 import {
   PollingSourceBase,
   type BasePollSubscriptionState,
+  type PollEventListener,
   type PollHookRejected,
 } from '@tools/github/PollingSourceBase';
 import {
@@ -84,8 +87,8 @@ class TestPollingSource extends PollingSourceBase<
     return 'subscription error';
   }
 
-  failWithAuthError(state: BasePollSubscriptionState): void {
-    this.handleFailure(
+  failWithAuthError(state: BasePollSubscriptionState): Effect.Effect<void> {
+    return this.handleFailure(
       'owner/repo',
       state,
       new GitHubAuthError('bad token'),
@@ -93,15 +96,23 @@ class TestPollingSource extends PollingSourceBase<
     );
   }
 
-  failWithTransient(key: string, state: BasePollSubscriptionState): void {
-    this.handleFailure(key, state, new Error('network down'), Date.now());
+  failWithTransient(
+    key: string,
+    state: BasePollSubscriptionState,
+  ): Effect.Effect<void> {
+    return this.handleFailure(
+      key,
+      state,
+      new Error('network down'),
+      Date.now(),
+    );
   }
 }
 
 class RegistryTestSource {
   private readonly keys = new Set<string>();
   private readonly keyListeners = new Set<(keys: readonly string[]) => void>();
-  private readonly onEventByKey = new Map<string, (text: string) => void>();
+  private readonly onEventByKey = new Map<string, PollEventListener>();
 
   activeKeys(): readonly string[] {
     return [...this.keys];
@@ -116,22 +127,30 @@ class RegistryTestSource {
 
   subscribe(
     input: string,
-    onEvent: (text: string) => void,
-  ): { dispose(): void } {
-    this.keys.add(input);
-    this.onEventByKey.set(input, onEvent);
-    this.emitKeysChanged();
-    return {
-      dispose: () => {
-        this.keys.delete(input);
-        this.onEventByKey.delete(input);
-        this.emitKeysChanged();
-      },
-    };
+    onEvent: PollEventListener,
+  ): Effect.Effect<{ dispose(): void }> {
+    return Effect.suspend(() => {
+      this.keys.add(input);
+      this.onEventByKey.set(input, onEvent);
+      this.emitKeysChanged();
+      return Effect.succeed({
+        dispose: () => {
+          this.keys.delete(input);
+          this.onEventByKey.delete(input);
+          this.emitKeysChanged();
+        },
+      });
+    });
   }
 
-  emit(input: string, text: string): void {
-    this.onEventByKey.get(input)?.(text);
+  /**
+   * Deliver one event the way `PollingSourceBase.emitToListener` does: the
+   * listener builds its delivery program on this turn, then the program runs.
+   * Awaiting the program keeps the assertions below deterministic.
+   */
+  async emit(input: string, text: string): Promise<void> {
+    const listener = this.onEventByKey.get(input);
+    if (listener) await effectRuntime().runPromise(listener(text));
   }
 
   private emitKeysChanged(): void {
@@ -146,13 +165,15 @@ describe('GitHub subscription app signals and follow-ups', () => {
     submitFollowUpMock.mockResolvedValue({ status: 'sent' as const });
   });
 
-  it('publishes githubSubscriptionsChanged through app signals', () => {
+  it('publishes githubSubscriptionsChanged through app signals', async () => {
     const signal = recordAppSignal('githubSubscriptionsChanged');
     const source = new RegistryTestSource();
     const registry = createTestRegistry(source);
 
     try {
-      registry.bind('stream-a' as StreamTabId, 'owner/repo');
+      await effectRuntime().runPromise(
+        registry.bind('stream-a' as StreamTabId, 'owner/repo'),
+      );
       expect(signal.events).toEqual([
         { event: 'githubSubscriptionsChanged', payload: undefined },
       ]);
@@ -168,65 +189,71 @@ describe('GitHub subscription app signals and follow-ups', () => {
     }
   });
 
-  it('reports token invalid events through app signals', () => {
-    const host = createRecordingHost();
-    const signal = recordAppSignal('githubTokenInvalid');
-    const listener = () => {};
-    const state: BasePollSubscriptionState = {
-      listeners: new Set([listener]),
-      lastSuccessAt: Date.now(),
-      consecutiveFailures: 0,
-      skipPollUntilMs: 0,
-    };
+  it.effect('reports token invalid events through app signals', () =>
+    Effect.gen(function* () {
+      const host = createRecordingHost();
+      const signal = recordAppSignal('githubTokenInvalid');
+      const listener = (): Effect.Effect<void> => Effect.void;
+      const state: BasePollSubscriptionState = {
+        listeners: new Set([listener]),
+        lastSuccessAt: Date.now(),
+        consecutiveFailures: 0,
+        skipPollUntilMs: 0,
+      };
 
-    try {
-      new TestPollingSource().failWithAuthError(state);
+      try {
+        yield* new TestPollingSource().failWithAuthError(state);
 
-      expect(signal.events).toContainEqual({
-        event: 'githubTokenInvalid',
-        payload: { message: 'bad token' },
+        expect(signal.events).toContainEqual({
+          event: 'githubTokenInvalid',
+          payload: { message: 'bad token' },
+        });
+        expect(host.events).toEqual([]);
+      } finally {
+        signal.dispose();
+      }
+    }),
+  );
+
+  it.effect('tracks transient backoff independently per subscription', () =>
+    Effect.gen(function* () {
+      const now = 1_800_000_000_000;
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const createState = (): BasePollSubscriptionState => ({
+        listeners: new Set(),
+        lastSuccessAt: now,
+        consecutiveFailures: 0,
+        skipPollUntilMs: 0,
       });
-      expect(host.events).toEqual([]);
-    } finally {
-      signal.dispose();
-    }
-  });
+      const source = new TestPollingSource();
+      const first = createState();
+      const second = createState();
 
-  it('tracks transient backoff independently per subscription', () => {
-    const now = 1_800_000_000_000;
-    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
-    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
-    const createState = (): BasePollSubscriptionState => ({
-      listeners: new Set(),
-      lastSuccessAt: now,
-      consecutiveFailures: 0,
-      skipPollUntilMs: 0,
-    });
-    const source = new TestPollingSource();
-    const first = createState();
-    const second = createState();
+      try {
+        yield* source.failWithTransient('owner/repo#1', first);
+        yield* source.failWithTransient('owner/repo#1', first);
+        yield* source.failWithTransient('owner/repo#2', second);
 
-    try {
-      source.failWithTransient('owner/repo#1', first);
-      source.failWithTransient('owner/repo#1', first);
-      source.failWithTransient('owner/repo#2', second);
+        expect(first.skipPollUntilMs).toBe(now + 2_000);
+        expect(second.skipPollUntilMs).toBe(now + 1_000);
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+      }
+    }),
+  );
 
-      expect(first.skipPollUntilMs).toBe(now + 2_000);
-      expect(second.skipPollUntilMs).toBe(now + 1_000);
-    } finally {
-      nowSpy.mockRestore();
-      randomSpy.mockRestore();
-    }
-  });
-
-  it('emits one binding change when unsubscribe disposes synchronously', () => {
+  it('emits one binding change when unsubscribe disposes synchronously', async () => {
     const host = createRecordingHost();
     const signal = recordAppSignal('githubSubscriptionsChanged');
     const source = new RegistryTestSource();
     const registry = createTestRegistry(source);
 
     try {
-      registry.bind('stream-a' as StreamTabId, 'owner/repo');
+      await effectRuntime().runPromise(
+        registry.bind('stream-a' as StreamTabId, 'owner/repo'),
+      );
       host.events.length = 0;
       signal.events.length = 0;
 
@@ -243,7 +270,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
     }
   });
 
-  it('passes the bind-time session to detached subscription follow-ups', () => {
+  it('passes the bind-time session to detached subscription follow-ups', async () => {
     const streamId = 'stream-a' as StreamTabId;
     const source = new RegistryTestSource();
     const session = createTestSession();
@@ -251,15 +278,11 @@ describe('GitHub subscription app signals and follow-ups', () => {
     const registry = createTestRegistry(source);
 
     try {
-      withRunContext(
-        createRunContext({
-          streamId,
-          session,
-        }),
-        () => registry.bind(streamId, 'owner/repo'),
+      await withRunContext(createRunContext({ streamId, session }), () =>
+        effectRuntime().runPromise(registry.bind(streamId, 'owner/repo')),
       );
 
-      source.emit('owner/repo', 'new github event');
+      await source.emit('owner/repo', 'new github event');
 
       expect(submitFollowUpMock).toHaveBeenCalledWith(
         streamId,
@@ -271,7 +294,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
     }
   });
 
-  it('rebinds an existing subscription to the session that rebound it', () => {
+  it('rebinds an existing subscription to the session that rebound it', async () => {
     const streamId = 'stream-a' as StreamTabId;
     const source = new RegistryTestSource();
     const firstSession = createTestSession();
@@ -281,16 +304,16 @@ describe('GitHub subscription app signals and follow-ups', () => {
     const registry = createTestRegistry(source);
 
     try {
-      withRunContext(
+      await withRunContext(
         createRunContext({ streamId, session: firstSession }),
-        () => registry.bind(streamId, 'owner/repo'),
+        () => effectRuntime().runPromise(registry.bind(streamId, 'owner/repo')),
       );
-      withRunContext(
+      await withRunContext(
         createRunContext({ streamId, session: secondSession }),
-        () => registry.bind(streamId, 'owner/repo'),
+        () => effectRuntime().runPromise(registry.bind(streamId, 'owner/repo')),
       );
 
-      source.emit('owner/repo', 'new github event');
+      await source.emit('owner/repo', 'new github event');
 
       expect(submitFollowUpMock).toHaveBeenCalledWith(
         streamId,
@@ -316,10 +339,11 @@ describe('GitHub subscription app signals and follow-ups', () => {
 
     try {
       process.once('unhandledRejection', unhandledRejection);
-      registry.bind(streamId, 'owner/repo');
+      await effectRuntime().runPromise(registry.bind(streamId, 'owner/repo'));
 
-      source.emit('owner/repo', 'new github event');
-      await new Promise((resolve) => setImmediate(resolve));
+      // emit() awaits the delivery program, so the recovery has run by the
+      // time it resolves — no settle-and-hope.
+      await source.emit('owner/repo', 'new github event');
 
       expect(unhandledRejection).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(

--- a/src/test-kernel/tools/PRPollingSource.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSource.vitest.ts
@@ -155,9 +155,15 @@ describe('PRPollingSource annotation drain', () => {
     const source = createDrainSource();
     const run = createCheckRun(12);
     const state = createDrainState([run]);
-    const defaultListener = vi.fn();
-    const warningListener = vi.fn();
-    const noticeListener = vi.fn();
+    const defaultListener = vi.fn<(text: string) => Effect.Effect<void>>(
+      () => Effect.void,
+    );
+    const warningListener = vi.fn<(text: string) => Effect.Effect<void>>(
+      () => Effect.void,
+    );
+    const noticeListener = vi.fn<(text: string) => Effect.Effect<void>>(
+      () => Effect.void,
+    );
     state.listeners.add(defaultListener);
     state.listeners.add(warningListener);
     state.listeners.add(noticeListener);
@@ -199,8 +205,10 @@ describe('PRPollingSource annotation drain', () => {
   it('updates the annotation level for an existing listener', async () => {
     const source = new PRPollingSource();
     const pr = { owner: 'owner', repo: 'repo', pullNumber: 7 };
-    const listener = vi.fn();
-    const disposable = source.subscribe(pr, listener);
+    const listener = vi.fn<(text: string) => Effect.Effect<void>>(
+      () => Effect.void,
+    );
+    const disposable = await Effect.runPromise(source.subscribe(pr, listener));
     const key = prKeyToString(pr);
     const state = drainAccess(source).getSubscriptionState(key);
     if (!state) throw new Error('Expected subscription state');

--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -28,7 +28,12 @@ function createState(
   events: string[],
   overrides: Partial<PRSubscriptionState> = {},
 ): PRSubscriptionState {
-  const listener = (text: string) => events.push(text);
+  const listener = (text: string): Effect.Effect<void> => {
+    // Record on the emit turn (PollEventListener's synchronous phase); there
+    // is no deferred delivery to run.
+    events.push(text);
+    return Effect.void;
+  };
   return createPRSubscriptionState({
     listeners: new Set([listener]),
     currentShaState: createPRCurrentShaState(SHA),

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_POLLING_BACKOFF_CONFIG,
   dedupeComments,
   type DedupedResource,
+  type PollEventListener,
   type PollHookRejected,
   PollingSourceBase,
   pollRequest,
@@ -92,7 +93,10 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
     });
   }
 
-  subscribe(issue: IssueKey, onEvent: (text: string) => void): Disposable {
+  subscribe(
+    issue: IssueKey,
+    onEvent: PollEventListener,
+  ): Effect.Effect<Disposable> {
     const key = issueKeyToString(issue);
     return this.register(key, () => createInitialState(issue), onEvent);
   }
@@ -154,12 +158,12 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
           // failsafe. Bound by `maxConcurrent`.
           if (state.initialized && state.state !== newState) {
             if (state.state === 'open' && newState === 'closed') {
-              this.emit(
+              yield* this.emit(
                 state,
                 formatIssueClosed(state.slug, issue.issueNumber, issueData),
               );
             } else if (state.state === 'closed') {
-              this.emit(
+              yield* this.emit(
                 state,
                 formatIssueReopened(state.slug, issue.issueNumber, issueData),
               );
@@ -186,7 +190,7 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
           `Skipping comments tick for ${state.slug}#${issue.issueNumber}: malformed comments payload`,
         );
         if (parsedComments) {
-          this.consumeCommentList(
+          yield* this.consumeCommentList(
             parsedComments,
             (etag) => {
               state.etags.comments = etag;

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -66,6 +66,7 @@ import {
   dedupeComments,
   DedupedResource,
   MAX_SEEN_IDS,
+  type PollEventListener,
   type PollHookRejected,
   PollingSourceBase,
   pollRequest,
@@ -147,10 +148,7 @@ export interface PRSubscriptionState extends BasePollSubscriptionState {
    * can't mistake a still-present run for a new one.
    */
   lastAnnotationKeys: Set<string>;
-  annotationLevelByListener: Map<
-    (text: string) => void,
-    GitHubCheckAnnotationLevel
-  >;
+  annotationLevelByListener: Map<PollEventListener, GitHubCheckAnnotationLevel>;
   /**
    * Everything scoped to the current head SHA: the SHA itself, the CI one-shot
    * markers, the check-runs page cache, and the pending annotation-fetch
@@ -222,28 +220,27 @@ export class PRPollingSource extends PollingSourceBase<
 
   subscribe(
     input: PRSubscribeInput,
-    onEvent: (text: string) => void,
-  ): Disposable {
+    onEvent: PollEventListener,
+  ): Effect.Effect<Disposable> {
     const key = prKeyToString(input);
-    const disposable = this.register(
-      key,
-      () => createInitialState(input),
-      onEvent,
+    return this.register(key, () => createInitialState(input), onEvent).pipe(
+      Effect.map((disposable) => {
+        this.setListenerAnnotationLevel(key, onEvent, input);
+        return {
+          dispose: () => {
+            this.getSubscriptionState(key)?.annotationLevelByListener.delete(
+              onEvent,
+            );
+            disposable.dispose();
+          },
+        };
+      }),
     );
-    this.setListenerAnnotationLevel(key, onEvent, input);
-    return {
-      dispose: () => {
-        this.getSubscriptionState(key)?.annotationLevelByListener.delete(
-          onEvent,
-        );
-        disposable.dispose();
-      },
-    };
   }
 
   updateSubscription(
     input: PRSubscribeInput,
-    onEvent: (text: string) => void,
+    onEvent: PollEventListener,
   ): void {
     const key = prKeyToString(input);
     this.setListenerAnnotationLevel(key, onEvent, input);
@@ -252,7 +249,7 @@ export class PRPollingSource extends PollingSourceBase<
   /** Resolve the effective annotation level and record it per listener. */
   private setListenerAnnotationLevel(
     key: string,
-    onEvent: (text: string) => void,
+    onEvent: PollEventListener,
     input: PRSubscribeInput,
   ): void {
     const minAnnotationLevel =
@@ -354,7 +351,7 @@ export class PRPollingSource extends PollingSourceBase<
     // before the checks/reviews seeding below, but the resources are
     // independent and the relative emit order (comments before reviews) is
     // unchanged from the original inline seed/diff blocks.
-    this.consumeCommentList(
+    yield* this.consumeCommentList(
       commentsRes,
       (etag) => {
         state.etags.issueComments = etag;
@@ -364,7 +361,7 @@ export class PRPollingSource extends PollingSourceBase<
         this.emit(state, formatPRIssueComment(state.slug, pr.pullNumber, c)),
       () => state.initialized,
     );
-    this.consumeCommentList(
+    yield* this.consumeCommentList(
       reviewCommentsRes,
       (etag) => {
         state.etags.reviewComments = etag;
@@ -389,17 +386,23 @@ export class PRPollingSource extends PollingSourceBase<
       // keep the same id when submitted, and emitting "reviewed" on a draft
       // would both be misleading and prevent the real submission event from
       // firing.
+      const freshReviews: GhReview[] = [];
       state.reviews.diff(reviewsRes.data.filter(isSubmittedReview), (r) => {
         if (shouldDropBotEvent(r.user)) return;
-        this.emit(state, formatReview(state.slug, pr.pullNumber, r));
+        freshReviews.push(r);
       });
+      yield* Effect.forEach(
+        freshReviews,
+        (r) => this.emit(state, formatReview(state.slug, pr.pullNumber, r)),
+        { discard: true },
+      );
     }
 
     if (checksRes.status === 200) {
       // ETag/page caching is owned by `fetchAllCheckRuns` via
       // `state.currentShaState.checkRunsCache`; nothing to record on
       // `state.etags` here.
-      this.consumeCheckRuns(
+      yield* this.consumeCheckRuns(
         state,
         checksRes.data.check_runs,
         checksRes.data.total_count,
@@ -454,7 +457,7 @@ export class PRPollingSource extends PollingSourceBase<
     // every closed 200 response here covers both initially-closed and
     // open-to-closed subscriptions without mirroring the remote state locally.
     if (prData.state === 'closed') {
-      this.emit(
+      yield* this.emit(
         state,
         formatPRClosed(state.slug, pr.pullNumber, prData.merged),
       );
@@ -490,12 +493,12 @@ export class PRPollingSource extends PollingSourceBase<
       state.mergeableState = newMergeable;
       if (isDefiniteMergeableState(prev) && prev !== newMergeable) {
         if (newMergeable === 'dirty') {
-          this.emit(
+          yield* this.emit(
             state,
             formatMergeConflictDetected(state.slug, pr.pullNumber, prev),
           );
         } else if (prev === 'dirty') {
-          this.emit(
+          yield* this.emit(
             state,
             formatMergeConflictResolved(
               state.slug,
@@ -582,11 +585,14 @@ export class PRPollingSource extends PollingSourceBase<
    * past {@link COALESCE_THRESHOLD}), the one-shot "CI complete"/"CI passed",
    * and the annotation candidates queued for the post-tick drain.
    */
-  private consumeCheckRuns(
+  private readonly consumeCheckRuns = Effect.fn(
+    'PRPollingSource.consumeCheckRuns',
+  )(function* (
+    this: PRPollingSource,
     state: PRSubscriptionState,
     runs: GhCheckRun[],
     totalCount: number,
-  ): void {
+  ) {
     const { pr } = state;
     const currentShaState = state.currentShaState;
     const headSha = currentShaState?.sha;
@@ -597,7 +603,7 @@ export class PRPollingSource extends PollingSourceBase<
       !currentShaState.ciStarted
     ) {
       currentShaState.ciStarted = true;
-      this.emit(
+      yield* this.emit(
         state,
         formatCIStarted(state.slug, pr.pullNumber, headSha, runs, totalCount),
       );
@@ -609,13 +615,16 @@ export class PRPollingSource extends PollingSourceBase<
     );
     state.lastFailedCheckKeys = currentFailureKeys;
     if (newFailures.length >= COALESCE_THRESHOLD) {
-      this.emit(
+      yield* this.emit(
         state,
         formatCheckFailureSummary(state.slug, pr.pullNumber, newFailures),
       );
     } else {
       for (const r of newFailures) {
-        this.emit(state, formatCheckFailure(state.slug, pr.pullNumber, r));
+        yield* this.emit(
+          state,
+          formatCheckFailure(state.slug, pr.pullNumber, r),
+        );
       }
     }
 
@@ -631,14 +640,14 @@ export class PRPollingSource extends PollingSourceBase<
     if (complete && currentShaState && headSha) {
       if (!currentShaState.ciComplete) {
         currentShaState.ciComplete = true;
-        this.emit(
+        yield* this.emit(
           state,
           formatCIComplete(state.slug, pr.pullNumber, headSha, runs),
         );
       }
       if (!currentShaState.ciPassed && passed) {
         currentShaState.ciPassed = true;
-        this.emit(
+        yield* this.emit(
           state,
           formatCIPassed(state.slug, pr.pullNumber, headSha, runs),
         );
@@ -651,7 +660,7 @@ export class PRPollingSource extends PollingSourceBase<
     // (including 304) so excess candidates aren't stranded once check-runs
     // settle.
     this.enqueueAnnotationCandidates(state, runs);
-  }
+  });
 
   /**
    * Commit the check-runs page cache staged by `fetchAllCheckRuns`. The single
@@ -731,7 +740,12 @@ export class PRPollingSource extends PollingSourceBase<
           // poll and several annotation pages, and timing the backoff from
           // `at` would put skipPollUntilMs in the past and retry at once.
           const failedAt = yield* Clock.currentTimeMillis;
-          this.handleFailure(key, state, drained.failure.cause, failedAt);
+          yield* this.handleFailure(
+            key,
+            state,
+            drained.failure.cause,
+            failedAt,
+          );
           if (drained.failure.cause instanceof GitHubRateLimitError) {
             this.nextAnnotationDrainKey = key;
             return;
@@ -815,7 +829,7 @@ export class PRPollingSource extends PollingSourceBase<
     if (fetched.ok) {
       this.removePendingAnnotationRun(state, run.id);
       if (fetched.annotations.length > 0) {
-        this.emitCheckAnnotations(state, run, fetched.annotations);
+        yield* this.emitCheckAnnotations(state, run, fetched.annotations);
       }
       return true;
     }
@@ -850,11 +864,14 @@ export class PRPollingSource extends PollingSourceBase<
       state.currentShaState.pendingAnnotationRuns.filter((p) => p.id !== runId);
   }
 
-  private emitCheckAnnotations(
+  private readonly emitCheckAnnotations = Effect.fn(
+    'PRPollingSource.emitCheckAnnotations',
+  )(function* (
+    this: PRPollingSource,
     state: PRSubscriptionState,
     run: GhCheckRun,
     annotations: readonly GhCheckAnnotation[],
-  ): void {
+  ) {
     for (const listener of state.listeners) {
       const minLevel =
         state.annotationLevelByListener.get(listener) ??
@@ -870,7 +887,7 @@ export class PRPollingSource extends PollingSourceBase<
           annotations_count: visibleAnnotations.length,
         },
       };
-      this.emitToListener(
+      yield* this.emitToListener(
         listener,
         formatCheckAnnotations(
           state.slug,
@@ -880,7 +897,7 @@ export class PRPollingSource extends PollingSourceBase<
         ),
       );
     }
-  }
+  });
 }
 
 /** Process-wide singleton. */

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -5,10 +5,16 @@
  * Subclasses implement only `pollOne()` — the actual endpoints to hit and
  * per-tick state to mutate — plus the error-formatting hook that names the
  * subscription type. Everything around it
- * (subscribe/unsubscribe, change-listener fan-out, the tick loop with
- * `tickInFlight` guard, classification of GitHub errors into auth /
+ * (subscribe/unsubscribe, change-listener fan-out, the poll loop,
+ * classification of GitHub errors into auth /
  * permanent / rate-limit / transient, jittered exponential backoff, and the
  * 24 h detach gate) lives here once.
+ *
+ * The subscribe path is Effect-typed end to end (`register` →
+ * `StreamSubscriptionRegistry.bind` → the tool's `execute()` runs it, R1);
+ * this module holds no `Effect.run*` call. Listener fan-out returns delivery
+ * programs that the emit turn forks detached ({@link PollEventListener}), so
+ * a slow listener never stalls a poll round.
  */
 
 import {
@@ -32,7 +38,6 @@ import {
   type LifecycleHost,
 } from '@platform/interfaces';
 import { platform } from '@platform/platform';
-import { effectRuntime } from '@platform/processRuntime';
 import { jitteredExponentialBackoffMs } from '@utils/core';
 import {
   createBoundedIdSet,
@@ -49,8 +54,18 @@ import { shouldDropBotEvent } from './botFilter';
 import type { GhUser } from './prTypes';
 import type { ZodType } from 'zod';
 
+/**
+ * A subscription event listener. The poller invokes it synchronously on the
+ * emitting turn — so any state the delivery depends on is captured with the
+ * emit, not with a later scheduler turn — and forks the returned program
+ * detached, the fire-and-forget shape the old `(text) => void` Promise
+ * listeners had. The program must recover its own failures and defects;
+ * `emitToListener` guards only the synchronous invocation itself.
+ */
+export type PollEventListener = (text: string) => Effect.Effect<void>;
+
 export interface BasePollSubscriptionState {
-  listeners: Set<(text: string) => void>;
+  listeners: Set<PollEventListener>;
   /** Most recent successful poll. The 24 h detach gate compares against this. */
   lastSuccessAt: number;
   consecutiveFailures: number;
@@ -310,55 +325,75 @@ export abstract class PollingSourceBase<
   /**
    * Subclass entry point. Looks up `key` in the map, creates initial state via
    * `initState()` if absent (enforcing the max-concurrent cap), adds the
-   * listener, and returns a Disposable that removes only this listener.
+   * listener, and returns the Disposable that removes only this listener.
+   *
+   * The returned Effect is run by the caller's boundary (the subscription
+   * tool's `execute()`): the map mutation happens in the run's synchronous
+   * prelude, and starting the poll loop is forking a daemon fiber of the
+   * runtime that runs it — so this module holds no `Effect.run*` call of its
+   * own (R1). The max-concurrent throw stays a defect: it reaches the tool as
+   * the same plain `Error` it always was.
    */
   protected register(
     key: K,
     initState: () => S,
-    onEvent: (text: string) => void,
-  ): Disposable {
-    let state = this.subscriptions.get(key);
-    let created = false;
-    if (!state) {
-      if (this.subscriptions.size >= this.config.maxConcurrent) {
-        throw new Error(
-          `Too many active ${this.config.name} subscriptions (max ${this.config.maxConcurrent}). Unsubscribe from one before adding another.`,
-        );
+    onEvent: PollEventListener,
+  ): Effect.Effect<Disposable> {
+    return Effect.suspend(() => {
+      let state = this.subscriptions.get(key);
+      let created = false;
+      if (!state) {
+        if (this.subscriptions.size >= this.config.maxConcurrent) {
+          throw new Error(
+            `Too many active ${this.config.name} subscriptions (max ${this.config.maxConcurrent}). Unsubscribe from one before adding another.`,
+          );
+        }
+        state = initState();
+        this.subscriptions.set(key, state);
+        this.logger.info(`Subscribed to ${key}`);
+        created = true;
       }
-      state = initState();
-      this.subscriptions.set(key, state);
-      this.logger.info(`Subscribed to ${key}`);
-      created = true;
-    }
-    state.listeners.add(onEvent);
-    if (created) this.notifyKeysChanged();
-    this.ensurePolling();
-    return {
-      dispose: () => this.removeListener(key, onEvent),
-    };
+      state.listeners.add(onEvent);
+      if (created) this.notifyKeysChanged();
+      const disposable: Disposable = {
+        dispose: () => this.removeListener(key, onEvent),
+      };
+      return this.ensurePolling().pipe(Effect.as(disposable));
+    });
   }
 
   /** Emit a text message to every listener attached to a subscription. */
-  protected emit(state: S, text: string): void {
-    for (const cb of state.listeners) {
-      this.emitToListener(cb, text);
-    }
+  protected emit(state: S, text: string): Effect.Effect<void> {
+    return Effect.forEach(
+      state.listeners,
+      (listener) => this.emitToListener(listener, text),
+      { discard: true },
+    );
   }
 
   /**
    * Deliver one message to one listener. The single guarded delivery point:
    * subclasses that build per-listener text (e.g. annotation filtering) route
    * through here instead of calling the listener directly.
+   *
+   * The listener is invoked on the emit turn — its capture (which binding,
+   * which owner) happens before any later detach can re-key the maps — and
+   * its delivery program is forked as a daemon, so a slow or hanging delivery
+   * never stalls the poll round. A synchronous throw while building the
+   * program is the defect the old try/catch logged as 'Listener threw'.
    */
   protected emitToListener(
-    listener: (text: string) => void,
+    listener: PollEventListener,
     text: string,
-  ): void {
-    try {
-      listener(text);
-    } catch (err) {
-      this.logger.warn('Listener threw', { data: err });
-    }
+  ): Effect.Effect<void> {
+    return Effect.suspend(() => Effect.forkDetach(listener(text))).pipe(
+      Effect.asVoid,
+      Effect.catchDefect((defect) =>
+        Effect.sync(() => {
+          this.logger.warn('Listener threw', { data: defect });
+        }),
+      ),
+    );
   }
 
   /**
@@ -410,25 +445,30 @@ export abstract class PollingSourceBase<
    * (formatting plus any URL gate). The seed-or-diff choice reads
    * `isInitialized()` so callers that interleave phases (Issue) and callers
    * that split them behind an early-return first-tick block (PR/Repo) both
-   * work. Never throws.
+   * work. Never fails: the whole batch is classified against the dedup window
+   * before the first delivery forks, exactly as the sync diff-then-emit did.
    */
   protected consumeCommentList<T extends { user: GhUser | null | undefined }>(
     res: ConditionalResponse<readonly T[]>,
     etagSlot: (etag: string | undefined) => void,
     deduped: DedupedResource<T>,
-    emitEvent: (item: T) => void,
+    emitEvent: (item: T) => Effect.Effect<void>,
     isInitialized: () => boolean,
-  ): void {
-    if (res.status !== 200) return;
-    etagSlot(res.etag);
-    if (isInitialized()) {
+  ): Effect.Effect<void> {
+    if (res.status !== 200) return Effect.void;
+    return Effect.suspend(() => {
+      etagSlot(res.etag);
+      if (!isInitialized()) {
+        deduped.seed(res.data);
+        return Effect.void;
+      }
+      const fresh: T[] = [];
       deduped.diff(res.data, (item) => {
         if (shouldDropBotEvent(item.user)) return;
-        emitEvent(item);
+        fresh.push(item);
       });
-    } else {
-      deduped.seed(res.data);
-    }
+      return Effect.forEach(fresh, emitEvent, { discard: true });
+    });
   }
 
   /**
@@ -441,13 +481,19 @@ export abstract class PollingSourceBase<
     this.notifyKeysChanged();
   }
 
-  /** Emit a formatted halted-subscription error, then detach the key. */
-  private emitErrorAndDetach(key: K, state: S, detail: string): void {
-    this.emit(state, this.formatErrorEvent(state, detail));
-    this.detach(key);
+  /** Emit a formatted halted-subscription error, then detach the key. The
+   *  listeners capture their delivery before the detach re-keys anything. */
+  private emitErrorAndDetach(
+    key: K,
+    state: S,
+    detail: string,
+  ): Effect.Effect<void> {
+    return this.emit(state, this.formatErrorEvent(state, detail)).pipe(
+      Effect.andThen(Effect.sync(() => this.detach(key))),
+    );
   }
 
-  private removeListener(key: K, onEvent: (text: string) => void): void {
+  private removeListener(key: K, onEvent: PollEventListener): void {
     const state = this.subscriptions.get(key);
     if (!state) return;
     state.listeners.delete(onEvent);
@@ -471,35 +517,42 @@ export abstract class PollingSourceBase<
   }
 
   /**
-   * Start the poll loop if it is not already running: one fiber, forked from
-   * the process runtime, that runs a round and then repeats on
-   * `Schedule.fixed(pollIntervalMs)`. `Effect.repeat` evaluates the round
-   * once before the schedule steps, so first-subscribe polls immediately
-   * instead of waiting a full interval, and a single sequential fiber makes
-   * overlapping rounds impossible — the in-flight guard the `setInterval`
-   * cadence needed is gone with it. A round that outruns the interval is
-   * followed immediately by the next one, as the interval's skip-then-fire
-   * behaviour did.
+   * Start the poll loop if it is not already running: one detached fiber that
+   * runs a round and then repeats on `Schedule.fixed(pollIntervalMs)`.
+   * `Effect.repeat` evaluates the round once before the schedule steps, so
+   * first-subscribe polls immediately instead of waiting a full interval, and
+   * a single sequential fiber makes overlapping rounds impossible — the
+   * in-flight guard the `setInterval` cadence needed is gone with it. A round
+   * that outruns the interval is followed immediately by the next one, as the
+   * interval's skip-then-fire behaviour did.
+   *
+   * The fiber is forked detached (into the global scope) by the returned
+   * Effect, so it roots at the runtime that runs the subscribe path — the
+   * tool boundary's process runtime in production (R1). It lives until
+   * `stopPolling` completes its stop Deferred (last unsubscribe,
+   * `disposeAll`) or the runtime itself shuts down.
    *
    * The loop sleeps on {@link unrefSleepClock}: a polling timer must never
    * keep a host process alive on its own. Its readings are the ambient
    * clock's, so `Clock.currentTimeMillis` inside a round is unaffected.
    */
-  private ensurePolling(): void {
-    this.registerShutdownIfNeeded();
-    if (this.pollLoopStop) return;
-    const stop = Deferred.makeUnsafe<void>();
-    this.pollLoopStop = stop;
-    effectRuntime().runFork(
-      Effect.raceFirst(this.pollLoopProgram(), Deferred.await(stop)).pipe(
-        Effect.ensuring(
-          Effect.sync(() => {
-            // A stopped loop may finish after a new subscription has started.
-            if (this.pollLoopStop === stop) this.pollLoopStop = undefined;
-          }),
+  private ensurePolling(): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      this.registerShutdownIfNeeded();
+      if (this.pollLoopStop) return Effect.void;
+      const stop = Deferred.makeUnsafe<void>();
+      this.pollLoopStop = stop;
+      return Effect.forkDetach(
+        Effect.raceFirst(this.pollLoopProgram(), Deferred.await(stop)).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              // A stopped loop may finish after a new subscription has started.
+              if (this.pollLoopStop === stop) this.pollLoopStop = undefined;
+            }),
+          ),
         ),
-      ),
-    );
+      ).pipe(Effect.asVoid);
+    });
   }
 
   private readonly pollLoopProgram = Effect.fn('PollingSourceBase.pollLoop')(
@@ -636,16 +689,14 @@ export abstract class PollingSourceBase<
         ),
         Effect.catchTag('PollHookRejected', (rejection) =>
           Effect.flatMap(Clock.currentTimeMillis, (failedAt) =>
-            Effect.sync(() =>
-              this.handleFailure(key, state, rejection.cause, failedAt),
-            ),
+            this.handleFailure(key, state, rejection.cause, failedAt),
           ),
         ),
         Effect.catchDefect((defect) =>
           Effect.flatMap(Clock.currentTimeMillis, (failedAt) =>
-            Effect.sync(() => {
+            Effect.suspend(() => {
               this.logger.warn('Poll threw a defect', { data: defect });
-              this.handleFailure(key, state, defect, failedAt);
+              return this.handleFailure(key, state, defect, failedAt);
             }),
           ),
         ),
@@ -658,14 +709,23 @@ export abstract class PollingSourceBase<
    * clock. The caller supplies it so this stays a pure function of the state
    * and that reading — the rate-limit branch compares it against GitHub's own
    * epoch (`resetAt`), which only a wall-clock reading can be measured
-   * against.
+   * against. Emits (the auth and permanent branches) run as Effects so the
+   * listener captures land before the detach.
    */
-  protected handleFailure(key: K, state: S, err: unknown, now: number): void {
+  protected readonly handleFailure = Effect.fn(
+    'PollingSourceBase.handleFailure',
+  )(function* (
+    this: PollingSourceBase<K, S>,
+    key: K,
+    state: S,
+    err: unknown,
+    now: number,
+  ) {
     if (err instanceof GitHubAuthError) {
       this.logger.warn(`Auth error for ${key}; stopping subscription.`, {
         data: err,
       });
-      this.emit(state, this.formatErrorEvent(state, err.message));
+      yield* this.emit(state, this.formatErrorEvent(state, err.message));
       appSignals.emit('githubTokenInvalid', { message: err.message });
       this.detach(key);
       return;
@@ -674,7 +734,7 @@ export abstract class PollingSourceBase<
       this.logger.warn(`Permanent error for ${key}; stopping subscription.`, {
         data: err,
       });
-      this.emitErrorAndDetach(key, state, err.message);
+      yield* this.emitErrorAndDetach(key, state, err.message);
       return;
     }
     if (err instanceof GitHubRateLimitError) {
@@ -688,7 +748,7 @@ export abstract class PollingSourceBase<
         this.logger.warn(
           `Rate limited polling ${key} and unreachable for over 24 h; detaching.`,
         );
-        this.emitErrorAndDetach(
+        yield* this.emitErrorAndDetach(
           key,
           state,
           'unreachable for over 24 h; detaching',
@@ -714,7 +774,7 @@ export abstract class PollingSourceBase<
         `Poll failed for ${key}; unreachable for over 24 h, detaching.`,
         { data: { failureCount: state.consecutiveFailures, error: err } },
       );
-      this.emitErrorAndDetach(
+      yield* this.emitErrorAndDetach(
         key,
         state,
         'unreachable for over 24 h; detaching',
@@ -728,5 +788,5 @@ export abstract class PollingSourceBase<
         error: err,
       },
     });
-  }
+  });
 }

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -55,6 +55,7 @@ import {
   DEFAULT_POLLING_BACKOFF_CONFIG,
   dedupeComments,
   type DedupedResource,
+  type PollEventListener,
   type PollHookRejected,
   PollingSourceBase,
   pollRequest,
@@ -171,8 +172,8 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
 
   subscribe(
     input: RepoSubscribeInput,
-    onEvent: (text: string) => void,
-  ): Disposable {
+    onEvent: PollEventListener,
+  ): Effect.Effect<Disposable> {
     const key = repoKeyToString(input);
     return this.register(key, () => createInitialState(input), onEvent);
   }
@@ -271,9 +272,9 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
             state.subscribedAt,
           );
           if (transition === 'opened') {
-            this.emit(state, formatRepoPROpened(state.slug, pr));
+            yield* this.emit(state, formatRepoPROpened(state.slug, pr));
           } else if (transition === 'closed') {
-            this.emit(
+            yield* this.emit(
               state,
               formatRepoPRClosed(state.slug, pr.number, next === 'merged'),
             );
@@ -286,26 +287,32 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
       // the bot filter applied centrally. The per-resource number-parsing gates
       // stay in the emit closures. The seed phase for these resources lives
       // inline in the first-tick block above.
-      this.consumeCommentList(
+      yield* this.consumeCommentList(
         issueRes,
         () => {},
         state.issueComments,
         (c) => {
           const number = parseTargetNumberFromIssueUrl(c);
-          if (number === undefined) return;
-          this.emit(state, formatRepoIssueComment(state.slug, number, c));
+          if (number === undefined) return Effect.void;
+          return this.emit(
+            state,
+            formatRepoIssueComment(state.slug, number, c),
+          );
         },
         () => state.initialized,
       );
 
-      this.consumeCommentList(
+      yield* this.consumeCommentList(
         reviewRes,
         () => {},
         state.reviewComments,
         (c) => {
           const prNumber = parsePRNumberFromReviewCommentUrl(c.html_url);
-          if (prNumber === undefined) return;
-          this.emit(state, formatRepoReviewComment(state.slug, prNumber, c));
+          if (prNumber === undefined) return Effect.void;
+          return this.emit(
+            state,
+            formatRepoReviewComment(state.slug, prNumber, c),
+          );
         },
         () => state.initialized,
       );
@@ -407,7 +414,7 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
     }
 
     if (newlyDirty.length >= MERGE_CONFLICT_COALESCE_THRESHOLD) {
-      this.emit(
+      yield* this.emit(
         state,
         formatRepoMergeConflictSummary(
           state.slug,
@@ -416,7 +423,7 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
       );
     } else {
       for (const { number, prev } of newlyDirty) {
-        this.emit(
+        yield* this.emit(
           state,
           formatRepoMergeConflictDetected(state.slug, number, prev),
         );

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -11,6 +11,8 @@
  * that queue's session are auto-disposed.
  */
 
+import { Effect } from 'effect';
+
 import type { AgentTrace } from '@agent/trace';
 import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import {
@@ -26,14 +28,19 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 
+import type { PollEventListener } from './PollingSourceBase';
+
 export interface SubscriptionBinding<K extends string> {
   key: K;
   streamIds: readonly StreamTabId[];
 }
 
 interface PollingSourceLike<K extends string, Input> {
-  subscribe(input: Input, onEvent: (text: string) => void): Disposable;
-  updateSubscription?(input: Input, onEvent: (text: string) => void): void;
+  subscribe(
+    input: Input,
+    onEvent: PollEventListener,
+  ): Effect.Effect<Disposable>;
+  updateSubscription?(input: Input, onEvent: PollEventListener): void;
   activeKeys(): readonly K[];
   onKeysChanged(listener: (keys: readonly K[]) => void): Disposable;
 }
@@ -51,7 +58,7 @@ export interface StreamSubscriptionRegistryOptions<K extends string, Input> {
 
 interface BoundSubscription {
   disposable: Disposable;
-  onEvent: (text: string) => void;
+  onEvent: PollEventListener;
   /**
    * Owning session captured at bind() time (inside the run's AsyncLocalStorage).
    * onEvent fires later from a detached polling timer where the ALS is empty, so
@@ -81,64 +88,92 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     });
   }
 
-  /** Returns true if a new subscription was created, false if it already existed. */
-  bind(streamId: StreamTabId, input: Input): boolean {
-    const key = this.opts.keyOf(input);
-    // Capture the session HERE: bind() runs inside the run's AsyncLocalStorage
-    // (the github tool's execute()), but onEvent fires later from a detached
-    // polling timer where the ALS is empty.
-    const session = currentSession();
-    const bound =
-      this.perStream.get(streamId) ?? new Map<K, BoundSubscription>();
-    const existing = bound.get(key);
-    if (existing) {
-      this.ensureReleaseHook(session);
-      const previousOwner = existing.owner;
-      existing.owner = session;
-      if (previousOwner !== session) {
-        this.detachReleaseHookIfUnused(previousOwner);
+  /**
+   * Returns true if a new subscription was created, false if it already existed.
+   *
+   * The returned Effect is run by the tool's `execute()` (R1 boundary). Its
+   * synchronous prelude runs inside that call — inside the run's
+   * AsyncLocalStorage — so the owning session capture below happens with the
+   * run's context exactly as the old synchronous `bind()` did.
+   */
+  bind(streamId: StreamTabId, input: Input): Effect.Effect<boolean> {
+    return Effect.suspend(() => {
+      const key = this.opts.keyOf(input);
+      // Capture the session HERE: the returned Effect runs inside the run's
+      // AsyncLocalStorage (the github tool's execute()), but onEvent fires
+      // later from the detached poll loop where the ALS is empty.
+      const session = currentSession();
+      const bound =
+        this.perStream.get(streamId) ?? new Map<K, BoundSubscription>();
+      const existing = bound.get(key);
+      if (existing) {
+        this.ensureReleaseHook(session);
+        const previousOwner = existing.owner;
+        existing.owner = session;
+        if (previousOwner !== session) {
+          this.detachReleaseHookIfUnused(previousOwner);
+        }
+        this.opts.source.updateSubscription?.(input, existing.onEvent);
+        return Effect.succeed(false);
       }
-      this.opts.source.updateSubscription?.(input, existing.onEvent);
-      return false;
-    }
-    const onEvent = (text: string) => {
-      const subscription = bound.get(key);
-      if (!subscription) return;
-      // Capture the owner before awaiting: bind() reassigns it on rebind, and
-      // the queued-follow-up refresh belongs to the session that delivered.
-      const owner = subscription.owner;
-      void submitFollowUp(streamId, text, {
-        session: owner,
-        mode: 'live_notification',
-      })
-        .then((result) => {
-          if (result.status !== 'sent' && result.status !== 'queued') return;
-          owner.publish([
-            {
-              type: 'updateQueuedFollowUps',
-              aggregateId: qualifyAggregateId('stream', streamId),
-              messages: owner.followUps.getAll(streamId),
-            },
-          ]);
-        })
-        .catch((err: unknown) => {
-          this.logger.warn('Failed to deliver subscription follow-up', {
-            data: { key, streamId, err },
+      const onEvent = (text: string): Effect.Effect<void> => {
+        // Invoked synchronously on the emit turn (see PollEventListener):
+        // capture the binding and its owner now — bind() reassigns the owner
+        // on rebind, and the queued-follow-up refresh belongs to the session
+        // that delivered. Only the delivery itself runs detached.
+        const subscription = bound.get(key);
+        if (!subscription) return Effect.void;
+        const owner = subscription.owner;
+        const reportDeliveryFailure = (err: unknown) =>
+          Effect.sync(() => {
+            this.logger.warn('Failed to deliver subscription follow-up', {
+              data: { key, streamId, err },
+            });
           });
-        });
-    };
-    const disposable = this.opts.source.subscribe(input, onEvent);
-    const subscription: BoundSubscription = {
-      disposable,
-      onEvent,
-      owner: session,
-    };
-    bound.set(key, subscription);
-    this.perStream.set(streamId, bound);
-    this.ensureReleaseHook(session);
-    this.logger.info(`Bound subscription ${key} → stream ${streamId}`);
-    this.emitBindingsChanged();
-    return true;
+        return Effect.tryPromise({
+          try: () =>
+            submitFollowUp(streamId, text, {
+              session: owner,
+              mode: 'live_notification',
+            }),
+          catch: (err) => err,
+        }).pipe(
+          Effect.flatMap((result) => {
+            if (result.status !== 'sent' && result.status !== 'queued') {
+              return Effect.void;
+            }
+            return Effect.sync(() => {
+              owner.publish([
+                {
+                  type: 'updateQueuedFollowUps',
+                  aggregateId: qualifyAggregateId('stream', streamId),
+                  messages: owner.followUps.getAll(streamId),
+                },
+              ]);
+            });
+          }),
+          Effect.catch(reportDeliveryFailure),
+          // A defect (e.g. publish throwing) got the same warn through the old
+          // promise chain's .catch; keep one message for both channels.
+          Effect.catchDefect(reportDeliveryFailure),
+        );
+      };
+      return this.opts.source.subscribe(input, onEvent).pipe(
+        Effect.map((disposable) => {
+          const subscription: BoundSubscription = {
+            disposable,
+            onEvent,
+            owner: session,
+          };
+          bound.set(key, subscription);
+          this.perStream.set(streamId, bound);
+          this.ensureReleaseHook(session);
+          this.logger.info(`Bound subscription ${key} → stream ${streamId}`);
+          this.emitBindingsChanged();
+          return true;
+        }),
+      );
+    });
   }
 
   /** Returns true if a subscription existed and was removed. */
@@ -149,7 +184,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     if (!bound || !binding) return false;
     this.removeBoundKey(streamId, bound, key);
     this.detachReleaseHookIfUnused(binding.owner);
-    this.disposeSafe(binding.disposable, 'explicit unsubscribe');
+    binding.disposable.dispose();
     this.emitBindingsChanged();
     return true;
   }
@@ -173,7 +208,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     if (removedBindings.length > 0) {
       for (const owner of owners) this.detachReleaseHookIfUnused(owner);
       for (const binding of removedBindings) {
-        this.disposeSafe(binding.disposable, 'unbindAll');
+        binding.disposable.dispose();
       }
       this.emitBindingsChanged();
     }
@@ -210,7 +245,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       if (bound.size === 0) this.perStream.delete(streamId);
       this.detachReleaseHookIfUnused(session);
       for (const [, binding] of owned) {
-        this.disposeSafe(binding.disposable, 'release');
+        binding.disposable.dispose();
       }
       this.emitBindingsChanged();
     });
@@ -252,14 +287,6 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   ): void {
     bound.delete(key);
     if (bound.size === 0) this.perStream.delete(streamId);
-  }
-
-  private disposeSafe(d: Disposable, context: string): void {
-    try {
-      d.dispose();
-    } catch (err) {
-      this.logger.warn(`Disposer threw during ${context}`, { data: err });
-    }
   }
 
   private emitBindingsChanged(): void {

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -17,12 +17,14 @@
  * - `owner/repo/pulls/N` and `owner/repo/issues/N` are nuanced (worker-friendly).
  */
 
+import { Cause, Effect, Exit } from 'effect';
 import { z } from 'zod';
 
 import {
   getRunContextWorkingDirectory,
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
@@ -163,13 +165,38 @@ function parsePath(raw: string): ParsedPath {
   );
 }
 
-async function requireToken(): Promise<void> {
-  if (!(await getGitHubToken())) {
-    throw new ToolError(
-      'No GitHub token configured. In the CLI, open /config → GitHub token. In VS Code, use TeXRA settings → Git tab → "Set token". Or export GITHUB_TOKEN or GH_TOKEN. Needs `repo` scope for private repos, `public_repo` for public.',
-    );
-  }
+/**
+ * One wrap of a Promise call across the tool's Effect edge: the rejection
+ * keeps its identity, so the fold in `execute()` rethrows exactly the
+ * ToolError (or plain error) the old promise chain rejected with.
+ */
+const port = <A>(promise: () => Promise<A>): Effect.Effect<A, unknown> =>
+  Effect.tryPromise({ try: promise, catch: (error) => error });
+
+/**
+ * The one run of a subscription-tool program settles here (R1: the tool
+ * execute() contract is the Promise boundary). A failure — the program's
+ * ToolError, or a defect such as the registry's max-concurrent guard — is
+ * rethrown as the squashed cause, the same identity the async implementation
+ * rejected with.
+ */
+function foldToolExit(exit: Exit.Exit<ToolResult, unknown>): ToolResult {
+  if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
+  return exit.value;
 }
+
+const requireToken = (): Effect.Effect<void, unknown> =>
+  Effect.flatMap(
+    port(() => getGitHubToken()),
+    (token) =>
+      token
+        ? Effect.void
+        : Effect.fail(
+            new ToolError(
+              'No GitHub token configured. In the CLI, open /config → GitHub token. In VS Code, use TeXRA settings → Git tab → "Set token". Or export GITHUB_TOKEN or GH_TOKEN. Needs `repo` scope for private repos, `public_repo` for public.',
+            ),
+          ),
+  );
 
 /** `owner/repo` for any parsed target. */
 function slugOf(target: { owner: string; repo: string }): string {
@@ -201,8 +228,10 @@ function prSubscriptionActivitySentence(
   return `New comments, reviews, line comments, failed CI checks, inline check annotations (${annotationLevelDescription} pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups.`;
 }
 
-async function execSubscribe(input: SubscribeInput): Promise<ToolResult> {
-  await requireToken();
+const execSubscribe = Effect.fn('GitHubSubscriptionTool.subscribe')(function* (
+  input: SubscribeInput,
+) {
+  yield* requireToken();
   const { streamId } = requireRunStream('github_subscription');
   const target = requirePath(input);
   const minAnnotationLevel =
@@ -210,7 +239,7 @@ async function execSubscribe(input: SubscribeInput): Promise<ToolResult> {
   const annotationLevelDescription =
     ANNOTATION_LEVEL_DESCRIPTIONS[minAnnotationLevel];
   if (target.kind === 'repo') {
-    const created = repoSubscriptionRegistry.bind(streamId, target);
+    const created = yield* repoSubscriptionRegistry.bind(streamId, target);
     const slug = slugOf(target);
     return executed(
       created
@@ -222,7 +251,7 @@ async function execSubscribe(input: SubscribeInput): Promise<ToolResult> {
     );
   }
   if (target.kind === 'pr') {
-    const created = prSubscriptionRegistry.bind(streamId, {
+    const created = yield* prSubscriptionRegistry.bind(streamId, {
       ...target,
       minAnnotationLevel,
     });
@@ -251,10 +280,10 @@ async function execSubscribe(input: SubscribeInput): Promise<ToolResult> {
   const isPR =
     knownPR ||
     (!knownIssue &&
-      (await resolveIssueIsPR(target.owner, target.repo, target.issueNumber)));
+      (yield* resolveIssueIsPR(target.owner, target.repo, target.issueNumber)));
 
   if (isPR) {
-    const created = prSubscriptionRegistry.bind(streamId, {
+    const created = yield* prSubscriptionRegistry.bind(streamId, {
       owner: target.owner,
       repo: target.repo,
       pullNumber: target.issueNumber,
@@ -275,7 +304,7 @@ async function execSubscribe(input: SubscribeInput): Promise<ToolResult> {
       summary,
     );
   }
-  const created = issueSubscriptionRegistry.bind(streamId, target);
+  const created = yield* issueSubscriptionRegistry.bind(streamId, target);
   return executed(
     created
       ? `Subscribed to ${issueSlug}. New comments and state transitions (closed / reopened) arrive as <github-webhook-activity> follow-ups. The subscription stays active across close so reopens are caught: call command="unsubscribe" to release the slot.`
@@ -284,27 +313,30 @@ async function execSubscribe(input: SubscribeInput): Promise<ToolResult> {
       ? `Subscribed to ${issueSlug}`
       : `Already subscribed to ${issueSlug}`,
   );
-}
+});
 
 /**
  * Returns true iff the given issue/PR number resolves to a PR. One GET to
  * `/repos/{o}/{r}/issues/{n}`; the response object has a `pull_request`
- * field iff this is actually a PR. Throws on non-200.
+ * field iff this is actually a PR. Fails with a ToolError on non-200.
  */
-async function resolveIssueIsPR(
+const resolveIssueIsPR = (
   owner: string,
   repo: string,
   number: number,
-): Promise<boolean> {
-  const res = await ghGet<GhIssue>(`/repos/${owner}/${repo}/issues/${number}`);
-  if (res.status !== 200) {
-    throw new ToolError(
-      `Failed to resolve ${owner}/${repo}/issues/${number}: GitHub returned status ${res.status}. ` +
-        `Verify the number exists and the repo is accessible.`,
-    );
-  }
-  return res.data.pull_request != null;
-}
+): Effect.Effect<boolean, unknown> =>
+  Effect.flatMap(
+    port(() => ghGet<GhIssue>(`/repos/${owner}/${repo}/issues/${number}`)),
+    (res) =>
+      res.status !== 200
+        ? Effect.fail(
+            new ToolError(
+              `Failed to resolve ${owner}/${repo}/issues/${number}: GitHub returned status ${res.status}. ` +
+                `Verify the number exists and the repo is accessible.`,
+            ),
+          )
+        : Effect.succeed(res.data.pull_request != null),
+  );
 
 function execUnsubscribe(input: UnsubscribeInput): ToolResult {
   const { streamId } = requireRunStream('github_subscription');
@@ -374,19 +406,27 @@ function parseGitHubRemote(
   return { owner: m[1], repo: m[2] };
 }
 
-async function gitInDir(args: string[], cwd: string): Promise<string> {
-  const result = await executeCommand(['git', ...args], {
-    cwd,
-    timeout: 10_000,
-    channel: 'github_subscription',
-  });
-  if (!result.success) {
-    throw new ToolError(
-      result.stderr || `git ${args.join(' ')} failed with no stderr.`,
-    );
-  }
-  return result.stdout.trim();
-}
+const gitInDir = (
+  args: string[],
+  cwd: string,
+): Effect.Effect<string, unknown> =>
+  Effect.flatMap(
+    port(() =>
+      executeCommand(['git', ...args], {
+        cwd,
+        timeout: 10_000,
+        channel: 'github_subscription',
+      }),
+    ),
+    (result) =>
+      result.success
+        ? Effect.succeed(result.stdout.trim())
+        : Effect.fail(
+            new ToolError(
+              result.stderr || `git ${args.join(' ')} failed with no stderr.`,
+            ),
+          ),
+  );
 
 interface OpenPullSummary {
   number: number;
@@ -394,15 +434,19 @@ interface OpenPullSummary {
   head?: { ref?: string };
 }
 
-async function getDefaultBranch(owner: string, repo: string): Promise<string> {
-  const res = await ghGet<{ default_branch?: string }>(
-    `/repos/${owner}/${repo}`,
+const getDefaultBranch = (
+  owner: string,
+  repo: string,
+): Effect.Effect<string, unknown> =>
+  Effect.flatMap(
+    port(() => ghGet<{ default_branch?: string }>(`/repos/${owner}/${repo}`)),
+    (res) =>
+      res.status !== 200
+        ? Effect.fail(
+            new ToolError(`Unexpected GitHub response status: ${res.status}`),
+          )
+        : Effect.succeed(res.data.default_branch ?? 'main'),
   );
-  if (res.status !== 200) {
-    throw new ToolError(`Unexpected GitHub response status: ${res.status}`);
-  }
-  return res.data.default_branch ?? 'main';
-}
 
 export function parseOriginHeadDefaultBranch(ref: string): string | undefined {
   const branch = ref.trim().replace(/^refs\/remotes\//, '');
@@ -410,116 +454,137 @@ export function parseOriginHeadDefaultBranch(ref: string): string | undefined {
   return branch.slice('origin/'.length) || undefined;
 }
 
-async function getLocalDefaultBranchHint(
+/** The local origin/HEAD hint: any lookup failure just means "no hint". */
+const getLocalDefaultBranchHint = (
   cwd: string,
-): Promise<string | undefined> {
-  try {
-    const ref = await gitInDir(
-      ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
-      cwd,
-    );
-    return parseOriginHeadDefaultBranch(ref);
-  } catch {
-    return undefined;
-  }
-}
+): Effect.Effect<string | undefined> =>
+  gitInDir(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], cwd).pipe(
+    Effect.map(parseOriginHeadDefaultBranch),
+    Effect.catch(() => Effect.succeed(undefined)),
+  );
 
-async function listOpenPullSuggestions(
+const listOpenPullSuggestions = (
   owner: string,
   repo: string,
-): Promise<string> {
-  const res = await ghGet<OpenPullSummary[]>(
-    `/repos/${owner}/${repo}/pulls?state=open&per_page=5`,
+): Effect.Effect<string, unknown> =>
+  Effect.map(
+    port(() =>
+      ghGet<OpenPullSummary[]>(
+        `/repos/${owner}/${repo}/pulls?state=open&per_page=5`,
+      ),
+    ),
+    (res) => {
+      if (res.status !== 200 || res.data.length === 0) {
+        return '';
+      }
+      const lines = res.data.map((pr) => {
+        const title = pr.title ? ` - ${pr.title}` : '';
+        const head = pr.head?.ref ? ` (${pr.head.ref})` : '';
+        return `- ${prRef(slugOf({ owner, repo }), pr.number)}${head}${title}`;
+      });
+      return `\n\nOpen PRs you can subscribe to directly:\n${lines.join('\n')}`;
+    },
   );
-  if (res.status !== 200 || res.data.length === 0) {
-    return '';
-  }
-  const lines = res.data.map((pr) => {
-    const title = pr.title ? ` - ${pr.title}` : '';
-    const head = pr.head?.ref ? ` (${pr.head.ref})` : '';
-    return `- ${prRef(slugOf({ owner, repo }), pr.number)}${head}${title}`;
-  });
-  return `\n\nOpen PRs you can subscribe to directly:\n${lines.join('\n')}`;
-}
 
-async function getFindCurrentFallbackInfo(
+/** Neither half is essential: each recovers to its absence, concurrently. */
+const getFindCurrentFallbackInfo = (
   owner: string,
   repo: string,
   cwd: string,
-): Promise<{ defaultBranch?: string; suggestions: string }> {
-  const [defaultBranchResult, suggestionsResult] = await Promise.allSettled([
-    getDefaultBranch(owner, repo).catch(() => getLocalDefaultBranchHint(cwd)),
-    listOpenPullSuggestions(owner, repo),
-  ]);
-  return {
-    defaultBranch:
-      defaultBranchResult.status === 'fulfilled'
-        ? defaultBranchResult.value
-        : undefined,
-    suggestions:
-      suggestionsResult.status === 'fulfilled' ? suggestionsResult.value : '',
-  };
-}
-
-async function execFindCurrent(input: FindCurrentInput): Promise<ToolResult> {
-  await requireToken();
-  const cwd =
-    parseWorkingDirectory(input.working_directory) ??
-    getRunContextWorkingDirectory(tryUseRunContext());
-  if (!cwd) {
-    throw new ToolError(
-      'No working_directory available. Provide one explicitly.',
-    );
-  }
-  let remoteUrl: string;
-  let branch: string;
-  try {
-    remoteUrl = await gitInDir(['remote', 'get-url', 'origin'], cwd);
-    branch = await gitInDir(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
-  } catch (err) {
-    throw new ToolError(
-      `git invocation failed in ${cwd}: ${toErrorMessage(err)}`,
-    );
-  }
-  const remote = parseGitHubRemote(remoteUrl);
-  if (!remote) {
-    throw new ToolError(`origin remote is not a github.com URL: ${remoteUrl}`);
-  }
-  if (branch === 'HEAD') {
-    throw new ToolError('HEAD is detached: cannot infer a PR branch.');
-  }
-  const apiPath = `/repos/${remote.owner}/${remote.repo}/pulls?state=open&head=${remote.owner}:${encodeURIComponent(branch)}&per_page=1`;
-  const res = await ghGet<Array<{ number: number; html_url: string }>>(apiPath);
-  if (res.status !== 200) {
-    throw new ToolError(`Unexpected GitHub response status: ${res.status}`);
-  }
-  const pr = res.data[0];
-  if (!pr) {
-    const { defaultBranch, suggestions } = await getFindCurrentFallbackInfo(
-      remote.owner,
-      remote.repo,
-      cwd,
-    );
-    if (branch === defaultBranch) {
-      throw new ToolError(
-        `Current branch is the default branch "${branch}", and no open PR uses it as the head branch. Pass command="subscribe" with an explicit path such as "${remote.owner}/${remote.repo}/pulls/N".${suggestions}`,
-      );
-    }
-    if (!defaultBranch && branch === 'main') {
-      throw new ToolError(
-        `Current branch is "main", no open PR uses it as the head branch, and the default branch could not be confirmed. Pass command="subscribe" with an explicit path such as "${remote.owner}/${remote.repo}/pulls/N".${suggestions}`,
-      );
-    }
-    throw new ToolError(
-      `No open PR found for ${remote.owner}/${remote.repo} head ${branch}. Push this branch and open a PR, or pass command="subscribe" with an explicit path for an existing PR.${suggestions}`,
-    );
-  }
-  const path = prRef(slugOf(remote), pr.number);
-  return executed(
-    `path: ${path}\nurl: ${pr.html_url}\n\nPass this path to command="subscribe" to start watching the PR.`,
-    path,
+): Effect.Effect<{ defaultBranch?: string; suggestions: string }> =>
+  Effect.zip(
+    getDefaultBranch(owner, repo).pipe(
+      Effect.catch(() => getLocalDefaultBranchHint(cwd)),
+    ),
+    listOpenPullSuggestions(owner, repo).pipe(
+      Effect.catch(() => Effect.succeed('')),
+    ),
+    { concurrent: true },
+  ).pipe(
+    Effect.map(([defaultBranch, suggestions]) => ({
+      defaultBranch,
+      suggestions,
+    })),
   );
-}
+
+const execFindCurrent = Effect.fn('GitHubSubscriptionTool.findCurrent')(
+  function* (input: FindCurrentInput) {
+    yield* requireToken();
+    const cwd =
+      parseWorkingDirectory(input.working_directory) ??
+      getRunContextWorkingDirectory(tryUseRunContext());
+    if (!cwd) {
+      return yield* Effect.fail(
+        new ToolError(
+          'No working_directory available. Provide one explicitly.',
+        ),
+      );
+    }
+    const [remoteUrl, branch] = yield* Effect.zip(
+      gitInDir(['remote', 'get-url', 'origin'], cwd),
+      gitInDir(['rev-parse', '--abbrev-ref', 'HEAD'], cwd),
+    ).pipe(
+      Effect.mapError(
+        (err) =>
+          new ToolError(
+            `git invocation failed in ${cwd}: ${toErrorMessage(err)}`,
+          ),
+      ),
+    );
+    const remote = parseGitHubRemote(remoteUrl);
+    if (!remote) {
+      return yield* Effect.fail(
+        new ToolError(`origin remote is not a github.com URL: ${remoteUrl}`),
+      );
+    }
+    if (branch === 'HEAD') {
+      return yield* Effect.fail(
+        new ToolError('HEAD is detached: cannot infer a PR branch.'),
+      );
+    }
+    const apiPath = `/repos/${remote.owner}/${remote.repo}/pulls?state=open&head=${remote.owner}:${encodeURIComponent(branch)}&per_page=1`;
+    const res = yield* port(() =>
+      ghGet<Array<{ number: number; html_url: string }>>(apiPath),
+    );
+    if (res.status !== 200) {
+      return yield* Effect.fail(
+        new ToolError(`Unexpected GitHub response status: ${res.status}`),
+      );
+    }
+    const pr = res.data[0];
+    if (!pr) {
+      const { defaultBranch, suggestions } = yield* getFindCurrentFallbackInfo(
+        remote.owner,
+        remote.repo,
+        cwd,
+      );
+      if (branch === defaultBranch) {
+        return yield* Effect.fail(
+          new ToolError(
+            `Current branch is the default branch "${branch}", and no open PR uses it as the head branch. Pass command="subscribe" with an explicit path such as "${remote.owner}/${remote.repo}/pulls/N".${suggestions}`,
+          ),
+        );
+      }
+      if (!defaultBranch && branch === 'main') {
+        return yield* Effect.fail(
+          new ToolError(
+            `Current branch is "main", no open PR uses it as the head branch, and the default branch could not be confirmed. Pass command="subscribe" with an explicit path such as "${remote.owner}/${remote.repo}/pulls/N".${suggestions}`,
+          ),
+        );
+      }
+      return yield* Effect.fail(
+        new ToolError(
+          `No open PR found for ${remote.owner}/${remote.repo} head ${branch}. Push this branch and open a PR, or pass command="subscribe" with an explicit path for an existing PR.${suggestions}`,
+        ),
+      );
+    }
+    const path = prRef(slugOf(remote), pr.number);
+    return executed(
+      `path: ${path}\nurl: ${pr.html_url}\n\nPass this path to command="subscribe" to start watching the PR.`,
+      path,
+    );
+  },
+);
 
 export class GitHubSubscriptionTool extends defineTool({
   name: 'github_subscription',
@@ -540,13 +605,17 @@ export class GitHubSubscriptionTool extends defineTool({
   protected async execute(input: GitHubSubscriptionInput): Promise<ToolResult> {
     switch (input.command) {
       case 'subscribe':
-        return execSubscribe(input);
+        return foldToolExit(
+          await effectRuntime().runPromiseExit(execSubscribe(input)),
+        );
       case 'unsubscribe':
         return execUnsubscribe(input);
       case 'list':
         return execList();
       case 'find_current':
-        return execFindCurrent(input);
+        return foldToolExit(
+          await effectRuntime().runPromiseExit(execFindCurrent(input)),
+        );
     }
   }
 }


### PR DESCRIPTION
## Summary

The wave-1 "tools: polling sources" lane of the Effect 4 migration (`.agents/docs/proposed/architecture/2026-08-26-effect-4-runtime-migration.md`, R1/R5/R7/R10; ratchet `Effect.run*` + `catch:effect-importer` rows). The GitHub subscription poll plane loses its last below-boundary run and its listener-side promise machinery:

- **`PollingSourceBase`** held the lane's `effectRuntime().runFork` that started the poll loop on first subscribe. `register`/`ensurePolling` now return Effects and the loop is `Effect.forkDetach`ed by the subscribe effect itself, so the fiber roots at the runtime that runs the subscribe path — the tool boundary's process runtime in production (R1), with no `Effect.run*` in the module. Stop stays synchronous (`Deferred.doneUnsafe`), so `dispose()`/`disposeAll()` and the settings UI's unbind paths are untouched.
- **Listener fan-out is now a two-phase contract** (`PollEventListener`): the listener is invoked synchronously on the emit turn — the owner/binding capture the old code did "before awaiting" still happens at exactly that moment — and returns a delivery program the emit forks detached. A slow `submitFollowUp` still never stalls a poll round, and the delivery ordering is unchanged (forks issue in emit order). The one listener implementation (`StreamSubscriptionRegistry`) recovers its own failures and defects into the same `warn` the promise chain's `.catch` produced; a synchronous throw while building the program is the defect `emitToListener` logs as `Listener threw`, as before.
- **`StreamSubscriptionRegistry.bind` returns `Effect<boolean>`**; its `submitFollowUp(...).then(publish).catch(warn)` chain becomes `tryPromise` + `catch`/`catchDefect` (one message for both channels, as the rejection semantics already were). `disposeSafe` is deleted: the only Disposable this registry stores is the poller's registration handle (map deletions plus an internally guarded key-notification), so the guard had no live failure mode (P12: a catch must classify something).
- **`githubSubscriptionTool.ts`** gains the one run (lexically inside `execute()`, boundary kind b): `execSubscribe`/`execFindCurrent` and their helpers (`requireToken`, `gitInDir`, `getDefaultBranch`, `getLocalDefaultBranchHint`, `listOpenPullSuggestions`, `getFindCurrentFallbackInfo`, `resolveIssueIsPR`) are Effect programs; the file's three raw catches and the `Promise.allSettled` + `.catch` fallback become `Effect.catch`/`Effect.mapError`, and `execute()` settles each program via `runPromiseExit` + a fold that rethrows the squashed cause — the identical `ToolError`/plain-`Error` identity the async implementations rejected with, so `defineTool`'s error rendering is byte-identical.

The `unsubscribe`/`list` commands and the settings Git tab (`src/controllers/settingsView/githubSubscriptions.ts`) stay synchronous and unchanged.

## Issue acceptance gates

No issue; the governing document is the migration PRD. Rules exercised: R1 (runs only at the tool `execute()` boundary — the ratchet verifies lexically), R5 (detached work via one named primitive, ownership recorded in the `PollEventListener`/`ensurePolling` docs), R7 (typed failure channels; the one remaining throw — the max-concurrent guard — stays a defect and reaches the caller as the same plain `Error`), R10 (the `runFork`, the listener promise chain, three raw catches, `Promise.allSettled`, and `disposeSafe` are deleted, not wrapped). Execution rule 2 (one pass per file): every retired mechanism family in each touched file converts here — which is why `githubSubscriptionTool.ts`'s `find_current` helpers converted in the same PR (adding a runtime `effect` import to the file would otherwise have pulled its three raw catches into the `catch:effect-importer` row).

## Single source of truth

- `PollEventListener` is the one listener contract for the poll plane; capture-on-emit-turn plus detached delivery is documented on the type.
- The poll loop's lifetime has one owner: the `pollLoopStop` Deferred (completed by `stopPolling` on last-unsubscribe/`disposeAll`), with the fiber rooted at the boundary run.
- `StreamSubscriptionRegistry` remains the one owner of (stream, key) → binding; its delivery failure has one log site.

## Duplication and abstraction budget

Removed: the hand-rolled fire-and-forget promise chain in `bind`, the defensive `disposeSafe`, and the sync-fan-out try/catch in `emitToListener` (superseded by `catchDefect` on the program-building suspend). Added: `port` in `githubSubscriptionTool.ts` (file-local, 7 call sites: a promise call's rejection keeps its identity across the edge — the same shape `ProgressApiKeyRetryController`'s `port` established in #11927) and `foldToolExit` (file-local; `LspTools.ts` has the analogous fold with a message mapper — two sites, different shapes, not yet worth a shared helper).

## Net elements (R6)

- Files: 10 modified, 0 added, 0 deleted (`git diff --stat origin/main...HEAD`: +675/−456; production 6 files, tests 3, ratchet baseline 1).
- Exported symbols: +1 (`PollEventListener` — consumed in this PR by the three pollers, the registry, and two suites); `^[+-]export` over the diff counts 1.
- Net LoC: +219; the growth is the tool file's move from exception-throwing async helpers to explicit failure channels plus the two-phase listener docs.
- Dependencies: none added or removed.
- Ratchet rows: `Effect.run*` loses `src/tools/github/PollingSourceBase.ts` (1 → 0; its `debtLanes` entry drops via `--update`); `catch:effect-importer` shrinks 2 → 1 on the same file (the sync keys-changed fan-out guard stays: `notifyKeysChanged` is reachable from `Disposable.dispose()` paths that cannot yield).

## Consumer counts (R8)

- `PollingSourceBase` subclasses: 3 production (`IssuePollingSource`, `PRPollingSource`, `RepoPollingSource`) + 2 test subclasses; all converted here.
- `PollingSourceLike.subscribe` implementations: the 3 pollers; sole caller is `StreamSubscriptionRegistry.bind`. `bind` callers: `githubSubscriptionTool.ts` only (4 sites, all converted). `updateSubscription`: same pair.
- `StreamSubscriptionRegistry` instances: `subscriptionBindings.ts` (3); other consumers use only the unchanged sync surface — `list`/`unbindAll` from `src/controllers/settingsView/githubSubscriptions.ts` (2 call groups) and `unbind`/`list` in the tool.
- `emit`/`emitToListener`/`consumeCommentList`/`handleFailure` call sites: 21 across the three pollers, all converted; no other consumers.
- Tool contract (`name`, schema, result text) unchanged; no host calls the tool's internals.

## Host impact

None. Extension, desktop, and CLI exercise this plane only through the `github_subscription` tool and the settings Git tab; both keep their exact behavior and message text. The poll loop now forks detached under the tool's boundary run on the same process runtime, so loop lifetime (subscribe starts it, last-unsubscribe/`disposeAll`/shutdown stops it) is unchanged.

## Scheduled refactoring

- The surviving raw catch in `PollingSourceBase.notifyKeysChanged` (a synchronous listener guard reachable from non-Effect dispose paths) waits for a repo-wide guarded-fan-out home; converting it alone would be a single-caller extraction.
- The two file-local folds (`foldToolExit` here, the mapping variant in `LspTools.ts`) collapse into one helper when a third tool lane lands.
- `UsageLogService` (wave-1, has open PR #11993) and `agentCliSessionRegistry` (wave-1, a Queue-drain conversion is in flight elsewhere) remain in the run row; this PR zeroes the polling half of the wave-1 tools label.

## Validation

All run on the branch head in the worktree (base `1fd5932a29`):

- `npm run typecheck:workspace` — clean; `npm run typecheck:test-kernel` — clean.
- `npx eslint` on the 9 touched source/test files — clean; `npx prettier --write` — applied (three files reformatted, no semantic change).
- Targeted vitest: `PollingSourceBase`, `PRPollingSource`, `PRPollingSourceCiStarted`, `PRPollingSourceAnnotationPages`, `GitHubSubscriptionTool`, `GitHubSubscriptionProgressEvents` — 6 files, 28 tests, all pass. The follow-up suite's two `handleFailure` cases moved to `@effect/vitest`'s `it.effect` (native idiom; the reference conversion is `DirectLspAdapter.vitest.ts`), and its delivery-failure case now awaits the delivery program instead of a `setImmediate` settle-and-hope.
- `node scripts/check-effect-migration-ratchet.mjs --update` — OK, no count grew; baseline committed here.
- `npm run check:dead-code-ratchet` — OK, no new findings.
- Full `npm test -- --maxWorkers=4` — 763 files passed / 1 skipped, 9085 tests passed / 5 skipped, exit 0; neither known parallel-load flake appeared.
