### PR TITLE
refactor(tools): settle the agent-CLI session registry at the tool edge

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -172,7 +172,6 @@
       "src/platform/defaults/jsonStore.ts": 1,
       "src/shared/signals.ts": 2,
       "src/telemetry/UsageLogService.ts": 4,
-      "src/tools/agentCliSessionRegistry.ts": 2,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/lean/direct/directLspAdapter.ts": 3
     },
@@ -219,7 +218,6 @@
     "src/platform/defaults/jsonStore.ts": "lane D — Platform ports become Effect-typed",
     "src/shared/signals.ts": "lane D — host composition root and session graph",
     "src/telemetry/UsageLogService.ts": "wave-1 rebuild — controllers, telemetry and session drafts",
-    "src/tools/agentCliSessionRegistry.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/github/PollingSourceBase.ts": "wave-1 rebuild — tools: memory, executions, polling sources",
     "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — the port is Effect-typed and the tool-facing runs moved to the tools' execute(); what remains is pool construction/disposal (the platform-lifetime seam) and the run-end hook's Promise seam, both owned by lane D"
   }

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -2,6 +2,7 @@
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
@@ -19,7 +20,11 @@ import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
 } from '@test/support/streamStatusTestUtils';
-import { launchAgentCliSession } from '@tools/agentCliShared';
+import {
+  launchAgentCliSession,
+  reraiseAgentCliCallFailure,
+} from '@tools/agentCliShared';
+import { codexThreadsFor } from '@tools/agentCliSessionStores';
 import {
   createChildStream,
   createRehydratedChildStream,
@@ -419,26 +424,31 @@ describe('child stream progress events', () => {
 
     try {
       await expect(
-        launchAgentCliSession({
-          parentStreamId,
-          parentExecutionId: undefined,
-          agentName: 'codex',
-          streamPrefix: 'codex',
-          description: 'Fail during synchronous loop setup',
-          config,
-          registerFailedMessage: 'registration failed',
-          startLoop: (context) => {
-            childStream = context.childStream;
-            childExecutionId = context.executionId;
-            handle = session.executions.getAgentHandleByStream(
-              context.childStream.childStreamId,
-            );
-            throw setupError;
-          },
-          summary: 'unreachable',
-          launchedLine: 'unreachable',
-          followUpLine: 'unreachable',
-        }),
+        Effect.runPromise(
+          reraiseAgentCliCallFailure(
+            launchAgentCliSession({
+              parentStreamId,
+              parentExecutionId: undefined,
+              agentName: 'codex',
+              streamPrefix: 'codex',
+              description: 'Fail during synchronous loop setup',
+              config,
+              registerFailedMessage: 'registration failed',
+              store: codexThreadsFor,
+              startLoop: (context) => {
+                childStream = context.childStream;
+                childExecutionId = context.executionId;
+                handle = session.executions.getAgentHandleByStream(
+                  context.childStream.childStreamId,
+                );
+                throw setupError;
+              },
+              summary: 'unreachable',
+              launchedLine: 'unreachable',
+              followUpLine: 'unreachable',
+            }),
+          ),
+        ),
       ).rejects.toBe(setupError);
 
       expect(childStream).toBeDefined();

--- a/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
+++ b/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect, Fiber } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
@@ -7,6 +8,19 @@ import {
   testExecutionRegistry,
 } from '@test/support/executionHandleFixtures';
 import { AgentCliSessionRegistry } from '@tools/agentCliSessionRegistry';
+
+/** Run the registry's persistence drain at the test's edge until it ends. */
+async function withDrain(
+  registry: AgentCliSessionRegistry,
+  body: () => Promise<void>,
+): Promise<void> {
+  const drain = Effect.runFork(registry.persistenceDrain());
+  try {
+    await body();
+  } finally {
+    await Effect.runPromise(Fiber.interrupt(drain));
+  }
+}
 
 describe('AgentCliSessionRegistry', () => {
   it.each([
@@ -39,22 +53,24 @@ describe('AgentCliSessionRegistry', () => {
       );
 
       try {
-        expect(
-          registry.register('session-write-failure', {
-            childStreamId: 'child-write-failure' as StreamTabId,
-            executionId,
-          }),
-        ).toBeUndefined();
+        await withDrain(registry, async () => {
+          expect(
+            registry.register('session-write-failure', {
+              childStreamId: 'child-write-failure' as StreamTabId,
+              executionId,
+            }),
+          ).toBeUndefined();
 
-        await vi.waitFor(() => {
-          expect(reportPersistenceFailure).toHaveBeenCalledWith(
-            executionId,
-            writeError,
-          );
+          await vi.waitFor(() => {
+            expect(reportPersistenceFailure).toHaveBeenCalledWith(
+              executionId,
+              writeError,
+            );
+          });
+          expect(reportPersistenceFailure).toHaveBeenCalledOnce();
+          expect(persistSessionId).toHaveBeenCalledOnce();
+          expect(registry.lookup('session-write-failure')).toBeDefined();
         });
-        expect(reportPersistenceFailure).toHaveBeenCalledOnce();
-        expect(persistSessionId).toHaveBeenCalledOnce();
-        expect(registry.lookup('session-write-failure')).toBeDefined();
       } finally {
         registry.release('session-write-failure');
         executions.dispose();
@@ -78,14 +94,16 @@ describe('AgentCliSessionRegistry', () => {
       },
     );
 
-    registry.register('session-log-failure', {
-      childStreamId: 'child-log-failure' as StreamTabId,
-      executionId: 'execution-log-failure' as ExecutionId,
-    });
+    await withDrain(registry, async () => {
+      registry.register('session-log-failure', {
+        childStreamId: 'child-log-failure' as StreamTabId,
+        executionId: 'execution-log-failure' as ExecutionId,
+      });
 
-    await vi.waitFor(() => expect(persistSessionId).toHaveBeenCalledOnce());
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(registry.lookup('session-log-failure')).toBeDefined();
+      await vi.waitFor(() => expect(persistSessionId).toHaveBeenCalledOnce());
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(registry.lookup('session-log-failure')).toBeDefined();
+    });
     registry.release('session-log-failure');
     executions.dispose();
   });
@@ -104,7 +122,7 @@ describe('AgentCliSessionRegistry', () => {
       expect(registry.claim('session-a')).toBeUndefined();
       expect(registry.lookup('session-a')).toBeUndefined();
 
-      const active = registry.waitForActive('session-a');
+      const active = Effect.runPromise(registry.waitForActive('session-a'));
       registry.register('session-a', entry);
 
       await expect(active).resolves.toBe(entry);
@@ -136,7 +154,7 @@ describe('AgentCliSessionRegistry', () => {
     try {
       const releaseClaim = registry.claim('session-a');
       expect(releaseClaim).toBeTypeOf('function');
-      const active = registry.waitForActive('session-a');
+      const active = Effect.runPromise(registry.waitForActive('session-a'));
 
       releaseClaim?.();
 
@@ -146,7 +164,7 @@ describe('AgentCliSessionRegistry', () => {
 
       releaseNextClaim?.();
       await expect(
-        registry.waitForActive('session-a'),
+        Effect.runPromise(registry.waitForActive('session-a')),
       ).resolves.toBeUndefined();
     } finally {
       executions.dispose();

--- a/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
+++ b/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
@@ -1,4 +1,4 @@
-import { Effect, Fiber } from 'effect';
+import { Effect, Fiber, type Scheduler } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
@@ -23,6 +23,64 @@ async function withDrain(
 }
 
 describe('AgentCliSessionRegistry', () => {
+  it('keeps a queued mapping when a drain is interrupted at a scheduler handoff', async () => {
+    // Sweep actual runtime yield points through dequeue and persistence. A
+    // surviving drain must find the write unless the retiring drain owns it.
+    for (let pauseAfter = 2; pauseAfter < 80; pauseAfter++) {
+      const tasks: Array<() => void> = [];
+      let operations = 0;
+      const scheduler: Scheduler.Scheduler = {
+        executionMode: 'async',
+        shouldYield: () => ++operations === pauseAfter,
+        makeDispatcher: () => ({
+          scheduleTask: (task) => tasks.push(task),
+          flush: () => {
+            while (tasks.length > 0) tasks.shift()?.();
+          },
+        }),
+      };
+      const executions = testExecutionRegistry();
+      const persistSessionId = vi.fn(async () => {});
+      const registry = new AgentCliSessionRegistry(
+        'test_session_id',
+        executions,
+        {
+          persistSessionId,
+          reportPersistenceFailure: vi.fn(),
+        },
+      );
+      registry.register('session-handoff', {
+        childStreamId: 'child-handoff' as StreamTabId,
+        executionId: 'execution-handoff' as ExecutionId,
+      });
+      const retiring = Effect.runFork(registry.persistenceDrain(), {
+        scheduler,
+      });
+      const interrupted = Effect.runPromise(Fiber.interrupt(retiring));
+      // The paused scheduler also owns cancellation cleanup and promise
+      // settlement. Drain it before starting the surviving consumer.
+      for (let step = 0; step < 100; step++) {
+        while (tasks.length > 0) tasks.shift()?.();
+        await Promise.resolve();
+      }
+      await interrupted;
+      try {
+        await withDrain(registry, async () => {
+          await vi.waitFor(() =>
+            expect(persistSessionId).toHaveBeenCalledOnce(),
+          );
+        });
+        expect(persistSessionId).toHaveBeenCalledWith(
+          'execution-handoff',
+          'test_session_id',
+          'session-handoff',
+        );
+      } finally {
+        executions.dispose();
+      }
+    }
+  });
+
   it.each([
     {
       kind: 'rejected',

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -195,6 +195,23 @@ describe('codex tool - atomic resume fallback', () => {
     });
   });
 
+  it('releases a resume reservation when launch rejects a missing run context', async () => {
+    mocks.getCurrentToolContexts.mockReturnValue(undefined);
+
+    await expect(
+      new CodexTool().call({
+        prompt: 'resume Codex',
+        sandbox_mode: 'workspace-write',
+        thread_id: 'stale-thread',
+      }),
+    ).resolves.toMatchObject({ status: 'error' });
+    expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
+
+    const release = CodexThreads.claim('stale-thread');
+    expect(release).toBeTypeOf('function');
+    release?.();
+  });
+
   it('launches one fallback loop when concurrent calls use the same stale thread_id', async () => {
     const sdkImportStarted = pDefer<void>();
     const sdkReady = pDefer<any>();

--- a/src/tools/agentCliSessionRegistry.ts
+++ b/src/tools/agentCliSessionRegistry.ts
@@ -1,10 +1,9 @@
-import { Data, Deferred, Effect } from 'effect';
+import { Data, Deferred, Effect, Queue } from 'effect';
 
 import { getExecutionStore } from '@agent/storage';
 import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { createLog } from '@logger/logUtils';
-import { effectRuntime } from '@platform/processRuntime';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 const logger = createLog('AgentCliSessionRegistry');
@@ -37,7 +36,7 @@ class SessionMappingWriteFailed extends Data.TaggedError(
  * Persist one SDK session id for a child execution. A write failure is
  * reported through the injected diagnostics sink and otherwise contained:
  * registration never waits on it and never fails because of it. The sink
- * itself throwing is a defect of the detached fiber, not a rejection anyone
+ * itself throwing is a defect of the drain fiber, not a rejection anyone
  * observes.
  */
 const persistSessionMapping = Effect.fn(
@@ -59,6 +58,12 @@ const persistSessionMapping = Effect.fn(
     ),
   );
 });
+
+/** One queued session-mapping persistence write. */
+interface SessionMappingWrite {
+  readonly executionId: ExecutionId;
+  readonly sessionId: string;
+}
 
 /**
  * What the registry tracks about one live agent-CLI session: the child run's
@@ -92,6 +97,13 @@ function settleReservation(
 export class AgentCliSessionRegistry {
   private readonly sessions = new Map<string, AgentCliSessionState>();
   private readonly inFlight = new Map<ExecutionId, AgentCliSessionEntry>();
+  /**
+   * The write queue a live drain takes from. Created by the first
+   * {@link persistenceDrain}; absent before any drain starts, in which case
+   * {@link register} buffers instead.
+   */
+  private writes: Queue.Queue<SessionMappingWrite> | undefined;
+  private readonly bufferedWrites: SessionMappingWrite[] = [];
 
   constructor(
     private readonly persistedSessionKey: string,
@@ -120,22 +132,62 @@ export class AgentCliSessionRegistry {
   }
 
   /**
-   * Register an active external-agent session and persist its SDK id for later
-   * display or cross-reference after an extension reload clears memory. When
-   * the id was reserved, registration also wakes callers waiting to enqueue a
-   * follow-up on the new loop. The persistence write runs on a detached fiber
-   * owned by this registry's process runtime; see {@link persistSessionMapping}.
+   * Register an active external-agent session and queue its SDK id for
+   * persistence (for later display or cross-reference after an extension
+   * reload clears memory). When the id was reserved, registration also wakes
+   * callers waiting to enqueue a follow-up on the new loop. The write itself
+   * is taken by a {@link persistenceDrain} fiber — the boundary that launches
+   * a loop forks one — so registration never waits on it and never fails
+   * because of it. A write registered before the first drain starts is
+   * buffered and flushed when one does.
    */
   register(sessionId: string, entry: AgentCliSessionEntry): void {
     const previous = this.sessions.get(sessionId);
     this.sessions.set(sessionId, { kind: 'active', entry });
     settleReservation(previous, entry);
-    effectRuntime().runFork(
-      persistSessionMapping(
-        this.dependencies,
-        entry.executionId,
-        this.persistedSessionKey,
-        sessionId,
+    const write: SessionMappingWrite = {
+      executionId: entry.executionId,
+      sessionId,
+    };
+    if (this.writes) Queue.offerUnsafe(this.writes, write);
+    else this.bufferedWrites.push(write);
+  }
+
+  /**
+   * The session-mapping write drain: takes queued writes one at a time and
+   * runs each to completion. One write is uninterruptible once taken, so a
+   * write racing its loop's teardown still lands; interruption between
+   * writes ends the drain at once. The boundary launching a loop forks this
+   * and races it against that loop's settlement; concurrent drains are safe
+   * because each queued write is taken exactly once. The first drain creates
+   * the queue and flushes anything buffered before it started.
+   */
+  persistenceDrain(): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      if (this.writes) return this.drainWrites(this.writes);
+      return Effect.flatMap(Queue.unbounded<SessionMappingWrite>(), (queue) => {
+        this.writes = queue;
+        for (const write of this.bufferedWrites.splice(0)) {
+          Queue.offerUnsafe(queue, write);
+        }
+        return this.drainWrites(queue);
+      });
+    });
+  }
+
+  private drainWrites(
+    queue: Queue.Queue<SessionMappingWrite>,
+  ): Effect.Effect<void> {
+    return Effect.forever(
+      Effect.flatMap(Queue.take(queue), (write) =>
+        Effect.uninterruptible(
+          persistSessionMapping(
+            this.dependencies,
+            write.executionId,
+            this.persistedSessionKey,
+            write.sessionId,
+          ),
+        ),
       ),
     );
   }
@@ -163,13 +215,15 @@ export class AgentCliSessionRegistry {
   }
 
   /** Wait for a reserved id to become active, or for its owner to release it. */
-  async waitForActive(
+  waitForActive(
     sessionId: string,
-  ): Promise<AgentCliSessionEntry | undefined> {
-    const state = this.sessions.get(sessionId);
-    if (!state) return undefined;
-    if (state.kind === 'active') return state.entry;
-    return effectRuntime().runPromise(Deferred.await(state.ready));
+  ): Effect.Effect<AgentCliSessionEntry | undefined> {
+    return Effect.suspend(() => {
+      const state = this.sessions.get(sessionId);
+      if (!state) return Effect.succeed(undefined);
+      if (state.kind === 'active') return Effect.succeed(state.entry);
+      return Deferred.await(state.ready);
+    });
   }
 
   release(sessionId: string): void {

--- a/src/tools/agentCliSessionRegistry.ts
+++ b/src/tools/agentCliSessionRegistry.ts
@@ -1,4 +1,4 @@
-import { Data, Deferred, Effect, Queue } from 'effect';
+import { Data, Deferred, Effect, Option, Queue } from 'effect';
 
 import { getExecutionStore } from '@agent/storage';
 import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
@@ -179,13 +179,19 @@ export class AgentCliSessionRegistry {
     queue: Queue.Queue<SessionMappingWrite>,
   ): Effect.Effect<void> {
     return Effect.forever(
-      Effect.flatMap(Queue.take(queue), (write) =>
-        Effect.uninterruptible(
-          persistSessionMapping(
-            this.dependencies,
-            write.executionId,
-            this.persistedSessionKey,
-            write.sessionId,
+      Effect.uninterruptibleMask((restore) =>
+        // Waiting owns no write. Dequeue and persistence share the mask;
+        // another drain may consume the peeked item before our poll.
+        Effect.flatMap(restore(Queue.peek(queue)), () =>
+          Effect.flatMap(Queue.poll(queue), (write) =>
+            Option.isSome(write)
+              ? persistSessionMapping(
+                  this.dependencies,
+                  write.value.executionId,
+                  this.persistedSessionKey,
+                  write.value.sessionId,
+                )
+              : Effect.void,
           ),
         ),
       ),

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -1,6 +1,8 @@
 // Shared helpers for the agent-CLI tool modules (codex.ts, claudeAgent.ts).
 // Host-agnostic, VS Code-free.
 
+import { Data, Deferred, Effect } from 'effect';
+
 import { registerExecution } from '@agent/storage';
 import { type AgentTrace } from '@agent/trace';
 import { runWithOwnedExecutionLeaseLaunchGuard } from '@agent/storage/executionLease';
@@ -65,6 +67,45 @@ export type AgentCliSessionStoreAccessor = (
 ) => AgentCliSessionRegistry;
 
 /**
+ * A Promise collaborator of the dispatch/launch chain (bash approval,
+ * follow-up submission, thread/session setup, the owned-lease launch guard)
+ * rejected. `cause` is what it raised. The tools' `execute()` edges re-raise
+ * the cause itself, so the tool runner surfaces the same error instance the
+ * collaborator raised, exactly as the previous `await` chain did.
+ */
+export class AgentCliCallFailed extends Data.TaggedError('AgentCliCallFailed')<{
+  readonly cause: unknown;
+}> {}
+
+/**
+ * The one wrap of the agent-CLI chain's Promise collaborators — the shared
+ * dispatch/launch steps and each provider tool's own setup (SDK import,
+ * binary lookup, config/env assembly).
+ */
+export const agentCliCall = <A>(
+  call: () => Promise<A>,
+): Effect.Effect<A, AgentCliCallFailed> =>
+  Effect.tryPromise({
+    try: call,
+    catch: (cause) => new AgentCliCallFailed({ cause }),
+  });
+
+/** The failures the agent-CLI dispatch/launch chain can raise. */
+export type AgentCliToolFailure = ToolError | AgentCliCallFailed;
+
+/**
+ * Re-raise a collaborator's rejection as its own cause: pipe this at the
+ * tool's `execute()` edge so `runPromise` rejects with the instance the
+ * collaborator raised (see ExecutionsTool for the same edge shape).
+ */
+export const reraiseAgentCliCallFailure = <A, R>(
+  effect: Effect.Effect<A, AgentCliToolFailure, R>,
+): Effect.Effect<A, ToolError, R> =>
+  effect.pipe(
+    Effect.catchTag('AgentCliCallFailed', (error) => Effect.die(error.cause)),
+  );
+
+/**
  * Publish a turn's token usage to the progress UI for an agent-CLI child stream.
  * Shared by the codex and claudeAgent session strategies.
  */
@@ -96,55 +137,65 @@ function requireCallerOwnership(
   callerStreamId: StreamTabId | undefined,
   handle: AgentExecutionHandle | undefined,
   labels: AgentCliResumeLabels,
-): void {
-  if (!callerStreamId || !handle || handle.isOwnedBy(callerStreamId)) return;
-  throw new ToolError(
-    `${labels.notActiveLabel} '${id}' is owned by a different session; start a new session without ${labels.idParamName} to run in this context.`,
-  );
-}
-
-async function queueAgentCliFollowUp(
-  registry: AgentCliSessionRegistry,
-  stored: AgentCliSessionEntry,
-  params: {
-    id: string;
-    prompt: string;
-    callerStreamId: StreamTabId | undefined;
-    labels: AgentCliResumeLabels;
-  },
-): Promise<ToolResult> {
-  const { id, prompt, callerStreamId, labels } = params;
-  // Ownership is a live-handle fact: a detached or re-parented child must not
-  // accept follow-ups from its former orchestrator. A missing handle falls
-  // through to submitFollowUp's no-session outcome below.
-  requireCallerOwnership(
-    id,
-    callerStreamId,
-    registry.getHandle(stored),
-    labels,
-  );
-
-  const result = await submitFollowUp(stored.childStreamId, prompt, {
-    session: currentSession(),
-  });
-  if (result.status === 'failed') {
-    throw new ToolError(
-      `${labels.notActiveLabel} '${id}' did not accept the follow-up (${result.reason}): ${describeFollowUpFailure(result.reason)}`,
-    );
+): Effect.Effect<void, ToolError> {
+  if (!callerStreamId || !handle || handle.isOwnedBy(callerStreamId)) {
+    return Effect.void;
   }
-
-  const preview = truncateWithEllipsis(prompt, 60);
-  // A queued follow-up whose wake failed is still queued: it is delivered
-  // when the agent is resumed, so the caller must not offer it again.
-  const wakeFailed = result.status === 'queued' && result.wake === 'failed';
-  const followUpLine = wakeFailed
-    ? `Follow-up instruction queued for ${labels.queuedLabel} '${id}', but the agent could not be resumed. ${FOLLOW_UP_WAKE_FAILED_MESSAGE}`
-    : `Follow-up instruction queued for ${labels.queuedLabel} '${id}'. The agent will process it and deliver a new result automatically.`;
-  return executed(
-    [followUpLine, `Execution ID: ${stored.executionId}`].join('\n'),
-    `Follow-up queued for ${labels.summaryLabel}: ${preview}`,
+  return Effect.fail(
+    new ToolError(
+      `${labels.notActiveLabel} '${id}' is owned by a different session; start a new session without ${labels.idParamName} to run in this context.`,
+    ),
   );
 }
+
+const queueAgentCliFollowUp = Effect.fn('agentCliShared.queueAgentCliFollowUp')(
+  function* (
+    registry: AgentCliSessionRegistry,
+    stored: AgentCliSessionEntry,
+    params: {
+      id: string;
+      prompt: string;
+      callerStreamId: StreamTabId | undefined;
+      labels: AgentCliResumeLabels;
+    },
+  ): Effect.fn.Return<ToolResult, AgentCliToolFailure> {
+    const { id, prompt, callerStreamId, labels } = params;
+    // Ownership is a live-handle fact: a detached or re-parented child must not
+    // accept follow-ups from its former orchestrator. A missing handle falls
+    // through to submitFollowUp's no-session outcome below.
+    yield* requireCallerOwnership(
+      id,
+      callerStreamId,
+      registry.getHandle(stored),
+      labels,
+    );
+
+    const result = yield* agentCliCall(() =>
+      submitFollowUp(stored.childStreamId, prompt, {
+        session: currentSession(),
+      }),
+    );
+    if (result.status === 'failed') {
+      return yield* Effect.fail(
+        new ToolError(
+          `${labels.notActiveLabel} '${id}' did not accept the follow-up (${result.reason}): ${describeFollowUpFailure(result.reason)}`,
+        ),
+      );
+    }
+
+    const preview = truncateWithEllipsis(prompt, 60);
+    // A queued follow-up whose wake failed is still queued: it is delivered
+    // when the agent is resumed, so the caller must not offer it again.
+    const wakeFailed = result.status === 'queued' && result.wake === 'failed';
+    const followUpLine = wakeFailed
+      ? `Follow-up instruction queued for ${labels.queuedLabel} '${id}', but the agent could not be resumed. ${FOLLOW_UP_WAKE_FAILED_MESSAGE}`
+      : `Follow-up instruction queued for ${labels.queuedLabel} '${id}'. The agent will process it and deliver a new result automatically.`;
+    return executed(
+      [followUpLine, `Execution ID: ${stored.executionId}`].join('\n'),
+      `Follow-up queued for ${labels.summaryLabel}: ${preview}`,
+    );
+  },
+);
 
 /**
  * Atomically choose between queueing onto an owned session id and launching a
@@ -155,40 +206,43 @@ async function queueAgentCliFollowUp(
  * cleanup so an acknowledged follow-up can never be stranded behind a failed
  * initial turn.
  */
-async function resumeOrLaunchAgentCliSession(
+const resumeOrLaunchAgentCliSession = Effect.fn(
+  'agentCliShared.resumeOrLaunchAgentCliSession',
+)(function* (
   store: AgentCliSessionRegistry,
   params: {
     id: string | undefined;
     prompt: string;
     callerStreamId: StreamTabId | undefined;
     labels: AgentCliResumeLabels;
-    launch: (releaseClaim?: () => void) => Promise<ToolResult>;
+    launch: (
+      releaseClaim?: () => void,
+    ) => Effect.Effect<ToolResult, AgentCliToolFailure>;
   },
-): Promise<ToolResult> {
+): Effect.fn.Return<ToolResult, AgentCliToolFailure> {
   const { id } = params;
-  if (!id) return params.launch();
+  if (!id) return yield* params.launch();
 
   while (true) {
     const releaseClaim = store.claim(id);
     if (releaseClaim) {
-      try {
-        return await params.launch(releaseClaim);
-      } catch (error) {
-        releaseClaim();
-        throw error;
-      }
+      // Any failure cause — typed or defect — releases the claim before it
+      // propagates, as the previous catch-release-rethrow did.
+      return yield* params
+        .launch(releaseClaim)
+        .pipe(Effect.onError(() => Effect.sync(() => releaseClaim())));
     }
 
-    const stored = await store.waitForActive(id);
+    const stored = yield* store.waitForActive(id);
     if (!stored) continue;
-    return queueAgentCliFollowUp(store, stored, {
+    return yield* queueAgentCliFollowUp(store, stored, {
       id,
       prompt: params.prompt,
       callerStreamId: params.callerStreamId,
       labels: params.labels,
     });
   }
-}
+});
 
 interface AgentCliLaunchParams {
   parentStreamId: StreamTabId;
@@ -198,9 +252,13 @@ interface AgentCliLaunchParams {
   description: string;
   config: AgentConfig;
   registerFailedMessage: string;
+  /** Session-keyed registry accessor; the launched loop's drain forks here. */
+  store: AgentCliSessionStoreAccessor;
   startLoop: (ctx: {
     childStream: ChildStream;
     executionId: ExecutionId;
+    /** Settled by the loop wrapper when the loop's completion settles. */
+    loopSettled: Deferred.Deferred<void>;
   }) => void | Promise<void>;
   summary: string;
   launchedLine: string;
@@ -210,10 +268,19 @@ interface AgentCliLaunchParams {
 /**
  * Register a fresh agent-CLI execution, create its child stream tab, start the
  * provider's turn loop, and return the "launched" ToolResult.
+ *
+ * The registry's persistence drain is forked here — on the tool's run edge,
+ * which is where this Effect runs — and raced against the loop's settlement,
+ * so the drain lives exactly as long as the loop it persists for. Session
+ * writes the loop registers afterwards queue into the drain without any
+ * fiber of their own, and an in-flight write still lands when the loop ends
+ * (see `AgentCliSessionRegistry.persistenceDrain`).
  */
-export async function launchAgentCliSession(
+export const launchAgentCliSession = Effect.fn(
+  'agentCliShared.launchAgentCliSession',
+)(function* (
   params: AgentCliLaunchParams,
-): Promise<ToolResult> {
+): Effect.fn.Return<ToolResult, AgentCliToolFailure> {
   const executionId = generateExecutionId();
   const childStreamId = getStreamTabId(params.streamPrefix, { executionId });
   // An external CLI drives this agent: the CLI is both the agent name and the
@@ -225,30 +292,36 @@ export async function launchAgentCliSession(
     tool: params.agentName,
   } as const;
 
-  try {
-    await registerExecution(executionId, params.config, params.agentName, {
-      streamId: childStreamId,
-      identity,
-      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.TERMINAL_BACKED,
-      parentExecutionId: params.parentExecutionId,
-      description: childStreamDescription(params.description),
-    });
-  } catch (error) {
+  yield* Effect.tryPromise({
+    try: () =>
+      registerExecution(executionId, params.config, params.agentName, {
+        streamId: childStreamId,
+        identity,
+        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.TERMINAL_BACKED,
+        parentExecutionId: params.parentExecutionId,
+        description: childStreamDescription(params.description),
+      }),
     // Keep the cause: registration aggregates real store-write failures
     // (unwritable storage root, torn record) that the per-provider prefix
     // alone cannot diagnose.
-    throw new ToolError(
-      `${params.registerFailedMessage} ${toErrorMessage(error)}`,
-      { cause: error },
-    );
-  }
+    catch: (error) =>
+      new ToolError(
+        `${params.registerFailedMessage} ${toErrorMessage(error)}`,
+        { cause: error },
+      ),
+  });
   // The launch guard owns the release-on-failure policy for every launch site
   // (bash background, the two detached child paths, and this one): a failed
   // launch must not leave a record that refuses a relaunch for the rest of the
   // process's life.
-  const childStream = await runWithOwnedExecutionLeaseLaunchGuard(
-    executionId,
-    async () => {
+  const registry = params.store(currentSession());
+  const loopSettled = Deferred.makeUnsafe<void>();
+  yield* Effect.forkDetach(
+    Effect.raceFirst(registry.persistenceDrain(), Deferred.await(loopSettled)),
+    { startImmediately: true },
+  );
+  const childStream = yield* agentCliCall(() =>
+    runWithOwnedExecutionLeaseLaunchGuard(executionId, async () => {
       const stream = createChildStream(executionId, params.parentStreamId, {
         streamPrefix: params.streamPrefix,
         run: identity,
@@ -256,25 +329,47 @@ export async function launchAgentCliSession(
         description: params.description,
         config: params.config,
       });
-      try {
-        await params.startLoop({ childStream: stream, executionId });
-      } catch (error) {
-        try {
-          await stream.finalize({
+      // The guard callback is Promise-land (the lease guard is an agent-layer
+      // Promise API), so failure capture here is a then-continuation, not a
+      // catch clause: a synchronous startLoop throw and a rejection both land
+      // in `startError`, as the previous try/catch delivered them.
+      const startError = await Promise.resolve()
+        .then(() =>
+          params.startLoop({ childStream: stream, executionId, loopSettled }),
+        )
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+      if (startError !== undefined) {
+        const finalizeError = await stream
+          .finalize({
             outcome: RUN_OUTCOME.FAILED,
-            error,
+            error: startError,
             persistence: { kind: 'finalize', flowRecord: 'delete' },
-          });
-        } catch (finalizeError) {
+          })
+          .then(
+            () => undefined,
+            (error: unknown) => error,
+          );
+        if (finalizeError !== undefined) {
           throw new AggregateError(
-            [error, finalizeError],
+            [startError, finalizeError],
             `Agent CLI execution ${executionId} failed and its child stream could not be finalized`,
           );
         }
-        throw error;
+        throw startError;
       }
       return stream;
-    },
+    }),
+  ).pipe(
+    // A launch that fails before its loop starts never settles the loop, so
+    // settle it here to end the drain forked above.
+    Effect.onError(() =>
+      Effect.sync(() => {
+        Deferred.doneUnsafe(loopSettled, Effect.void);
+      }),
+    ),
   );
 
   return executed(
@@ -286,7 +381,7 @@ export async function launchAgentCliSession(
     ].join('\n'),
     params.summary,
   );
-}
+});
 
 /**
  * Run the shared agent-CLI execute() prelude: refuse a run that cannot collect
@@ -299,26 +394,34 @@ export async function launchAgentCliSession(
  * in a turn that never happens and the child's result is stranded. Fail before
  * prompting for approval rather than launching work nobody collects.
  */
-async function withAgentCliApproval(
-  toolName: string,
-  approvalLabel: string,
-  run: (runContext: RunContext | undefined) => ToolResult | Promise<ToolResult>,
-): Promise<ToolResult> {
-  const contexts = getCurrentToolContexts();
-  if (contexts?.runContext?.stopAfterCycle) {
-    throw new ToolError(
-      `${toolName} is unavailable in one-shot runs: it delivers its result as a follow-up message, and this run ends after the current cycle so no follow-up can be collected. Delegate with delegate_agent, which returns the child's result directly.`,
+const withAgentCliApproval = Effect.fn('agentCliShared.withAgentCliApproval')(
+  function* (
+    toolName: string,
+    approvalLabel: string,
+    run: (
+      runContext: RunContext | undefined,
+    ) => Effect.Effect<ToolResult, AgentCliToolFailure>,
+  ): Effect.fn.Return<ToolResult, AgentCliToolFailure> {
+    const contexts = getCurrentToolContexts();
+    if (contexts?.runContext?.stopAfterCycle) {
+      return yield* Effect.fail(
+        new ToolError(
+          `${toolName} is unavailable in one-shot runs: it delivers its result as a follow-up message, and this run ends after the current cycle so no follow-up can be collected. Delegate with delegate_agent, which returns the child's result directly.`,
+        ),
+      );
+    }
+
+    const approval = yield* agentCliCall(() =>
+      requestBashApproval({ command: approvalLabel }),
     );
-  }
+    if (approval.action !== 'approve') {
+      return buildBashApprovalRejectedResult(approvalLabel, approval);
+    }
 
-  const approval = await requestBashApproval({ command: approvalLabel });
-  if (approval.action !== 'approve') {
-    return buildBashApprovalRejectedResult(approvalLabel, approval);
-  }
-
-  contexts?.callContext?.hooks?.onExecutionReady?.();
-  return run(contexts?.runContext);
-}
+    contexts?.callContext?.hooks?.onExecutionReady?.();
+    return yield* run(contexts?.runContext);
+  },
+);
 
 /** Run context resolved for an agent-CLI launch, handed to the provider's
  * `launch` callback by {@link dispatchAgentCliTool}. */
@@ -341,6 +444,9 @@ interface AgentCliLaunchContext {
  * `releaseFallbackClaim` it must promote or release. Callers supply only their
  * approval label, session store, resume id, resume labels, and the
  * provider-specific launch.
+ *
+ * The returned Effect is the tool's whole dispatch: the tool's `execute()`
+ * runs it at its own edge with {@link reraiseAgentCliCallFailure} piped in.
  */
 export function dispatchAgentCliTool(params: {
   agentName: string;
@@ -351,8 +457,10 @@ export function dispatchAgentCliTool(params: {
   sourceId?: string;
   prompt: string;
   labels: AgentCliResumeLabels;
-  launch: (context: AgentCliLaunchContext) => Promise<ToolResult>;
-}): Promise<ToolResult> {
+  launch: (
+    context: AgentCliLaunchContext,
+  ) => Effect.Effect<ToolResult, AgentCliToolFailure>;
+}): Effect.Effect<ToolResult, AgentCliToolFailure> {
   const {
     agentName,
     approvalLabel,
@@ -363,34 +471,40 @@ export function dispatchAgentCliTool(params: {
     labels,
     launch,
   } = params;
-  return withAgentCliApproval(agentName, approvalLabel, (runContext) => {
-    const registry = store(currentSession());
-    const callerStreamId = getRunContextStreamId(runContext);
-    if (sourceId) {
-      requireCallerOwnership(
-        sourceId,
+  return withAgentCliApproval(agentName, approvalLabel, (runContext) =>
+    Effect.gen(function* () {
+      const registry = store(currentSession());
+      const callerStreamId = getRunContextStreamId(runContext);
+      if (sourceId) {
+        yield* requireCallerOwnership(
+          sourceId,
+          callerStreamId,
+          registry.getHandle(registry.lookup(sourceId)),
+          labels,
+        );
+      }
+      return yield* resumeOrLaunchAgentCliSession(registry, {
+        id: resumeId,
+        prompt,
         callerStreamId,
-        registry.getHandle(registry.lookup(sourceId)),
         labels,
-      );
-    }
-    return resumeOrLaunchAgentCliSession(registry, {
-      id: resumeId,
-      prompt,
-      callerStreamId,
-      labels,
-      launch: (releaseFallbackClaim) => {
-        // A missing in-memory entry denotes a disk-based SDK fallback.
-        const { streamId } = requireRunStream(agentName, runContext);
-        return launch({
-          parentStreamId: streamId,
-          parentExecutionId: getRunContextExecutionId(runContext),
-          parentWorkingDirectory: getRunContextWorkingDirectory(runContext),
-          releaseFallbackClaim,
-        });
-      },
-    });
-  });
+        launch: (releaseFallbackClaim) => {
+          // A missing in-memory entry denotes a disk-based SDK fallback.
+          // requireRunStream throws its ToolError synchronously; as a defect
+          // it still reaches the tool runner as the same instance and the
+          // claim-release in resumeOrLaunchAgentCliSession still fires
+          // (onError observes every cause).
+          const { streamId } = requireRunStream(agentName, runContext);
+          return launch({
+            parentStreamId: streamId,
+            parentExecutionId: getRunContextExecutionId(runContext),
+            parentWorkingDirectory: getRunContextWorkingDirectory(runContext),
+            releaseFallbackClaim,
+          });
+        },
+      });
+    }),
+  );
 }
 
 // ============================================================================
@@ -415,6 +529,11 @@ interface AgentCliLoopParams<TTurn> {
   initialPrompt: string;
   /** Session/thread registry the loop tracks in-flight and successful turns in. */
   store: AgentCliSessionStoreAccessor;
+  /**
+   * Settled when the loop's completion promise settles, ending the
+   * persistence drain the launch forked for this loop.
+   */
+  loopSettled: Deferred.Deferred<void>;
   /**
    * The disk-based fallback session/thread id claimed synchronously before the
    * loop starts, if any. Release it if the loop exits before promoting it.
@@ -471,6 +590,7 @@ export function startAgentCliLoop<TTurn>(
     stageLabel,
     initialPrompt,
     store,
+    loopSettled,
     releaseFallbackClaim,
     runProviderTurn,
     resolveSessionIds,
@@ -552,7 +672,14 @@ export function startAgentCliLoop<TTurn>(
     agentName,
     strategy,
   });
-  void completion.catch((error: unknown) => {
-    logger.error(loopFailedMessage, { data: error });
-  });
+  // The loop's completion is the agent layer's Promise, so settling
+  // `loopSettled` is a then-continuation on it; either way it settles, the
+  // launch's drain race ends. A rejection is still logged here, as before.
+  void completion.then(
+    () => Deferred.doneUnsafe(loopSettled, Effect.void),
+    (error: unknown) => {
+      logger.error(loopFailedMessage, { data: error });
+      Deferred.doneUnsafe(loopSettled, Effect.void);
+    },
+  );
 }

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -228,9 +228,9 @@ const resumeOrLaunchAgentCliSession = Effect.fn(
     if (releaseClaim) {
       // Any failure cause — typed or defect — releases the claim before it
       // propagates, as the previous catch-release-rethrow did.
-      return yield* params
-        .launch(releaseClaim)
-        .pipe(Effect.onError(() => Effect.sync(() => releaseClaim())));
+      return yield* Effect.suspend(() => params.launch(releaseClaim)).pipe(
+        Effect.onError(() => Effect.sync(() => releaseClaim())),
+      );
     }
 
     const stored = yield* store.waitForActive(id);

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -34,6 +34,7 @@ import {
   type AgentTrace,
   type ToolUseCardRef,
 } from '@agent/trace';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   ClaudeAgentEffortSchema,
   ClaudeAgentPermissionModeSchema,
@@ -49,7 +50,6 @@ import type {
   ToolUseLog,
 } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
-import { effectRuntime } from '@platform/processRuntime';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import {
   formatWallTimeSeconds,
@@ -71,7 +71,7 @@ import { type ChildStream } from './delegation/childStream';
 import { claudeAgentSessionsFor } from './agentCliSessionStores';
 import {
   agentCliCall,
-  type AgentCliCallFailed,
+  type AgentCliToolFailure,
   dispatchAgentCliTool,
   launchAgentCliSession,
   reraiseAgentCliCallFailure,
@@ -533,7 +533,7 @@ export class ClaudeAgentTool extends defineTool({
   private readonly run = Effect.fn('ClaudeAgentTool.run')(function* (
     this: ClaudeAgentTool,
     input: ClaudeAgentInput,
-  ): Effect.fn.Return<ToolResult, ToolError | AgentCliCallFailed> {
+  ): Effect.fn.Return<ToolResult, AgentCliToolFailure> {
     const config = yield* agentCliCall(() => getClaudeAgentConfig());
     const permissionMode =
       input.permission_mode ?? config.getClaudeAgentPermissionMode();
@@ -583,7 +583,7 @@ const launchClaudeAgentSession = Effect.fn(
   parentExecutionId: ExecutionId | undefined,
   parentWorkingDirectory: string | undefined,
   releaseFallbackClaim: (() => void) | undefined,
-): Effect.fn.Return<ToolResult, ToolError | AgentCliCallFailed> {
+): Effect.fn.Return<ToolResult, AgentCliToolFailure> {
   const config = yield* agentCliCall(() => getClaudeAgentConfig());
   const workingDir = parseWorkingDirectory(parentWorkingDirectory);
   // Mirrors codex behavior so subagents can see the project: when the call

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -24,6 +24,7 @@
  */
 
 // Third-party imports
+import { Effect, type Deferred } from 'effect';
 import { z } from 'zod';
 
 // Local imports
@@ -37,6 +38,7 @@ import {
   ClaudeAgentEffortSchema,
   ClaudeAgentPermissionModeSchema,
   MESSAGE_TYPES,
+  ToolError,
 } from '@shared/schemas';
 import type {
   ClaudeAgentEffort,
@@ -47,6 +49,7 @@ import type {
   ToolUseLog,
 } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
+import { effectRuntime } from '@platform/processRuntime';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import {
   formatWallTimeSeconds,
@@ -67,8 +70,11 @@ import {
 import { type ChildStream } from './delegation/childStream';
 import { claudeAgentSessionsFor } from './agentCliSessionStores';
 import {
+  agentCliCall,
+  type AgentCliCallFailed,
   dispatchAgentCliTool,
   launchAgentCliSession,
+  reraiseAgentCliCallFailure,
   startAgentCliLoop,
 } from './agentCliShared';
 import {
@@ -411,6 +417,8 @@ function startClaudeAgentLoop(params: {
   resumeSessionId: string | undefined;
   /** Release the fallback claim if the loop exits before promoting it. */
   releaseFallbackClaim: (() => void) | undefined;
+  /** Settled by the loop wrapper when the loop's completion settles. */
+  loopSettled: Deferred.Deferred<void>;
 }): void {
   const { childStream, parentStreamId, executionId, initialPrompt } = params;
   const { logger } = childStream;
@@ -432,6 +440,7 @@ function startClaudeAgentLoop(params: {
     stageLabel: 'Claude Code session',
     initialPrompt,
     store: claudeAgentSessionsFor,
+    loopSettled: params.loopSettled,
     releaseFallbackClaim: params.releaseFallbackClaim,
     runProviderTurn: async (prompt, _ports, signal) => {
       const forkSession = isFirstTurn && params.forkSession;
@@ -511,8 +520,21 @@ export class ClaudeAgentTool extends defineTool({
     'Set fork_session to branch from that session while leaving the original unchanged.',
   schema: ClaudeAgentInputSchema,
 }) {
-  protected async execute(input: ClaudeAgentInput): Promise<ToolResult> {
-    const config = await getClaudeAgentConfig();
+  protected execute(input: ClaudeAgentInput): Promise<ToolResult> {
+    // The one run edge of this tool (PRD run-edge category b): the dispatch
+    // below is an Effect program, run once here on the process runtime. A
+    // collaborator's rejection is re-raised as its own cause; a `ToolError`
+    // stays a typed failure and `runPromise` rejects with it.
+    return effectRuntime().runPromise(
+      reraiseAgentCliCallFailure(this.run(input)),
+    );
+  }
+
+  private readonly run = Effect.fn('ClaudeAgentTool.run')(function* (
+    this: ClaudeAgentTool,
+    input: ClaudeAgentInput,
+  ): Effect.fn.Return<ToolResult, ToolError | AgentCliCallFailed> {
+    const config = yield* agentCliCall(() => getClaudeAgentConfig());
     const permissionMode =
       input.permission_mode ?? config.getClaudeAgentPermissionMode();
     const model = input.model ?? config.getClaudeAgentModel();
@@ -520,7 +542,7 @@ export class ClaudeAgentTool extends defineTool({
     const sessionId = input.session_id ?? undefined;
     const isFork = input.fork_session === true;
 
-    return dispatchAgentCliTool({
+    return yield* dispatchAgentCliTool({
       agentName: CLAUDE_AGENT_NAME,
       approvalLabel: `[${CLAUDE_AGENT_NAME} ${permissionMode}] ${input.prompt}`,
       store: claudeAgentSessionsFor,
@@ -547,10 +569,12 @@ export class ClaudeAgentTool extends defineTool({
           context.releaseFallbackClaim,
         ),
     });
-  }
+  });
 }
 
-async function launchClaudeAgentSession(
+const launchClaudeAgentSession = Effect.fn(
+  'claudeAgent.launchClaudeAgentSession',
+)(function* (
   input: ClaudeAgentInput,
   permissionMode: ClaudeAgentPermissionMode,
   model: string,
@@ -559,8 +583,8 @@ async function launchClaudeAgentSession(
   parentExecutionId: ExecutionId | undefined,
   parentWorkingDirectory: string | undefined,
   releaseFallbackClaim: (() => void) | undefined,
-): Promise<ToolResult> {
-  const config = await getClaudeAgentConfig();
+): Effect.fn.Return<ToolResult, ToolError | AgentCliCallFailed> {
+  const config = yield* agentCliCall(() => getClaudeAgentConfig());
   const workingDir = parseWorkingDirectory(parentWorkingDirectory);
   // Mirrors codex behavior so subagents can see the project: when the call
   // is made from inside the workspace, the agent runs in that directory but
@@ -570,12 +594,14 @@ async function launchClaudeAgentSession(
   // `additionalDirectories`, unlike codex's `workingDirectory`.
   const { workingDirectory, additionalDirectories } =
     buildAgentWorkspaceOptions(workingDir);
-  const env = await config.buildClaudeAgentEnv();
-  const pathToClaudeCodeExecutable = await findClaudeBinaryPath();
+  const env = yield* agentCliCall(() => config.buildClaudeAgentEnv());
+  const pathToClaudeCodeExecutable = yield* agentCliCall(() =>
+    findClaudeBinaryPath(),
+  );
   const agentConfig = config.buildClaudeAgentConfig(input.prompt);
   const preview = truncateWithEllipsis(input.prompt, 60);
 
-  return launchAgentCliSession({
+  return yield* launchAgentCliSession({
     parentStreamId,
     parentExecutionId,
     agentName: CLAUDE_AGENT_NAME,
@@ -583,7 +609,8 @@ async function launchClaudeAgentSession(
     description: input.prompt,
     config: agentConfig,
     registerFailedMessage: 'Failed to register Claude Code CLI execution.',
-    startLoop: ({ childStream, executionId }) =>
+    store: claudeAgentSessionsFor,
+    startLoop: ({ childStream, executionId, loopSettled }) =>
       startClaudeAgentLoop({
         childStream,
         parentStreamId,
@@ -599,9 +626,10 @@ async function launchClaudeAgentSession(
         resumeSessionId: input.session_id ?? undefined,
         forkSession: input.fork_session === true,
         releaseFallbackClaim,
+        loopSettled,
       }),
     summary: `Launched Claude Code CLI: ${preview}`,
     launchedLine: `Claude Code agent launched (model: ${model}, permission: ${permissionMode}).`,
     followUpLine: `Result will be delivered as a follow-up message when the turn completes. The delivery includes the session_id. Pass it back on a later call to send a follow-up.`,
   });
-}
+});

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -18,6 +18,7 @@
  */
 
 // Third-party imports
+import { Effect, type Deferred } from 'effect';
 import { z } from 'zod';
 
 // Local imports
@@ -43,6 +44,7 @@ import {
   ToolError,
 } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
+import { effectRuntime } from '@platform/processRuntime';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { formatWallTimeSeconds } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -59,8 +61,11 @@ import {
 import { type ChildStream } from './delegation/childStream';
 import { codexThreadsFor } from './agentCliSessionStores';
 import {
+  agentCliCall,
+  type AgentCliCallFailed,
   dispatchAgentCliTool,
   launchAgentCliSession,
+  reraiseAgentCliCallFailure,
   startAgentCliLoop,
 } from './agentCliShared';
 import {
@@ -350,6 +355,8 @@ function startCodexLoop(params: {
   resumeThreadId: string | undefined;
   /** Release the fallback claim if the loop exits before promoting it. */
   releaseFallbackClaim: (() => void) | undefined;
+  /** Settled by the loop wrapper when the loop's completion settles. */
+  loopSettled: Deferred.Deferred<void>;
 }): void {
   const {
     thread,
@@ -359,6 +366,7 @@ function startCodexLoop(params: {
     initialPrompt,
     resumeThreadId: fallbackThreadId,
     releaseFallbackClaim,
+    loopSettled,
   } = params;
   const { childStreamId, logger } = childStream;
 
@@ -370,6 +378,7 @@ function startCodexLoop(params: {
     stageLabel: 'Codex session',
     initialPrompt,
     store: codexThreadsFor,
+    loopSettled,
     releaseFallbackClaim,
     runProviderTurn: (prompt, _ports, signal) =>
       runStreamedTurn(thread, prompt, childStreamId, logger, signal),
@@ -458,13 +467,27 @@ export class CodexTool extends defineTool({
     'Pass thread_id on a later call to send a follow-up instruction to an existing session, like delegate_agent(execution_id=…).',
   schema: CodexInputSchema,
 }) {
-  protected async execute(input: CodexInput): Promise<ToolResult> {
+  protected execute(input: CodexInput): Promise<ToolResult> {
+    // The one run edge of this tool (PRD run-edge category b): the dispatch
+    // below is an Effect program, run once here on the process runtime. A
+    // collaborator's rejection is re-raised as its own cause; a `ToolError`
+    // stays a typed failure and `runPromise` rejects with it.
+    return effectRuntime().runPromise(
+      reraiseAgentCliCallFailure(this.run(input)),
+    );
+  }
+
+  private readonly run = Effect.fn('CodexTool.run')(function* (
+    this: CodexTool,
+    input: CodexInput,
+  ): Effect.fn.Return<ToolResult, ToolError | AgentCliCallFailed> {
     // Resolve the effective sandbox mode once (per-call override, else the
     // user-configured default) rather than mutating the parsed input object.
     const sandboxMode =
-      input.sandbox_mode ?? (await getCodexConfig()).getCodexSandboxMode();
+      input.sandbox_mode ??
+      (yield* agentCliCall(() => getCodexConfig())).getCodexSandboxMode();
 
-    return dispatchAgentCliTool({
+    return yield* dispatchAgentCliTool({
       agentName: 'codex',
       approvalLabel: `[codex ${sandboxMode}] ${input.prompt}`,
       store: codexThreadsFor,
@@ -486,23 +509,27 @@ export class CodexTool extends defineTool({
           context.releaseFallbackClaim,
         ),
     });
-  }
+  });
 }
 
-async function launchCodexSession(
+const launchCodexSession = Effect.fn('codex.launchCodexSession')(function* (
   input: CodexInput,
   sandboxMode: SandboxMode,
   parentStreamId: StreamTabId,
   parentExecutionId: ExecutionId | undefined,
   parentWorkingDirectory: string | undefined,
   releaseFallbackClaim: (() => void) | undefined,
-): Promise<ToolResult> {
+): Effect.fn.Return<ToolResult, ToolError | AgentCliCallFailed> {
   const workingDir = parseWorkingDirectory(parentWorkingDirectory);
-  const thread = await createCodexThread(input, sandboxMode, workingDir);
-  const config = (await getCodexConfig()).buildCodexConfig(input.prompt);
+  const thread = yield* agentCliCall(() =>
+    createCodexThread(input, sandboxMode, workingDir),
+  );
+  const config = (yield* agentCliCall(() => getCodexConfig())).buildCodexConfig(
+    input.prompt,
+  );
   const preview = truncateWithEllipsis(input.prompt, 60);
 
-  return launchAgentCliSession({
+  return yield* launchAgentCliSession({
     parentStreamId,
     parentExecutionId,
     agentName: 'codex',
@@ -510,7 +537,8 @@ async function launchCodexSession(
     description: input.prompt,
     config,
     registerFailedMessage: 'Failed to register Codex execution.',
-    startLoop: ({ childStream, executionId }) =>
+    store: codexThreadsFor,
+    startLoop: ({ childStream, executionId, loopSettled }) =>
       startCodexLoop({
         thread,
         childStream,
@@ -519,9 +547,10 @@ async function launchCodexSession(
         initialPrompt: input.prompt,
         resumeThreadId: input.thread_id ?? undefined,
         releaseFallbackClaim,
+        loopSettled,
       }),
     summary: `Launched Codex: ${preview}`,
     launchedLine: `Codex agent launched (sandbox: ${sandboxMode}).`,
     followUpLine: `Result will be delivered as a follow-up message when the turn completes. The delivery includes the thread_id. Pass it to codex on a later call to send a follow-up instruction.`,
   });
-}
+});

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -30,6 +30,7 @@ import {
   type ToolUseCardRef,
 } from '@agent/trace';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
+import { effectRuntime } from '@platform/processRuntime';
 import type {
   ExecutionId,
   StreamTabId,
@@ -44,7 +45,6 @@ import {
   ToolError,
 } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
-import { effectRuntime } from '@platform/processRuntime';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { formatWallTimeSeconds } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -62,7 +62,7 @@ import { type ChildStream } from './delegation/childStream';
 import { codexThreadsFor } from './agentCliSessionStores';
 import {
   agentCliCall,
-  type AgentCliCallFailed,
+  type AgentCliToolFailure,
   dispatchAgentCliTool,
   launchAgentCliSession,
   reraiseAgentCliCallFailure,
@@ -480,7 +480,7 @@ export class CodexTool extends defineTool({
   private readonly run = Effect.fn('CodexTool.run')(function* (
     this: CodexTool,
     input: CodexInput,
-  ): Effect.fn.Return<ToolResult, ToolError | AgentCliCallFailed> {
+  ): Effect.fn.Return<ToolResult, AgentCliToolFailure> {
     // Resolve the effective sandbox mode once (per-call override, else the
     // user-configured default) rather than mutating the parsed input object.
     const sandboxMode =
@@ -519,7 +519,7 @@ const launchCodexSession = Effect.fn('codex.launchCodexSession')(function* (
   parentExecutionId: ExecutionId | undefined,
   parentWorkingDirectory: string | undefined,
   releaseFallbackClaim: (() => void) | undefined,
-): Effect.fn.Return<ToolResult, ToolError | AgentCliCallFailed> {
+): Effect.fn.Return<ToolResult, AgentCliToolFailure> {
   const workingDir = parseWorkingDirectory(parentWorkingDirectory);
   const thread = yield* agentCliCall(() =>
     createCodexThread(input, sandboxMode, workingDir),


### PR DESCRIPTION
The agent-CLI session registry started detached Effects internally for session-ID persistence and converted its wait program back into a Promise. This change carries both programs through the existing Codex/Claude dispatch chain and runs that chain once at each tool's execution boundary. It implements the tools lane of the Effect 4 migration PRD, R1 as amended September 6.

`register()` keeps its synchronous state-registration contract and queues one persistence write. Each running CLI loop owns a drain against the shared queue. Waiting for work is interruptible; dequeue and persistence share one interruption mask, so loop teardown cannot lose another loop's queued mapping. Competing drains may observe the same availability notification but only the successful poll owns the write. Persistence remains best effort and never blocks registration.

Resume claims release on typed failures, defects and interruption, including a synchronous failure while constructing the launch program. Existing regressions reproduce both the lost-mapping scheduler handoff and the missing-run-context reservation leak against the original source, and pass with the fixes. The existing Claude/Codex fallback tests preserve shared-resume behavior.

`ToolError` remains a tool failure. The dispatch chain uses its existing single `AgentCliCallFailed` boundary for Promise collaborators and restores the original cause at the tool edge. The child run-loop and launch-guard Promise APIs remain owned by the subsequent runtime migration; this PR introduces no second registry or compatibility runner.

Scope and migration accounting:

- Eight files, +572/-227 against main `89c467b391`, including existing-suite adaptations and the two demonstrated regressions. The authored main integration `f79d14673ac60009f36db389c517613364cdf44f` is preserved.
- Registry internal run sites: 2 to 0; total below-boundary runs: 9 files/25 sites to 8 files/23 sites. The corresponding ratchet and debt-lane entries are removed; no baseline is widened.
- `waitForActive`, `register` and `persistenceDrain` each have one production consumer. Codex and Claude each consume `dispatchAgentCliTool`, `launchAgentCliSession` and `startAgentCliLoop`.
- Added exports remain `AgentCliCallFailed`, `agentCliCall`, `AgentCliToolFailure` and `reraiseAgentCliCallFailure`, all consumed by the two tools. `persistenceDrain` replaces the old detached per-write runner. No host/controller/platform/storage interface changes are introduced by this PR.

Validation at 1025c8d71fd990bb70f6ea7a39af4601e8d8b806:

- Formatting, all six typechecks, full lint and extension build passed.
- Full Vitest: 9,091 tests passed, five skipped; 763 suites passed and one skipped, zero unhandled errors.
- Focused registry/Codex/Claude suites: 28 tests passed. Both new cases fail against their original production source.
- Effect migration, dead-code and package/catalog/path/NOTICE checks passed on the equivalent pre-commit source tree.
- All applicable current-head CI passed: static checks, both Linux kernel-test shards, build artifacts, macOS webview smoke, guidance references and final validation. Both demonstrated review defects are resolved after current-head source, regression and CI verification; a fresh review-thread query has zero unresolved threads.
