### PR TITLE
refactor(common): convert sdkError/loopback catches to typed Effect recovery

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -189,9 +189,6 @@
       "src/agent/remote/remoteAgentList.ts": 2,
       "src/agent/runtime/SessionHandle.ts": 10,
       "src/agent/runtime/bundledPrompts.ts": 1,
-      "src/auth/oauth/loopbackLogin.ts": 2,
-      "src/common/errors/sdkError/errorInspection.ts": 1,
-      "src/common/errors/sdkError/providerErrorFormat.ts": 2,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/utils/files/relativeFS.ts": 2
     }

--- a/src/auth/oauth/loopbackLogin.ts
+++ b/src/auth/oauth/loopbackLogin.ts
@@ -13,7 +13,7 @@
  */
 import http from 'node:http';
 
-import { Deferred, Duration, Effect } from 'effect';
+import { Deferred, Duration, Effect, Fiber, Result } from 'effect';
 import { AUTH_CALLBACK_TIMEOUT_MS } from '../config';
 import type { HttpClient } from 'effect/unstable/http';
 
@@ -126,6 +126,50 @@ function bindLoopbackServer(
 }
 
 /**
+ * What one callback request asks the login flow to do. Parsed as a pure
+ * decision so the Node `http` request callback — a foreign-runtime edge that
+ * cannot return an Effect — only interprets it: the URL parse, the one throw
+ * risk, sits in `Result.try`, and every fallible branch is a success value.
+ */
+type CallbackDecision =
+  | { readonly kind: 'not-found' }
+  | { readonly kind: 'stale-state' }
+  | { readonly kind: 'oauth-error'; readonly error: string }
+  | { readonly kind: 'missing-code' }
+  | { readonly kind: 'code'; readonly code: string };
+
+function decideCallback(
+  rawUrl: string | undefined,
+  base: string,
+  callbackPath: string,
+  expectedState: string,
+): Result.Result<CallbackDecision, Error> {
+  return Result.try({
+    try: (): CallbackDecision => {
+      const url = new URL(rawUrl ?? '', base);
+      if (url.pathname !== callbackPath) {
+        return { kind: 'not-found' };
+      }
+      // A stale or foreign callback answers with the error page but keeps
+      // the wait open; only a state-matched callback settles it.
+      if (url.searchParams.get('state') !== expectedState) {
+        return { kind: 'stale-state' };
+      }
+      const oauthError = url.searchParams.get('error');
+      if (oauthError) {
+        return { kind: 'oauth-error', error: oauthError };
+      }
+      const authCode = url.searchParams.get('code');
+      if (!authCode) {
+        return { kind: 'missing-code' };
+      }
+      return { kind: 'code', code: authCode };
+    },
+    catch: (error) => error as Error,
+  });
+}
+
+/**
  * The loopback sign-in flow end to end: bind, open the browser, wait for the
  * callback, and persist the session via the coordinator.
  */
@@ -138,8 +182,12 @@ export function loginWithOAuthLoopback<S>(
   // implementation's observable ordering: it bound the server, armed the
   // callback wait, and invoked `openBrowser` before its first cancellation
   // check, so a launcher that never settles must still be started and an
-  // abort must still settle the login. Interruption is observed from the
-  // launcher await onward — the same points the old code raced against its
+  // abort must still settle the login. The launch promise is consumed on a
+  // detached fiber: interruption of the login abandons the join but never
+  // the launcher, and a late launch failure dies on that fiber with a typed
+  // error — observed and inert — where the old code swallowed a late
+  // rejection with a `.catch` no-op. Interruption is observed from the
+  // launcher join onward — the same points the old code raced against its
   // cancellation promise.
   const setup = Effect.uninterruptible(
     Effect.gen(function* () {
@@ -157,41 +205,42 @@ export function loginWithOAuthLoopback<S>(
         req: http.IncomingMessage,
         res: http.ServerResponse,
       ): void => {
-        try {
-          const url = new URL(req.url ?? '', `http://127.0.0.1:${port}`);
-          if (url.pathname !== callbackPath) {
+        const decision = decideCallback(
+          req.url,
+          `http://127.0.0.1:${port}`,
+          callbackPath,
+          authorize.state,
+        );
+        if (Result.isFailure(decision)) {
+          res.statusCode = 500;
+          res.end('Internal error');
+          Deferred.doneUnsafe(code, Effect.fail(decision.failure));
+          return;
+        }
+        switch (decision.success.kind) {
+          case 'not-found':
             res.statusCode = 404;
             res.end('Not found');
             return;
-          }
-          // A stale or foreign callback answers with the error page but keeps
-          // the wait open; only a state-matched callback settles it.
-          if (url.searchParams.get('state') !== authorize.state) {
+          case 'stale-state':
+          case 'missing-code':
             respondHtml(res, ERROR_HTML, 400);
             return;
-          }
-          const oauthError = url.searchParams.get('error');
-          if (oauthError) {
+          case 'oauth-error':
             respondHtml(res, ERROR_HTML, 400);
             Deferred.doneUnsafe(
               code,
               Effect.fail(
-                new Error(`${displayName} sign-in failed: ${oauthError}`),
+                new Error(
+                  `${displayName} sign-in failed: ${decision.success.error}`,
+                ),
               ),
             );
             return;
-          }
-          const authCode = url.searchParams.get('code');
-          if (!authCode) {
-            respondHtml(res, ERROR_HTML, 400);
+          case 'code':
+            respondHtml(res, successHtml(displayName));
+            Deferred.doneUnsafe(code, Effect.succeed(decision.success.code));
             return;
-          }
-          respondHtml(res, successHtml(displayName));
-          Deferred.doneUnsafe(code, Effect.succeed(authCode));
-        } catch (error) {
-          res.statusCode = 500;
-          res.end('Internal error');
-          Deferred.doneUnsafe(code, Effect.fail(error as Error));
         }
       };
       yield* Effect.acquireRelease(
@@ -202,10 +251,15 @@ export function loginWithOAuthLoopback<S>(
           }),
       );
 
-      const browserLaunch = Promise.resolve(openBrowser(authorize.url));
-      // A launch failure that loses to cancellation is abandoned, as before;
-      // keep its late rejection observed.
-      void browserLaunch.catch(() => {});
+      // Invoked synchronously here (the old Promise code's ordering), then
+      // observed by the detached fiber the login joins below.
+      const launchPromise = Promise.resolve(openBrowser(authorize.url));
+      const browserLaunch = yield* Effect.forkDetach(
+        Effect.tryPromise<void, unknown>({
+          try: () => launchPromise,
+          catch: (error) => error,
+        }),
+      );
       return { authorize, code, browserLaunch };
     }),
   );
@@ -214,10 +268,7 @@ export function loginWithOAuthLoopback<S>(
     Effect.gen(function* () {
       const { authorize, code, browserLaunch } = yield* setup;
 
-      yield* Effect.tryPromise({
-        try: () => browserLaunch,
-        catch: (error) => error,
-      });
+      yield* Fiber.join(browserLaunch);
 
       const authCode = yield* Deferred.await(code).pipe(
         Effect.timeoutOrElse({

--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -89,11 +89,7 @@ export function matchUsageLimitMessage(
 
 /** Get reason phrase, returning undefined for unknown codes (getReasonPhrase throws). */
 export function safeGetReasonPhrase(statusCode: number): string | undefined {
-  try {
-    return getReasonPhrase(statusCode);
-  } catch {
-    return undefined;
-  }
+  return Result.getOrUndefined(Result.try(() => getReasonPhrase(statusCode)));
 }
 
 export function getErrorClassNames(err: unknown): string[] {

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -172,14 +172,13 @@ function describeHttpError(
     }
 
     if (typeof rawErrorBody === 'object' && rawErrorBody !== null) {
-      try {
-        const serializedRawBody = JSON.stringify(rawErrorBody);
+      // Non-serializable diagnostic bodies cannot have been JSON-stringified
+      // into the SDK wrapper message by the path guarded here.
+      const serialized = Result.try(() => JSON.stringify(rawErrorBody));
+      if (Result.isSuccess(serialized) && serialized.success !== undefined) {
         wrapperMessageContainsRawBody =
-          serializedRawBody.length > 2 &&
-          extractedMessage.includes(serializedRawBody);
-      } catch {
-        // Non-serializable diagnostic bodies cannot have been JSON-stringified
-        // into the SDK wrapper message by the path guarded here.
+          serialized.success.length > 2 &&
+          extractedMessage.includes(serialized.success);
       }
 
       if (!wrapperMessageContainsRawBody) {
@@ -191,13 +190,15 @@ function describeHttpError(
           const embeddedBody = Result.getOrUndefined(
             safeParseJson(extractedMessage.slice(start, end + 1)),
           );
-          try {
-            wrapperMessageContainsRawBody =
-              stableStringify(embeddedBody) === stableStringify(rawErrorBody);
-          } catch {
-            // Circular or otherwise non-JSON diagnostics cannot match a JSON
-            // fragment parsed from the wrapper message.
-          }
+          // Circular or otherwise non-JSON diagnostics cannot match a JSON
+          // fragment parsed from the wrapper message.
+          wrapperMessageContainsRawBody = Result.getOrElse(
+            Result.try(
+              () =>
+                stableStringify(embeddedBody) === stableStringify(rawErrorBody),
+            ),
+            () => false,
+          );
         }
       }
     }


### PR DESCRIPTION
## Summary

Converts the raw catch sites in three of the four files of the common/errors + utils + auth catch lane to native Effect-typed recovery (PRD R7, execution rule 2 — one pass per file). All three are below R1's boundary, so no `Effect.run*` appears or moves; the two sdkError files are pure formatters whose signatures do not change at all, and `loginWithOAuthLoopback` was already Effect-typed end to end after #11990 — this PR removes the two raw catches its Promise seam still carried.

- `src/common/errors/sdkError/errorInspection.ts` (1 → 0): `safeGetReasonPhrase`'s try/catch around the throwing `getReasonPhrase` becomes `Result.try` + `Result.getOrUndefined`. Same signature, same fallback.
- `src/common/errors/sdkError/providerErrorFormat.ts` (2 → 0): the two stringify guards in `describeHttpError` (circular/non-serializable diagnostic bodies) become `Result.try` folds — failure maps to "cannot contain/match the body", exactly what the catch blocks encoded. Signatures unchanged; classification output is byte-identical.
- `src/auth/oauth/loopbackLogin.ts` (2 → 0): the `http` request callback's try/catch becomes a pure `decideCallback` returning `Result<CallbackDecision, Error>` — the one throw risk (the `URL` parse) sits in `Result.try`, every other fallible branch is a success value, and the foreign-runtime callback only interprets the decision. The browser launcher's `void promise.catch(() => {})` becomes a detached fiber (`Effect.forkDetach`) observing the launch promise, joined by the login; interruption abandons the join, never the launcher, and a late launch failure dies on that fiber as a typed error — observed and inert, the old no-op's exact semantics. `openBrowser` is still invoked synchronously inside the uninterruptible setup, preserving the ordering the code documents.

`src/utils/files/relativeFS.ts` (stays at 2, deliberately): `cleanupOldFiles`' only production callers are `src/tools/media/audio.ts` (`stopRecordingAndTranscribe`) and `src/utils/files/pastedImageUtils.ts` (`savePastedImageBuffer`), and both chains terminate in `src/controllers/session/hostDraftRequests.ts` — a file this lane is barred from touching. Making `cleanupOldFiles` Effect-typed would force the conversion through that file, or a new below-boundary `Effect.run*` in src/** that the ratchet's `--update` refuses. The conversion belongs to the lane that owns the session-controller seam.

## Issue acceptance gates

No issue; the lane is the `catch:effect-importer` row of `config/ratchets/effect-migration-baseline.json`.

- `errorInspection.ts` 1 → 0: done.
- `providerErrorFormat.ts` 2 → 0: done.
- `loopbackLogin.ts` 2 → 0: done.
- `relativeFS.ts` 2 → 2: not done — blocked by the lane-excluded `src/controllers/session/hostDraftRequests.ts` caller chain (see Summary); the baseline entry stays.
- No new `Effect.run*` below R1's boundary kinds: done — none added anywhere; no run edges moved because no signature crossed a module boundary.

## Single source of truth

`decideCallback` in `loopbackLogin.ts` now owns the callback-URL classification (path, state match, provider error, code presence) as one pure function; the `http` callback holds only response rendering and `Deferred` settlement. The sdkError formatters' fallback policy ("a body that cannot be serialized cannot have been embedded in the wrapper message") is unchanged and still owned by `describeHttpError`.

## Duplication and abstraction budget

No new abstraction: `CallbackDecision` replaces a try/catch whose catch arm duplicated the oauth-error response path. The two `Result.try` folds in `describeHttpError` replace catch blocks one-for-one. Deleted: one promise `.catch` no-op (its "late rejection observed" job is now structural — the detached fiber is the observer).

## Net elements (R6)

- Files: 4 changed (+100/−55) — 3 production, 1 ratchet baseline.
- Exported symbols: 0 added, 0 deleted (`^[+-]export` over the diff: only line-wrapping of an existing export in `errorInspection.ts`).
- Classes/interfaces/enums: none added or removed (`CallbackDecision` is a file-local type).
- Net LoC: +45. The growth is the loopback callback restructure (pure decision + switch) and its ordering documentation; the sdkError diffs are near-neutral.

## Consumer counts (R8)

- `safeGetReasonPhrase`: 3 call sites, all in `src/common/errors/sdkError/` — signature unchanged.
- `describeHttpError` (file-local): 2 call sites, same file — internal only.
- `loginWithOAuthLoopback`: 2 consumers (`src/auth/codex/codexLoopbackLogin.ts`, `src/auth/xai/xaiLoopbackLogin.ts`) — signature unchanged (`Effect<S, unknown, HttpClient>`), no caller edits.
- `RelativeFS.cleanupOldFiles`: 2 callers (`src/tools/media/audio.ts`, `src/utils/files/pastedImageUtils.ts`) — untouched this lane (see Summary).
- n/a for emit paths: none re-routed.

## Host impact

Extension: none — no host code touched; loopback login behavior, HTTP responses, and error identities are unchanged (covered by `CodexLoopbackLogin.vitest.ts`).
Desktop: none — `DesktopCredentialSettingsController` reads only the unchanged `LoopbackTransportUnavailableError`.
CLI: none.

## Scheduled refactoring

`src/utils/files/relativeFS.ts` keeps its 2-catch baseline entry; convert it when the lane owning `src/controllers/session/hostDraftRequests.ts` lands, since both `cleanupOldFiles` call chains terminate there.

## Validation

- `npm run typecheck:workspace` and `npm run typecheck:test-kernel` — clean.
- `npx eslint` on the three changed source files — clean.
- `npx prettier --write` on all changed files — no diffs after formatting.
- Affected suites: `CodexLoopbackLogin` (4), `SdkErrorUtils`, `ChatGptSubscriptionDetection`, `XaiSubscriptionDetection`, `KimiCodeSubscriptionDetection`, `GlmCodingPlanDetection`, `FilesUtils`, `DesktopCredentialSettingsController` — 8 files / 133 tests passed.
- Full Vitest suite (`npm test -- --maxWorkers=4`): 763 files / 9,091 tests passed, 1 file / 5 tests skipped (pre-existing skip); zero failures — the known `DesktopPreviewHost`/`DesktopProgressFileActions` flakes did not appear.
- `node scripts/check-effect-migration-ratchet.mjs --update` then re-run without: OK — the `catch:effect-importer` row shrinks by exactly the three converted files; no count grew, no file added.
- `npm run check:dead-code-ratchet` — OK, no new findings.
- `node scripts/check-browser-safe-utils.mjs` — OK (65 total, 5 reachable; `relativeFS.ts` untouched and not browser-reachable).
