### PR TITLE
Tighten four data-structure smells from the complexity audit

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -268,16 +268,19 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const display = buildStatusBarDisplay({
     status: displayStatus,
     statusLabel: displayStream?.statusLabel,
-    elapsedMs: runStartedAt !== undefined ? now - runStartedAt : undefined,
-    runningFrame: runStartedAt !== undefined ? loadingFrameAt(now) : undefined,
+    turn: {
+      elapsedMs: runStartedAt !== undefined ? now - runStartedAt : undefined,
+      runningFrame:
+        runStartedAt !== undefined ? loadingFrameAt(now) : undefined,
+      thinkingActive: displayStream?.thinkingActive ?? false,
+      compactingActive: displayStream?.compactingActive ?? false,
+    },
     transientNotice,
     commandName: props.commandName,
     bypass:
       displayStreamId === undefined
         ? undefined
         : view.policy.get(displayStreamId)?.bypasses,
-    thinkingActive: displayStream?.thinkingActive ?? false,
-    compactingActive: displayStream?.compactingActive ?? false,
     queuedFollowUpMessages:
       displayStreamId === undefined
         ? []

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -127,21 +127,13 @@ export interface StatusBarDisplayInput {
   readonly status: StreamPhase | undefined;
   /** The fold's label for `status` (G4, one table); undefined with no stream. */
   readonly statusLabel: string | undefined;
-  /** Milliseconds since the running turn began. When set and `status` is
-   *  `running`, the bar shows a live `Ns` segment so a long token-less
-   *  "thinking" turn still reads as alive. Omitted in tests/headless. */
-  readonly elapsedMs?: number;
-  /** Current 1 Hz spin-cycle character (see `ui/LoadingIndicator`'s
-   *  `loadingFrameAt`) shown ahead of the status label while a turn is
-   *  active, so "running" reads as alive rather than a static word. Omitted
-   *  in tests/headless, same as `elapsedMs`. */
-  readonly runningFrame?: string;
+  /** Liveness of the running turn — omitted entirely in tests/headless runs,
+   *  same as each of its fields individually. */
+  readonly turn?: StatusBarTurnInput;
   readonly transientNotice: TransientNotice | undefined;
   readonly commandName?: string;
   /** The stream's policy snapshot bypasses; absent before `approval.policy` folds. */
   readonly bypass?: BypassState;
-  readonly thinkingActive?: boolean;
-  readonly compactingActive?: boolean;
   readonly queuedFollowUpMessages: readonly string[];
   /** Latest usage snapshot — read for `usageRoute` (which subscription quota
    *  to show), never for context occupancy: that is `contextState`. */
@@ -181,6 +173,20 @@ export interface StatusBarDisplayInput {
   /** Availability/labels for the normal chat shortcuts row, shown when
    *  neither `foreground` nor `childList` owns input. */
   readonly shortcuts: StatusBarShortcutsInput;
+}
+
+/** Liveness of the currently running turn, shown in the status bar's left
+ *  segments so a long token-less "thinking" turn still reads as alive. */
+interface StatusBarTurnInput {
+  /** Milliseconds since the running turn began. When set and `status` is
+   *  `running`, the bar shows a live `Ns` segment. */
+  readonly elapsedMs?: number;
+  /** Current 1 Hz spin-cycle character (see `ui/LoadingIndicator`'s
+   *  `loadingFrameAt`) shown ahead of the status label while a turn is
+   *  active, so "running" reads as alive rather than a static word. */
+  readonly runningFrame?: string;
+  readonly thinkingActive?: boolean;
+  readonly compactingActive?: boolean;
 }
 
 interface StatusBarForegroundInput {
@@ -962,12 +968,13 @@ export function buildStatusBarDisplay(
   const left: StatusBarSegment[] = [
     { text: STATUS_DIAMOND, color: COLOR_HINT, decorative: true },
   ];
+  const turn = input.turn;
 
   // No stream yet: a child row has no status column, the root keeps its slot.
   const statusLabel = input.statusLabel ?? (input.isChildStream ? '' : '-');
   const spinPrefix =
-    isActivePhase(input.status) && input.runningFrame
-      ? `${input.runningFrame} `
+    isActivePhase(input.status) && turn?.runningFrame
+      ? `${turn.runningFrame} `
       : '';
 
   // A notice must not hide the only indication that an active run is still
@@ -976,16 +983,16 @@ export function buildStatusBarDisplay(
   if (input.transientNotice) {
     if (isActivePhase(input.status)) {
       const elapsed =
-        input.elapsedMs === undefined
+        turn?.elapsedMs === undefined
           ? ''
-          : ` ${formatCompactDuration(input.elapsedMs)}`;
+          : ` ${formatCompactDuration(turn.elapsedMs)}`;
       transientLivenessIndex = left.length;
       left.push({
         text: `${spinPrefix}${statusLabel}${elapsed}`,
         compactText:
-          input.elapsedMs === undefined
+          turn?.elapsedMs === undefined
             ? 'run'
-            : `run ${formatCompactDuration(input.elapsedMs)}`,
+            : `run ${formatCompactDuration(turn.elapsedMs)}`,
         color: 'dim',
       });
     }
@@ -994,9 +1001,9 @@ export function buildStatusBarDisplay(
       text: `${spinPrefix}${statusLabel}`,
       color: 'dim',
     });
-    if (isActivePhase(input.status) && input.elapsedMs !== undefined) {
+    if (isActivePhase(input.status) && turn?.elapsedMs !== undefined) {
       left.push({
-        text: formatCompactDuration(input.elapsedMs),
+        text: formatCompactDuration(turn.elapsedMs),
         color: 'dim',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.elapsed,
       });
@@ -1005,13 +1012,13 @@ export function buildStatusBarDisplay(
   // Routine activity, not caution: these sit onscreen for whole turns, and
   // painting them yellow trains the eye to ignore the color that also
   // announces auto-approval bypasses and quota exhaustion.
-  if (input.compactingActive === true && isActivePhase(input.status)) {
+  if (turn?.compactingActive === true && isActivePhase(input.status)) {
     left.push({
       text: 'compacting...',
       color: 'dim',
       compactPriority: STATUS_BAR_COMPACT_PRIORITY.compacting,
     });
-  } else if (input.thinkingActive === true && isActivePhase(input.status)) {
+  } else if (turn?.thinkingActive === true && isActivePhase(input.status)) {
     left.push({
       text: 'thinking...',
       color: 'dim',

--- a/packages/desktop/src/renderer/paperWorkbench.ts
+++ b/packages/desktop/src/renderer/paperWorkbench.ts
@@ -61,8 +61,21 @@ export function createPaperWorkbench(options: {
   });
 
   let disposed = false;
-  const getState = () =>
-    surface.surface$.get().workbench as DesktopTaskShellState;
+  // `Surface.workbench` is untyped storage (`Record<string, unknown> | null`)
+  // shared with hosts that have no workbench at all; validate on every read
+  // rather than trusting a cast, but skip the reparse when the raw value is
+  // still the one `updateState` last wrote.
+  let cachedRaw: unknown = surface.surface$.get().workbench;
+  let cachedState: DesktopTaskShellState =
+    DesktopTaskShellStateSchema.parse(cachedRaw);
+  const getState = (): DesktopTaskShellState => {
+    const raw = surface.surface$.get().workbench;
+    if (raw !== cachedRaw) {
+      cachedState = DesktopTaskShellStateSchema.parse(raw);
+      cachedRaw = raw;
+    }
+    return cachedState;
+  };
   function updateState(next: DesktopTaskShellState): void {
     if (disposed) return;
     const previous = getState();

--- a/packages/extension/src/settingsView/frontend/slices/latexSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/latexSlice.ts
@@ -7,9 +7,9 @@
  */
 
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import type {
-  LatexConfigValues,
-  SettingsViewOutboundHandlerRegistry,
+import {
+  LatexConfigValuesSchema,
+  type SettingsViewOutboundHandlerRegistry,
 } from '@shared/schemas';
 import { LATEX_CONFIG_FIELD_TO_KEY } from '@shared/constants/latexConfig';
 
@@ -28,12 +28,14 @@ export const latexHandlers = {
 
   [SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES]: (data) => {
     latexConfigValues.set(
-      Object.fromEntries(
-        Object.entries(LATEX_CONFIG_FIELD_TO_KEY).map(([field, key]) => [
-          field,
-          data.values[key],
-        ]),
-      ) as LatexConfigValues,
+      LatexConfigValuesSchema.parse(
+        Object.fromEntries(
+          Object.entries(LATEX_CONFIG_FIELD_TO_KEY).map(([field, key]) => [
+            field,
+            data.values[key],
+          ]),
+        ),
+      ),
     );
   },
 

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -72,6 +72,7 @@ import {
   TEXCOUNT_INSTALL_GUIDE,
   IMAGE_PROCESSING_INSTALL_GUIDE,
   DEPENDENCY_INSTALL_COMMANDS,
+  hasInstallCommands,
   HOMEBREW_INSTALL_COMMAND,
   SCOOP_INSTALL_COMMAND,
   type InstallCommand,
@@ -283,8 +284,8 @@ export class LaTeXTab extends LitElement {
    */
   private getInstallCommand(dep: DependencyInfo): InstallCommand | null {
     const platform = this.settings.platform;
+    if (!hasInstallCommands(dep.key)) return null;
     const commands = DEPENDENCY_INSTALL_COMMANDS[dep.key];
-    if (!commands) return null;
     const options = commands[platform];
     if (!options?.length) return null;
     const pm = this.settings.packageManager;

--- a/src/shared/constants/latexToolchain.ts
+++ b/src/shared/constants/latexToolchain.ts
@@ -317,6 +317,20 @@ export const SCOOP_INSTALL_COMMAND =
   'Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; irm get.scoop.sh | iex';
 
 /**
+ * The `LatexSettingsStatus` fields `DEPENDENCY_INSTALL_COMMANDS` has an entry
+ * for. Closed so a typo'd key fails at compile time instead of silently
+ * missing the lookup in `DependencyInfo.key` (`keyof LatexSettingsStatus`,
+ * a much wider interface that also carries `platform`, detected paths, and
+ * `latexWorkshopInstalled`, which installs through a VS Code command instead).
+ */
+type DependencyInstallKey =
+  | 'texDistributionInstalled'
+  | 'latexdiffInstalled'
+  | 'latexindentInstalled'
+  | 'texcountInstalled'
+  | 'imageProcessingInstalled';
+
+/**
  * Per-dependency install commands keyed by `DependencyInfo.key`.
  *
  * Each platform maps to an **ordered** list of install options, ranked by
@@ -327,7 +341,7 @@ export const SCOOP_INSTALL_COMMAND =
  * An empty array means there is no automatable install for that platform.
  */
 export const DEPENDENCY_INSTALL_COMMANDS: Record<
-  string,
+  DependencyInstallKey,
   Record<OSPlatform, readonly InstallCommand[]>
 > = {
   texDistributionInstalled: {
@@ -416,6 +430,13 @@ export const DEPENDENCY_INSTALL_COMMANDS: Record<
     ],
   },
 };
+
+/** Narrows a `DependencyInfo.key` to whether `DEPENDENCY_INSTALL_COMMANDS` has
+ *  an entry for it — most `LatexSettingsStatus` keys (paths, `platform`,
+ *  `latexWorkshopInstalled`) do not. */
+export function hasInstallCommands(key: string): key is DependencyInstallKey {
+  return key in DEPENDENCY_INSTALL_COMMANDS;
+}
 
 // ============================================================
 // Utility functions

--- a/src/shared/constants/latexToolchain.ts
+++ b/src/shared/constants/latexToolchain.ts
@@ -435,7 +435,7 @@ export const DEPENDENCY_INSTALL_COMMANDS: Record<
  *  an entry for it — most `LatexSettingsStatus` keys (paths, `platform`,
  *  `latexWorkshopInstalled`) do not. */
 export function hasInstallCommands(key: string): key is DependencyInstallKey {
-  return key in DEPENDENCY_INSTALL_COMMANDS;
+  return Object.hasOwn(DEPENDENCY_INSTALL_COMMANDS, key);
 }
 
 // ============================================================

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -10,13 +10,13 @@
 import { z } from 'zod';
 
 import { SETTINGS_VIEW_CMD, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import type {
+import {
   LATEX_FORMATTER_VALUES,
   LATEXDIFF_MATH_MARKUP_VALUES,
 } from '@shared/constants/latexConfig';
-import type {
-  NonRegexReplacementCategory,
-  RegexReplacementCategory,
+import {
+  NON_REGEX_REPLACEMENT_CATEGORIES,
+  REGEX_REPLACEMENT_CATEGORIES,
 } from '@shared/constants/replacementCategories';
 import {
   createDispatcher,
@@ -623,23 +623,34 @@ const UpdateLatexSettingsStatusMessageSchema = z.object({
   settings: LatexSettingsStatusSchema,
 });
 
-/** Frontend field projection of the catalog-derived LaTeX snapshot. */
-export interface LatexConfigValues {
-  workflowAutoCompile?: boolean;
-  workflowAutoCompileTimeoutMs?: number;
-  workflowAutoOpenPdf?: boolean;
-  workflowRejectOnCompileFailure?: boolean;
-  latexdiffBetweenRounds?: boolean;
-  latexdiffTimeoutMs?: number;
-  latexdiffMathMarkup?: (typeof LATEXDIFF_MATH_MARKUP_VALUES)[number];
-  latexdiffChangesOnly?: boolean;
-  latexFormatter?: (typeof LATEX_FORMATTER_VALUES)[number];
-  wrapCritiqueInAlign?: boolean;
-  enabledReplacements?: NonRegexReplacementCategory[];
-  enabledReplacementsRegex?: RegexReplacementCategory[];
-  customReplacementsRegex?: Record<string, string>;
-  customReplacements?: Record<string, string>;
-}
+/**
+ * Frontend field projection of the catalog-derived LaTeX snapshot. Every
+ * field is optional because `latexSlice` projects only the wire keys named in
+ * `LATEX_CONFIG_FIELD_TO_KEY`, not a fixed subset — parsing through this
+ * schema (rather than casting) turns a future drift between that map and this
+ * shape into a loud failure instead of a silently wrong-typed field.
+ */
+export const LatexConfigValuesSchema = z.object({
+  workflowAutoCompile: z.boolean().optional(),
+  workflowAutoCompileTimeoutMs: z.number().optional(),
+  workflowAutoOpenPdf: z.boolean().optional(),
+  workflowRejectOnCompileFailure: z.boolean().optional(),
+  latexdiffBetweenRounds: z.boolean().optional(),
+  latexdiffTimeoutMs: z.number().optional(),
+  latexdiffMathMarkup: z.enum(LATEXDIFF_MATH_MARKUP_VALUES).optional(),
+  latexdiffChangesOnly: z.boolean().optional(),
+  latexFormatter: z.enum(LATEX_FORMATTER_VALUES).optional(),
+  wrapCritiqueInAlign: z.boolean().optional(),
+  enabledReplacements: z
+    .array(z.enum(NON_REGEX_REPLACEMENT_CATEGORIES))
+    .optional(),
+  enabledReplacementsRegex: z
+    .array(z.enum(REGEX_REPLACEMENT_CATEGORIES))
+    .optional(),
+  customReplacementsRegex: z.record(z.string(), z.string()).optional(),
+  customReplacements: z.record(z.string(), z.string()).optional(),
+});
+export type LatexConfigValues = z.infer<typeof LatexConfigValuesSchema>;
 
 /** Outbound: backend → frontend current LaTeX/compile/diff config values. */
 const UpdateLatexConfigValuesMessageSchema = snapshotMessage('latex');

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -32,16 +32,17 @@ function leftTexts(display: StatusBarDisplay): string[] {
   return display.left.map((segment) => segment.text);
 }
 
-// `StatusBarDisplayInput` with every field optional and its three grouped
+// `StatusBarDisplayInput` with every field optional and its four grouped
 // members individually overridable, so a test still names one field at a time
 // without a flat mirror of the group members drifting alongside them.
 type StatusInputOverrides = Omit<
   Partial<StatusBarDisplayInput>,
-  'foreground' | 'childList' | 'shortcuts'
+  'foreground' | 'childList' | 'shortcuts' | 'turn'
 > & {
   readonly foreground?: Partial<StatusBarDisplayInput['foreground']>;
   readonly childList?: Partial<StatusBarDisplayInput['childList']>;
   readonly shortcuts?: Partial<StatusBarDisplayInput['shortcuts']>;
+  readonly turn?: Partial<StatusBarDisplayInput['turn']>;
 };
 
 // Idle single-stream baseline; each test overrides only the fields it exercises.
@@ -50,7 +51,7 @@ const NO_BYPASS = { bash: false, superYolo: false, toolEdit: false } as const;
 function statusInput(
   overrides: StatusInputOverrides = {},
 ): StatusBarDisplayInput {
-  const { foreground, childList, shortcuts, ...rest } = overrides;
+  const { foreground, childList, shortcuts, turn, ...rest } = overrides;
 
   return {
     status: STREAM_PHASE.WAITING,
@@ -67,6 +68,7 @@ function statusInput(
     approvalDepth: 0,
     modelAccess: 'personal',
     ...rest,
+    turn: { ...turn },
     foreground: { ...foreground },
     childList: { ...childList },
     shortcuts: {
@@ -555,7 +557,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        elapsedMs: 12_000,
+        turn: { elapsedMs: 12_000 },
         modelAccess: 'included',
         ctrlCAction: 'stop',
         shortcuts: { modifierLabel: 'Option' },
@@ -592,7 +594,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        elapsedMs: 12_000,
+        turn: { elapsedMs: 12_000 },
         subagents: 1,
         modelAccess: 'included',
         ctrlCAction: 'stop',
@@ -707,7 +709,10 @@ describe('CLI StatusBar display model', () => {
 
   it('prefixes the running label with the current spin frame', () => {
     const display = buildStatusBarDisplay(
-      statusInput({ status: STREAM_PHASE.RUNNING, runningFrame: '/' }),
+      statusInput({
+        status: STREAM_PHASE.RUNNING,
+        turn: { runningFrame: '/' },
+      }),
     );
 
     expect(leftTexts(display)).toContain('/ Running');
@@ -715,7 +720,10 @@ describe('CLI StatusBar display model', () => {
 
   it('omits the spin prefix outside active phases', () => {
     const display = buildStatusBarDisplay(
-      statusInput({ status: STREAM_PHASE.WAITING, runningFrame: '/' }),
+      statusInput({
+        status: STREAM_PHASE.WAITING,
+        turn: { runningFrame: '/' },
+      }),
     );
 
     expect(leftTexts(display).some((text) => text.includes('/'))).toBe(false);
@@ -794,7 +802,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        elapsedMs: 88_000,
+        turn: { elapsedMs: 88_000 },
         subagents: 3,
         ctrlCAction: 'stop',
         width: 60,
@@ -811,7 +819,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        elapsedMs: 88_000,
+        turn: { elapsedMs: 88_000 },
         subagents: 3,
         ctrlCAction: 'stop',
         width: 44,
@@ -827,7 +835,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        elapsedMs: 88_000,
+        turn: { elapsedMs: 88_000 },
         subagents: 3,
         ctrlCAction: 'stop',
         width: 27,
@@ -857,7 +865,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        elapsedMs: 75_000,
+        turn: { elapsedMs: 75_000 },
         subagents: 3,
         ctrlCAction: 'stop',
         width: 34,
@@ -882,7 +890,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        elapsedMs: 75_000,
+        turn: { elapsedMs: 75_000 },
         approvalDepth: 3,
         ctrlCAction: 'stop',
         width: 30,
@@ -901,7 +909,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        elapsedMs: 75_000,
+        turn: { elapsedMs: 75_000 },
         ctrlCAction: 'stop',
         width: 16,
       }),
@@ -917,7 +925,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        elapsedMs: 75_000,
+        turn: { elapsedMs: 75_000 },
         queuedFollowUpMessages: ['Keep the proof under one page.'],
         approvalDepth: 3,
         ctrlCAction: 'stop',
@@ -1349,7 +1357,7 @@ describe('CLI StatusBar display model', () => {
   it('shows a live elapsed segment only while running', () => {
     const runningInput = statusInput({
       status: STREAM_PHASE.RUNNING,
-      elapsedMs: 110_000,
+      turn: { elapsedMs: 110_000 },
     });
     const running = buildStatusBarDisplay(runningInput);
 
@@ -1373,7 +1381,7 @@ describe('CLI StatusBar display model', () => {
 
     const justStarted = buildStatusBarDisplay({
       ...runningInput,
-      elapsedMs: -20_000,
+      turn: { ...runningInput.turn, elapsedMs: -20_000 },
     });
     expect(leftTexts(justStarted)).toEqual([
       '◆',
@@ -1384,7 +1392,7 @@ describe('CLI StatusBar display model', () => {
 
     const thinking = buildStatusBarDisplay({
       ...runningInput,
-      thinkingActive: true,
+      turn: { ...runningInput.turn, thinkingActive: true },
     });
     expect(leftTexts(thinking)).toEqual([
       '◆',
@@ -1396,8 +1404,11 @@ describe('CLI StatusBar display model', () => {
 
     const compacting = buildStatusBarDisplay({
       ...runningInput,
-      compactingActive: true,
-      thinkingActive: true,
+      turn: {
+        ...runningInput.turn,
+        compactingActive: true,
+        thinkingActive: true,
+      },
     });
     expect(leftTexts(compacting)).toEqual([
       '◆',
@@ -1410,9 +1421,11 @@ describe('CLI StatusBar display model', () => {
     // The same elapsed reading is suppressed once the turn is no longer running.
     const idle = buildStatusBarDisplay(
       statusInput({
-        compactingActive: true,
-        elapsedMs: 110_000,
-        thinkingActive: true,
+        turn: {
+          compactingActive: true,
+          elapsedMs: 110_000,
+          thinkingActive: true,
+        },
       }),
     );
 
@@ -1526,8 +1539,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        runningFrame: '/',
-        elapsedMs: 45_000,
+        turn: { runningFrame: '/', elapsedMs: 45_000 },
         transientNotice: UNKNOWN_COMMAND_NOTICE,
         width: 20,
       }),
@@ -1540,9 +1552,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        runningFrame: '/',
-        elapsedMs: 45_000,
-        thinkingActive: true,
+        turn: { runningFrame: '/', elapsedMs: 45_000, thinkingActive: true },
         transientNotice: UNKNOWN_COMMAND_NOTICE,
       }),
     );
@@ -1581,8 +1591,7 @@ describe('CLI StatusBar display model', () => {
       statusInput({
         status: STREAM_PHASE.RUNNING,
         bypass,
-        runningFrame: '/',
-        elapsedMs: 45_000,
+        turn: { runningFrame: '/', elapsedMs: 45_000 },
         transientNotice: {
           kind: 'exit',
           text: 'Press Ctrl-C again to exit',


### PR DESCRIPTION
## Summary

A scheduled data-structure-complexity audit of this repo flagged several spots where an unchecked cast or a flat, over-optional-field object was standing in for real type safety. This PR fixes the four that were self-contained enough to land without touching UI behavior:

- **`packages/desktop/src/renderer/paperWorkbench.ts`** — `getState()` read `Surface.workbench` (typed `Record<string, unknown> | null`) via `as DesktopTaskShellState`, an unchecked cast. Replaced with an accessor that re-validates through `DesktopTaskShellStateSchema.parse` whenever the raw value's identity changes (cached otherwise, so no per-call parse cost), matching `updateState`'s own write path.
- **`src/shared/schemas/settingsViewMessages.ts` / `packages/extension/src/settingsView/frontend/slices/latexSlice.ts`** — `LatexConfigValues` was a hand-written interface, and `latexSlice` projected the wire-keyed snapshot into it with `Object.fromEntries(...) as LatexConfigValues`. Promoted `LatexConfigValues` to a Zod schema (SSOT, per this repo's own schema conventions) and replaced the cast with `LatexConfigValuesSchema.parse(...)`, so a future drift between `LATEX_CONFIG_FIELD_TO_KEY` and the schema fails loudly instead of silently mistyping a field.
- **`src/shared/constants/latexToolchain.ts` / `packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts`** — `DEPENDENCY_INSTALL_COMMANDS` was `Record<string, ...>` looked up by `dep.key: keyof LatexSettingsStatus` (a much wider interface including paths/`platform`), with a runtime `if (!commands) return null` masking that most keys have no entry. Narrowed the record to a closed `DependencyInstallKey` union and added a `hasInstallCommands` type guard, so an unmapped key is a compile-time-checked branch rather than a silently-`undefined` runtime lookup.
- **`packages/cli/src/chat/tui/panes/statusBarDisplay.ts` / `StatusBar.tsx`** — `StatusBarDisplayInput` had four independent turn-liveness fields (`elapsedMs`, `runningFrame`, `thinkingActive`, `compactingActive`) flattened alongside a dozen unrelated ones. Grouped them into a `turn?` sub-object, matching the existing `foreground`/`childList`/`shortcuts` grouping already on this same type.

Left out of scope (broader blast radius, not worth an unattended refactor): `ExternalToolDef`'s 17 flat optional fields (8 call-site files across CLI/desktop/extension) and `Surface.groups`' map-of-maps (28 usages, and rated Low severity in the audit) — both are readability improvements, not bug sources, and better done as their own reviewed change.

## Issue acceptance gates

No tracked issue; this follows directly from the scheduled data-structure-complexity audit's findings (paperWorkbench unchecked cast and the LaTeX config cast were the two Medium-severity items; the other two are Low-severity readability fixes bundled in because they were equally self-contained).

## Single source of truth

- `LatexConfigValuesSchema` (new) is now the SSOT for the LaTeX config frontend projection; `LatexConfigValues` is derived via `z.infer`.
- `DependencyInstallKey` is the SSOT for which `LatexSettingsStatus` keys `DEPENDENCY_INSTALL_COMMANDS` covers.

## Duplication and abstraction budget

No duplication removed; no new abstractions beyond the schema/guard needed to replace each cast. No pass-through layers added.

## Net elements (R6)

Diffstat: 8 files changed, 155 insertions(+), 88 deletions(-) (`git diff --stat`).

Exported symbols (`^[+-]export` over the diff):
- `-export interface LatexConfigValues` → `+export const LatexConfigValuesSchema` / `+export type LatexConfigValues` (interface → schema-derived type, same name preserved for existing consumers)
- `+export function hasInstallCommands` (new guard, one caller)

## Consumer counts (R8)

Not an emit-path or export removal/re-route: `LatexConfigValues` keeps its name and shape for all 8 existing consumers (verified via `npm run typecheck` across every package). n/a otherwise.

## Host impact

Extension: `LaTeXTab.ts` install-command lookup now compile-time-guarded; `latexSlice.ts` now parses instead of casting the LaTeX config snapshot.

Desktop: `paperWorkbench.ts`'s workbench-state accessor now validates instead of casting.

CLI: `StatusBarDisplayInput`'s turn-liveness fields are now grouped under `turn`; `StatusBar.tsx` updated to match.

## Scheduled refactoring

None. (Two lower-priority findings — `ExternalToolDef` field grouping and `Surface.groups`' map-of-maps — are noted above as deliberately out of scope; no follow-up issue filed.)

## Validation

- `npm run typecheck` — all six sub-projects (workspace, test-kernel, agent, cli, trace-viewer, desktop) pass.
- `npm run lint` — clean.
- `npm test` — full suite: 763 files / 9088 tests passed, 1 file / 6 tests pre-existing skips (unchanged from baseline).
- `npm run check:dead-code-ratchet` — no new findings.
- `npx prettier --check` on every changed file — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfBA3jetYmUYVPR3hCJw5


---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfBA3jetYmUYVPR3hCJw5)_