### PR TITLE
refactor(controllers): run wave-1 rebuild effects at the host edges

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -163,15 +163,11 @@
     "Effect.run*": {
       "packages/extension/src/progressView/frontend/sessionTransport.ts": 4,
       "src/agent/runtime/SessionHandle.ts": 3,
-      "src/controllers/onboarding/OnboardingRefreshQueue.ts": 1,
-      "src/controllers/progressView/ProgressApiKeyRetryController.ts": 3,
       "src/controllers/session/SessionBridge.ts": 6,
-      "src/controllers/session/hostDraftRequests.ts": 1,
       "src/controllers/session/hostRunActions.ts": 1,
       "src/controllers/session/sessionLayer.ts": 3,
       "src/platform/defaults/jsonStore.ts": 1,
       "src/shared/signals.ts": 2,
-      "src/telemetry/UsageLogService.ts": 4,
       "src/tools/agentCliSessionRegistry.ts": 2,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/lean/direct/directLspAdapter.ts": 3
@@ -210,15 +206,11 @@
   "debtLanes": {
     "packages/extension/src/progressView/frontend/sessionTransport.ts": "webview frontends — the progress view subscribes through an Effect-typed session plane instead of running fibers in the view",
     "src/agent/runtime/SessionHandle.ts": "Phase 3 — run lifecycle and cancellation",
-    "src/controllers/onboarding/OnboardingRefreshQueue.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
-    "src/controllers/progressView/ProgressApiKeyRetryController.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/controllers/session/SessionBridge.ts": "lane D — host composition root and session graph",
-    "src/controllers/session/hostDraftRequests.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/controllers/session/hostRunActions.ts": "lane D — host composition root and session graph",
     "src/controllers/session/sessionLayer.ts": "lane D — host composition root and session graph",
     "src/platform/defaults/jsonStore.ts": "lane D — Platform ports become Effect-typed",
     "src/shared/signals.ts": "lane D — host composition root and session graph",
-    "src/telemetry/UsageLogService.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
     "src/tools/agentCliSessionRegistry.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/github/PollingSourceBase.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — the port is Effect-typed and the tool-facing runs moved to the tools' execute(); what remains is pool construction/disposal (the platform-lifetime seam) and the run-end hook's Promise seam, both owned by lane D"

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -385,7 +385,9 @@ export async function initCliPlatform(
       // The default session is installed later by whichever entry point opens
       // transcripts, so its shutdown lookup remains lazy.
       flushArtifacts: () => tryDefaultSession()?.flushArtifacts(),
-      afterFlushArtifacts: [() => UsageLogService.dispose()],
+      afterFlushArtifacts: [
+        () => effectRuntime().runPromise(UsageLogService.dispose()),
+      ],
       afterExecutionSettlement: [
         () => teardownDefaultSession(),
         () => flushNdjsonStdout(),
@@ -398,7 +400,9 @@ export async function initCliPlatform(
     // dispose() flushes any queued entries; it
     // runs on normal exit (bin/texra.ts finally) and on signals, both of
     // which call lifecycle.runShutdown().
-    UsageLogService.initialize({}, context.version, 'cli');
+    await effectRuntime().runPromise(
+      UsageLogService.initialize({}, context.version, 'cli'),
+    );
   }
 
   if (!supabaseAuthInitialized) {

--- a/packages/desktop/src/main/desktopHostRequests.ts
+++ b/packages/desktop/src/main/desktopHostRequests.ts
@@ -18,6 +18,7 @@ import {
 import { prepareSurfaceLaunch } from '@controllers/mainView/backend/MainViewExecutionLaunchController';
 import type { ChatExportController } from '@controllers/progressView/ChatExportController';
 import { exportStreamTranscript } from '@controllers/progressView/exportTranscript';
+import { installProgressApiKeyRetryEdge } from '@controllers/progressView/ProgressApiKeyRetryController';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import {
   ProgressWorkflowRunActionsController,
@@ -39,6 +40,7 @@ import {
 import { runCleanRunDir, runPackRunDir } from '@housekeeping/runDirOps';
 import { LaTeXdiffService } from '@latex/latexdiff';
 import { computeModelOptionsData } from '@model/computeModelOptions';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   cloneRoundIndexed,
   type ExecutionId,
@@ -129,6 +131,12 @@ export function createDesktopHostRequests(
   options: DesktopHostRequestsOptions,
 ): DesktopHostRequests {
   const { session, host, execution, logger } = options;
+  // The retry controller's programs settle through this edge (PRD R1): the
+  // run stays in boundary code while its lane-D consumer keeps a Promise
+  // surface.
+  installProgressApiKeyRetryEdge((program) =>
+    effectRuntime().runPromiseExit(program),
+  );
   // Shared controllers propagate request failures to the dispatcher.
   const rejectRequest = async (reason: string): Promise<never> => {
     throw new Rejected({ reason });
@@ -613,7 +621,7 @@ export function createDesktopHostRequests(
       case 'record':
       case 'polish':
       case 'savePastedImage':
-        return draftRequests.handle(request, port);
+        return effectRuntime().runPromise(draftRequests.handle(request, port));
       case 'popOut':
       case 'popBack':
         throw notOnDesktop('Pop-out to editor');

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -3,6 +3,7 @@ import { OnboardingRefreshQueue } from '@controllers/onboarding/OnboardingRefres
 import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { StateStore } from '@platform/interfaces';
+import { effectRuntime } from '@platform/processRuntime';
 import type { OnboardingFunnelState } from '@shared/schemas';
 import {
   readOnboardingFlags,
@@ -158,7 +159,7 @@ export function createDesktopOnboardingIpc(
   }
 
   function refreshOnboardingFunnel(): Promise<void> {
-    return funnelRefreshQueue.run();
+    return effectRuntime().runPromise(funnelRefreshQueue.run());
   }
 
   async function dismiss(): Promise<void> {

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -157,8 +157,12 @@ export async function initializeElectronPlatform(
   // carries an undefined host/version, so a queue shorter than one batch is
   // lost at quit — including plan accounting. `dispose()` drains it, from the
   // same BEFORE phase the other two hosts use.
-  UsageLogService.initialize({}, app.getVersion(), 'desktop');
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => UsageLogService.dispose());
+  await effectRuntime().runPromise(
+    UsageLogService.initialize({}, app.getVersion(), 'desktop'),
+  );
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+    effectRuntime().runPromise(UsageLogService.dispose()),
+  );
 
   // Reconcile the persisted enabled-models list against the current curated
   // defaults, as the extension and CLI hosts do at startup. Preferred defaults

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -513,7 +513,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
   registerRuntimeShutdownHandlers(lifecycle, {
     afterAgentShutdown: [
       () => killActiveRecording(),
-      () => UsageLogService.dispose(),
+      () => effectRuntime().runPromise(UsageLogService.dispose()),
     ],
     flushArtifacts: () => runtimeSession.flushArtifacts(),
     afterExecutionSettlement: [
@@ -632,10 +632,12 @@ async function activateExtension(context: vscode.ExtensionContext) {
       ? context.extension.packageJSON.version
       : undefined;
   try {
-    UsageLogService.initialize(
-      {},
-      extensionVersion,
-      vscode.env.appName || undefined,
+    await effectRuntime().runPromise(
+      UsageLogService.initialize(
+        {},
+        extensionVersion,
+        vscode.env.appName || undefined,
+      ),
     );
   } catch (error) {
     log.warn(`Failed to initialize usage logging: ${toErrorMessage(error)}`);

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -389,7 +389,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
    * auto-starts setup; the user launches it from the setup card.
    */
   public refreshOnboardingFunnel(): Promise<void> {
-    return this.onboardingFunnelRefreshQueue.run();
+    return effectRuntime().runPromise(this.onboardingFunnelRefreshQueue.run());
   }
 
   private async refreshOnboardingFunnelSerially(): Promise<void> {

--- a/packages/extension/src/progressView/extensionHostRequests.ts
+++ b/packages/extension/src/progressView/extensionHostRequests.ts
@@ -34,6 +34,7 @@ import {
   TRANSCRIPT_EXPORT_FORMAT_CHOICES,
   type TranscriptExportOpenKind,
 } from '@controllers/progressView/exportTranscript';
+import { installProgressApiKeyRetryEdge } from '@controllers/progressView/ProgressApiKeyRetryController';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { ProgressWorkflowRunActionsController } from '@controllers/progressView/ProgressWorkflowRunActionsController';
 import {
@@ -53,6 +54,7 @@ import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { parseVersionControlDiffFilename } from '@latex/latexdiff/diffFileNameManager';
 import { createLog } from '@logger/logUtils';
 import { computeModelOptionsData } from '@model/computeModelOptions';
+import { effectRuntime } from '@platform/processRuntime';
 import latexPreamble from '@resources/templates/chatExport.tex';
 import {
   GETTING_STARTED_COMMANDS,
@@ -143,6 +145,12 @@ export function createExtensionHostRequests(
   options: ExtensionHostRequestsOptions,
 ): ExtensionHostRequests {
   const { session, snapshot, toolEditApprovals } = options;
+  // The retry controller's programs settle through this edge (PRD R1): the
+  // run stays in boundary code while its lane-D consumer keeps a Promise
+  // surface.
+  installProgressApiKeyRetryEdge((program) =>
+    effectRuntime().runPromiseExit(program),
+  );
   const draftRequests = options.draftRequests.attach(session, (recording) =>
     options.snapshot.setRecording(recording),
   );
@@ -664,7 +672,7 @@ export function createExtensionHostRequests(
       case 'record':
       case 'polish':
       case 'savePastedImage':
-        return draftRequests.handle(request, port);
+        return effectRuntime().runPromise(draftRequests.handle(request, port));
       case 'popOut':
         await options.popOutToEditor();
         return done;

--- a/src/controllers/onboarding/OnboardingRefreshQueue.ts
+++ b/src/controllers/onboarding/OnboardingRefreshQueue.ts
@@ -1,7 +1,5 @@
 import { Effect, Semaphore } from 'effect';
 
-import { effectRuntime } from '@platform/processRuntime';
-
 /** Serialize funnel refreshes and collapse an in-flight burst to one rerun. */
 export class OnboardingRefreshQueue {
   /** One permit: a refresh holds it while it runs; callers that arrive
@@ -24,8 +22,12 @@ export class OnboardingRefreshQueue {
     }
   });
 
-  run(): Promise<void> {
-    this.rerunRequested = true;
-    return effectRuntime().runPromise(this.lane.withPermit(this.drain()));
+  /** Ask for a refresh. The host edge runs the returned effect; a rejection
+   *  is the refresh's own error. */
+  run(): Effect.Effect<void, unknown> {
+    return Effect.suspend(() => {
+      this.rerunRequested = true;
+      return this.lane.withPermit(this.drain());
+    });
   }
 }

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, Semaphore } from 'effect';
+import { Cause, Effect, Exit, Option, Semaphore } from 'effect';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports
@@ -10,7 +10,6 @@ import {
   quotaFallbackRuntimes,
   type QuotaFallbackRuntime,
 } from '@model/quotaFallbackRoutes';
-import { effectRuntime } from '@platform/processRuntime';
 import type { ExhaustionReason, StreamTabId } from '@shared/schemas';
 import {
   isKimiCodeExclusiveModel,
@@ -48,6 +47,47 @@ function port<A>(call: () => A | PromiseLike<A>): Effect.Effect<A, unknown> {
     try: async () => call(),
     catch: (error) => error,
   });
+}
+
+/**
+ * Settles one of the controller's programs as an `Exit`, for the
+ * Promise-facing facade below. Installed like the process roots: exactly once
+ * per process, by the host entry, as
+ * `(program) => effectRuntime().runPromiseExit(program)` — which keeps the
+ * `Effect.run*` call itself in boundary code (PRD R1).
+ */
+type ProgressApiKeyRetryEdge = <A, E>(
+  program: Effect.Effect<A, E>,
+) => Promise<Exit.Exit<A, E>>;
+
+let progressApiKeyRetryEdge: ProgressApiKeyRetryEdge | null = null;
+
+/** Install the process-wide run edge for the retry controller's programs. */
+export function installProgressApiKeyRetryEdge(
+  edge: ProgressApiKeyRetryEdge,
+): void {
+  progressApiKeyRetryEdge = edge;
+}
+
+/**
+ * Run one retry program on the installed edge and settle it as a Promise.
+ * An expected failure (a port's own rejection, carried through the identity
+ * catch) is re-thrown unchanged, so the caller's `instanceof` and message
+ * checks still hold; defects and interruption propagate as they are.
+ */
+async function runProgressApiKeyRetryProgram<A>(
+  program: Effect.Effect<A, unknown>,
+): Promise<A> {
+  if (!progressApiKeyRetryEdge) {
+    throw new Error(
+      'Progress API-key retry edge not installed: the host entry installs it beside the process runtime.',
+    );
+  }
+  const exit = await progressApiKeyRetryEdge(program);
+  if (Exit.isSuccess(exit)) return exit.value;
+  const failure = Cause.findErrorOption(exit.cause);
+  if (Option.isSome(failure)) throw failure.value;
+  throw Cause.squash(exit.cause);
 }
 
 export interface ProgressApiKeyRetryControllerDeps {
@@ -115,11 +155,12 @@ export class ProgressApiKeyRetryController {
     return this.deps.quotaFallbackRuntimes ?? quotaFallbackRuntimes;
   }
 
-  useOwnApiKey(request: ProgressApiKeyRetryRequest): Promise<void> {
-    return effectRuntime().runPromise(this.switchToOwnApiKey(request));
-  }
-
-  private readonly switchToOwnApiKey = Effect.fn(
+  /**
+   * Switch a quota-exhausted retry to the user's own key: prompt for a usable
+   * key when the exhaustion requires it, commit the routing switches, and
+   * launch the retry. The Effect surface of the former `useOwnApiKey`.
+   */
+  readonly switchToOwnApiKey = Effect.fn(
     'ProgressApiKeyRetryController.useOwnApiKey',
   )(function* (
     this: ProgressApiKeyRetryController,
@@ -227,13 +268,11 @@ export class ProgressApiKeyRetryController {
     return yield* port(action);
   });
 
-  ensureOwnApiKey(
-    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
-  ): Promise<boolean> {
-    return effectRuntime().runPromise(this.ensureOwnApiKeyReady(request));
-  }
-
-  private readonly ensureOwnApiKeyReady = Effect.fn(
+  /**
+   * Whether a usable own key is on file for `request` after prompting when
+   * one is needed. The Effect surface of the former `ensureOwnApiKey`.
+   */
+  readonly ensureOwnApiKeyReady = Effect.fn(
     'ProgressApiKeyRetryController.ensureOwnApiKey',
   )(function* (
     this: ProgressApiKeyRetryController,
@@ -316,16 +355,41 @@ export class ProgressApiKeyRetryController {
     );
   }
 
-  /** Apply Copilot fallback routing only for the duration of a launch attempt. */
+  /** Apply Copilot fallback routing only for the duration of a launch attempt.
+   *  The Effect surface of the former `runCopilotFallbackWithRouting`. */
+  copilotFallbackWithRouting(
+    request: ProgressApiKeyRetryRequest,
+    start: (copilotRouteOverride: CopilotRouteOverride) => Promise<boolean>,
+  ): Effect.Effect<boolean, unknown> {
+    // The user chose "use own API key" for this retry. The direct-route
+    // override travels only with the replacement launch; the standing
+    // preference remains visible to concurrent and future runs.
+    return this.commitOwnApiKeyRouting(request, () => start('direct'));
+  }
+
+  // --- Promise facade -------------------------------------------------------
+  // The one consumer of these Promise methods is `createHostRunActions`
+  // (src/controllers/session/hostRunActions.ts), owned by lane D (host
+  // composition root and session graph) in the Effect-migration debt-lane
+  // register. Each facade method settles the Effect surface above through
+  // the host-installed edge and deletes as that lane converts its caller.
+
+  useOwnApiKey(request: ProgressApiKeyRetryRequest): Promise<void> {
+    return runProgressApiKeyRetryProgram(this.switchToOwnApiKey(request));
+  }
+
+  ensureOwnApiKey(
+    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
+  ): Promise<boolean> {
+    return runProgressApiKeyRetryProgram(this.ensureOwnApiKeyReady(request));
+  }
+
   runCopilotFallbackWithRouting(
     request: ProgressApiKeyRetryRequest,
     start: (copilotRouteOverride: CopilotRouteOverride) => Promise<boolean>,
   ): Promise<boolean> {
-    // The user chose "use own API key" for this retry. The direct-route
-    // override travels only with the replacement launch; the standing
-    // preference remains visible to concurrent and future runs.
-    return effectRuntime().runPromise(
-      this.commitOwnApiKeyRouting(request, () => start('direct')),
+    return runProgressApiKeyRetryProgram(
+      this.copilotFallbackWithRouting(request, start),
     );
   }
 

--- a/src/controllers/session/hostDraftRequests.ts
+++ b/src/controllers/session/hostDraftRequests.ts
@@ -4,7 +4,6 @@ import { Deferred, Effect } from 'effect';
 import { runInSession } from '@agent/runtime/RunContext';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { polishTextWithAI } from '@agent/runtime/textEnhancement';
-import { effectRuntime } from '@platform/processRuntime';
 import type { HostRequest } from '@shared/session/hostRequest';
 import type { HostSnapshot } from '@shared/session/hostSnapshot';
 import { Cancelled, Rejected } from '@shared/session/requestErrors';
@@ -69,12 +68,15 @@ export class HostDraftRequests {
     return () => this.listeners.delete(listener);
   }
 
+  /** Answer one draft request. The host edge runs the returned effect; a
+   *  failure is the request's own error (`Rejected`, `Cancelled`, or the
+   *  port's rejection). */
   handle(
     session: SessionHandle,
     request: DraftRequest,
     port: string,
-  ): Promise<HostOutcome> {
-    return effectRuntime().runPromise(this.draft(session, request, port));
+  ): Effect.Effect<HostOutcome, unknown> {
+    return this.draft(session, request, port);
   }
 
   private readonly draft = Effect.fn('HostDraftRequests.handle')(function* (

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -1,13 +1,20 @@
 import { randomUUID } from 'node:crypto';
 
-import { Clock, Data, Duration, Effect, Fiber, Semaphore } from 'effect';
+import {
+  Clock,
+  Data,
+  Deferred,
+  Duration,
+  Effect,
+  Fiber,
+  Semaphore,
+} from 'effect';
 import ky from 'ky';
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';
 import { createLog } from '@logger/logUtils';
 import type { ConfigProvider } from '@platform/interfaces';
-import { effectRuntime } from '@platform/processRuntime';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import type { UsageRoute } from '@shared/schemas';
 import {
@@ -216,6 +223,18 @@ class UsageLogServiceImpl {
    *  and interrupted by `dispose`. It only schedules: each flush runs on a
    *  fiber of its own, so interrupting the ticker never touches a send. */
   private flushTimer: Fiber.Fiber<never> | null = null;
+  /** The batch-size trigger's fiber, forked and interrupted beside the
+   *  ticker. It parks on `wakeFlush` between triggers. */
+  private flushTrigger: Fiber.Fiber<never> | null = null;
+  /** Set when the queue reaches the batch size before the trigger fiber has
+   *  parked (entries logged ahead of `initialize`): honoured at once when it
+   *  starts. */
+  private flushRequested = false;
+  /** The wait the trigger fiber is parked on, if any; `log` completes it
+   *  when the batch fills. Completion resumes the fiber synchronously, so the
+   *  flush starts in `log`'s own call stack, as it did when `log` forked it
+   *  directly. */
+  private wakeFlush: Deferred.Deferred<void> | null = null;
   /** One permit: batches leave in order, and disposal joins an active drain. */
   private readonly flushLane = Semaphore.makeUnsafe(1);
   /** Coalesce triggers before they wait for the lane; failed sends wait for
@@ -227,15 +246,18 @@ class UsageLogServiceImpl {
   private extensionVersion: string | undefined;
   private editorType: string | undefined;
 
-  initialize(
+  /** Configure the service and start its flusher loop. The host edge runs
+   *  the returned effect once, at startup. */
+  readonly initialize = Effect.fn('UsageLogService.initialize')(function* (
+    this: UsageLogServiceImpl,
     config?: Partial<UsageLogConfig>,
     extensionVersion?: string,
     editorType?: string,
-  ): void {
+  ) {
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.extensionVersion = extensionVersion;
     this.editorType = editorType;
-    this.startFlushTimer();
+    yield* this.startFlusher();
 
     if (isTelemetryDisabledByEnv()) {
       log.info(
@@ -246,7 +268,7 @@ class UsageLogServiceImpl {
     log.debug(
       `UsageLogService initialized (batchSize=${this.config.batchSize}, flushIntervalMs=${this.config.flushIntervalMs}, enabled=${this.config.enabled})`,
     );
-  }
+  });
 
   log(
     entry: Omit<UsageLogEntry, 'timestamp' | 'extensionVersion' | 'editorType'>,
@@ -275,7 +297,12 @@ class UsageLogServiceImpl {
     log.debug(`Queued usage entry (queue size: ${this.queue.length})`);
 
     if (this.queue.length >= this.config.batchSize) {
-      effectRuntime().runFork(this.backgroundFlush());
+      // Wake the trigger fiber now rather than at the next interval. Both
+      // writes are synchronous, so `log` stays a fire-and-forget enqueue for
+      // its callers (the agent runtime's UsageMonitor among them).
+      this.flushRequested = true;
+      const wake = this.wakeFlush;
+      if (wake) Deferred.doneUnsafe(wake, Effect.void);
     }
   }
 
@@ -474,37 +501,90 @@ class UsageLogServiceImpl {
     },
   );
 
-  private startFlushTimer(): void {
-    const runtime = effectRuntime();
-    if (this.flushTimer) runtime.runFork(Fiber.interrupt(this.flushTimer));
-    // The ticker lives until dispose() interrupts it, and it must not keep a
-    // short-lived host (the CLI) alive on its own: an active run keeps the
-    // loop running so the tick still fires, but at exit dispose() flushes and
-    // interrupts it rather than the ticker pinning the process. Its sleep
-    // therefore runs on `unrefSleepClock`; a host that never disposes exits
-    // on an empty loop as before, with whatever the queue holds unsent.
-    //
-    // Detached on purpose: a flush belongs to the lane, not to the tick that
-    // scheduled it. `sendNextBatch` takes the batch before the request goes
-    // out, and an interrupt landing there would abort the request without
-    // failing it, so nothing would requeue what was taken. Running the flush
-    // on its own fiber keeps a dispose (or re-initialize) that lands mid-send
-    // from reaching it: dispose waits behind the send on the lane instead.
-    // The flush ends with its drain and is observed by nothing else.
+  private readonly startFlusher = Effect.fn('UsageLogService.startFlusher')(
+    function* (this: UsageLogServiceImpl) {
+      if (this.flushTimer) {
+        yield* Fiber.interrupt(this.flushTimer);
+        this.flushTimer = null;
+      }
+      if (this.flushTrigger) {
+        yield* Fiber.interrupt(this.flushTrigger);
+        this.flushTrigger = null;
+      }
+      // The ticker lives until dispose() interrupts it, and it must not keep
+      // a short-lived host (the CLI) alive on its own: an active run keeps
+      // the loop running so the tick still fires, but at exit dispose()
+      // flushes and interrupts it rather than the ticker pinning the
+      // process. Its sleep therefore runs on `unrefSleepClock`; a host that
+      // never disposes exits on an empty loop as before, with whatever the
+      // queue holds unsent.
+      //
+      // Detached on purpose: both fibers belong to the service, not to the
+      // `initialize` run that forked them. And each flush they schedule is
+      // detached in turn: a flush belongs to the lane, not to the tick or
+      // trigger that scheduled it. `sendNextBatch` takes the batch before
+      // the request goes out, and an interrupt landing there would abort the
+      // request without failing it, so nothing would requeue what was taken.
+      // Running the flush on its own fiber keeps a dispose (or re-initialize)
+      // that lands mid-send from reaching it: dispose waits behind the send
+      // on the lane instead.
+      //
+      // Started immediately so both fibers are parked (the ticker's first
+      // timer registered) before `initialize` settles, as they were when the
+      // ticker was forked straight off the runtime.
+      this.flushTimer = yield* Effect.forkDetach(this.tickerLoop(), {
+        startImmediately: true,
+      });
+      this.flushTrigger = yield* Effect.forkDetach(this.triggerLoop(), {
+        startImmediately: true,
+      });
+    },
+  );
+
+  /** Sleep to the next interval, then schedule a flush, forever. */
+  private tickerLoop(): Effect.Effect<never> {
     const tick = Clock.clockWith((clock) =>
       Effect.sleep(Duration.millis(this.config.flushIntervalMs)).pipe(
         Effect.provideService(Clock.Clock, unrefSleepClock(clock)),
       ),
     );
-    this.flushTimer = runtime.runFork(
-      Effect.forever(
-        tick.pipe(Effect.andThen(Effect.forkDetach(this.backgroundFlush()))),
-      ),
+    return Effect.forever(
+      tick.pipe(Effect.andThen(Effect.forkDetach(this.backgroundFlush()))),
     );
   }
 
-  dispose(): Promise<void> {
-    return effectRuntime().runPromise(this.shutdown());
+  /** Wait for the batch-size trigger, then schedule a flush, forever. The
+   *  wake resumes this fiber inside `log`'s call, and the flush fiber starts
+   *  immediately, so a batch-full `log` begins its drain in its own call
+   *  stack — what the direct `runFork` it replaces did. */
+  private triggerLoop(): Effect.Effect<never> {
+    return Effect.forever(
+      Effect.suspend(() => {
+        if (this.flushRequested) {
+          this.flushRequested = false;
+          return this.startFlushNow();
+        }
+        const wake = Deferred.makeUnsafe<void>();
+        this.wakeFlush = wake;
+        return Effect.andThen(Deferred.await(wake), this.startFlushNow());
+      }),
+    );
+  }
+
+  private startFlushNow(): Effect.Effect<Fiber.Fiber<void>> {
+    return Effect.suspend(() => {
+      this.wakeFlush = null;
+      this.flushRequested = false;
+      return Effect.forkDetach(this.backgroundFlush(), {
+        startImmediately: true,
+      });
+    });
+  }
+
+  /** Stop the flusher and drain what remains. The host edge runs the
+   *  returned effect from its shutdown path. */
+  dispose(): Effect.Effect<void> {
+    return this.shutdown();
   }
 
   private readonly shutdown = Effect.fn('UsageLogService.dispose')(function* (
@@ -514,6 +594,12 @@ class UsageLogServiceImpl {
       yield* Fiber.interrupt(this.flushTimer);
       this.flushTimer = null;
     }
+    if (this.flushTrigger) {
+      yield* Fiber.interrupt(this.flushTrigger);
+      this.flushTrigger = null;
+    }
+    this.wakeFlush = null;
+    this.flushRequested = false;
     this.config.enabled = false;
 
     // An in-flight background flush is waited for without

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -137,9 +137,15 @@ vi.mock('@platform/defaults/nodeAgentRuntime', () => ({
   initNodeAgentRuntime: mocks.initNodeAgentRuntime,
 }));
 
-vi.mock('@telemetry/UsageLogService', () => ({
-  UsageLogService: { initialize: vi.fn(), dispose: vi.fn() },
-}));
+vi.mock('@telemetry/UsageLogService', async () => {
+  const { Effect } = await import('effect');
+  return {
+    UsageLogService: {
+      initialize: vi.fn(() => Effect.void),
+      dispose: vi.fn(() => Effect.void),
+    },
+  };
+});
 
 // First-init dependencies: only exercised when tryPlatform() returns undefined.
 // Most cases keep tryPlatform truthy and skip this block, so these stubs are

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -2,14 +2,22 @@ import pDefer from 'p-defer';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  installProgressApiKeyRetryEdge,
   ProgressApiKeyRetryController,
   type ProgressApiKeyRetryControllerDeps,
 } from '@controllers/progressView/ProgressApiKeyRetryController';
 import type { ApiProvider } from '@model/apiProviders';
 import { prefersCopilotRoute } from '@model/copilotRouting';
 import type { QuotaFallbackRuntime } from '@model/quotaFallbackRoutes';
+import { effectRuntime } from '@platform/processRuntime';
 import type { QuotaFallbackRoute } from '@shared/quotaFallbackRoutes';
 import { installPlatform } from '@test/support/setupPlatform';
+
+// The controller's Promise facade settles through the edge a host entry
+// installs; this suite stands in for the host.
+installProgressApiKeyRetryEdge((program) =>
+  effectRuntime().runPromiseExit(program),
+);
 
 const PROVIDERS = [
   'openai',

--- a/src/test-kernel/controllers/session/hostDraftRequests.vitest.ts
+++ b/src/test-kernel/controllers/session/hostDraftRequests.vitest.ts
@@ -5,6 +5,8 @@ import { expect, it, vi } from 'vitest';
 // Local imports
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { HostDraftRequests } from '@controllers/session/hostDraftRequests';
+import { effectRuntime } from '@platform/processRuntime';
+import type { HostOutcome } from '@shared/session/sessionFrames';
 
 const audio = vi.hoisted(() => ({
   startRecording: vi.fn(),
@@ -28,12 +30,18 @@ it('returns transcription to Start when another paper stops the process recorder
     text: 'A conserved quantity.',
   });
   const requests = new HostDraftRequests();
+  // The request surface is Effect-typed; the test settles it on the process
+  // runtime the fake host installs, as the host edge does.
+  const handle = (
+    ...args: Parameters<HostDraftRequests['handle']>
+  ): Promise<HostOutcome> =>
+    effectRuntime().runPromise(requests.handle(...args));
   const first = { roots: { storage: '/papers/first' } } as SessionHandle;
   const second = { roots: { storage: '/papers/second' } } as SessionHandle;
   const snapshot = vi.fn();
   const unsubscribe = requests.subscribe(snapshot);
 
-  const started = requests.handle(
+  const started = handle(
     first,
     {
       kind: 'record',
@@ -42,7 +50,7 @@ it('returns transcription to Start when another paper stops the process recorder
     'origin',
   );
   await expect(
-    requests.handle(
+    handle(
       second,
       {
         kind: 'record',
@@ -57,11 +65,7 @@ it('returns transcription to Start when another paper stops the process recorder
   });
 
   await expect(
-    requests.handle(
-      second,
-      { kind: 'record', action: { kind: 'stop' } },
-      'other',
-    ),
+    handle(second, { kind: 'record', action: { kind: 'stop' } }, 'other'),
   ).resolves.toEqual({ kind: 'done' });
   expect(audio.stopRecordingAndTranscribe).not.toHaveBeenCalled();
   startup.resolve({ success: true });
@@ -75,7 +79,7 @@ it('returns transcription to Start when another paper stops the process recorder
 
   const nextStartup = pDefer<{ success: boolean }>();
   audio.startRecording.mockReturnValueOnce(nextStartup.promise);
-  const nextTake = requests.handle(
+  const nextTake = handle(
     first,
     {
       kind: 'record',

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
@@ -1,6 +1,7 @@
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { StreamTabId } from '@shared/schemas';
@@ -130,8 +131,8 @@ describe('desktop preview host', () => {
       shell.openExternal.mockRejectedValue(new Error('Browser unavailable'));
       const preview = createDesktopPreviewHost({ shell });
       const draftRequests = new HostDraftRequests();
-      vi.spyOn(draftRequests, 'handle').mockRejectedValue(
-        new Error('Text service unavailable'),
+      vi.spyOn(draftRequests, 'handle').mockReturnValue(
+        Effect.fail(new Error('Text service unavailable')),
       );
       const files = createDesktopFileSelection({
         workspacePath: undefined,

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -10,6 +10,7 @@ import {
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import * as logger from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import { AgentCategory, TELEMETRY_ENABLED_KEY } from '@shared/schemas';
 import { UsageLogService } from '@telemetry/UsageLogService';
@@ -20,6 +21,18 @@ import {
 } from '@test/support/FakePlatform';
 import { jsonResponse } from '@test/support/fetchTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
+
+// The service surface is Effect-typed; the suite settles it on the process
+// runtime the fake host installs.
+function runInitialize(
+  config: Parameters<typeof UsageLogService.initialize>[0],
+) {
+  return effectRuntime().runPromise(UsageLogService.initialize(config));
+}
+
+function runDispose() {
+  return effectRuntime().runPromise(UsageLogService.dispose());
+}
 
 function usageEntry(model: string) {
   return {
@@ -73,9 +86,9 @@ function stubBatchFetch(
 }
 
 describe('UsageLogService', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-    UsageLogService.initialize({
+    await runInitialize({
       batchSize: 1,
       flushIntervalMs: 60_000,
       enabled: true,
@@ -83,7 +96,7 @@ describe('UsageLogService', () => {
   });
 
   afterEach(async () => {
-    await UsageLogService.dispose();
+    await runDispose();
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
@@ -130,7 +143,7 @@ describe('UsageLogService', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     UsageLogService.log(usageEntry('second'));
-    const disposal = UsageLogService.dispose();
+    const disposal = runDispose();
 
     releaseFirstFetch();
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
@@ -155,7 +168,7 @@ describe('UsageLogService', () => {
   // had already taken from the queue.
   it('waits for a timer-driven flush during disposal instead of aborting it', async () => {
     stubAccessToken();
-    UsageLogService.initialize({
+    await runInitialize({
       batchSize: 100,
       flushIntervalMs: 20,
       enabled: true,
@@ -170,7 +183,7 @@ describe('UsageLogService', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     const request = fetchMock.mock.calls[0]?.[0] as Request;
 
-    const disposal = UsageLogService.dispose();
+    const disposal = runDispose();
     let disposed = false;
     void disposal.then(() => {
       disposed = true;
@@ -190,19 +203,23 @@ describe('UsageLogService', () => {
   // that reaches initialize() and exits without dispose() still exits on an
   // empty loop, so the ticker's timer is unref'd while the request a flush
   // sends holds the loop on its own.
-  it('schedules the ticker on a timer that does not hold the event loop', () => {
+  it('schedules the ticker on a timer that does not hold the event loop', async () => {
     vi.useRealTimers();
     const timers = vi.spyOn(globalThis, 'setTimeout');
-    UsageLogService.initialize({
+    await runInitialize({
       batchSize: 100,
       flushIntervalMs: 12_345,
       enabled: true,
     });
 
-    const tick = timers.mock.calls.findIndex(([, delay]) => delay === 12_345);
-    expect(tick).toBeGreaterThanOrEqual(0);
-    const handle = timers.mock.results[tick]?.value as NodeJS.Timeout;
-    expect(handle.hasRef()).toBe(false);
+    // The flusher loop's first sleep is scheduled on its own fiber, just
+    // after the initialize run settles.
+    await vi.waitFor(() => {
+      const tick = timers.mock.calls.findIndex(([, delay]) => delay === 12_345);
+      expect(tick).toBeGreaterThanOrEqual(0);
+      const handle = timers.mock.results[tick]?.value as NodeJS.Timeout;
+      expect(handle.hasRef()).toBe(false);
+    });
   });
 
   it('warns after five seconds without bounding disposal', async () => {
@@ -217,7 +234,7 @@ describe('UsageLogService', () => {
     UsageLogService.log(usageEntry('slow'));
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
-    const disposal = UsageLogService.dispose();
+    const disposal = runDispose();
     let disposed = false;
     void disposal.then(() => {
       disposed = true;
@@ -408,7 +425,7 @@ describe('UsageLogService', () => {
     // queued under the old value rather than letting the next flush ship them.
     it('discards entries queued before the setting was turned off', async () => {
       stubAccessToken();
-      UsageLogService.initialize({ batchSize: 100, flushIntervalMs: 60_000 });
+      await runInitialize({ batchSize: 100, flushIntervalMs: 60_000 });
 
       const { batches, fetchMock } = stubBatchFetch();
 
@@ -481,7 +498,7 @@ describe('UsageLogService', () => {
 
     it('drops optional entries from a batch but keeps the accounted ones', async () => {
       stubAccessToken();
-      UsageLogService.initialize({ batchSize: 100, flushIntervalMs: 60_000 });
+      await runInitialize({ batchSize: 100, flushIntervalMs: 60_000 });
 
       const { batches, fetchMock } = stubBatchFetch();
 


### PR DESCRIPTION
## Summary

Effect 4 migration, **wave-1 rebuild — controllers, telemetry and session drafts** lane: moves the four below-boundary `Effect.run*` sites the debt-lane register assigns to this lane up to the host edges, per PRD R1 (as amended 2026-09-06: the module surface becomes Effect-typed; the run happens only in boundary code).

Run sites eliminated, before → after (against this PR's base, which includes #11993's flush-API removal):

- `src/controllers/onboarding/OnboardingRefreshQueue.ts`: 1 → 0. `run()` now returns the drain as an `Effect`; the two boundary callers (`ProgressViewProvider.refreshOnboardingFunnel`, `desktopOnboardingIpc.refreshOnboardingFunnel`) run it with `effectRuntime().runPromise`.
- `src/controllers/progressView/ProgressApiKeyRetryController.ts`: 3 → 0. The former private programs (`switchToOwnApiKey`, `ensureOwnApiKeyReady`) are now the public Effect surface, joined by `copilotFallbackWithRouting`. Its one production consumer is `createHostRunActions` (`src/controllers/session/hostRunActions.ts`), owned by **lane D** — per the lane-boundary rule it stays on its current Promise surface, so the three original method names remain as a facade settled through a host-installed run edge (`installProgressApiKeyRetryEdge`), mirroring #11981's `installAuthProgramEdge`. Install points: `createExtensionHostRequests`, `createDesktopHostRequests`, and the controller's own test suite. A file comment names the consumer and its lane; the facade deletes when lane D converts `hostRunActions`.
- `src/controllers/session/hostDraftRequests.ts`: 1 → 0. `handle()` (and the handle `attach()` returns) is Effect-typed; the two dispatchers (`extensionHostRequests`, `desktopHostRequests`) run it at the request edge. Error identity is unchanged (`Rejected`/`Cancelled`/port rejections reach the dispatcher as before).
- `src/telemetry/UsageLogService.ts`: 4 → 0. `initialize` and `dispose` are Effect-typed and run by the three host entries (extension activate, CLI `initPlatform`, desktop platform init) and their shutdown hooks. `log()` keeps its synchronous `void` surface — its caller `src/agent/runtime/UsageMonitor.ts` belongs to the **main track** — and the batch-full `runFork` is replaced by a trigger fiber parked on a `Deferred`: `log` completes it with `Deferred.doneUnsafe`, which resumes the fiber synchronously, and the flush fiber starts `startImmediately`, so a batch-full `log` still begins its drain in its own call stack (what the direct `runFork` did — the fake-timer suites depend on it). The ticker fiber is byte-equivalent to main's.

Behavior preservation: approval/draft request semantics, retry routing-commit/rollback timing, telemetry batching/flushing — unchanged. No raw catches in the touched files (the R7 row counts none of them, and no host file gained a runtime `effect` import, so existing catch clauses stay out of the row).

Consumers deliberately left on their current surface, with owners:

- `createHostRunActions` (`src/controllers/session/hostRunActions.ts`) — lane D; consumes the retry controller's Promise facade (above).
- `src/agent/runtime/UsageMonitor.ts` (`UsageLogService.log`) — main track; `log` keeps its `void` surface.
- `platform()` calls everywhere — lane D, untouched.

## Issue acceptance gates

- The lane's four files are gone from the `Effect.run*` row: `node scripts/check-effect-migration-ratchet.mjs` reports `OK: no count grew, no baseline headroom`, zero failure lines, no `@adapter-until` markers.
- The regenerated baseline (`--update`, committed here) drops exactly the four debtLanes entries and nothing else.
- Full `npx vitest run`: 763 files passed, 9085 tests, 0 failures.

## Single source of truth

The four modules own their policy as Effect programs; the host entry owns the run edge (directly, or installed once per process for the retry controller's lane-D facade).

## Duplication and abstraction budget

No new abstraction layers: `installProgressApiKeyRetryEdge` mirrors the already-merged `installAuthProgramEdge` pattern rather than inventing a new one; the telemetry trigger fiber replaces a `runFork` call site with the repo's established `Deferred.makeUnsafe`/`doneUnsafe` idiom (as in `hostDraftRequests`). Removed: five `effectRuntime` imports and the four modules' run sites.

## Net elements (R6)

17 files changed, +315/−106 (net +209 LoC); +0 files. Exported symbols: +1/−0 (`installProgressApiKeyRetryEdge`). Classes/interfaces/enums: +0/−0 — surfaces retyped in place.

## Consumer counts (R8)

- `OnboardingRefreshQueue.run()`: 2 production consumers (extension `ProgressViewProvider`, desktop `desktopOnboardingIpc`) — both converted; 0 Promise-surface references remain.
- `HostDraftRequests.handle`: 2 production consumers (`extensionHostRequests`, `desktopHostRequests` dispatchers) + 2 test suites; `attach().handle` retyped with it.
- `ProgressApiKeyRetryController` Promise facade: 1 production consumer (`createHostRunActions`, lane D) left as-is; `installProgressApiKeyRetryEdge` installers: 2 host factories + 1 test suite.
- `UsageLogService.initialize`: 3 host entries + 1 CLI test mock; `dispose`: 3 shutdown registrations + 1 test suite; `log`: 1 production caller (`UsageMonitor`, main track) — signature unchanged. (`flush()` was removed upstream by #11993, before this PR's base.)

## Host impact

Extension: `activate` runs `UsageLogService.initialize` at its edge and wraps `dispose` in the shutdown hook; `ProgressViewProvider` runs the onboarding refresh queue; `extensionHostRequests` installs the retry edge and runs draft requests.

Desktop: platform init runs initialize/dispose at its edge; `desktopOnboardingIpc` runs the refresh queue; `desktopHostRequests` installs the retry edge and runs draft requests.

CLI: `initPlatform` runs initialize at its edge and wraps dispose in `afterFlushArtifacts`.

## Scheduled refactoring

Lane D deletes the retry controller's Promise facade when it converts `src/controllers/session/hostRunActions.ts` (the facade's file comment records this).

## Validation

- `npx prettier --check` on changed files — clean.
- `npm run typecheck` (all six projects) — clean.
- `npm run lint` — clean.
- Targeted vitest: UsageLogService (35), ProgressApiKeyRetryController, hostDraftRequests, DesktopPreviewHost, CliInitPlatform, TuiApprovalRetry, chatSessionController, ModelAccess(Selection), DesktopIpcAdapters, UsageMonitorLastTotals — all pass.
- `npx vitest run src/test-kernel/controllers src/test-kernel/agent` — 3268 passed.
- Full `npx vitest run` — 763 files, 9085 tests, 0 failures.
- `node scripts/check-effect-migration-ratchet.mjs` — OK (baseline regenerated, four debtLanes entries dropped).
- `npm run check:dead-code-ratchet` — OK, no new findings.
