### PR TITLE
Read hostEnvironment through tryPlatform() for a real production consumer

### DIFF
--- a/src/test-kernel/tools/codexImport.vitest.ts
+++ b/src/test-kernel/tools/codexImport.vitest.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import { afterEach, describe, it } from 'vitest';
 
 // Local imports
+import type { HostEnvironmentPort } from '@platform/interfaces';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { findCodexBinaryPath } from '@tools/codexImport';
@@ -50,11 +51,30 @@ const PLATFORM_PACKAGES: Record<
 
 describe('findCodexBinaryPath', () => {
   let tempDir: string | undefined;
+  // Strategy 1 reads this through tryPlatform()?.hostEnvironment; each test
+  // that wants to impersonate a packaged Electron app sets it here instead
+  // of mutating the real `process` global.
+  let packagedResourcesPath: string | undefined;
 
   // pathExists() probes the real filesystem through platform().fs.
-  setupPlatform({}, { fs: nodeFilesystem });
+  setupPlatform(
+    {},
+    {
+      fs: nodeFilesystem,
+      hostEnvironment: {
+        hostInfo: () => ({
+          platform: 'linux',
+          arch: 'x64',
+          osRelease: 'fake-release',
+          shell: '/bin/bash',
+        }),
+        packagedElectronResourcesPath: () => packagedResourcesPath,
+      } satisfies HostEnvironmentPort,
+    },
+  );
 
   afterEach(() => {
+    packagedResourcesPath = undefined;
     if (tempDir != null) {
       fs.rmSync(tempDir, { recursive: true, force: true });
       tempDir = undefined;
@@ -83,26 +103,9 @@ describe('findCodexBinaryPath', () => {
     fs.mkdirSync(path.dirname(binaryPath), { recursive: true });
     fs.writeFileSync(binaryPath, '');
 
-    // Impersonate a packaged Electron app: nodeHostEnvironment's
-    // packagedElectronResourcesPath() (a frozen, shared singleton — see
-    // nodeHostEnvironment.ts) reads process.versions.electron,
-    // process.defaultApp, and process.resourcesPath directly, so mutating
-    // those is the only way to steer it from a test.
-    const electronProcess = process as NodeJS.Process & {
-      defaultApp?: boolean;
-      resourcesPath?: string;
-    };
-    Object.defineProperty(process.versions, 'electron', {
-      value: '30.0.0',
-      configurable: true,
-      enumerable: true,
-    });
-    electronProcess.resourcesPath = tempDir;
-    try {
-      assert.equal(await findCodexBinaryPath(), binaryPath);
-    } finally {
-      Reflect.deleteProperty(process.versions, 'electron');
-      Reflect.deleteProperty(electronProcess, 'resourcesPath');
-    }
+    // Impersonate a packaged Electron app: the resolver's highest-priority
+    // probe reads this through tryPlatform()?.hostEnvironment.
+    packagedResourcesPath = tempDir;
+    assert.equal(await findCodexBinaryPath(), binaryPath);
   });
 });

--- a/src/tools/setup/ProbeEnvironmentTool.ts
+++ b/src/tools/setup/ProbeEnvironmentTool.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { z } from 'zod';
 
 // Local imports
+import { tryPlatform } from '@platform/platform';
 import { nodeHostEnvironment } from '@platform/defaults/nodeHostEnvironment';
 import { type ToolResult } from '@shared/schemas';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latexToolchain';
@@ -53,7 +54,13 @@ export class ProbeEnvironmentTool extends defineTool({
     const homedir = safeHomedir() ?? '<unresolved>';
     const extendedPath = extendEnvPath();
     const pm = detectPackageManager();
-    const hostInfo = nodeHostEnvironment.hostInfo();
+    // tryPlatform() picks up an installed Platform's hostEnvironment (a test
+    // fake, in suites that override it); nodeHostEnvironment is the fallback
+    // for the rare caller running before initPlatform(). Neither call grows
+    // the frozen platform() ratchet — see effect-migration-ratchet.mjs.
+    const hostInfo = (
+      tryPlatform()?.hostEnvironment ?? nodeHostEnvironment
+    ).hostInfo();
     const [
       core,
       optionalTools,

--- a/src/tools/support/externalBinaryUtils.ts
+++ b/src/tools/support/externalBinaryUtils.ts
@@ -22,6 +22,7 @@ import * as path from 'node:path';
 
 import which from 'which';
 
+import { tryPlatform } from '@platform/platform';
 import { nodeHostEnvironment } from '@platform/defaults/nodeHostEnvironment';
 import { executeCommandSync } from '@utils/system/execUtils';
 import { IS_WINDOWS, extendEnvPath } from '@utils/system/platformPaths';
@@ -117,7 +118,13 @@ async function resolveBinary(
   // Highest priority when present — packaged apps cannot execute binaries
   // from inside app.asar.
   {
-    const resourcesPath = nodeHostEnvironment.packagedElectronResourcesPath();
+    // tryPlatform() picks up an installed Platform's hostEnvironment (a test
+    // fake, in suites that override it); nodeHostEnvironment is the fallback
+    // for the rare caller running before initPlatform(). Neither call grows
+    // the frozen platform() ratchet — see effect-migration-ratchet.mjs.
+    const resourcesPath = (
+      tryPlatform()?.hostEnvironment ?? nodeHostEnvironment
+    ).packagedElectronResourcesPath();
     if (resourcesPath != null) {
       for (const pkg of config.platformPackages) {
         const platformPkgDir = path.join(


### PR DESCRIPTION
## Summary

Follow-up to #12013 (merged), addressing a review comment that landed after that PR was merged.

#12013 added `HostEnvironmentPort`/`nodeHostEnvironment` and routed `externalBinaryUtils.ts` and `ProbeEnvironmentTool.ts` through it by importing the concrete `nodeHostEnvironment` singleton directly (to avoid growing the frozen `platform()` count in `config/ratchets/effect-migration-baseline.json`). Codex review correctly pointed out that this left `Platform.hostEnvironment` with no production consumer: a test or future host that overrides it would silently be ignored.

Fix: both call sites now read `tryPlatform()?.hostEnvironment ?? nodeHostEnvironment` instead of importing the Node default directly.
- `tryPlatform()` is explicitly excluded from the effect-migration ratchet's `platform()` count (per the check script's own doc comment and self-test), so this doesn't grow the frozen baseline.
- It gives the port a real DI path — a suite's fake platform (or a future non-Node host) now actually reaches these two call sites, with `nodeHostEnvironment` only as the fallback for the rare caller running before `initPlatform()`.
- `codexImport.vitest.ts` goes back to overriding `hostEnvironment` on its fake platform (verified this now genuinely reaches `resolveBinary`, rather than mutating the real `process` global).

## Test plan

- [x] `npm run typecheck` (workspace, test-kernel, agent, cli, trace-viewer, desktop)
- [x] `npm run lint`
- [x] `npm run format` (prettier check)
- [x] `npm run check:dead-code-ratchet`
- [x] `node scripts/check-effect-migration-ratchet.mjs` (confirms `tryPlatform()` doesn't grow the frozen `platform()` count)
- [x] `npm test` (full vitest suite — 9098 passed, 6 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdDjgUzAhkGuPNxCkocS7Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdDjgUzAhkGuPNxCkocS7Y)_