### PR TITLE
feat(editor): apply VS Code LM token counts to max_tokens

### DIFF
--- a/packages/extension/src/frontend/lm/createLanguageModelPort.ts
+++ b/packages/extension/src/frontend/lm/createLanguageModelPort.ts
@@ -143,6 +143,9 @@ function toVscodeOptions(
       inputSchema: tool.inputSchema,
     })),
     toolMode: toVscodeToolMode(options.toolMode),
+    ...(options.maxTokens == null
+      ? {}
+      : { modelOptions: { max_tokens: options.maxTokens } }),
   };
 }
 

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -246,6 +246,21 @@ export class ModelHandlerVscodeLm extends ModelHandler<
     const output = this.createOutputStream();
     const text: string[] = [];
     const toolCalls: LanguageModelToolCallPart[] = [];
+    let maxTokens = this.getEffectiveMaxOutputTokens();
+    await this.applyTokenCountLimit({
+      countTokens: () =>
+        this.estimateTokenCount(options.messages, {
+          client: options.client,
+          tools: options.tools,
+          signal,
+        }),
+      currentMaxTokens: maxTokens,
+      contextWindow: this.getEffectiveContextWindow(),
+      detailLabel: 'VS Code LM: max_tokens reduced to fit context window',
+      applyReduced: (adjusted) => {
+        maxTokens = adjusted;
+      },
+    });
 
     try {
       for await (const part of options.client.sendRequest(
@@ -253,6 +268,7 @@ export class ModelHandlerVscodeLm extends ModelHandler<
         options.messages,
         {
           justification: 'Run the selected TeXRA agent.',
+          maxTokens,
           ...(tools ? { tools, toolMode: 'auto' as const } : {}),
         },
         signal,

--- a/src/platform/languageModel.ts
+++ b/src/platform/languageModel.ts
@@ -80,6 +80,11 @@ export interface LanguageModelRequestOptions {
   readonly justification?: string;
   readonly tools?: readonly LanguageModelToolDefinition[];
   readonly toolMode?: 'auto' | 'required';
+  /**
+   * Max completion tokens. Mapped to the editor API's `modelOptions.max_tokens`,
+   * which Copilot accepts as a number.
+   */
+  readonly maxTokens?: number;
 }
 
 export type LanguageModelResponsePart =

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
@@ -347,6 +347,7 @@ describe('ModelHandlerVscodeLm streaming and tools', () => {
           },
         ],
         toolMode: 'auto',
+        maxTokens: 4096,
       },
       expect.any(AbortSignal),
     );
@@ -366,6 +367,7 @@ describe('ModelHandlerVscodeLm streaming and tools', () => {
     expect(response.stopReason).toBe(OPENAI_CHAT_FINISH.STOP);
     expect(port.sendRequest.mock.calls[0]?.[2]).toEqual({
       justification: 'Run the selected TeXRA agent.',
+      maxTokens: 4096,
     });
   });
 
@@ -499,6 +501,34 @@ describe('ModelHandlerVscodeLm streaming and tools', () => {
     ).resolves.toBe(8);
     expect(port.countTokens).toHaveBeenCalledTimes(2);
     expect(handler.normalizeUsage(undefined, 100)).toBeUndefined();
+  });
+
+  it('reduces request maxTokens when the counted prompt leaves no output room', async () => {
+    const port = fakePort([{ kind: 'text', text: 'ok' }]);
+    port.countTokens.mockResolvedValue(90);
+    const handler = new ModelHandlerVscodeLm({
+      ...modelConfig(false),
+      maxOutputTokens: 50,
+      contextWindow: 100,
+    });
+
+    await handler.createResponse({
+      client: port,
+      messages: [
+        { role: 'user', content: [{ kind: 'text', text: 'question' }] },
+      ],
+      temperature: 0,
+    });
+
+    expect(port.sendRequest).toHaveBeenCalledWith(
+      { vendor: ModelProvider.COPILOT, id: 'copilot-model-id' },
+      expect.any(Array),
+      {
+        justification: 'Run the selected TeXRA agent.',
+        maxTokens: 10,
+      },
+      expect.any(AbortSignal),
+    );
   });
 });
 

--- a/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
+++ b/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
@@ -258,6 +258,7 @@ describe('createLanguageModelPort', () => {
           },
         ],
         toolMode: 'required',
+        maxTokens: 128,
       },
       new AbortController().signal,
     )) {
@@ -298,6 +299,7 @@ describe('createLanguageModelPort', () => {
         },
       ],
       toolMode: 2,
+      modelOptions: { max_tokens: 128 },
     });
   });
 


### PR DESCRIPTION
## Summary

Keep the editor-supplied language-model token-counting path and actually use it.

`ModelHandlerVscodeLm` now runs `applyTokenCountLimit` before `sendRequest`, using the existing `LanguageModelPort.countTokens` estimator. Reduced output budgets are passed as `maxTokens` on the host-neutral request options and mapped to Copilot's `modelOptions.max_tokens`.

This replaces the previous approach of deleting the unused counting API and advertising `supportsTokenCounting: false`. The VS Code `countTokens` API remains, and Copilot requests now get a real max-token cap instead of an advertised-but-unwired capability.

## Review follow-up

Addresses the request to turn counting on rather than retire it. Counting failures still follow the shared soft-failure envelope (proceed with the unreduced budget unless the prompt already exceeds the context window).

## Test plan

- [x] Existing VS Code LM handler and port suites
- [x] New handler case: counted prompt leaves no output room → `sendRequest` gets reduced `maxTokens`
- [x] Port adapter maps `maxTokens` to `modelOptions.max_tokens`