### PR TITLE
refactor(agent): convert agent catalog scanning and loading to Effect programs

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -119,7 +119,6 @@
       "src/utils/core/perKeyQueue.ts": 1
     },
     "import:p-map": {
-      "src/agent/index/agentYamlScanner.ts": 1,
       "src/agent/modelHandlers/support/MediaAttachmentProcessor.ts": 1,
       "src/agent/storage/executionListing.ts": 1,
       "src/latex/LatexMediaManager.ts": 1,
@@ -184,9 +183,7 @@
       "packages/desktop/src/main/desktopProcessStores.ts": 1,
       "packages/desktop/src/main/index.ts": 13,
       "packages/extension/src/progressView/ProgressViewProvider.ts": 1,
-      "src/agent/index/agentYamlScanner.ts": 3,
       "src/agent/remote/RemoteAgentLoader.ts": 1,
-      "src/agent/remote/remoteAgentList.ts": 2,
       "src/agent/runtime/SessionHandle.ts": 9,
       "src/agent/runtime/bundledPrompts.ts": 1,
       "src/tools/github/PollingSourceBase.ts": 1,

--- a/packages/agent/src/effect/sessions.ts
+++ b/packages/agent/src/effect/sessions.ts
@@ -282,15 +282,15 @@ function admitInput(
   return Effect.gen(function* () {
     const tools = input.tools ?? [];
     yield* admitTools(tools);
-    // The agent scan reads the configured directories through the
-    // platform, so it can fail on the environment. That is a failure of
-    // `start`, in the vocabulary the surface already names, not a defect
-    // an embedder's `catchTag` never sees.
-    yield* Effect.tryPromise({
-      try: () => loadAgents({ includeRemote: false }),
-      catch: (cause) =>
-        new RunFailure({ cause, message: toErrorMessage(cause) }),
-    });
+    yield* loadAgents({ includeRemote: false }).pipe(
+      Effect.mapError((cause) => {
+        // The agent scan reads the configured directories through the
+        // platform, so it can fail on the environment. That is a failure of
+        // `start`, in the vocabulary the surface already names, not a defect
+        // an embedder's `catchTag` never sees.
+        return new RunFailure({ cause, message: toErrorMessage(cause) });
+      }),
+    );
     const resolved = resolveAgent(input.agent);
     if (!resolved) {
       return yield* new AgentNotFound({

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -448,7 +448,7 @@ if (process.env.HARNESS_VISIBLE_MODELS !== undefined) {
     HARNESS_VISIBLE_MODELS,
   );
 }
-await loadAgents({ includeRemote: false });
+await effectRuntime().runPromise(loadAgents({ includeRemote: false }));
 
 // Models the production boundary: `listCliHistoryEntries` already applies
 // `isUserVisibleExecution`, so menu builders only ever see user-started rows.

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -9,6 +9,7 @@ import {
   computeSelectWindowSize,
   isCompactFormRows,
 } from '@cli/tui/selectWindow';
+import { effectRuntime } from '@platform/processRuntime';
 import type { AgentOptionData } from '@shared/schemas';
 import { agentName } from '@shared/schemas';
 
@@ -143,7 +144,9 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     title: '/agent',
     loadingLabel: 'Loading agents...',
     load: async () => {
-      const options = await computeAgentOptionsData();
+      const options = await effectRuntime().runPromise(
+        computeAgentOptionsData(),
+      );
       return { toolUse: options.toolUse, workflow: options.workflow };
     },
     isEmpty: (groups) => groups.toolUse.length === 0,

--- a/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
@@ -97,7 +97,7 @@ function selectionSizeLabel(selection: AgentRosterCategorySelection): string {
 const AGENT_ROSTER_SELECT_CHROME_ROWS = 5;
 
 async function loadRosterData(): Promise<AgentRosterData> {
-  await loadAgents({ includeRemote: false });
+  await effectRuntime().runPromise(loadAgents({ includeRemote: false }));
   return {
     record: await readCliAgentRoster(),
     presets: createWorkspaceAgentRosterController().allPresets(),

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -40,6 +40,7 @@ import {
   clearTerminalScrollback,
   installTerminalRestoreOnExit,
 } from '@cli/tui/terminalCleanup';
+import { effectRuntime } from '@platform/processRuntime';
 import { DisposableStore } from '@platform/disposable';
 import { platform } from '@platform/platform';
 import {
@@ -199,7 +200,7 @@ export async function runChat(
     firstRunDone: getFirstRunDone(platform().globalState),
     pinnedAgent: explicitAgent ?? context.envAgent,
   });
-  await loadAgents();
+  await effectRuntime().runPromise(loadAgents());
   const visibleToolUseAgents = getVisibleAgents(AgentCategory.ToolUse);
   const defaults = await resolveChatDefaults({
     cwd: context.cwd,

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -99,7 +99,7 @@ async function configureAgentRoster(
   await initLocalCliPlatform(context);
   // The controller below resolves agent keys, so the registry must be loaded
   // first; the honest roster read happens once, later, where it is emitted.
-  await loadAgents({ includeRemote: false });
+  await effectRuntime().runPromise(loadAgents({ includeRemote: false }));
   const roster = createWorkspaceAgentRosterController();
   const customRequested =
     input.workflow !== undefined || input.toolUse !== undefined;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { getVisibleAgents, loadAgents } from '@agent/index';
+import { effectRuntime } from '@platform/processRuntime';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { AgentCategory } from '@shared/schemas';
 import { implicitDefaultToolUseAgents } from '@shared/constants/agents';
@@ -36,7 +37,7 @@ async function gatherOptions(): Promise<{
   agents: readonly InitAgentOption[];
   models: CliModelAccess[];
 }> {
-  await loadAgents({ includeRemote: false });
+  await effectRuntime().runPromise(loadAgents({ includeRemote: false }));
   const agents = implicitDefaultToolUseAgents(
     getVisibleAgents(AgentCategory.ToolUse),
   );

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty';
 
-import { getVisibleAgents } from '@agent/index';
+import { getVisibleAgents, refresh } from '@agent/index';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { preflightTeamAvailability } from '@common/teams/TeamAvailabilityPreflight';
 import {
@@ -40,6 +40,7 @@ import {
 import {
   loadCliMultiAgentRunPlan,
   loadCliMultiAgentPresetPlanSet,
+  planCurrentMultiAgentRun,
   writeMissingPresetAgents,
 } from '../runtime/multiAgentRunPlan';
 import {
@@ -243,41 +244,46 @@ async function runOrchestration(context: CliContext): Promise<number> {
               { reloadRemoteAgents: false },
             )
           ).plan;
-        const preflight = await preflightTeamAvailability({
-          initial: initialPlan,
-          unresolvedNames: teamTexraHostedMissingNames,
-          texraHostedNames: teamHostedNamesForPreflight(initialPlan.preset, [
-            ...initialPlan.missingAgents.workflow,
-            ...initialPlan.missingAgents.toolUse,
-          ]),
-          remoteCatalogRefreshAttempted:
-            presetPlanSet.remoteCatalogRefreshAttempted,
-          canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
-          choose: async (names) => {
-            writeTextStderr(
-              `Team ${action.preset} has unavailable TeXRA-hosted members: ${names.join(', ')}.`,
-            );
-            const answer = (
-              await askCliQuestion(
-                `Choose: [s] ${RESEARCHER_ACCESS_AUTH.signInLabel}, [c] Continue with available members, [q] Cancel: `,
+        const preflight = await effectRuntime().runPromise(
+          preflightTeamAvailability({
+            initial: initialPlan,
+            unresolvedNames: teamTexraHostedMissingNames,
+            texraHostedNames: teamHostedNamesForPreflight(initialPlan.preset, [
+              ...initialPlan.missingAgents.workflow,
+              ...initialPlan.missingAgents.toolUse,
+            ]),
+            remoteCatalogRefreshAttempted:
+              presetPlanSet.remoteCatalogRefreshAttempted,
+            canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
+            choose: async (names) => {
+              writeTextStderr(
+                `Team ${action.preset} has unavailable TeXRA-hosted members: ${names.join(', ')}.`,
+              );
+              const answer = (
+                await askCliQuestion(
+                  `Choose: [s] ${RESEARCHER_ACCESS_AUTH.signInLabel}, [c] Continue with available members, [q] Cancel: `,
+                )
               )
-            )
-              .trim()
-              .toLowerCase();
-            if (answer === 's' || answer === 'sign-in') return 'sign-in';
-            if (answer === 'c' || answer === 'continue') return 'continue';
-            return 'cancel';
-          },
-          signIn: async () => {
-            const code = await runLoginCommand(context, loginInitFromArgs({}));
-            return (
-              code === CliExitCode.Success &&
-              (await SupabaseClient.isAuthenticated())
-            );
-          },
-          refresh: async () =>
-            (await loadCliMultiAgentRunPlan({ preset: action.preset })).plan,
-        });
+                .trim()
+                .toLowerCase();
+              if (answer === 's' || answer === 'sign-in') return 'sign-in';
+              if (answer === 'c' || answer === 'continue') return 'continue';
+              return 'cancel';
+            },
+            signIn: async () => {
+              const code = await runLoginCommand(
+                context,
+                loginInitFromArgs({}),
+              );
+              return (
+                code === CliExitCode.Success &&
+                (await SupabaseClient.isAuthenticated())
+              );
+            },
+            refreshRemote: () => refresh({ includeRemote: true }),
+            replan: () => planCurrentMultiAgentRun({ preset: action.preset }),
+          }),
+        );
         if (
           preflight.status === 'choice-required' ||
           preflight.status === 'cancelled'

--- a/packages/cli/src/runtime/agentRoster.ts
+++ b/packages/cli/src/runtime/agentRoster.ts
@@ -1,4 +1,5 @@
 import { createWorkspaceAgentRosterController, loadAgents } from '@agent/index';
+import { effectRuntime } from '@platform/processRuntime';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import {
   byCategory,
@@ -20,7 +21,7 @@ export type CliAgentRosterRecord = AgentRosterSnapshot & {
 };
 
 export async function readCliAgentRoster(): Promise<CliAgentRosterRecord> {
-  await loadAgents({ includeRemote: false });
+  await effectRuntime().runPromise(loadAgents({ includeRemote: false }));
   const roster = createWorkspaceAgentRosterController();
   const cwd = workspaceRoots().workspace;
   const config = cwd ? await loadWorkspaceCliConfig(cwd) : undefined;

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -7,6 +7,7 @@ import {
   type AgentEntry,
 } from '@agent/index';
 import { SupabaseClient } from '@auth/SupabaseClient';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   AGENT_CATEGORIES,
   AgentSourceSchema,
@@ -162,7 +163,7 @@ export async function resolveCliAgent(
   name: string,
   lookupCategory?: AgentCategory,
 ): Promise<AgentEntry | undefined> {
-  await loadAgents({ includeRemote: false });
+  await effectRuntime().runPromise(loadAgents({ includeRemote: false }));
   const agent = lookupCliAgent(name, lookupCategory);
 
   // Keep the local hit only when a remote-inclusive reload could not change
@@ -176,7 +177,7 @@ export async function resolveCliAgent(
     return agent;
   }
 
-  await loadAgents();
+  await effectRuntime().runPromise(loadAgents());
   return lookupCliAgent(name, lookupCategory);
 }
 
@@ -208,7 +209,9 @@ export async function loadCliAgentList(
   options: CliAgentListOptions = {},
 ): Promise<CliAgentListResult> {
   const includeHidden = options.includeHidden === true;
-  await loadAgents(includeHidden ? undefined : { includeRemote: false });
+  await effectRuntime().runPromise(
+    loadAgents(includeHidden ? undefined : { includeRemote: false }),
+  );
 
   const agents = collectCliAgents(
     includeHidden ? 'all' : 'visible',

--- a/packages/cli/src/runtime/multiAgentRunPlan.ts
+++ b/packages/cli/src/runtime/multiAgentRunPlan.ts
@@ -8,6 +8,7 @@ import {
   teamPlanHasGaps,
   type TeamPreset,
 } from '@common/teams/TeamPlan';
+import { effectRuntime } from '@platform/processRuntime';
 import { byCategory } from '@shared/schemas';
 
 import { missingMultiAgentPresetMessage } from './agents';
@@ -34,7 +35,7 @@ interface MultiAgentPresetPlansLoadResult {
   readonly remoteCatalogRefreshAttempted: boolean;
 }
 
-function planCurrentMultiAgentRun(
+export function planCurrentMultiAgentRun(
   init: MultiAgentRunPlanInit,
 ): CliMultiAgentPresetRunPlan {
   const preset = findTeamPreset(readCliMultiAgentPresets(), init.preset);
@@ -66,7 +67,7 @@ export async function loadCliMultiAgentRunPlan(
   init: MultiAgentRunPlanInit,
   options: { readonly reloadRemoteAgents?: boolean } = {},
 ): Promise<MultiAgentRunPlanLoadResult> {
-  await loadAgents({ includeRemote: false });
+  await effectRuntime().runPromise(loadAgents({ includeRemote: false }));
   const localPlan = planCurrentMultiAgentRun(init);
   if (options.reloadRemoteAgents === false) {
     return {
@@ -88,7 +89,7 @@ export async function loadCliMultiAgentRunPlan(
 export async function loadCliMultiAgentPresetPlanSet(
   presets: readonly TeamPreset[],
 ): Promise<MultiAgentPresetPlansLoadResult> {
-  await loadAgents({ includeRemote: false });
+  await effectRuntime().runPromise(loadAgents({ includeRemote: false }));
   const result = await reloadRemoteAgentsForGaps(
     planLoadedCliMultiAgentPresets(presets),
     (plans) => plans.some(teamPlanHasGaps),
@@ -108,10 +109,12 @@ function reloadRemoteAgentsForGaps<T>(
   readonly value: T;
   readonly remoteCatalogRefreshAttempted: boolean;
 }> {
-  return refreshRemoteCatalogForGaps(value, hasGaps, replan, {
-    canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
-    refreshRemote: () => refresh({ includeRemote: true }),
-  });
+  return effectRuntime().runPromise(
+    refreshRemoteCatalogForGaps(value, hasGaps, replan, {
+      canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
+      refreshRemote: () => refresh({ includeRemote: true }),
+    }),
+  );
 }
 
 export function writeMissingPresetAgents(

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -187,7 +187,7 @@ export async function signOutCliSupabase(): Promise<void> {
   const authCoordinator = initializeCliSupabaseAuth();
   await runAuthProgram(authCoordinator.clearSession());
   await refreshRemoteAgentCatalogAfterSignOut(
-    invalidateRemoteAgentsAfterSignOut,
+    () => effectRuntime().runPromise(invalidateRemoteAgentsAfterSignOut()),
     (message) => activeAuthLog?.warn?.('cli-auth', message),
   );
 }

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -20,6 +20,7 @@ import {
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
 import { applySettingsTeamRoster } from '@controllers/settingsView/SettingsTeamRosterController';
 import type { MessageHost } from '@hosts/uiHosts';
+import { effectRuntime } from '@platform/processRuntime';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   agentKey,
@@ -243,7 +244,8 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
   private async postAgentSelectionData(): Promise<void> {
     this.renderer.postToRenderer(
       await buildAgentSelectionMessage({
-        loadAgents: this.registry.loadAgents,
+        loadAgents: () =>
+          effectRuntime().runPromise(this.registry.loadAgents()),
         buildSelectionItems: () => this.catalogController.buildSelectionItems(),
         getCustomAgentScanIssues,
       }),
@@ -425,27 +427,29 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
       typeof SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET
     >,
   ): Promise<void> {
-    await applySettingsTeamRoster(message.presetId, {
-      catalog: this.catalogController,
-      loadLocalCatalog: () =>
-        this.registry.loadAgents({ includeRemote: false }),
-      canAccessRemoteCatalog: this.remoteCatalog.canAccess,
-      signIn: this.remoteCatalog.signIn,
-      forceRefreshRemoteCatalog: () =>
-        this.registry.refreshAgents({ includeRemote: true }),
-      presentation: {
-        chooseTeamAvailability: this.prompts.chooseTeamAvailability,
-        showInfoMessage: this.notifications.showInfoMessage,
-        showErrorMessage: this.notifications.showErrorMessage,
-      },
-      refreshAfterApply: async (selectedToolUseAgent) => {
-        this.postAgentModePresets();
-        await Promise.all([
-          this.postAgentSelectionData(),
-          this.postMainAgentAndTeamOptionsData(selectedToolUseAgent),
-        ]);
-      },
-    });
+    await effectRuntime().runPromise(
+      applySettingsTeamRoster(message.presetId, {
+        catalog: this.catalogController,
+        loadLocalCatalog: () =>
+          this.registry.loadAgents({ includeRemote: false }),
+        canAccessRemoteCatalog: this.remoteCatalog.canAccess,
+        signIn: this.remoteCatalog.signIn,
+        forceRefreshRemoteCatalog: () =>
+          this.registry.refreshAgents({ includeRemote: true }),
+        presentation: {
+          chooseTeamAvailability: this.prompts.chooseTeamAvailability,
+          showInfoMessage: this.notifications.showInfoMessage,
+          showErrorMessage: this.notifications.showErrorMessage,
+        },
+        refreshAfterApply: async (selectedToolUseAgent) => {
+          this.postAgentModePresets();
+          await Promise.all([
+            this.postAgentSelectionData(),
+            this.postMainAgentAndTeamOptionsData(selectedToolUseAgent),
+          ]);
+        },
+      }),
+    );
   }
 
   private async saveAgentModePreset(): Promise<void> {
@@ -454,7 +458,7 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
       prompt: 'Name for the new team',
     });
     if (!name?.trim()) return;
-    await this.registry.loadAgents();
+    await effectRuntime().runPromise(this.registry.loadAgents());
     const preset = await this.catalogController.saveCurrentPreset(name);
     this.postAgentModePresets();
     await this.onCatalogChanged();

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -316,7 +316,7 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
    * registry was built from, so a plain re-post would serve a stale catalog.
    */
   private async refreshAfterAgentMutation(): Promise<void> {
-    await this.registry.refreshAgents();
+    await effectRuntime().runPromise(this.registry.refreshAgents());
     await this.refreshCatalogData();
   }
 

--- a/packages/desktop/src/main/desktopHostRequests.ts
+++ b/packages/desktop/src/main/desktopHostRequests.ts
@@ -622,10 +622,10 @@ export function createDesktopHostRequests(
         postDesktopSettingsView((message) => options.postToRenderer(message));
         return done;
       case 'refreshCommits':
-        await options.snapshot.refreshCommits();
+        await effectRuntime().runPromise(options.snapshot.refreshCommits);
         return done;
       case 'refreshFiles':
-        await options.snapshot.refreshFiles();
+        await effectRuntime().runPromise(options.snapshot.refreshFiles);
         return done;
       case 'openSettings':
         postDesktopSettingsView(
@@ -654,7 +654,9 @@ export function createDesktopHostRequests(
           ),
         };
       case 'launch':
-        await execution.runValidated(await prepareSurfaceLaunch(request, host));
+        await execution.runValidated(
+          await effectRuntime().runPromise(prepareSurfaceLaunch(request, host)),
+        );
         return done;
       case 'compileInputPdf':
         throw notOnDesktop('Compiling the input PDF');

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -386,7 +386,7 @@ export function createDesktopSupabaseAuth(
         await coordinator.clearSession();
       });
       await refreshRemoteAgentCatalogAfterSignOut(
-        invalidateRemoteAgentsAfterSignOut,
+        () => effectRuntime().runPromise(invalidateRemoteAgentsAfterSignOut()),
         (message) => log.warn(message),
       );
       await host.onSessionChanged();

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -529,7 +529,7 @@ function createWindow(options: {
   const refreshDesktopAuthSurfaces = async () => {
     await Promise.all(
       [...paperBindings.values()].map((binding) =>
-        binding.snapshot.refreshAuth(),
+        effectRuntime().runPromise(binding.snapshot.refreshAuth),
       ),
     );
     await settingsIpcRef.current?.refreshAuthDependentData({
@@ -799,7 +799,7 @@ function createWindow(options: {
         postToRendererIfAlive(message);
       },
     });
-    void snapshot.refresh();
+    void effectRuntime().runPromise(snapshot.refresh);
     return {
       paper,
       bridge,
@@ -856,7 +856,7 @@ function createWindow(options: {
     await Promise.all(
       [...paperBindings.values()].map((binding) =>
         runInSession(binding.paper.session, () =>
-          binding.snapshot.refreshCatalogs(),
+          effectRuntime().runPromise(binding.snapshot.refreshCatalogs),
         ),
       ),
     );
@@ -1198,15 +1198,14 @@ function createWindow(options: {
                   'No model is available for your current credentials. Sign in with ChatGPT or add a provider or coding-plan API key in Models, then try setup again.',
                 );
               }
-              // Idempotent: returns the in-flight/initialized registry so a kickoff
+              // Idempotent: joins the in-flight/initialized registry so a kickoff
               // racing the startup `loadAgents()` cannot hit "Could not find agent:
               // setup" (mirrors `setupAssistantCommand.launchSetupAssistant`).
-              await loadAgents();
+              await effectRuntime().runPromise(loadAgents());
               await runInSession(binding.paper.session, async () =>
                 binding.execution.runValidated(
-                  await prepareMainViewExecutionLaunch(
-                    message,
-                    agentExecutionHost,
+                  await effectRuntime().runPromise(
+                    prepareMainViewExecutionLaunch(message, agentExecutionHost),
                   ),
                 ),
               );

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -13,6 +13,7 @@ import { signInWithSubscription } from '@frontend/auth/subscriptionSignIn';
 import { createLog } from '@logger/logUtils';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { platform } from '@platform/platform';
+import { effectRuntime } from '@platform/processRuntime';
 import { presentLaunchedProgressStream } from '@progressView/progressNavigation';
 import { agentName } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
@@ -238,10 +239,10 @@ export async function launchSetupAssistant(): Promise<
 
     // Activation initializes the registry, but this command can also be
     // invoked directly in tests or unusual startup paths. `loadAgents()` is
-    // idempotent: it returns the in-flight promise if loading is still
-    // running, resolves immediately if already initialized, or kicks off a
+    // idempotent: it joins the in-flight load through the catalog lane if one
+    // is running, returns immediately if already initialized, or kicks off a
     // fresh load.
-    await loadAgents();
+    await effectRuntime().runPromise(loadAgents());
 
     const launch = () =>
       runAgent(

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -594,10 +594,12 @@ async function activateExtension(context: vscode.ExtensionContext) {
       );
       await registerAgentDirectoryRoots(context);
       try {
-        await loadAgents({ includeRemote: false });
-        void loadAgents().catch((err) => {
-          log.warn(`Remote agent refresh failed: ${toErrorMessage(err)}`);
-        });
+        await effectRuntime().runPromise(loadAgents({ includeRemote: false }));
+        void effectRuntime()
+          .runPromise(loadAgents())
+          .catch((err) => {
+            log.warn(`Remote agent refresh failed: ${toErrorMessage(err)}`);
+          });
       } catch (err) {
         log.error(`Failed to initialize agent index: ${toErrorMessage(err)}`);
       }

--- a/packages/extension/src/frontend/agents/register.ts
+++ b/packages/extension/src/frontend/agents/register.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { createWorkspaceAgentRosterController, refresh } from '@agent/index';
 import { appSignals } from '@eventBus/AppSignals';
 import { createLog } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import type { AgentSource } from '@shared/schemas';
 
 const log = createLog('AgentRegister');
@@ -44,7 +45,7 @@ export async function promptToAddAgentToConfig(
   // reload it performs is conditional on an unrelated view being open. The
   // agent-creator just wrote this YAML, so a listener posting against the
   // stale cache would render a roster missing the agent it was told about.
-  await refresh();
+  await effectRuntime().runPromise(refresh());
   // The write above rewrites the selection as `custom`, retiring any applied
   // team, so an open settings view needs the same notice `apply_team` sends.
   appSignals.emit('agentRosterChanged', undefined);

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -617,7 +617,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
   private async afterLocalSessionCleared(sessionId: string): Promise<void> {
     await refreshRemoteAgentCatalogAfterSignOut(
-      invalidateRemoteAgentsAfterSignOut,
+      () => effectRuntime().runPromise(invalidateRemoteAgentsAfterSignOut()),
       log.warn,
     );
     this._onDidChangeSessions.fire({

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -290,7 +290,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public async initialize(): Promise<void> {
-    await this.snapshot.refresh();
+    await effectRuntime().runPromise(this.snapshot.refresh);
     await this.refreshOnboardingFunnel();
     this.logger.debug('ProgressViewProvider initialized');
   }
@@ -304,7 +304,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this.disposables.push(
       vscode.workspace.onDidChangeWorkspaceFolders(() => {
         this.snapshot.refreshWorkspaceRoots();
-        void this.snapshot.refreshFiles();
+        void effectRuntime().runPromise(this.snapshot.refreshFiles);
       }),
     );
     // Watch exactly the categories the launcher file lists are built from
@@ -316,7 +316,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     const filePattern =
       extensions.size === 0 ? '**/*' : `**/*.{${[...extensions].join(',')}}`;
     const fileWatcher = vscode.workspace.createFileSystemWatcher(filePattern);
-    const refreshFiles = () => void this.snapshot.refreshFiles();
+    const refreshFiles = () =>
+      void effectRuntime().runPromise(this.snapshot.refreshFiles);
     fileWatcher.onDidCreate(refreshFiles);
     fileWatcher.onDidDelete(refreshFiles);
     this.disposables.push(
@@ -329,8 +330,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       if (isAgentCatalogAuthRefreshDeferred()) {
         runAfterAgentCatalogAuthRefresh(async () => {
           await Promise.all([
-            this.snapshot.refreshCatalogs(),
-            this.snapshot.refreshAuth(),
+            effectRuntime().runPromise(this.snapshot.refreshCatalogs),
+            effectRuntime().runPromise(this.snapshot.refreshAuth),
             this.refreshOnboardingFunnel(),
           ]);
         });
@@ -342,11 +343,11 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
   /** Every credential-dependent surface: catalogs, sign-in, the funnel. */
   public async refreshAfterCredentialChange(): Promise<void> {
-    await refresh();
+    await effectRuntime().runPromise(refresh());
     await Promise.all([
-      this.snapshot.refreshCatalogs(),
-      this.snapshot.refreshAuth(),
-      this.snapshot.refreshHostBanners(),
+      effectRuntime().runPromise(this.snapshot.refreshCatalogs),
+      effectRuntime().runPromise(this.snapshot.refreshAuth),
+      effectRuntime().runPromise(this.snapshot.refreshHostBanners),
       this.refreshOnboardingFunnel(),
     ]);
   }
@@ -358,8 +359,10 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       selectedToolUseAgent?: string;
     } = {},
   ): Promise<void> {
-    if (!options.agentCatalogAlreadyFresh) await refresh();
-    await this.snapshot.refreshCatalogs();
+    if (!options.agentCatalogAlreadyFresh) {
+      await effectRuntime().runPromise(refresh());
+    }
+    await effectRuntime().runPromise(this.snapshot.refreshCatalogs);
     if (options.selectedToolUseAgent) {
       this.surfaceAction({
         kind: 'launch',
@@ -370,7 +373,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
   /** The API-key banner after a key changed in Settings. */
   public refreshHostBanners(): Promise<void> {
-    return this.snapshot.refreshHostBanners();
+    return effectRuntime().runPromise(this.snapshot.refreshHostBanners);
   }
 
   /** A run loaded an agent from the custom directory. */

--- a/packages/extension/src/progressView/extensionHostRequests.ts
+++ b/packages/extension/src/progressView/extensionHostRequests.ts
@@ -359,24 +359,28 @@ export function createExtensionHostRequests(
           'Choose one of the open workspace folders as the working directory.',
       });
     }
-    const prepared = await prepareSurfaceLaunch(request, {
-      showInfoMessage: showInfo,
-      chooseTeamAvailability: async (unavailableNames) => {
-        const prompt = teamAvailabilityPrompt(unavailableNames);
-        const choice = await vscode.window.showWarningMessage(
-          prompt.message,
-          ...prompt.actions.map((action) => action.label),
-        );
-        return (
-          prompt.actions.find((action) => action.label === choice)?.choice ??
-          'cancel'
-        );
-      },
-      signInForRemoteAgentCatalog: async () =>
-        Boolean(
-          await vscode.commands.executeCommand<boolean>(AUTH_COMMANDS.SIGN_IN),
-        ),
-    });
+    const prepared = await effectRuntime().runPromise(
+      prepareSurfaceLaunch(request, {
+        showInfoMessage: showInfo,
+        chooseTeamAvailability: async (unavailableNames) => {
+          const prompt = teamAvailabilityPrompt(unavailableNames);
+          const choice = await vscode.window.showWarningMessage(
+            prompt.message,
+            ...prompt.actions.map((action) => action.label),
+          );
+          return (
+            prompt.actions.find((action) => action.label === choice)?.choice ??
+            'cancel'
+          );
+        },
+        signInForRemoteAgentCatalog: async () =>
+          Boolean(
+            await vscode.commands.executeCommand<boolean>(
+              AUTH_COMMANDS.SIGN_IN,
+            ),
+          ),
+      }),
+    );
     await runCommand('texra.execute', prepared);
   }
 
@@ -488,7 +492,7 @@ export function createExtensionHostRequests(
           );
         }
         if (await WorkspaceFS.exists(parsed.sourcePath)) {
-          await snapshot.refreshFiles();
+          await effectRuntime().runPromise(snapshot.refreshFiles);
           return { kind: 'files', paths: [parsed.sourcePath] };
         }
         void showInfo(
@@ -561,8 +565,8 @@ export function createExtensionHostRequests(
   async function refreshAfterCredentialChange(): Promise<void> {
     await Promise.all([
       vscode.commands.executeCommand('texra.refreshApiKeyStatus'),
-      snapshot.refreshCatalogs(),
-      snapshot.refreshAuth(),
+      effectRuntime().runPromise(snapshot.refreshCatalogs),
+      effectRuntime().runPromise(snapshot.refreshAuth),
       options.refreshOnboardingFunnel(),
     ]);
   }
@@ -676,10 +680,10 @@ export function createExtensionHostRequests(
         await runCommand('texra.showDashboard');
         return done;
       case 'refreshCommits':
-        await snapshot.refreshCommits();
+        await effectRuntime().runPromise(snapshot.refreshCommits);
         return done;
       case 'refreshFiles':
-        await snapshot.refreshFiles();
+        await effectRuntime().runPromise(snapshot.refreshFiles);
         return done;
       case 'openSettings':
         switch (request.section) {
@@ -761,7 +765,7 @@ export function createExtensionHostRequests(
         return done;
       case 'recheckDependencies':
         await checkCoreDependencies(true);
-        await snapshot.refreshHostBanners();
+        await effectRuntime().runPromise(snapshot.refreshHostBanners);
         return done;
       case 'openInstallGuide': {
         const docsCommand = getToolDocsCommand(request.tool);

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -33,6 +33,7 @@ import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { confirmModal } from '@frontend/ui/dialogs';
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { platform } from '@platform/platform';
+import { effectRuntime } from '@platform/processRuntime';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import {
   agentKey,
@@ -111,7 +112,7 @@ export class AgentHandlers {
   async sendAgentSelectionData(webview: vscode.Webview): Promise<void> {
     await webview.postMessage(
       await buildAgentSelectionMessage({
-        loadAgents,
+        loadAgents: () => effectRuntime().runPromise(loadAgents()),
         buildSelectionItems: () => this.catalogController.buildSelectionItems(),
         getCustomAgentScanIssues,
       }),
@@ -304,35 +305,37 @@ export class AgentHandlers {
       'Failed to apply agent team',
       async () => {
         await withAgentCatalogAuthRefreshDeferred(() =>
-          applySettingsTeamRoster(data.presetId, {
-            catalog: this.catalogController,
-            loadLocalCatalog: () => loadAgents({ includeRemote: false }),
-            canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
-            signIn: async () =>
-              (await vscode.commands.executeCommand<boolean>(
-                AUTH_COMMANDS.SIGN_IN,
-              )) === true,
-            forceRefreshRemoteCatalog: () =>
-              refreshAgents({ includeRemote: true }),
-            presentation: {
-              chooseTeamAvailability: (prompt) =>
-                this.chooseTeamAvailability(prompt),
-              showInfoMessage: async (message) => {
-                void vscode.window.showInformationMessage(message);
+          effectRuntime().runPromise(
+            applySettingsTeamRoster(data.presetId, {
+              catalog: this.catalogController,
+              loadLocalCatalog: () => loadAgents({ includeRemote: false }),
+              canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
+              signIn: async () =>
+                (await vscode.commands.executeCommand<boolean>(
+                  AUTH_COMMANDS.SIGN_IN,
+                )) === true,
+              forceRefreshRemoteCatalog: () =>
+                refreshAgents({ includeRemote: true }),
+              presentation: {
+                chooseTeamAvailability: (prompt) =>
+                  this.chooseTeamAvailability(prompt),
+                showInfoMessage: async (message) => {
+                  void vscode.window.showInformationMessage(message);
+                },
+                showErrorMessage: async (message) => {
+                  void showLoggedMessage(this.ctx.channel, message).catch(
+                    (err: unknown) => {
+                      this.ctx.log.warn(
+                        `Error notification failed after handoff: ${toErrorMessage(err)}`,
+                      );
+                    },
+                  );
+                },
               },
-              showErrorMessage: async (message) => {
-                void showLoggedMessage(this.ctx.channel, message).catch(
-                  (err: unknown) => {
-                    this.ctx.log.warn(
-                      `Error notification failed after handoff: ${toErrorMessage(err)}`,
-                    );
-                  },
-                );
-              },
-            },
-            refreshAfterApply: (selectedToolUseAgent) =>
-              this.refreshAfterAgentMutation(selectedToolUseAgent, true),
-          }),
+              refreshAfterApply: (selectedToolUseAgent) =>
+                this.refreshAfterAgentMutation(selectedToolUseAgent, true),
+            }),
+          ),
         );
       },
     );
@@ -350,7 +353,7 @@ export class AgentHandlers {
         });
         if (!name) return; // cancelled
 
-        await loadAgents();
+        await effectRuntime().runPromise(loadAgents());
 
         await this.catalogController.saveCurrentPreset(name);
 

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -1,5 +1,6 @@
 /** Agent Registry - Flat agent metadata cache with source-priority lookup. */
 
+import { Data, Effect } from 'effect';
 import { DEFAULT_WORKFLOW_AGENT } from '@agent/core/definition/AgentConfig';
 import { AgentRosterController } from '@agent/roster/AgentRosterController';
 import { createLog } from '@logger/logUtils';
@@ -24,6 +25,8 @@ import { PREFERRED_TOOL_USE_AGENTS } from '@shared/constants/agents';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { byName } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+import { withPerKeyLane, type PerKeyLane } from '@utils/core/perKeyQueue';
 import { scanDirectory } from './agentYamlScanner';
 import {
   clearInlineAgentDefinitions,
@@ -35,6 +38,14 @@ import { loadRemoteAgents, persistRemoteAgentMeta } from './remoteAgentMeta';
 import type { AgentEntry, ResolvedAgent } from './agentEntry';
 
 const log = createLog('agentRegistry');
+
+/** Resolving an agent directory failed (I/O or a rejected configured path). */
+export class AgentCatalogLoadError extends Data.TaggedError(
+  'AgentCatalogLoadError',
+)<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
 
 /**
  * Source priority for lookups (higher priority first). `inline` must be listed,
@@ -76,13 +87,14 @@ let catalog: { readonly includesRemote: boolean } | undefined;
 let customScanIssues: readonly AgentScanIssue[] = Object.freeze([]);
 
 /**
- * The load producing the next catalog. Every load chains on it, so the registry
- * has one serialization point instead of a promise plus a queue. Nothing on the
- * load path may await a load of its own: that await would wait on the chain it
- * is running inside. Fire-and-forget re-entry (the sign-out invalidation) is
- * fine — it queues behind the running load.
+ * Loads are serialized on one per-key lane: every load enters it, so the
+ * registry has one serialization point instead of a promise plus a queue.
+ * A fiber that arrives while a load runs waits for it, then re-checks what
+ * that load published — nothing on the load path may take the lane from
+ * inside a load of its own.
  */
-let inFlight: Promise<void> | undefined;
+const catalogLoadLanes = new Map<string, PerKeyLane>();
+const onCatalogLoadLane = withPerKeyLane(catalogLoadLanes, 'agentCatalogLoad');
 
 /**
  * Advanced by {@link refresh} only. A load carries the epoch it was requested
@@ -102,33 +114,39 @@ export interface LoadAgentsOptions {
 
 /**
  * Load all agents into cache. Call once at activation.
- * Concurrent calls join the in-flight load and re-check what it published, so
- * only one scan runs.
+ * Concurrent calls join the in-flight load through the lane and re-check what
+ * it published, so only one scan runs.
  */
-export async function loadAgents(
+export function loadAgents(
   options: LoadAgentsOptions = {},
-): Promise<void> {
+): Effect.Effect<void, AgentCatalogLoadError> {
   const includeRemote = options.includeRemote ?? true;
-  if (inFlight) await inFlight;
-  if (catalog && (!includeRemote || catalog.includesRemote)) return;
-  await startLoad(includeRemote, epoch);
+  return onCatalogLoadLane(
+    Effect.suspend(() =>
+      catalog && (!includeRemote || catalog.includesRemote)
+        ? Effect.void
+        : queueLoad(includeRemote, epoch),
+    ),
+  );
 }
 
-/** Rebuild the cache after every older load has settled. */
-function startLoad(includeRemote: boolean, loadEpoch: number): Promise<void> {
-  const previous = inFlight?.catch(() => undefined) ?? Promise.resolve();
-  const load: Promise<void> = previous
-    .then(async () => {
-      if (loadEpoch !== epoch) return;
-      if (await doLoad(includeRemote, loadEpoch)) {
-        catalog = { includesRemote: includeRemote };
-      }
-    })
-    .finally(() => {
-      if (inFlight === load) inFlight = undefined;
-    });
-  inFlight = load;
-  return load;
+/**
+ * Run one load, superseding checks included. The caller holds the lane, so a
+ * stale-epoch load skips without publishing and a failed load fails only its
+ * own caller — the lane hands the next entrant off regardless.
+ */
+function queueLoad(
+  includeRemote: boolean,
+  loadEpoch: number,
+): Effect.Effect<void, AgentCatalogLoadError> {
+  return Effect.suspend(() => {
+    if (loadEpoch !== epoch) return Effect.void;
+    return doLoad(includeRemote, loadEpoch).pipe(
+      Effect.map((loaded) => {
+        if (loaded) catalog = { includesRemote: includeRemote };
+      }),
+    );
+  });
 }
 
 /**
@@ -158,52 +176,73 @@ export function clearInlineAgents(): void {
   }
 }
 
-async function doLoad(
+function doLoad(
   includeRemote: boolean,
   loadEpoch: number,
-): Promise<boolean> {
-  const startTime = Date.now();
+): Effect.Effect<boolean, AgentCatalogLoadError> {
+  return Effect.gen(function* () {
+    const startTime = Date.now();
 
-  // Load from all sources in parallel
-  const dirs = platform().agentDirectories;
-  const [customDir, builtInDir, toolUseDir] = await Promise.all([
-    dirs.custom(),
-    dirs.builtIn(),
-    dirs.builtInToolUse(),
-  ]);
+    // Load from all sources in parallel
+    const dirs = platform().agentDirectories;
+    const resolveDir = (
+      read: () => Promise<string>,
+    ): Effect.Effect<string, AgentCatalogLoadError> =>
+      Effect.tryPromise({
+        try: read,
+        catch: (cause) =>
+          new AgentCatalogLoadError({
+            message: toErrorMessage(cause),
+            cause,
+          }),
+      });
+    const [customDir, builtInDir, toolUseDir] = yield* Effect.all(
+      [
+        resolveDir(() => dirs.custom()),
+        resolveDir(() => dirs.builtIn()),
+        resolveDir(() => dirs.builtInToolUse()),
+      ],
+      { concurrency: 'unbounded' },
+    );
 
-  const [customScan, builtInScan, toolUseScan, remoteEntries] =
-    await Promise.all([
-      scanDirectory(customDir, 'custom'),
-      scanDirectory(builtInDir, 'builtInWorkflow'),
-      scanDirectory(toolUseDir, 'builtInToolUse'),
-      includeRemote ? loadRemoteAgents() : Promise.resolve([]),
-    ]);
-  // builtInScan.issues and toolUseScan.issues are intentionally unused:
-  // only custom-agent scan failures are a product surface.
+    const [customScan, builtInScan, toolUseScan, remoteEntries] =
+      yield* Effect.all(
+        [
+          scanDirectory(customDir, 'custom'),
+          scanDirectory(builtInDir, 'builtInWorkflow'),
+          scanDirectory(toolUseDir, 'builtInToolUse'),
+          includeRemote
+            ? loadRemoteAgents()
+            : Effect.succeed([] as AgentEntry[]),
+        ],
+        { concurrency: 'unbounded' },
+      );
+    // builtInScan.issues and toolUseScan.issues are intentionally unused:
+    // only custom-agent scan failures are a product surface.
 
-  // Register all entries. Inline definitions were normalized at registration
-  // and live outside the directory scan, so they are re-merged on every load —
-  // a catalog refresh rebuilds the cache from scratch and would otherwise drop
-  // them.
-  const allEntries = [
-    ...inlineAgentEntries(),
-    ...customScan.entries,
-    ...builtInScan.entries,
-    ...toolUseScan.entries,
-    ...remoteEntries,
-  ];
+    // Register all entries. Inline definitions were normalized at registration
+    // and live outside the directory scan, so they are re-merged on every load —
+    // a catalog refresh rebuilds the cache from scratch and would otherwise drop
+    // them.
+    const allEntries = [
+      ...inlineAgentEntries(),
+      ...customScan.entries,
+      ...builtInScan.entries,
+      ...toolUseScan.entries,
+      ...remoteEntries,
+    ];
 
-  if (loadEpoch !== epoch) return false;
+    if (loadEpoch !== epoch) return false;
 
-  cache.clear();
-  customScanIssues = Object.freeze(customScan.issues);
-  for (const entry of allEntries) {
-    cache.set(agentKeyOf(entry), entry);
-  }
+    cache.clear();
+    customScanIssues = Object.freeze(customScan.issues);
+    for (const entry of allEntries) {
+      cache.set(agentKeyOf(entry), entry);
+    }
 
-  log.info(`Loaded ${cache.size} agents in ${Date.now() - startTime}ms`);
-  return true;
+    log.info(`Loaded ${cache.size} agents in ${Date.now() - startTime}ms`);
+    return true;
+  });
 }
 
 /**
@@ -320,10 +359,19 @@ export function getCustomAgentScanIssues(): readonly AgentScanIssue[] {
 /**
  * Force a new load after every older one has settled, superseding any load
  * still queued from before. The cache keeps serving the catalog it already
- * published until the new one lands, including when the refresh fails.
+ * published until the new one lands, including when the refresh fails. The
+ * epoch advances only once the refresh actually starts, so constructing a
+ * refresh without running it is inert.
  */
-export function refresh(options: LoadAgentsOptions = {}): Promise<void> {
-  return startLoad(options.includeRemote ?? true, ++epoch);
+export function refresh(
+  options: LoadAgentsOptions = {},
+): Effect.Effect<void, AgentCatalogLoadError> {
+  return Effect.suspend(() => {
+    const loadEpoch = ++epoch;
+    return onCatalogLoadLane(
+      queueLoad(options.includeRemote ?? true, loadEpoch),
+    );
+  });
 }
 
 function removeRemoteEntries(): void {
@@ -336,16 +384,22 @@ function removeRemoteEntries(): void {
 }
 
 /** Remove remote definitions immediately, then rebuild the local catalog. */
-export function invalidateRemoteAgentsAfterSignOut(): Promise<void> {
-  removeRemoteEntries();
-  return refresh({ includeRemote: false }).catch((error: unknown) => {
-    // An older in-flight remote load may have settled before the rebuild.
-    // Preserve the signed-out invariant even when local directory I/O fails.
+export function invalidateRemoteAgentsAfterSignOut(): Effect.Effect<void> {
+  return Effect.suspend(() => {
     removeRemoteEntries();
-    log.warn(
-      `Local agent catalog rebuild failed after sign-out: ${String(error)}`,
-    );
-  });
+    return refresh({ includeRemote: false });
+  }).pipe(
+    Effect.catch((error: AgentCatalogLoadError) =>
+      Effect.sync(() => {
+        // An older in-flight remote load may have settled before the rebuild.
+        // Preserve the signed-out invariant even when local directory I/O fails.
+        removeRemoteEntries();
+        log.warn(
+          `Local agent catalog rebuild failed after sign-out: ${error.message}`,
+        );
+      }),
+    ),
+  );
 }
 
 // =============================================================================
@@ -583,15 +637,16 @@ function sortAgentEntries(
  * Compute typed agent options data for Lit-native rendering.
  * Ensures cache is loaded first.
  */
-export async function computeAgentOptionsData(): Promise<AgentOptionsDataPayload> {
-  await loadAgents();
-
-  return {
+export function computeAgentOptionsData(): Effect.Effect<
+  AgentOptionsDataPayload,
+  AgentCatalogLoadError
+> {
+  return Effect.map(loadAgents(), () => ({
     workflow: entriesToOptionData(
       sortAgentEntries(getVisibleAgents('workflow'), [DEFAULT_WORKFLOW_AGENT]),
     ),
     toolUse: entriesToOptionData(
       sortAgentEntries(getVisibleAgents('toolUse'), PREFERRED_TOOL_USE_AGENTS),
     ),
-  };
+  }));
 }

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -3,10 +3,9 @@
 import * as path from 'node:path';
 
 import { glob } from 'glob';
-import pMap from 'p-map';
 import { ZodError, type ZodIssue } from 'zod';
 
-import { Result } from 'effect';
+import { Data, Effect, Result } from 'effect';
 import { mergeInheritedAgentObject } from '@agent/core/definition/agentDefinitionInheritance';
 import {
   AgentDefinitionSchema,
@@ -23,6 +22,19 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { AgentEntry } from './agentEntry';
 
 const log = createLog('agentRegistry');
+
+/**
+ * One file- or directory-level scan failure. Scanning is a best-effort
+ * projection: a bad YAML file becomes an issue entry and an unreadable
+ * directory becomes an empty scan with one issue, so the error never escapes
+ * `scanDirectory`'s channel — it exists to be recovered from, and the channel
+ * is `never` at the export. Defects (programming errors) stay defects.
+ */
+class AgentScanError extends Data.TaggedError('AgentScanError')<{
+  readonly path: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
 
 interface AgentDirectoryScan {
   readonly entries: AgentEntry[];
@@ -49,29 +61,41 @@ export function extractToolNames(
   });
 }
 
-export async function scanDirectory(
+export function scanDirectory(
   dir: string,
   source: AgentSource,
-): Promise<AgentDirectoryScan> {
-  if (!dir) return { entries: [], issues: [] };
+): Effect.Effect<AgentDirectoryScan> {
+  if (!dir) return Effect.succeed({ entries: [], issues: [] });
 
-  try {
-    const files = (
-      await glob('**/*.yaml', {
-        cwd: dir,
-        absolute: true,
-        nodir: true,
-      })
-    ).toSorted();
+  return Effect.gen(function* () {
+    const files = (yield* Effect.tryPromise({
+      try: () =>
+        glob('**/*.yaml', {
+          cwd: dir,
+          absolute: true,
+          nodir: true,
+        }),
+      catch: (cause) =>
+        new AgentScanError({
+          path: dir,
+          message: toErrorMessage(cause),
+          cause,
+        }),
+    })).toSorted();
     const issues: AgentScanIssue[] = [];
     const parsed: ParsedAgentYaml[] = [];
-    for (const result of await pMap(
+    for (const result of yield* Effect.forEach(
       files,
-      (yamlPath) => readYamlDefinition(yamlPath, dir),
+      (yamlPath) => Effect.result(readYamlDefinition(yamlPath, dir)),
       { concurrency: 8 },
     )) {
-      if (result.ok) parsed.push(result.value);
-      else issues.push(result.issue);
+      if (Result.isSuccess(result)) parsed.push(result.success);
+      else {
+        issues.push({
+          path: result.failure.path,
+          message: result.failure.message,
+        });
+      }
     }
     const unique = entriesWithUniqueNames(parsed, dir, issues);
     const definitions = new Map(
@@ -79,24 +103,30 @@ export async function scanDirectory(
     );
     const entries: AgentEntry[] = [];
     for (const entry of unique) {
-      const scanned = scanYaml(entry, source, definitions);
-      if (scanned.ok) {
-        entries.push(scanned.entry);
+      const scanned = yield* Effect.result(
+        scanYaml(entry, source, definitions),
+      );
+      if (Result.isSuccess(scanned)) {
+        entries.push(scanned.success);
         continue;
       }
+      log.warn(`Failed to scan ${entry.path}: ${scanned.failure.message}`);
       issues.push({
         path: path.relative(dir, entry.path),
-        message: scanned.message,
+        message: scanned.failure.message,
       });
     }
 
     log.debug(`Scanned ${entries.length} agents from ${source}`);
     return { entries, issues };
-  } catch (err) {
-    const message = toErrorMessage(err);
-    log.error(`Failed to scan ${dir}: ${message}`);
-    return { entries: [], issues: [{ path: dir, message }] };
-  }
+  }).pipe(
+    Effect.catch((error: AgentScanError) =>
+      Effect.sync(() => {
+        log.error(`Failed to scan ${dir}: ${error.message}`);
+        return { entries: [], issues: [{ path: dir, message: error.message }] };
+      }),
+    ),
+  );
 }
 
 function entriesWithUniqueNames(
@@ -126,34 +156,38 @@ function entriesWithUniqueNames(
   return unique;
 }
 
-async function readYamlDefinition(
+function readYamlDefinition(
   yamlPath: string,
   dir: string,
-): Promise<
-  { ok: true; value: ParsedAgentYaml } | { ok: false; issue: AgentScanIssue }
-> {
+): Effect.Effect<ParsedAgentYaml, AgentScanError> {
   const displayPath = path.relative(dir, yamlPath);
-  try {
-    const content = await AbsoluteFS.read(yamlPath);
-    const parsed = parseYamlWith(content, AgentDefinitionSchema);
-    if (Result.isFailure(parsed)) {
-      const message = formatScanFailure(parsed.failure);
-      log.warn(`Failed to scan ${yamlPath}: ${message}`);
-      return { ok: false, issue: { path: displayPath, message } };
-    }
-    return {
-      ok: true,
-      value: {
+  const scanError = (cause: unknown) =>
+    new AgentScanError({
+      path: displayPath,
+      message: formatScanFailure(cause),
+      cause,
+    });
+  return Effect.tryPromise({
+    try: () => AbsoluteFS.read(yamlPath),
+    catch: scanError,
+  }).pipe(
+    Effect.flatMap((content) => {
+      const parsed = parseYamlWith(content, AgentDefinitionSchema);
+      if (Result.isFailure(parsed)) {
+        return Effect.fail(scanError(parsed.failure));
+      }
+      return Effect.succeed({
         name: parsed.success.name,
         path: yamlPath,
         definition: parsed.success,
-      },
-    };
-  } catch (err) {
-    const message = formatScanFailure(err);
-    log.warn(`Failed to scan ${yamlPath}: ${message}`);
-    return { ok: false, issue: { path: displayPath, message } };
-  }
+      });
+    }),
+    Effect.tapError((error) =>
+      Effect.sync(() =>
+        log.warn(`Failed to scan ${yamlPath}: ${error.message}`),
+      ),
+    ),
+  );
 }
 
 function formatScanFailure(error: unknown): string {
@@ -225,54 +259,53 @@ function scanYaml(
   entry: ParsedAgentYaml,
   source: AgentSource,
   definitions: Map<string, ParsedAgentYaml>,
-): { ok: true; entry: AgentEntry } | { ok: false; message: string } {
-  try {
-    const settingsBlock = inheritedDefinitionBlock(
-      entry,
-      definitions,
-      'settings',
-    );
-    const promptsBlock = inheritedDefinitionBlock(
-      entry,
-      definitions,
-      'prompts',
-    );
-    const rawSettings = settingsBlock.value;
-    const rawPrompts = promptsBlock.value;
-    const defaultOutputFiles = rawSettings.defaultOutputFiles;
-
-    const tools = extractToolNames(rawSettings.tools);
-
-    const rawCategory = rawSettings.agentCategory;
-    const category =
-      source === 'builtInToolUse' || rawCategory === AgentCategory.ToolUse
-        ? AgentCategory.ToolUse
-        : AgentCategory.Workflow;
-
-    let rounds: number | undefined;
-    if (
-      category === AgentCategory.Workflow &&
-      settingsBlock.complete &&
-      promptsBlock.complete
-    ) {
-      const parsedRounds = AgentWorkflowSettingSchema.shape.rounds.safeParse(
-        rawSettings.rounds,
+): Effect.Effect<AgentEntry, AgentScanError> {
+  return Effect.try({
+    try: () => {
+      const settingsBlock = inheritedDefinitionBlock(
+        entry,
+        definitions,
+        'settings',
       );
-      if (parsedRounds.success) {
-        rounds = Math.max(
-          parsedRounds.data,
-          userRequestTemplateCount(rawPrompts.userRequest),
-        );
-      } else {
-        log.warn(
-          `Ignoring malformed rounds in ${entry.path}: ${toErrorMessage(parsedRounds.error)}`,
-        );
-      }
-    }
+      const promptsBlock = inheritedDefinitionBlock(
+        entry,
+        definitions,
+        'prompts',
+      );
+      const rawSettings = settingsBlock.value;
+      const rawPrompts = promptsBlock.value;
+      const defaultOutputFiles = rawSettings.defaultOutputFiles;
 
-    return {
-      ok: true,
-      entry: {
+      const tools = extractToolNames(rawSettings.tools);
+
+      const rawCategory = rawSettings.agentCategory;
+      const category =
+        source === 'builtInToolUse' || rawCategory === AgentCategory.ToolUse
+          ? AgentCategory.ToolUse
+          : AgentCategory.Workflow;
+
+      let rounds: number | undefined;
+      if (
+        category === AgentCategory.Workflow &&
+        settingsBlock.complete &&
+        promptsBlock.complete
+      ) {
+        const parsedRounds = AgentWorkflowSettingSchema.shape.rounds.safeParse(
+          rawSettings.rounds,
+        );
+        if (parsedRounds.success) {
+          rounds = Math.max(
+            parsedRounds.data,
+            userRequestTemplateCount(rawPrompts.userRequest),
+          );
+        } else {
+          log.warn(
+            `Ignoring malformed rounds in ${entry.path}: ${toErrorMessage(parsedRounds.error)}`,
+          );
+        }
+      }
+
+      return {
         name: entry.name,
         source,
         path: entry.path,
@@ -283,10 +316,13 @@ function scanYaml(
           ? defaultOutputFiles
           : undefined,
         rounds,
-      },
-    };
-  } catch (err) {
-    log.warn(`Failed to scan ${entry.path}: ${toErrorMessage(err)}`);
-    return { ok: false, message: toErrorMessage(err) };
-  }
+      };
+    },
+    catch: (cause) =>
+      new AgentScanError({
+        path: entry.path,
+        message: toErrorMessage(cause),
+        cause,
+      }),
+  });
 }

--- a/src/agent/index/remoteAgentMeta.ts
+++ b/src/agent/index/remoteAgentMeta.ts
@@ -1,5 +1,7 @@
 /** Remote agent metadata persistence and loading for the agent registry. */
 
+import { Effect } from 'effect';
+import { RemoteAgentListError } from '@agent/remote/errorData';
 import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { AgentCategory } from '@shared/schemas';
@@ -41,10 +43,14 @@ function getPersistedRemoteAgentMeta(): RemoteAgentMetaCache {
   );
 }
 
-export async function loadRemoteAgents(): Promise<AgentEntry[]> {
-  try {
-    const { listRemoteAgents } = await import('@agent/remote/remoteAgentList');
-    const remotes = await listRemoteAgents();
+export function loadRemoteAgents(): Effect.Effect<AgentEntry[]> {
+  return Effect.gen(function* () {
+    const { listRemoteAgents } = yield* Effect.tryPromise({
+      try: () => import('@agent/remote/remoteAgentList'),
+      catch: (cause) =>
+        new RemoteAgentListError({ message: toErrorMessage(cause), cause }),
+    });
+    const remotes = yield* listRemoteAgents();
     const metaCache = getPersistedRemoteAgentMeta();
 
     return remotes.map((remote) => {
@@ -62,8 +68,12 @@ export async function loadRemoteAgents(): Promise<AgentEntry[]> {
         defaultOutputFiles: cached?.defaultOutputFiles,
       };
     });
-  } catch (err) {
-    log.warn(`Failed to load remote agents: ${toErrorMessage(err)}`);
-    return [];
-  }
+  }).pipe(
+    Effect.catch((error: RemoteAgentListError) =>
+      Effect.sync(() => {
+        log.warn(`Failed to load remote agents: ${error.message}`);
+        return [];
+      }),
+    ),
+  );
 }

--- a/src/agent/remote/errorData.ts
+++ b/src/agent/remote/errorData.ts
@@ -1,3 +1,19 @@
+import { Data } from 'effect';
+
+/**
+ * A failure to list or load the remote agent catalog. Lives here rather than
+ * in `remoteAgentList.ts` so `remoteAgentMeta.ts` can name the type without a
+ * static import of the listing module — that module stays lazily imported to
+ * keep ky and the auth client out of generic tool closures (see
+ * `inlineAgents.ts`).
+ */
+export class RemoteAgentListError extends Data.TaggedError(
+  'RemoteAgentListError',
+)<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
 /**
  * Convert ky's `HTTPError.data` (a parsed JSON value for JSON responses, or a
  * plain string otherwise) into a flat string for error messages, or `undefined`

--- a/src/agent/remote/remoteAgentList.ts
+++ b/src/agent/remote/remoteAgentList.ts
@@ -14,7 +14,7 @@
 import ky, { HTTPError } from 'ky';
 import { z } from 'zod';
 
-import { Result } from 'effect';
+import { Effect, Result } from 'effect';
 import { SUPABASE_CONFIG } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { parseJsonWith } from '@common/parsing/safeParseJson';
@@ -22,7 +22,11 @@ import { createLog } from '@logger/logUtils';
 import { filterNotNull } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import { errorDataToString, FETCH_TIMEOUT_MS } from './errorData';
+import {
+  errorDataToString,
+  FETCH_TIMEOUT_MS,
+  RemoteAgentListError,
+} from './errorData';
 import { RemoteAgentListItemSchema, type RemoteAgentListItem } from './types';
 
 export const CHANNEL = 'RemoteAgentLoader';
@@ -71,72 +75,99 @@ function parseListItemRow(row: RemoteAgentListRow): RemoteAgentListItem | null {
   return result.data;
 }
 
-/** List all available remote agents for the current user. */
-export async function listRemoteAgents(): Promise<RemoteAgentListItem[]> {
-  try {
-    const token = await SupabaseClient.getAccessToken();
+/**
+ * List all available remote agents for the current user. The listing is a
+ * best-effort projection behind registry/settings refreshes: a signed-out
+ * user, an unreachable relay, or a rejected query all yield an empty list
+ * (logged at debug) rather than a failure of the catalog load that awaits it.
+ */
+export function listRemoteAgents(): Effect.Effect<RemoteAgentListItem[]> {
+  return Effect.gen(function* () {
+    const token = yield* Effect.tryPromise({
+      try: () => SupabaseClient.getAccessToken(),
+      catch: (cause) =>
+        new RemoteAgentListError({ message: toErrorMessage(cause), cause }),
+    });
     if (!token) return [];
 
-    const { data, error } = await fetchRemoteAgentListRows(token);
+    const { data, error } = yield* fetchRemoteAgentListRows(token);
 
     if (error) {
-      log.debug(`Failed to list remote agents: ${error.message}`);
-      return [];
+      return yield* new RemoteAgentListError({
+        message: error.message ?? 'remote list request failed',
+      });
     }
 
     return (data ?? []).map(parseListItemRow).filter(filterNotNull);
-  } catch (error) {
-    log.debug(`Error listing remote agents: ${toErrorMessage(error)}`);
-    return [];
-  }
+  }).pipe(
+    Effect.catch((error: RemoteAgentListError) =>
+      Effect.sync(() => {
+        log.debug(`Error listing remote agents: ${error.message}`);
+        return [];
+      }),
+    ),
+  );
 }
 
-async function fetchRemoteAgentListRows(
+function fetchRemoteAgentListRows(
   accessToken: string,
-): Promise<RemoteAgentListQueryResult> {
+): Effect.Effect<RemoteAgentListQueryResult, RemoteAgentListError> {
   const url = new URL('/rest/v1/remote_agents', SUPABASE_CONFIG.url);
   url.searchParams.set('select', REMOTE_AGENT_LIST_COLUMNS);
   url.searchParams.set('order', 'name.asc');
 
-  try {
-    // retry: 0 preserves the old fetch's fail-fast contract — listRemoteAgents
-    // is awaited by registry/settings refreshes and treats failure as an empty
-    // list, so ky's default GET retries (which honor Retry-After on 429/503)
-    // would block the UI rather than surfacing immediately.
-    const data = await ky
-      .get(url, {
-        headers: {
-          apikey: SUPABASE_CONFIG.publicKey,
-          Authorization: `Bearer ${accessToken}`,
-          Accept: 'application/json',
-        },
-        retry: 0,
-        timeout: false,
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      })
-      .json<RemoteAgentListRow[]>();
-    return { data, error: null };
-  } catch (error) {
-    if (!(error instanceof HTTPError)) throw error;
+  // retry: 0 preserves the old fetch's fail-fast contract — listRemoteAgents
+  // is awaited by registry/settings refreshes and treats failure as an empty
+  // list, so ky's default GET retries (which honor Retry-After on 429/503)
+  // would block the UI rather than surfacing immediately.
+  const request = Effect.tryPromise({
+    try: () =>
+      ky
+        .get(url, {
+          headers: {
+            apikey: SUPABASE_CONFIG.publicKey,
+            Authorization: `Bearer ${accessToken}`,
+            Accept: 'application/json',
+          },
+          retry: 0,
+          timeout: false,
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        })
+        .json<RemoteAgentListRow[]>(),
+    catch: (cause) => cause,
+  });
 
-    const rawBody = errorDataToString(error.data);
-    const parsedError = rawBody
-      ? Result.getOrElse(
-          parseJsonWith(rawBody, RemoteAgentListQueryErrorSchema),
-          () => ({ message: rawBody }),
-        )
-      : {};
-    const fallbackMessage =
-      `${error.response.status} ${error.response.statusText}`.trim();
-    return {
-      data: null,
-      error: {
-        ...parsedError,
-        message:
-          parsedError.message ||
-          fallbackMessage ||
-          'remote list request failed',
-      },
-    };
-  }
+  return request.pipe(
+    Effect.map((data): RemoteAgentListQueryResult => ({ data, error: null })),
+    Effect.catch((error: unknown) => {
+      if (!(error instanceof HTTPError)) {
+        return Effect.fail(
+          new RemoteAgentListError({
+            message: toErrorMessage(error),
+            cause: error,
+          }),
+        );
+      }
+
+      const rawBody = errorDataToString(error.data);
+      const parsedError = rawBody
+        ? Result.getOrElse(
+            parseJsonWith(rawBody, RemoteAgentListQueryErrorSchema),
+            () => ({ message: rawBody }),
+          )
+        : {};
+      const fallbackMessage =
+        `${error.response.status} ${error.response.statusText}`.trim();
+      return Effect.succeed({
+        data: null,
+        error: {
+          ...parsedError,
+          message:
+            parsedError.message ||
+            fallbackMessage ||
+            'remote list request failed',
+        },
+      });
+    }),
+  );
 }

--- a/src/common/teams/TeamAvailabilityPreflight.ts
+++ b/src/common/teams/TeamAvailabilityPreflight.ts
@@ -1,3 +1,5 @@
+import { Effect } from 'effect';
+
 export type TeamAvailabilityChoice = 'sign-in' | 'continue' | 'cancel';
 
 export type TeamAvailabilityPreflightResult<T> =
@@ -25,7 +27,10 @@ export interface TeamAvailabilityPreflightOptions<T> {
     unavailableNames: readonly string[],
   ) => Promise<TeamAvailabilityChoice | undefined>;
   readonly signIn: () => Promise<boolean>;
-  readonly refresh: () => Promise<T>;
+  /** Force a remote catalog refresh; the failure channel is the refresh's own. */
+  readonly refreshRemote: () => Effect.Effect<void, unknown>;
+  /** Recompute the planned value against the refreshed catalog. */
+  readonly replan: () => T;
   /** The caller already forced a remote catalog fetch for `initial`. */
   readonly remoteCatalogRefreshAttempted?: boolean;
 }
@@ -39,70 +44,87 @@ function unavailableTexraHostedNames<T>(
     .filter((name) => options.texraHostedNames.has(name));
 }
 
+/** Call a host dialog or auth port from the preflight program. */
+const hostPort = <A>(
+  call: () => A | PromiseLike<A>,
+): Effect.Effect<A, unknown> =>
+  Effect.tryPromise({ try: async () => call(), catch: (error) => error });
+
 /**
  * Decide whether an incomplete team may proceed before its caller writes or
  * launches anything. Model credentials are deliberately absent from this API:
  * only TeXRA authentication can make TeXRA-hosted definitions available.
  */
-export async function preflightTeamAvailability<T>(
+export function preflightTeamAvailability<T>(
   options: TeamAvailabilityPreflightOptions<T>,
-): Promise<TeamAvailabilityPreflightResult<T>> {
-  const refreshAndRecheck = async (): Promise<
-    TeamAvailabilityPreflightResult<T>
-  > => {
-    const refreshed = await options.refresh();
-    const unavailableNames = unavailableTexraHostedNames(refreshed, options);
-    return unavailableNames.length === 0
-      ? { status: 'proceed', value: refreshed, partial: false }
-      : { status: 'unavailable', value: refreshed, unavailableNames };
-  };
+): Effect.Effect<TeamAvailabilityPreflightResult<T>, unknown> {
+  return Effect.gen(function* () {
+    const refreshAndRecheck = Effect.gen(function* () {
+      yield* options.refreshRemote();
+      const refreshed = yield* Effect.try({
+        try: () => options.replan(),
+        catch: (error) => error,
+      });
+      const unavailableNames = unavailableTexraHostedNames(refreshed, options);
+      return unavailableNames.length === 0
+        ? { status: 'proceed' as const, value: refreshed, partial: false }
+        : {
+            status: 'unavailable' as const,
+            value: refreshed,
+            unavailableNames,
+          };
+    });
 
-  const initialUnavailable = unavailableTexraHostedNames(
-    options.initial,
-    options,
-  );
-  if (initialUnavailable.length === 0) {
-    return { status: 'proceed', value: options.initial, partial: false };
-  }
+    const initialUnavailable = unavailableTexraHostedNames(
+      options.initial,
+      options,
+    );
+    if (initialUnavailable.length === 0) {
+      return { status: 'proceed', value: options.initial, partial: false };
+    }
 
-  if (options.providedChoice === 'cancel') {
-    return { status: 'cancelled', value: options.initial };
-  }
-  if (options.providedChoice === 'continue') {
-    return { status: 'proceed', value: options.initial, partial: true };
-  }
+    if (options.providedChoice === 'cancel') {
+      return { status: 'cancelled', value: options.initial };
+    }
+    if (options.providedChoice === 'continue') {
+      return { status: 'proceed', value: options.initial, partial: true };
+    }
 
-  const canAccessRemoteCatalog = await options.canAccessRemoteCatalog();
-  if (canAccessRemoteCatalog) {
-    if (options.remoteCatalogRefreshAttempted) {
+    const canAccessRemoteCatalog = yield* hostPort(() =>
+      options.canAccessRemoteCatalog(),
+    );
+    if (canAccessRemoteCatalog) {
+      if (options.remoteCatalogRefreshAttempted) {
+        return {
+          status: 'unavailable',
+          value: options.initial,
+          unavailableNames: initialUnavailable,
+        };
+      }
+      return yield* refreshAndRecheck;
+    }
+
+    const choice =
+      options.providedChoice ??
+      (yield* hostPort(() => options.choose(initialUnavailable)));
+    if (choice === undefined) {
       return {
-        status: 'unavailable',
+        status: 'choice-required',
         value: options.initial,
         unavailableNames: initialUnavailable,
       };
     }
-    return refreshAndRecheck();
-  }
+    if (choice === 'cancel') {
+      return { status: 'cancelled', value: options.initial };
+    }
+    if (choice === 'continue') {
+      return { status: 'proceed', value: options.initial, partial: true };
+    }
 
-  const choice =
-    options.providedChoice ?? (await options.choose(initialUnavailable));
-  if (choice === undefined) {
-    return {
-      status: 'choice-required',
-      value: options.initial,
-      unavailableNames: initialUnavailable,
-    };
-  }
-  if (choice === 'cancel') {
-    return { status: 'cancelled', value: options.initial };
-  }
-  if (choice === 'continue') {
-    return { status: 'proceed', value: options.initial, partial: true };
-  }
+    if (!(yield* hostPort(() => options.signIn()))) {
+      return { status: 'cancelled', value: options.initial };
+    }
 
-  if (!(await options.signIn())) {
-    return { status: 'cancelled', value: options.initial };
-  }
-
-  return refreshAndRecheck();
+    return yield* refreshAndRecheck;
+  });
 }

--- a/src/common/teams/TeamPlan.ts
+++ b/src/common/teams/TeamPlan.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import {
   AGENT_CATEGORIES,
   AGENT_MODE_PRESETS,
@@ -254,24 +255,26 @@ export function buildTeamOptions(
     });
 }
 
-export async function loadTeamOptions<T extends TeamCatalogAgent>(ports: {
+export function loadTeamOptions<T extends TeamCatalogAgent>(ports: {
   customPresetsRaw: unknown;
-  ensureCatalogLoaded: () => Promise<void>;
+  ensureCatalogLoaded: () => Effect.Effect<void, unknown>;
   getAgents: (category: AgentCategory) => readonly T[];
   canAccessRemoteCatalog: () => Promise<boolean>;
-  refreshRemote: () => Promise<void>;
-}): Promise<TeamOptionData[]> {
-  await ports.ensureCatalogLoaded();
-  const presets = teamPresets(ports.customPresetsRaw);
-  const planCurrent = () =>
-    planTeamRuns(presets, currentCatalogOptions(ports.getAgents));
-  const result = await refreshRemoteCatalogForGaps(
-    planCurrent(),
-    (plans) => plans.some(teamPlanHasGaps),
-    planCurrent,
-    ports,
-  );
-  return buildTeamOptions(result.value);
+  refreshRemote: () => Effect.Effect<void, unknown>;
+}): Effect.Effect<TeamOptionData[], unknown> {
+  return Effect.gen(function* () {
+    yield* ports.ensureCatalogLoaded();
+    const presets = teamPresets(ports.customPresetsRaw);
+    const planCurrent = () =>
+      planTeamRuns(presets, currentCatalogOptions(ports.getAgents));
+    const result = yield* refreshRemoteCatalogForGaps(
+      planCurrent(),
+      (plans) => plans.some(teamPlanHasGaps),
+      planCurrent,
+      ports,
+    );
+    return buildTeamOptions(result.value);
+  });
 }
 
 export type TeamLaunchResolution =
@@ -296,96 +299,109 @@ export type TeamLaunchResolution =
       readonly unavailableNames: readonly string[];
     };
 
-export async function resolveTeamLaunch<T extends TeamCatalogAgent>(args: {
+export function resolveTeamLaunch<T extends TeamCatalogAgent>(args: {
   teamId: string;
   customPresetsRaw: unknown;
-  ensureCatalogLoaded: () => Promise<void>;
+  ensureCatalogLoaded: () => Effect.Effect<void, unknown>;
   getAgents: (category: AgentCategory) => readonly T[];
   canAccessRemoteCatalog: () => Promise<boolean>;
-  refreshRemote: () => Promise<void>;
+  refreshRemote: () => Effect.Effect<void, unknown>;
   choose: (
     unavailableNames: readonly string[],
   ) => Promise<TeamAvailabilityChoice | undefined>;
   signIn: () => Promise<boolean>;
   providedChoice?: TeamAvailabilityChoice;
-}): Promise<TeamLaunchResolution> {
-  const preset = findTeamPreset(
-    teamPresets(args.customPresetsRaw),
-    args.teamId,
-  );
-  if (!preset) return { status: 'unknown-team' };
+}): Effect.Effect<TeamLaunchResolution, unknown> {
+  return Effect.gen(function* () {
+    const preset = findTeamPreset(
+      teamPresets(args.customPresetsRaw),
+      args.teamId,
+    );
+    if (!preset) return { status: 'unknown-team' as const };
 
-  await args.ensureCatalogLoaded();
-  const planCurrent = () =>
-    planTeamRun(preset, currentCatalogOptions(args.getAgents));
-  const refreshed = await refreshRemoteCatalogForGaps(
-    planCurrent(),
-    teamPlanHasGaps,
-    planCurrent,
-    args,
-  );
-  const preflight = await preflightTeamAvailability({
-    initial: refreshed.value,
-    unresolvedNames: teamTexraHostedMissingNames,
-    texraHostedNames: teamHostedNamesForPreflight(
-      preset,
-      missingMemberNames(refreshed.value),
-    ),
-    canAccessRemoteCatalog: args.canAccessRemoteCatalog,
-    providedChoice: args.providedChoice,
-    choose: args.choose,
-    signIn: args.signIn,
-    refresh: async () => {
-      await args.refreshRemote();
-      return planCurrent();
-    },
-    remoteCatalogRefreshAttempted: refreshed.remoteCatalogRefreshAttempted,
+    yield* args.ensureCatalogLoaded();
+    const planCurrent = () =>
+      planTeamRun(preset, currentCatalogOptions(args.getAgents));
+    const refreshed = yield* refreshRemoteCatalogForGaps(
+      planCurrent(),
+      teamPlanHasGaps,
+      planCurrent,
+      args,
+    );
+    const preflight = yield* preflightTeamAvailability({
+      initial: refreshed.value,
+      unresolvedNames: teamTexraHostedMissingNames,
+      texraHostedNames: teamHostedNamesForPreflight(
+        preset,
+        missingMemberNames(refreshed.value),
+      ),
+      canAccessRemoteCatalog: args.canAccessRemoteCatalog,
+      providedChoice: args.providedChoice,
+      choose: args.choose,
+      signIn: args.signIn,
+      refreshRemote: args.refreshRemote,
+      replan: planCurrent,
+      remoteCatalogRefreshAttempted: refreshed.remoteCatalogRefreshAttempted,
+    });
+
+    // 'choice-required' is reachable only when no provided choice exists and the
+    // interactive choice port returns no decision; hosts treat dismissal as cancel.
+    if (
+      preflight.status === 'cancelled' ||
+      preflight.status === 'choice-required'
+    ) {
+      return { status: 'cancelled' as const };
+    }
+    if (preflight.status === 'unavailable') {
+      return {
+        status: 'unavailable' as const,
+        unavailableNames: preflight.unavailableNames,
+      };
+    }
+
+    const plan = preflight.value;
+    if (!canLaunchTeam(plan)) {
+      return {
+        status: 'blocked' as const,
+        reason: teamLaunchBlockReason(plan)!,
+      };
+    }
+    return {
+      status: 'ready' as const,
+      fields: teamExecutionFields(plan),
+      partial: preflight.partial,
+      missingNames: missingMemberNames(plan),
+    };
   });
-
-  // 'choice-required' is reachable only when no provided choice exists and the
-  // interactive choice port returns no decision; hosts treat dismissal as cancel.
-  if (
-    preflight.status === 'cancelled' ||
-    preflight.status === 'choice-required'
-  ) {
-    return { status: 'cancelled' };
-  }
-  if (preflight.status === 'unavailable') {
-    return {
-      status: 'unavailable',
-      unavailableNames: preflight.unavailableNames,
-    };
-  }
-
-  const plan = preflight.value;
-  if (!canLaunchTeam(plan)) {
-    return {
-      status: 'blocked',
-      reason: teamLaunchBlockReason(plan)!,
-    };
-  }
-  return {
-    status: 'ready',
-    fields: teamExecutionFields(plan),
-    partial: preflight.partial,
-    missingNames: missingMemberNames(plan),
-  };
 }
 
-export async function refreshRemoteCatalogForGaps<T>(
+export function refreshRemoteCatalogForGaps<T>(
   value: T,
   hasGaps: (value: T) => boolean,
   replan: () => T,
   ports: {
     canAccessRemoteCatalog: () => Promise<boolean>;
-    refreshRemote: () => Promise<void>;
+    refreshRemote: () => Effect.Effect<void, unknown>;
   },
-): Promise<{ value: T; remoteCatalogRefreshAttempted: boolean }> {
-  if (hasGaps(value) && (await ports.canAccessRemoteCatalog())) {
-    await ports.refreshRemote();
-    return { value: replan(), remoteCatalogRefreshAttempted: true };
-  }
-  return { value, remoteCatalogRefreshAttempted: false };
+): Effect.Effect<
+  { value: T; remoteCatalogRefreshAttempted: boolean },
+  unknown
+> {
+  return Effect.gen(function* () {
+    // `hasGaps` first, as in the Promise original: a gapless plan must not
+    // even probe remote access.
+    if (hasGaps(value)) {
+      const canAccess = yield* Effect.tryPromise({
+        try: () => ports.canAccessRemoteCatalog(),
+        catch: (error) => error,
+      });
+      if (canAccess) {
+        yield* ports.refreshRemote();
+        return { value: replan(), remoteCatalogRefreshAttempted: true };
+      }
+    }
+    return { value, remoteCatalogRefreshAttempted: false };
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/common/teams/TeamRosterApplication.ts
+++ b/src/common/teams/TeamRosterApplication.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import {
   preflightTeamAvailability,
   type TeamAvailabilityChoice,
@@ -36,7 +37,7 @@ type TeamRosterApplicationResult =
 
 export interface TeamRosterApplicationDeps {
   readonly catalog: TeamRosterCatalog;
-  readonly loadLocalCatalog: () => Promise<void>;
+  readonly loadLocalCatalog: () => Effect.Effect<void, unknown>;
   readonly canAccessRemoteCatalog: () => Promise<boolean>;
   /** A decision already supplied by a non-interactive caller. */
   readonly providedChoice?: TeamAvailabilityChoice;
@@ -45,59 +46,69 @@ export interface TeamRosterApplicationDeps {
     unavailableNames: readonly string[],
   ) => Promise<TeamAvailabilityChoice | undefined>;
   readonly signIn: () => Promise<boolean>;
-  readonly forceRefreshRemoteCatalog: () => Promise<void>;
+  readonly forceRefreshRemoteCatalog: () => Effect.Effect<void, unknown>;
 }
 
+/** Call a host dialog, auth, or roster-store port from the program. */
+const hostPort = <A>(
+  call: () => A | PromiseLike<A>,
+): Effect.Effect<A, unknown> =>
+  Effect.tryPromise({ try: async () => call(), catch: (error) => error });
+
 /** Host sequence for preflighting and committing one team roster. */
-export async function applyTeamRosterWithPreflight(
+export function applyTeamRosterWithPreflight(
   presetId: string,
   deps: TeamRosterApplicationDeps,
-): Promise<TeamRosterApplicationResult> {
-  await deps.loadLocalCatalog();
-  const initial = deps.catalog.resolvePreset(presetId);
-  if (!initial.ok) return { status: 'unknown' };
+): Effect.Effect<TeamRosterApplicationResult, unknown> {
+  return Effect.gen(function* () {
+    yield* deps.loadLocalCatalog();
+    const initial = deps.catalog.resolvePreset(presetId);
+    if (!initial.ok) return { status: 'unknown' as const };
 
-  const preflight = await preflightTeamAvailability<ResolvedTeam>({
-    initial,
-    unresolvedNames: (value) => value.resolution.unresolvedNames,
-    texraHostedNames: teamHostedNamesForPreflight(
-      initial.preset,
-      initial.resolution.unresolvedNames,
-    ),
-    canAccessRemoteCatalog: deps.canAccessRemoteCatalog,
-    providedChoice: deps.providedChoice,
-    choose: (names) => deps.choose(initial.preset, names),
-    signIn: deps.signIn,
-    refresh: async () => {
-      await deps.forceRefreshRemoteCatalog();
-      const refreshed = deps.catalog.resolvePreset(presetId);
-      if (!refreshed.ok) throw new Error(`Team no longer exists: ${presetId}`);
-      return refreshed;
-    },
+    const preflight = yield* preflightTeamAvailability<ResolvedTeam>({
+      initial,
+      unresolvedNames: (value) => value.resolution.unresolvedNames,
+      texraHostedNames: teamHostedNamesForPreflight(
+        initial.preset,
+        initial.resolution.unresolvedNames,
+      ),
+      canAccessRemoteCatalog: deps.canAccessRemoteCatalog,
+      providedChoice: deps.providedChoice,
+      choose: (names) => deps.choose(initial.preset, names),
+      signIn: deps.signIn,
+      refreshRemote: deps.forceRefreshRemoteCatalog,
+      replan: () => {
+        const refreshed = deps.catalog.resolvePreset(presetId);
+        if (!refreshed.ok) {
+          throw new Error(`Team no longer exists: ${presetId}`);
+        }
+        return refreshed;
+      },
+    });
+
+    if (preflight.status === 'cancelled') {
+      return { status: 'cancelled' as const, preset: initial.preset };
+    }
+    if (preflight.status === 'choice-required') {
+      return {
+        status: 'choice-required' as const,
+        preset: initial.preset,
+        unavailableNames: preflight.unavailableNames,
+      };
+    }
+    if (preflight.status === 'unavailable') {
+      return {
+        status: 'unavailable' as const,
+        preset: initial.preset,
+        unavailableNames: preflight.unavailableNames,
+      };
+    }
+
+    yield* hostPort(() => deps.catalog.commitPreset(preflight.value.preset));
+    return {
+      status: 'applied' as const,
+      preset: preflight.value.preset,
+      resolution: preflight.value.resolution,
+    };
   });
-
-  if (preflight.status === 'cancelled') {
-    return { status: 'cancelled', preset: initial.preset };
-  }
-  if (preflight.status === 'choice-required') {
-    return {
-      status: 'choice-required',
-      preset: initial.preset,
-      unavailableNames: preflight.unavailableNames,
-    };
-  }
-  if (preflight.status === 'unavailable') {
-    return {
-      status: 'unavailable',
-      preset: initial.preset,
-      unavailableNames: preflight.unavailableNames,
-    };
-  }
-
-  await deps.catalog.commitPreset(preflight.value.preset);
-  return {
-    status: 'applied',
-    preset: preflight.value.preset,
-    resolution: preflight.value.resolution,
-  };
 }

--- a/src/controllers/mainView/backend/MainViewExecutionLaunchController.ts
+++ b/src/controllers/mainView/backend/MainViewExecutionLaunchController.ts
@@ -1,4 +1,5 @@
 // Local imports - execution requests
+import { Effect } from 'effect';
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
 
 // Local imports - team launch
@@ -37,75 +38,87 @@ export interface MainViewExecutionLaunchHost {
 }
 
 /** Resolve an ordinary or team launch and answer refusals on the request path. */
-export async function prepareMainViewExecutionLaunch(
+export function prepareMainViewExecutionLaunch(
   message: MainViewExecuteMessage,
   host: MainViewExecutionLaunchHost,
-): Promise<ValidatedExecutionRequest> {
-  let preparation: MainViewExecutionPreparationResult;
-  let infoMessage: string | undefined;
-  if (message.session?.launchTarget !== 'team') {
-    preparation = prepareMainViewExecutionRequest(message);
-  } else {
-    const teamId = message.session.teamId;
-    if (!teamId)
-      throw new Rejected({ reason: TEAM_SELECTION_REQUIRED_MESSAGE });
-    const resolution = await resolveTeamLaunch({
-      teamId,
-      ...createTeamCatalogPorts(),
-      choose: (unavailableNames) =>
-        host.chooseTeamAvailability(unavailableNames),
-      signIn: () => host.signInForRemoteAgentCatalog(),
-    }).catch((error: unknown) => {
-      throw new Rejected({
-        reason: `Team launch failed: ${toErrorMessage(error)}`,
-      });
-    });
-    switch (resolution.status) {
-      case 'cancelled':
-        throw new Cancelled();
-      case 'unknown-team':
-        throw new Rejected({ reason: formatUnknownTeamMessage(teamId) });
-      case 'blocked':
-        throw new Rejected({
-          reason: formatTeamLaunchBlockedMessage(teamId, resolution.reason),
-        });
-      case 'unavailable':
-        throw new Rejected({
-          reason: formatTeamUnavailableMessage(
-            teamId,
-            resolution.unavailableNames,
+): Effect.Effect<ValidatedExecutionRequest, Rejected | Cancelled> {
+  return Effect.gen(function* () {
+    let preparation: MainViewExecutionPreparationResult;
+    let infoMessage: string | undefined;
+    if (message.session?.launchTarget !== 'team') {
+      preparation = prepareMainViewExecutionRequest(message);
+    } else {
+      const teamId = message.session.teamId;
+      if (!teamId)
+        return yield* new Rejected({ reason: TEAM_SELECTION_REQUIRED_MESSAGE });
+      const resolution = yield* resolveTeamLaunch({
+        teamId,
+        ...createTeamCatalogPorts(),
+        choose: (unavailableNames) =>
+          host.chooseTeamAvailability(unavailableNames),
+        signIn: () => host.signInForRemoteAgentCatalog(),
+      }).pipe(
+        Effect.catch((error: unknown) =>
+          Effect.fail(
+            new Rejected({
+              reason: `Team launch failed: ${toErrorMessage(error)}`,
+            }),
           ),
-        });
-      case 'ready':
-        preparation = prepareMainViewTeamExecutionRequest(
-          message,
-          resolution.fields,
-        );
-        if (resolution.partial)
-          infoMessage = formatPartialTeamLaunchMessage(resolution.missingNames);
-        break;
-      default:
-        return assertNever(
-          resolution,
-          'Unhandled main-view team launch resolution',
-        );
+        ),
+      );
+      switch (resolution.status) {
+        case 'cancelled':
+          return yield* new Cancelled();
+        case 'unknown-team':
+          return yield* new Rejected({
+            reason: formatUnknownTeamMessage(teamId),
+          });
+        case 'blocked':
+          return yield* new Rejected({
+            reason: formatTeamLaunchBlockedMessage(teamId, resolution.reason),
+          });
+        case 'unavailable':
+          return yield* new Rejected({
+            reason: formatTeamUnavailableMessage(
+              teamId,
+              resolution.unavailableNames,
+            ),
+          });
+        case 'ready':
+          preparation = prepareMainViewTeamExecutionRequest(
+            message,
+            resolution.fields,
+          );
+          if (resolution.partial)
+            infoMessage = formatPartialTeamLaunchMessage(
+              resolution.missingNames,
+            );
+          break;
+        default:
+          return assertNever(
+            resolution,
+            'Unhandled main-view team launch resolution',
+          );
+      }
     }
-  }
-  if (!preparation.valid) {
-    throw new Rejected({
-      reason: preparation.message,
-      ...(preparation.docsCommand && { docsCommand: preparation.docsCommand }),
-    });
-  }
-  if (infoMessage) void host.showInfoMessage(infoMessage);
-  return preparation.request;
+    if (!preparation.valid) {
+      return yield* new Rejected({
+        reason: preparation.message,
+        ...(preparation.docsCommand && {
+          docsCommand: preparation.docsCommand,
+        }),
+      });
+    }
+    if (infoMessage) void host.showInfoMessage(infoMessage);
+    return preparation.request;
+  });
 }
 
 /** Both GUI hosts launch the selections carried by the requesting surface. */
 export function prepareSurfaceLaunch(
   { launch, instruction }: Extract<HostRequest, { kind: 'launch' }>,
   host: MainViewExecutionLaunchHost,
-): Promise<ValidatedExecutionRequest> {
+): Effect.Effect<ValidatedExecutionRequest, Rejected | Cancelled> {
   return prepareMainViewExecutionLaunch(
     {
       agent: launch.agent[launch.sessionType],

--- a/src/controllers/mainView/teamCatalogPorts.ts
+++ b/src/controllers/mainView/teamCatalogPorts.ts
@@ -3,6 +3,7 @@ import { getAgentsByCategory, loadAgents, refresh } from '@agent/index';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import type { Effect } from 'effect';
 
 /**
  * Live team-catalog ports shared by every host's main view. Launch resolution
@@ -13,16 +14,16 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
  */
 export function createTeamCatalogPorts(): {
   readonly customPresetsRaw: unknown;
-  readonly ensureCatalogLoaded: () => Promise<void>;
+  readonly ensureCatalogLoaded: () => Effect.Effect<void, unknown>;
   readonly getAgents: typeof getAgentsByCategory;
   readonly canAccessRemoteCatalog: () => Promise<boolean>;
-  readonly refreshRemote: () => Promise<void>;
+  readonly refreshRemote: () => Effect.Effect<void, unknown>;
 } {
   return {
     customPresetsRaw: workspaceRoots().workspaceState.get<unknown>(
       WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
     ),
-    ensureCatalogLoaded: loadAgents,
+    ensureCatalogLoaded: () => loadAgents(),
     getAgents: getAgentsByCategory,
     canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
     refreshRemote: () => refresh({ includeRemote: true }),

--- a/src/controllers/session/hostSnapshotSource.ts
+++ b/src/controllers/session/hostSnapshotSource.ts
@@ -9,8 +9,10 @@
  * banners only it can answer (a VS Code host knows its API-key status and
  * its missing tools; the desktop keeps both in Settings).
  */
+import { Cause, Effect, Exit } from 'effect';
 import { computeAgentOptionsData } from '@agent/index';
 import { loadTeamOptions } from '@common/teams/TeamPlan';
+import { hostPort } from '@controllers/effectPort';
 import { createTeamCatalogPorts } from '@controllers/mainView/teamCatalogPorts';
 import {
   computeModelOptionsData,
@@ -46,17 +48,17 @@ export interface HostSnapshotSourceOptions {
 
 export interface HostSnapshotSource {
   /** Reassemble every catalog and publish the result. */
-  refresh(): Promise<void>;
+  readonly refresh: Effect.Effect<void>;
   /** The agent, team, and model catalogs changed (a roster edit, a
    *  credential, a sign-in). */
-  refreshCatalogs(): Promise<void>;
+  readonly refreshCatalogs: Effect.Effect<void>;
   /** The paper's files changed on disk, or the surface asked for a relist. */
-  refreshFiles(): Promise<void>;
-  refreshCommits(): Promise<void>;
+  readonly refreshFiles: Effect.Effect<void>;
+  readonly refreshCommits: Effect.Effect<void>;
   /** The sign-in state changed. */
-  refreshAuth(): Promise<void>;
+  readonly refreshAuth: Effect.Effect<void>;
   /** The host's own banners changed (a key stored, a tool installed). */
-  refreshHostBanners(): Promise<void>;
+  readonly refreshHostBanners: Effect.Effect<void>;
   /** The workspace folders changed. */
   refreshWorkspaceRoots(): void;
   /** The one recorder per process started or stopped. */
@@ -130,60 +132,72 @@ export function createHostSnapshotSource(
     });
   }
 
-  async function loadAgents(): Promise<void> {
-    catalogs = { ...catalogs, agentOptions: await computeAgentOptionsData() };
-  }
+  const loadAgents = Effect.gen(function* () {
+    catalogs = { ...catalogs, agentOptions: yield* computeAgentOptionsData() };
+  });
 
-  async function loadTeams(): Promise<void> {
+  const loadTeams = Effect.gen(function* () {
     catalogs = {
       ...catalogs,
-      teamOptions: await loadTeamOptions(createTeamCatalogPorts()),
+      teamOptions: yield* loadTeamOptions(createTeamCatalogPorts()),
     };
-  }
+  });
 
-  async function loadModels(): Promise<void> {
+  const loadModels = Effect.gen(function* () {
     catalogs = {
       ...catalogs,
-      modelOptions: await computeModelOptionsData(
-        getEnabledModels(options.globalState),
+      modelOptions: yield* hostPort(() =>
+        computeModelOptionsData(getEnabledModels(options.globalState)),
       ),
     };
-  }
+  });
 
-  async function loadFiles(): Promise<void> {
-    fileOptions = await options.fileOptions();
+  const loadFiles = Effect.gen(function* () {
+    fileOptions = yield* hostPort(() => options.fileOptions());
     hasInputFiles = fileOptions.baseFile.length > 0;
-  }
+  });
 
-  async function loadCommits(): Promise<void> {
-    commits = await options.readRecentCommits();
-  }
+  const loadCommits = Effect.gen(function* () {
+    commits = yield* hostPort(() => options.readRecentCommits());
+  });
 
-  async function loadAuth(): Promise<void> {
-    authenticated = await options.isAuthenticated();
-  }
+  const loadAuth = Effect.gen(function* () {
+    authenticated = yield* hostPort(() => options.isAuthenticated());
+  });
 
-  async function loadHostBanners(): Promise<void> {
-    const [key, tools] = await Promise.all([
-      options.apiKeyBanner?.(),
-      options.dependencyBanner?.(),
-    ]);
+  const loadHostBanners = Effect.gen(function* () {
+    const [key, tools] = yield* Effect.all(
+      [
+        options.apiKeyBanner
+          ? hostPort(() => options.apiKeyBanner!())
+          : Effect.succeed(undefined),
+        options.dependencyBanner
+          ? hostPort(() => options.dependencyBanner!())
+          : Effect.succeed(undefined),
+      ],
+      { concurrency: 'unbounded' },
+    );
     if (key) apiKey = key;
     if (tools) dependency = tools;
-  }
+  });
 
   /** Each producer settles on its own: one that fails is reported and keeps
    *  its last value, and the snapshot still publishes what the others read,
    *  so a single unavailable source never leaves the shell blank. */
-  const guarded =
-    (...loads: (() => Promise<void>)[]) =>
-    async (): Promise<void> => {
-      const settled = await Promise.allSettled(loads.map((load) => load()));
-      for (const result of settled) {
-        if (result.status === 'rejected') options.onError(result.reason);
+  const guarded = (
+    ...loads: Effect.Effect<void, unknown>[]
+  ): Effect.Effect<void> =>
+    Effect.gen(function* () {
+      const settled = yield* Effect.forEach(
+        loads,
+        (load) => Effect.exit(load),
+        { concurrency: 'unbounded' },
+      );
+      for (const exit of settled) {
+        if (Exit.isFailure(exit)) options.onError(Cause.squash(exit.cause));
       }
       publish();
-    };
+    });
 
   const catalogLoads = [loadAgents, loadTeams, loadModels];
 

--- a/src/controllers/settingsView/SettingsTeamRosterController.ts
+++ b/src/controllers/settingsView/SettingsTeamRosterController.ts
@@ -10,6 +10,7 @@ import {
   applyTeamRosterWithPreflight,
   type TeamRosterApplicationDeps,
 } from '@common/teams/TeamRosterApplication';
+import { hostPort } from '@controllers/effectPort';
 import type { MessageHost } from '@hosts/uiHosts';
 import { assertNever } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
@@ -38,12 +39,6 @@ interface SettingsTeamRosterOptions extends Omit<
   readonly presentation: SettingsTeamRosterPresentation;
   readonly refreshAfterApply: (selectedToolUseAgent?: string) => Promise<void>;
 }
-
-/** Call a host presentation port from the program. */
-const hostPort = <A>(
-  call: () => A | PromiseLike<A>,
-): Effect.Effect<A, unknown> =>
-  Effect.tryPromise({ try: async () => call(), catch: (error) => error });
 
 /** Apply a settings team and present its outcome consistently across hosts. */
 export function applySettingsTeamRoster(

--- a/src/controllers/settingsView/SettingsTeamRosterController.ts
+++ b/src/controllers/settingsView/SettingsTeamRosterController.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPreflight';
 import {
   formatTeamUnavailableMessage,
@@ -38,52 +39,66 @@ interface SettingsTeamRosterOptions extends Omit<
   readonly refreshAfterApply: (selectedToolUseAgent?: string) => Promise<void>;
 }
 
+/** Call a host presentation port from the program. */
+const hostPort = <A>(
+  call: () => A | PromiseLike<A>,
+): Effect.Effect<A, unknown> =>
+  Effect.tryPromise({ try: async () => call(), catch: (error) => error });
+
 /** Apply a settings team and present its outcome consistently across hosts. */
-export async function applySettingsTeamRoster(
+export function applySettingsTeamRoster(
   presetId: string,
   options: SettingsTeamRosterOptions,
-): Promise<void> {
-  const result = await applyTeamRosterWithPreflight(presetId, {
-    ...options,
-    choose: (preset, unavailableNames) =>
-      options.presentation.chooseTeamAvailability(
-        teamAvailabilityPrompt(unavailableNames, preset.name),
-      ),
-  });
-
-  switch (result.status) {
-    case 'unknown':
-      await options.presentation.showErrorMessage(
-        formatUnknownTeamMessage(presetId),
-      );
-      return;
-    case 'choice-required':
-    case 'cancelled':
-      return;
-    case 'unavailable':
-      await options.presentation.showErrorMessage(
-        formatTeamUnavailableMessage(
-          result.preset.name,
-          result.unavailableNames,
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    const result = yield* applyTeamRosterWithPreflight(presetId, {
+      ...options,
+      choose: (preset, unavailableNames) =>
+        options.presentation.chooseTeamAvailability(
+          teamAvailabilityPrompt(unavailableNames, preset.name),
         ),
-      );
-      return;
-    case 'applied': {
-      const selectedToolUseAgent = options.catalog.getPresetToolUseRoot(
-        result.preset.agents.toolUse,
-        result.preset.id,
-      );
-      await options.refreshAfterApply(selectedToolUseAgent);
+    });
 
-      const unresolvedCount = result.resolution.unresolvedNames.length;
-      await options.presentation.showInfoMessage(
-        unresolvedCount === 0
-          ? `Applied "${result.preset.name}" team`
-          : `Applied "${result.preset.name}" with ${formatResultCount(unresolvedCount, 'member')} still unavailable`,
-      );
-      return;
+    switch (result.status) {
+      case 'unknown':
+        yield* hostPort(() =>
+          options.presentation.showErrorMessage(
+            formatUnknownTeamMessage(presetId),
+          ),
+        );
+        return;
+      case 'choice-required':
+      case 'cancelled':
+        return;
+      case 'unavailable':
+        yield* hostPort(() =>
+          options.presentation.showErrorMessage(
+            formatTeamUnavailableMessage(
+              result.preset.name,
+              result.unavailableNames,
+            ),
+          ),
+        );
+        return;
+      case 'applied': {
+        const selectedToolUseAgent = options.catalog.getPresetToolUseRoot(
+          result.preset.agents.toolUse,
+          result.preset.id,
+        );
+        yield* hostPort(() => options.refreshAfterApply(selectedToolUseAgent));
+
+        const unresolvedCount = result.resolution.unresolvedNames.length;
+        yield* hostPort(() =>
+          options.presentation.showInfoMessage(
+            unresolvedCount === 0
+              ? `Applied "${result.preset.name}" team`
+              : `Applied "${result.preset.name}" with ${formatResultCount(unresolvedCount, 'member')} still unavailable`,
+          ),
+        );
+        return;
+      }
+      default:
+        return assertNever(result, 'Unhandled settings team roster outcome');
     }
-    default:
-      return assertNever(result, 'Unhandled settings team roster outcome');
-  }
+  });
 }

--- a/src/test-kernel/agent/AgentCategoryResolution.vitest.ts
+++ b/src/test-kernel/agent/AgentCategoryResolution.vitest.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports
@@ -81,7 +82,7 @@ describe('cross-category agent resolution', () => {
       },
     );
 
-    await refresh({ includeRemote: false });
+    await Effect.runPromise(refresh({ includeRemote: false }));
   });
 
   afterAll(async () => {

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -295,7 +295,7 @@ describe('agent package run lifecycle', () => {
       mocks.ownerInstalled = false;
     });
     mocks.foldDeath = Effect.runSync(Deferred.make<never, Error>());
-    mocks.loadAgents.mockResolvedValue(undefined);
+    mocks.loadAgents.mockReturnValue(Effect.void);
     mocks.runValidatedAgent.mockImplementation(
       (_input: unknown, options: RunAgentOptions) => driveRun(options),
     );

--- a/src/test-kernel/agent/AgentRegistry.vitest.ts
+++ b/src/test-kernel/agent/AgentRegistry.vitest.ts
@@ -2,7 +2,8 @@
 import { resolve } from 'node:path';
 
 // Third-party imports
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import {
@@ -34,7 +35,7 @@ const { listRemoteAgents, ORCHESTRATOR_AGENT } = vi.hoisted(() => {
   };
   return {
     ORCHESTRATOR_AGENT,
-    listRemoteAgents: vi.fn(async () => [ORCHESTRATOR_AGENT]),
+    listRemoteAgents: vi.fn(),
   };
 });
 
@@ -98,11 +99,17 @@ function remoteAgentFixture(id: string, name: string, description: string) {
 }
 
 describe('agent registry', () => {
+  beforeEach(() => {
+    listRemoteAgents.mockImplementation(() =>
+      Effect.succeed([ORCHESTRATOR_AGENT]),
+    );
+  });
+
   beforeAll(async () => {
     // Use the real bundled agent YAMLs rather than synthetic fixtures.
     await initPlatformWithState({});
     useAgentDirectories();
-    await refresh({ includeRemote: false });
+    await Effect.runPromise(refresh({ includeRemote: false }));
   });
 
   it('keeps unknown names unresolved', () => {
@@ -134,7 +141,9 @@ describe('agent registry', () => {
     });
 
     try {
-      const pendingRefresh = refresh({ includeRemote: false });
+      const pendingRefresh = Effect.runPromise(
+        refresh({ includeRemote: false }),
+      );
       await delay(0);
 
       expect(getAgent('assistant')?.name).toBe('assistant');
@@ -149,23 +158,27 @@ describe('agent registry', () => {
 
   it('forces a new remote fetch after an older initialization settles', async () => {
     useAgentDirectories();
-    await refresh({ includeRemote: false });
+    await Effect.runPromise(refresh({ includeRemote: false }));
 
     const staleLoadGate = createDeferred<void>();
     let remoteCall = 0;
-    listRemoteAgents.mockImplementation(async () => {
-      remoteCall += 1;
-      if (remoteCall === 1) {
-        await staleLoadGate.promise;
-        return [remoteAgentFixture('stale-agent', 'staleAgent', 'Stale')];
-      }
-      return [remoteAgentFixture('fresh-agent', 'freshAgent', 'Fresh')];
-    });
+    listRemoteAgents.mockImplementation(() =>
+      Effect.promise(async () => {
+        remoteCall += 1;
+        if (remoteCall === 1) {
+          await staleLoadGate.promise;
+          return [remoteAgentFixture('stale-agent', 'staleAgent', 'Stale')];
+        }
+        return [remoteAgentFixture('fresh-agent', 'freshAgent', 'Fresh')];
+      }),
+    );
 
     try {
-      const staleInitialization = loadAgents({ includeRemote: true });
+      const staleInitialization = Effect.runPromise(
+        loadAgents({ includeRemote: true }),
+      );
       await vi.waitFor(() => expect(listRemoteAgents).toHaveBeenCalledOnce());
-      const forcedRefresh = refresh({ includeRemote: true });
+      const forcedRefresh = Effect.runPromise(refresh({ includeRemote: true }));
 
       staleLoadGate.resolve();
       await staleInitialization;
@@ -177,18 +190,20 @@ describe('agent registry', () => {
     } finally {
       staleLoadGate.resolve();
       listRemoteAgents.mockReset();
-      listRemoteAgents.mockResolvedValue([ORCHESTRATOR_AGENT]);
-      await refresh({ includeRemote: false });
+      listRemoteAgents.mockImplementation(() =>
+        Effect.succeed([ORCHESTRATOR_AGENT]),
+      );
+      await Effect.runPromise(refresh({ includeRemote: false }));
     }
   });
 
   it('reloads local-only definitions after sign-out invalidation', async () => {
     useAgentDirectories();
-    await refresh({ includeRemote: true });
+    await Effect.runPromise(refresh({ includeRemote: true }));
     expect(isRemoteAgent('orchestrator')).toBe(true);
     const remoteFetchCount = listRemoteAgents.mock.calls.length;
 
-    await invalidateRemoteAgentsAfterSignOut();
+    await Effect.runPromise(invalidateRemoteAgentsAfterSignOut());
 
     expect(isRemoteAgent('orchestrator')).toBe(false);
     expect(listRemoteAgents).toHaveBeenCalledTimes(remoteFetchCount);
@@ -197,7 +212,7 @@ describe('agent registry', () => {
   it('removes remote definitions even when the local rebuild fails', async () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     useAgentDirectories();
-    await refresh({ includeRemote: true });
+    await Effect.runPromise(refresh({ includeRemote: true }));
     expect(isRemoteAgent('orchestrator')).toBe(true);
     useAgentDirectories({
       builtIn: async () => {
@@ -206,7 +221,9 @@ describe('agent registry', () => {
     });
 
     try {
-      const invalidation = invalidateRemoteAgentsAfterSignOut();
+      const invalidation = Effect.runPromise(
+        invalidateRemoteAgentsAfterSignOut(),
+      );
       expect(isRemoteAgent('orchestrator')).toBe(false);
       await expect(invalidation).resolves.toBeUndefined();
       expect(isRemoteAgent('orchestrator')).toBe(false);
@@ -218,14 +235,14 @@ describe('agent registry', () => {
       );
     } finally {
       useAgentDirectories();
-      await refresh({ includeRemote: false });
+      await Effect.runPromise(refresh({ includeRemote: false }));
       warn.mockRestore();
     }
   });
 
   it('fences an in-flight remote load before rebuilding locally', async () => {
     useAgentDirectories();
-    await refresh({ includeRemote: false });
+    await Effect.runPromise(refresh({ includeRemote: false }));
     const remoteLoad = createDeferred<void>();
     const localRebuild = createDeferred<void>();
     let builtInCalls = 0;
@@ -236,18 +253,22 @@ describe('agent registry', () => {
         return BUILTIN_AGENTS_DIR;
       },
     });
-    listRemoteAgents.mockImplementationOnce(async () => {
-      await remoteLoad.promise;
-      return [
-        remoteAgentFixture('late-remote', 'lateRemote', 'Late remote result'),
-      ];
-    });
+    listRemoteAgents.mockImplementationOnce(() =>
+      Effect.promise(async () => {
+        await remoteLoad.promise;
+        return [
+          remoteAgentFixture('late-remote', 'lateRemote', 'Late remote result'),
+        ];
+      }),
+    );
 
-    const staleLoad = loadAgents({ includeRemote: true });
+    const staleLoad = Effect.runPromise(loadAgents({ includeRemote: true }));
     await vi.waitFor(() => expect(listRemoteAgents).toHaveBeenCalled());
 
     try {
-      const invalidation = invalidateRemoteAgentsAfterSignOut();
+      const invalidation = Effect.runPromise(
+        invalidateRemoteAgentsAfterSignOut(),
+      );
       remoteLoad.resolve();
       await staleLoad;
 
@@ -273,7 +294,9 @@ describe('agent registry', () => {
     });
 
     try {
-      await expect(loadAgents()).rejects.toThrow('refresh failed');
+      await expect(Effect.runPromise(loadAgents())).rejects.toThrow(
+        'refresh failed',
+      );
 
       expect(getAgent('assistant')?.name).toBe('assistant');
     } finally {
@@ -283,18 +306,18 @@ describe('agent registry', () => {
 
   it('includes remote agents in launcher options after local-only startup load', async () => {
     try {
-      await refresh({ includeRemote: false });
+      await Effect.runPromise(refresh({ includeRemote: false }));
       expect(
         getVisibleAgents('toolUse').map((agent) => agent.name),
       ).not.toContain('orchestrator');
 
-      const options = await computeAgentOptionsData();
+      const options = await Effect.runPromise(computeAgentOptionsData());
 
       expect(options.toolUse.map((option) => option.label)).toContain(
         'orchestrator',
       );
     } finally {
-      await refresh({ includeRemote: false });
+      await Effect.runPromise(refresh({ includeRemote: false }));
     }
   });
 
@@ -309,9 +332,11 @@ describe('agent registry', () => {
         },
       });
 
-      const pendingRefresh = refresh({ includeRemote: false });
+      const pendingRefresh = Effect.runPromise(
+        refresh({ includeRemote: false }),
+      );
       await delay(0);
-      const optionsPromise = computeAgentOptionsData();
+      const optionsPromise = Effect.runPromise(computeAgentOptionsData());
 
       builtInToolUseDir.resolve();
       await pendingRefresh;
@@ -323,7 +348,7 @@ describe('agent registry', () => {
     } finally {
       builtInToolUseDir.resolve();
       useAgentDirectories();
-      await refresh({ includeRemote: false });
+      await Effect.runPromise(refresh({ includeRemote: false }));
     }
   });
 });

--- a/src/test-kernel/agent/AgentYamlScanner.vitest.ts
+++ b/src/test-kernel/agent/AgentYamlScanner.vitest.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports
@@ -71,7 +72,9 @@ describe('agent YAML scanner', () => {
       ],
     });
 
-    const { entries } = await scanDirectory(agentDir, 'custom');
+    const { entries } = await Effect.runPromise(
+      scanDirectory(agentDir, 'custom'),
+    );
 
     expect(entries.find((entry) => entry.name === 'child')?.rounds).toBe(4);
     expect(entries.find((entry) => entry.name === 'prompt-child')?.rounds).toBe(
@@ -87,7 +90,9 @@ describe('agent YAML scanner', () => {
       'Readable Helper.yaml': toolUseAgent('helper', 'help'),
     });
 
-    const { entries } = await scanDirectory(agentDir, 'custom');
+    const { entries } = await Effect.runPromise(
+      scanDirectory(agentDir, 'custom'),
+    );
 
     expect(entries.map((entry) => entry.name)).toEqual(['helper']);
   });
@@ -104,7 +109,9 @@ describe('agent YAML scanner', () => {
       ],
     });
 
-    const { entries } = await scanDirectory(agentDir, 'custom');
+    const { entries } = await Effect.runPromise(
+      scanDirectory(agentDir, 'custom'),
+    );
 
     expect(entries).toEqual([]);
   });
@@ -116,7 +123,9 @@ describe('agent YAML scanner', () => {
       'unique.yaml': toolUseAgent('unique', 'unique'),
     });
 
-    const { entries } = await scanDirectory(agentDir, 'custom');
+    const { entries } = await Effect.runPromise(
+      scanDirectory(agentDir, 'custom'),
+    );
 
     expect(entries.map((entry) => entry.name)).toEqual(['unique']);
   });
@@ -127,7 +136,9 @@ describe('agent YAML scanner', () => {
       'valid.yaml': toolUseAgent('valid', 'hi'),
     });
 
-    const { entries } = await scanDirectory(agentDir, 'custom');
+    const { entries } = await Effect.runPromise(
+      scanDirectory(agentDir, 'custom'),
+    );
 
     expect(entries.map((entry) => entry.name)).toEqual(['valid']);
   });
@@ -144,7 +155,9 @@ describe('agent YAML scanner', () => {
       'valid.yaml': toolUseAgent('valid', 'hi'),
     });
 
-    const { entries, issues } = await scanDirectory(agentDir, 'custom');
+    const { entries, issues } = await Effect.runPromise(
+      scanDirectory(agentDir, 'custom'),
+    );
 
     expect(entries.map((entry) => entry.name)).toEqual(['valid']);
     expect(issues).toEqual([

--- a/src/test-kernel/agent/remote/RemoteAgentLoader.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentLoader.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loadRemoteAgent } from '@agent/remote/RemoteAgentLoader';
@@ -68,7 +69,7 @@ describe('remote agent listing', () => {
       error: null,
     });
 
-    const agents = await listRemoteAgents();
+    const agents = await Effect.runPromise(listRemoteAgents());
 
     expect(agents.map((agent) => agent.name)).toEqual(['review']);
   });
@@ -82,7 +83,7 @@ describe('remote agent listing', () => {
       error: null,
     });
 
-    const agents = await listRemoteAgents();
+    const agents = await Effect.runPromise(listRemoteAgents());
 
     expect(agents.map((agent) => agent.name)).toEqual(['review']);
   });
@@ -96,7 +97,7 @@ describe('remote agent listing', () => {
       },
     });
 
-    const agents = await listRemoteAgents();
+    const agents = await Effect.runPromise(listRemoteAgents());
 
     expect(agents).toEqual([]);
     expect(selectedColumns).toEqual([

--- a/src/test-kernel/agent/runtime/agentLoad.vitest.ts
+++ b/src/test-kernel/agent/runtime/agentLoad.vitest.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
+import { Effect } from 'effect';
 import {
   afterAll,
   beforeAll,
@@ -253,7 +254,7 @@ describe('inline agent definitions', () => {
       await makeTempDir('texra-empty-agents-', tempDirs),
     );
     registerInlineAgents([SCRATCHPAD]);
-    await loadAgents({ includeRemote: false });
+    await Effect.runPromise(loadAgents({ includeRemote: false }));
   });
 
   it('resolves a registered definition with no YAML behind it', () => {
@@ -290,7 +291,7 @@ describe('inline agent definitions', () => {
   });
 
   it('survives a catalog refresh that rebuilds the cache', async () => {
-    await refresh({ includeRemote: false });
+    await Effect.runPromise(refresh({ includeRemote: false }));
     assert.strictEqual(getAgent('inline:scratchpad')?.source, 'inline');
   });
 
@@ -421,7 +422,7 @@ describe('inline agent definitions', () => {
     first.tools.push('bash');
     first.defaultOutputFiles.push('mutated.md');
 
-    await refresh({ includeRemote: false });
+    await Effect.runPromise(refresh({ includeRemote: false }));
     const restored = getAgent('inline:immutableEntry');
     assert.deepStrictEqual(restored?.tools, ['grep']);
     assert.deepStrictEqual(restored?.defaultOutputFiles, ['report.md']);
@@ -497,7 +498,7 @@ describe('inline agent definitions', () => {
       ].join('\n'),
     );
     await useAgentDirectories(customDir);
-    await refresh({ includeRemote: false });
+    await Effect.runPromise(refresh({ includeRemote: false }));
 
     // Distinct keys, so neither registration displaces the other...
     assert.strictEqual(
@@ -555,12 +556,12 @@ describe('agent registry load state', () => {
   it('runs a single scan for loads that start together', async () => {
     const counter = { scans: 0 };
     await installDirectories(countingDirectories(counter));
-    await refresh({ includeRemote: false });
+    await Effect.runPromise(refresh({ includeRemote: false }));
     counter.scans = 0;
 
     await Promise.all([
-      loadAgents({ includeRemote: true }),
-      loadAgents({ includeRemote: true }),
+      Effect.runPromise(loadAgents({ includeRemote: true })),
+      Effect.runPromise(loadAgents({ includeRemote: true })),
     ]);
 
     assert.strictEqual(counter.scans, 1);
@@ -570,7 +571,7 @@ describe('agent registry load state', () => {
   it('keeps serving the published catalog when a refresh fails', async () => {
     const counter = { scans: 0 };
     await installDirectories(countingDirectories(counter));
-    await refresh({ includeRemote: false });
+    await Effect.runPromise(refresh({ includeRemote: false }));
     assert.strictEqual(getAgent('custom:stateProbe')?.name, 'stateProbe');
 
     const scanFailure = new Error('agent directory unavailable');
@@ -582,7 +583,14 @@ describe('agent registry load state', () => {
       builtInToolUse: async () => agentDir,
     });
 
-    await assert.rejects(refresh({ includeRemote: false }), scanFailure);
+    await assert.rejects(
+      Effect.runPromise(refresh({ includeRemote: false })),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.strictEqual(error.message, scanFailure.message);
+        return true;
+      },
+    );
 
     // A failed rebuild leaves the previously published catalog in place.
     assert.strictEqual(getAgent('custom:stateProbe')?.name, 'stateProbe');

--- a/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
+++ b/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const providerMocks = vi.hoisted(() => ({
   asExternalUri: vi.fn(async (uri: { toString: () => string }) => uri),
   getUser: vi.fn(),
-  invalidateRemoteAgentsAfterSignOut: vi.fn(async () => {}),
+  invalidateRemoteAgentsAfterSignOut: vi.fn(() => Effect.void),
   openExternal: vi.fn(async () => true),
   withPkcePermit: vi.fn((operation: unknown) => {
     const result = testDoubles.pkceTail.then(() =>

--- a/src/test-kernel/cli/CliAgentShadow.vitest.ts
+++ b/src/test-kernel/cli/CliAgentShadow.vitest.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports
@@ -58,7 +59,7 @@ describe('CLI agent validation with a shadowed name', () => {
       },
     );
 
-    await refresh({ includeRemote: false });
+    await Effect.runPromise(refresh({ includeRemote: false }));
   });
 
   afterAll(async () => {

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
@@ -134,7 +134,7 @@ describe('CLI Supabase auth', () => {
     mocks.authCoordinator.clearSession.mockReturnValue(Effect.void);
     mocks.authCoordinator.storeSession.mockReturnValue(Effect.void);
     mocks.platform.mockReturnValue({ secrets: { kind: 'platform-secrets' } });
-    mocks.invalidateRemoteAgentsAfterSignOut.mockResolvedValue(undefined);
+    mocks.invalidateRemoteAgentsAfterSignOut.mockReturnValue(Effect.void);
   });
 
   it('uses platform-owned secrets after CLI platform init', async () => {
@@ -289,8 +289,8 @@ describe('CLI Supabase auth', () => {
   });
 
   it('completes sign-out when the local catalog rebuild fails', async () => {
-    mocks.invalidateRemoteAgentsAfterSignOut.mockRejectedValueOnce(
-      new Error('local rebuild failed'),
+    mocks.invalidateRemoteAgentsAfterSignOut.mockReturnValueOnce(
+      Effect.fail(new Error('local rebuild failed')),
     );
     const warn = vi.fn();
     const { initializeCliSupabaseAuth, signOutCliSupabase } =

--- a/src/test-kernel/cli/InitCommand.vitest.ts
+++ b/src/test-kernel/cli/InitCommand.vitest.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -90,7 +91,7 @@ describe('CLI init command', () => {
         { name: 'assistant', category: AgentCategory.ToolUse },
       ]);
     mocks.initCliPlatform.mockReset().mockResolvedValue(undefined);
-    mocks.loadAgents.mockReset().mockResolvedValue(undefined);
+    mocks.loadAgents.mockReset().mockReturnValue(Effect.void);
     stdoutSpy = spyOnStreamWrite(process.stdout, (chunk) => {
       stdout += chunk;
     });

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
@@ -2,6 +2,7 @@
 import { createRequire } from 'node:module';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import '@test/support/sessionGraphTestSetup';
@@ -241,7 +242,7 @@ function captureNextRenderOnSubmit(options?: { recordRender?: boolean }): {
 async function stubAgentRegistry(): Promise<() => void> {
   const agents = await import('@agent/index');
   const spies = [
-    vi.spyOn(agents, 'loadAgents').mockResolvedValue(undefined),
+    vi.spyOn(agents, 'loadAgents').mockReturnValue(Effect.void),
     vi.spyOn(agents, 'getVisibleAgents').mockReturnValue([]),
   ];
   return () => {

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -171,9 +171,10 @@ vi.mock('vscode', () => ({
   FileType: { Unknown: 0, File: 1, Directory: 2, SymbolicLink: 64 },
 }));
 
-vi.mock('@agent/index', () => ({
-  loadAgents: () => Promise.resolve(),
-}));
+vi.mock('@agent/index', async () => {
+  const { Effect } = await import('effect');
+  return { loadAgents: () => Effect.void };
+});
 
 vi.mock('@agent/runtime/runAgent', () => ({
   runAgent: () => Promise.resolve(),

--- a/src/test-kernel/common/teams/TeamAvailabilityPreflight.vitest.ts
+++ b/src/test-kernel/common/teams/TeamAvailabilityPreflight.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 
 import { preflightTeamAvailability } from '@common/teams/TeamAvailabilityPreflight';
@@ -18,9 +19,7 @@ function options(overrides: {
   refreshed?: Resolution;
   remoteCatalogRefreshAttempted?: boolean;
 }) {
-  const refresh = vi.fn(
-    async () => overrides.refreshed ?? { unresolvedNames: [] },
-  );
+  const refresh = vi.fn(() => undefined);
   const signIn = vi.fn(async () => overrides.signedIn ?? true);
   const choose = vi.fn(async () =>
     overrides.choiceRequired ? undefined : (overrides.choice ?? 'cancel'),
@@ -37,7 +36,11 @@ function options(overrides: {
       providedChoice: overrides.providedChoice,
       choose,
       signIn,
-      refresh,
+      refreshRemote: () =>
+        Effect.sync(() => {
+          refresh();
+        }),
+      replan: () => overrides.refreshed ?? { unresolvedNames: [] },
       remoteCatalogRefreshAttempted: overrides.remoteCatalogRefreshAttempted,
     },
   };
@@ -46,7 +49,9 @@ function options(overrides: {
 describe('team availability preflight', () => {
   it('does not prompt or refresh a local-only team', async () => {
     const deps = options({ initial: { unresolvedNames: ['local-plugin'] } });
-    await expect(preflightTeamAvailability(deps.input)).resolves.toEqual({
+    await expect(
+      Effect.runPromise(preflightTeamAvailability(deps.input)),
+    ).resolves.toEqual({
       status: 'proceed',
       value: { unresolvedNames: ['local-plugin'] },
       partial: false,
@@ -57,7 +62,9 @@ describe('team availability preflight', () => {
 
   it('continues only after an explicit partial-team choice', async () => {
     const deps = options({ choice: 'continue' });
-    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+    await expect(
+      Effect.runPromise(preflightTeamAvailability(deps.input)),
+    ).resolves.toMatchObject({
       status: 'proceed',
       partial: true,
     });
@@ -67,7 +74,9 @@ describe('team availability preflight', () => {
 
   it('cancels without signing in or refreshing', async () => {
     const deps = options({ choice: 'cancel' });
-    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+    await expect(
+      Effect.runPromise(preflightTeamAvailability(deps.input)),
+    ).resolves.toMatchObject({
       status: 'cancelled',
     });
     expect(deps.signIn).not.toHaveBeenCalled();
@@ -76,7 +85,9 @@ describe('team availability preflight', () => {
 
   it('honors a supplied partial-team choice before authenticated refresh', async () => {
     const deps = options({ authenticated: true, providedChoice: 'continue' });
-    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+    await expect(
+      Effect.runPromise(preflightTeamAvailability(deps.input)),
+    ).resolves.toMatchObject({
       status: 'proceed',
       partial: true,
     });
@@ -86,7 +97,9 @@ describe('team availability preflight', () => {
 
   it('honors a supplied cancellation before authenticated refresh', async () => {
     const deps = options({ authenticated: true, providedChoice: 'cancel' });
-    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+    await expect(
+      Effect.runPromise(preflightTeamAvailability(deps.input)),
+    ).resolves.toMatchObject({
       status: 'cancelled',
     });
     expect(deps.choose).not.toHaveBeenCalled();
@@ -96,7 +109,9 @@ describe('team availability preflight', () => {
   it('returns an actionable choice-required result without side effects', async () => {
     const deps = options({ choiceRequired: true });
 
-    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+    await expect(
+      Effect.runPromise(preflightTeamAvailability(deps.input)),
+    ).resolves.toMatchObject({
       status: 'choice-required',
       unavailableNames: ['orchestrator'],
     });
@@ -106,7 +121,9 @@ describe('team availability preflight', () => {
 
   it('refreshes and retries exactly once after successful sign-in', async () => {
     const deps = options({ choice: 'sign-in', signedIn: true });
-    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+    await expect(
+      Effect.runPromise(preflightTeamAvailability(deps.input)),
+    ).resolves.toMatchObject({
       status: 'proceed',
       partial: false,
     });
@@ -119,7 +136,9 @@ describe('team availability preflight', () => {
       authenticated: true,
       refreshed: { unresolvedNames: ['orchestrator'] },
     });
-    await expect(preflightTeamAvailability(deps.input)).resolves.toEqual({
+    await expect(
+      Effect.runPromise(preflightTeamAvailability(deps.input)),
+    ).resolves.toEqual({
       status: 'unavailable',
       value: { unresolvedNames: ['orchestrator'] },
       unavailableNames: ['orchestrator'],
@@ -134,7 +153,9 @@ describe('team availability preflight', () => {
       authenticated: true,
       remoteCatalogRefreshAttempted: true,
     });
-    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+    await expect(
+      Effect.runPromise(preflightTeamAvailability(deps.input)),
+    ).resolves.toMatchObject({
       status: 'unavailable',
       unavailableNames: ['orchestrator'],
     });

--- a/src/test-kernel/common/teams/TeamPlan.vitest.ts
+++ b/src/test-kernel/common/teams/TeamPlan.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -378,28 +379,33 @@ describe('buildTeamOptions', () => {
 
 describe('loadTeamOptions', () => {
   it('refreshes a gapped plan when remote access exists and builds final options', async () => {
+    let ensured = false;
     let refreshed = false;
-    const ensureCatalogLoaded = vi.fn(async () => undefined);
-    const refreshRemote = vi.fn(async () => {
-      refreshed = true;
-    });
     const custom = preset();
 
-    const options = await loadTeamOptions({
-      customPresetsRaw: [custom],
-      ensureCatalogLoaded,
-      getAgents: (category) => {
-        if (!refreshed) return [];
-        return category === 'workflow'
-          ? [agent('writer', { source: 'builtInWorkflow' })]
-          : [agent('lead', { tools: delegateTools }), agent('member')];
-      },
-      canAccessRemoteCatalog: async () => true,
-      refreshRemote,
-    });
+    const options = await Effect.runPromise(
+      loadTeamOptions({
+        customPresetsRaw: [custom],
+        ensureCatalogLoaded: () =>
+          Effect.sync(() => {
+            ensured = true;
+          }),
+        getAgents: (category) => {
+          if (!refreshed) return [];
+          return category === 'workflow'
+            ? [agent('writer', { source: 'builtInWorkflow' })]
+            : [agent('lead', { tools: delegateTools }), agent('member')];
+        },
+        canAccessRemoteCatalog: async () => true,
+        refreshRemote: () =>
+          Effect.sync(() => {
+            refreshed = true;
+          }),
+      }),
+    );
 
-    expect(ensureCatalogLoaded).toHaveBeenCalledOnce();
-    expect(refreshRemote).toHaveBeenCalledOnce();
+    expect(ensured).toBe(true);
+    expect(refreshed).toBe(true);
     expect(options.find((option) => option.value === custom.id)).toMatchObject({
       disabled: undefined,
       unavailableMembers: [],
@@ -407,17 +413,22 @@ describe('loadTeamOptions', () => {
   });
 
   it('does not refresh gapped plans without remote catalog access', async () => {
-    const refreshRemote = vi.fn(async () => undefined);
+    let refreshed = false;
 
-    await loadTeamOptions({
-      customPresetsRaw: [preset()],
-      ensureCatalogLoaded: async () => undefined,
-      getAgents: () => [],
-      canAccessRemoteCatalog: async () => false,
-      refreshRemote,
-    });
+    await Effect.runPromise(
+      loadTeamOptions({
+        customPresetsRaw: [preset()],
+        ensureCatalogLoaded: () => Effect.void,
+        getAgents: () => [],
+        canAccessRemoteCatalog: async () => false,
+        refreshRemote: () =>
+          Effect.sync(() => {
+            refreshed = true;
+          }),
+      }),
+    );
 
-    expect(refreshRemote).not.toHaveBeenCalled();
+    expect(refreshed).toBe(false);
   });
 
   it('loads the catalog before planning team options', async () => {
@@ -427,15 +438,18 @@ describe('loadTeamOptions', () => {
       return [];
     });
 
-    await loadTeamOptions({
-      customPresetsRaw: [],
-      ensureCatalogLoaded: async () => {
-        loaded = true;
-      },
-      getAgents,
-      canAccessRemoteCatalog: async () => false,
-      refreshRemote: async () => undefined,
-    });
+    await Effect.runPromise(
+      loadTeamOptions({
+        customPresetsRaw: [],
+        ensureCatalogLoaded: () =>
+          Effect.sync(() => {
+            loaded = true;
+          }),
+        getAgents,
+        canAccessRemoteCatalog: async () => false,
+        refreshRemote: () => Effect.void,
+      }),
+    );
 
     expect(getAgents).toHaveBeenCalled();
   });
@@ -453,11 +467,11 @@ describe('resolveTeamLaunch', () => {
     return {
       teamId: 'custom-team',
       customPresetsRaw: [preset()],
-      ensureCatalogLoaded: async () => undefined,
+      ensureCatalogLoaded: () => Effect.void,
       getAgents: (category: string) =>
         category === 'workflow' ? workflowAgents : toolUseAgents,
       canAccessRemoteCatalog: async () => false,
-      refreshRemote: async () => undefined,
+      refreshRemote: () => Effect.void,
       choose: async () => 'cancel' as const,
       signIn: async () => false,
       ...overrides,
@@ -473,7 +487,9 @@ describe('resolveTeamLaunch', () => {
   }
 
   it('returns execution-scoped fields for a ready team', async () => {
-    await expect(resolveTeamLaunch(launchArgs())).resolves.toEqual({
+    await expect(
+      Effect.runPromise(resolveTeamLaunch(launchArgs())),
+    ).resolves.toEqual({
       status: 'ready',
       fields: {
         agent: 'builtInToolUse:lead',
@@ -498,13 +514,16 @@ describe('resolveTeamLaunch', () => {
     });
 
     await expect(
-      resolveTeamLaunch(
-        launchArgs({
-          ensureCatalogLoaded: async () => {
-            loaded = true;
-          },
-          getAgents,
-        }),
+      Effect.runPromise(
+        resolveTeamLaunch(
+          launchArgs({
+            ensureCatalogLoaded: () =>
+              Effect.sync(() => {
+                loaded = true;
+              }),
+            getAgents,
+          }),
+        ),
       ),
     ).resolves.toMatchObject({ status: 'ready' });
     expect(getAgents).toHaveBeenCalled();
@@ -520,11 +539,13 @@ describe('resolveTeamLaunch', () => {
     });
 
     await expect(
-      resolveTeamLaunch(
-        launchArgs({
-          customPresetsRaw: [hostedPreset],
-          choose: async () => 'continue' as const,
-        }),
+      Effect.runPromise(
+        resolveTeamLaunch(
+          launchArgs({
+            customPresetsRaw: [hostedPreset],
+            choose: async () => 'continue' as const,
+          }),
+        ),
       ),
     ).resolves.toMatchObject({
       status: 'ready',
@@ -536,12 +557,14 @@ describe('resolveTeamLaunch', () => {
   it('uses a provided continue choice without invoking the interactive port', async () => {
     const choose = vi.fn(async () => undefined);
     await expect(
-      resolveTeamLaunch(
-        launchArgs({
-          customPresetsRaw: [hostedWriterPreset()],
-          providedChoice: 'continue',
-          choose,
-        }),
+      Effect.runPromise(
+        resolveTeamLaunch(
+          launchArgs({
+            customPresetsRaw: [hostedWriterPreset()],
+            providedChoice: 'continue',
+            choose,
+          }),
+        ),
       ),
     ).resolves.toMatchObject({ status: 'ready', partial: true });
     expect(choose).not.toHaveBeenCalled();
@@ -549,59 +572,72 @@ describe('resolveTeamLaunch', () => {
 
   it('treats an explicit cancel or dismissed choice as cancelled', async () => {
     await expect(
-      resolveTeamLaunch(
-        launchArgs({
-          customPresetsRaw: [hostedWriterPreset()],
-        }),
+      Effect.runPromise(
+        resolveTeamLaunch(
+          launchArgs({
+            customPresetsRaw: [hostedWriterPreset()],
+          }),
+        ),
       ),
     ).resolves.toEqual({ status: 'cancelled' });
     await expect(
-      resolveTeamLaunch(
-        launchArgs({
-          customPresetsRaw: [hostedWriterPreset()],
-          choose: async () => undefined,
-        }),
+      Effect.runPromise(
+        resolveTeamLaunch(
+          launchArgs({
+            customPresetsRaw: [hostedWriterPreset()],
+            choose: async () => undefined,
+          }),
+        ),
       ),
     ).resolves.toEqual({ status: 'cancelled' });
   });
 
   it('reports hosted members still unavailable after remote refresh', async () => {
-    const refreshRemote = vi.fn(async () => undefined);
+    let refreshed = false;
     await expect(
-      resolveTeamLaunch(
-        launchArgs({
-          customPresetsRaw: [hostedWriterPreset()],
-          canAccessRemoteCatalog: async () => true,
-          refreshRemote,
-        }),
+      Effect.runPromise(
+        resolveTeamLaunch(
+          launchArgs({
+            customPresetsRaw: [hostedWriterPreset()],
+            canAccessRemoteCatalog: async () => true,
+            refreshRemote: () =>
+              Effect.sync(() => {
+                refreshed = true;
+              }),
+          }),
+        ),
       ),
     ).resolves.toEqual({
       status: 'unavailable',
       unavailableNames: ['hosted-writer'],
     });
-    expect(refreshRemote).toHaveBeenCalledOnce();
+    expect(refreshed).toBe(true);
   });
 
   it('reports an unknown team without consulting catalog ports', async () => {
     const getAgents = vi.fn(() => []);
     await expect(
-      resolveTeamLaunch(launchArgs({ teamId: 'missing', getAgents })),
+      Effect.runPromise(
+        resolveTeamLaunch(launchArgs({ teamId: 'missing', getAgents })),
+      ),
     ).resolves.toEqual({ status: 'unknown-team' });
     expect(getAgents).not.toHaveBeenCalled();
   });
 
   it('blocks a planned team with no delegation-capable root', async () => {
     await expect(
-      resolveTeamLaunch(
-        launchArgs({
-          customPresetsRaw: [
-            preset({ agents: { workflow: ['writer'], toolUse: ['plain'] } }),
-          ],
-          getAgents: (category: string) =>
-            category === 'workflow'
-              ? [agent('writer', { source: 'builtInWorkflow' })]
-              : [agent('plain')],
-        }),
+      Effect.runPromise(
+        resolveTeamLaunch(
+          launchArgs({
+            customPresetsRaw: [
+              preset({ agents: { workflow: ['writer'], toolUse: ['plain'] } }),
+            ],
+            getAgents: (category: string) =>
+              category === 'workflow'
+                ? [agent('writer', { source: 'builtInWorkflow' })]
+                : [agent('plain')],
+          }),
+        ),
       ),
     ).resolves.toEqual({
       status: 'blocked',
@@ -612,22 +648,25 @@ describe('resolveTeamLaunch', () => {
 
 describe('refreshRemoteCatalogForGaps', () => {
   it('refreshes and returns the replanned value only when gaps and access exist', async () => {
-    const refreshRemote = vi.fn(async () => undefined);
+    let refreshed = false;
     const replan = vi.fn(() => 'remote');
     const canAccessRemoteCatalog = vi.fn(async () => true);
 
-    const result = await refreshRemoteCatalogForGaps(
-      'local',
-      () => true,
-      replan,
-      { canAccessRemoteCatalog, refreshRemote },
+    const result = await Effect.runPromise(
+      refreshRemoteCatalogForGaps('local', () => true, replan, {
+        canAccessRemoteCatalog,
+        refreshRemote: () =>
+          Effect.sync(() => {
+            refreshed = true;
+          }),
+      }),
     );
 
     expect(result).toEqual({
       value: 'remote',
       remoteCatalogRefreshAttempted: true,
     });
-    expect(refreshRemote).toHaveBeenCalledOnce();
+    expect(refreshed).toBe(true);
     expect(replan).toHaveBeenCalledOnce();
   });
 
@@ -648,14 +687,17 @@ describe('refreshRemoteCatalogForGaps', () => {
     'returns the local plan $name without refreshing or replanning',
     async ({ hasGaps, canAccess, accessChecks }) => {
       const canAccessRemoteCatalog = vi.fn(async () => canAccess);
-      const refreshRemote = vi.fn(async () => undefined);
+      let refreshed = false;
       const replan = vi.fn(() => 'remote');
 
-      const result = await refreshRemoteCatalogForGaps(
-        'local',
-        () => hasGaps,
-        replan,
-        { canAccessRemoteCatalog, refreshRemote },
+      const result = await Effect.runPromise(
+        refreshRemoteCatalogForGaps('local', () => hasGaps, replan, {
+          canAccessRemoteCatalog,
+          refreshRemote: () =>
+            Effect.sync(() => {
+              refreshed = true;
+            }),
+        }),
       );
 
       expect(result).toEqual({
@@ -663,7 +705,7 @@ describe('refreshRemoteCatalogForGaps', () => {
         remoteCatalogRefreshAttempted: false,
       });
       expect(canAccessRemoteCatalog).toHaveBeenCalledTimes(accessChecks);
-      expect(refreshRemote).not.toHaveBeenCalled();
+      expect(refreshed).toBe(false);
       expect(replan).not.toHaveBeenCalled();
     },
   );

--- a/src/test-kernel/controllers/MainViewExecutionLaunchController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewExecutionLaunchController.vitest.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
@@ -49,7 +50,9 @@ function teamMessage(teamId = 'physicist'): MainViewExecuteMessage {
 }
 
 function launchTeam(host: ReturnType<typeof createHost>, teamId = 'physicist') {
-  return prepareMainViewExecutionLaunch(teamMessage(teamId), host);
+  return Effect.runPromise(
+    prepareMainViewExecutionLaunch(teamMessage(teamId), host),
+  );
 }
 
 describe('main-view execution launch controller', () => {
@@ -66,7 +69,7 @@ describe('main-view execution launch controller', () => {
     });
 
     await expect(
-      prepareMainViewExecutionLaunch(message, createHost()),
+      Effect.runPromise(prepareMainViewExecutionLaunch(message, createHost())),
     ).resolves.toEqual(request);
     expect(mocks.resolveTeamLaunch).not.toHaveBeenCalled();
   });
@@ -101,7 +104,7 @@ describe('main-view execution launch controller', () => {
     'returns $resolution.status team failures',
     async ({ resolution, expected }) => {
       const host = createHost();
-      mocks.resolveTeamLaunch.mockResolvedValue(resolution);
+      mocks.resolveTeamLaunch.mockReturnValue(Effect.succeed(resolution));
 
       await expect(launchTeam(host)).rejects.toMatchObject({
         _tag: 'Rejected',
@@ -113,7 +116,9 @@ describe('main-view execution launch controller', () => {
 
   it('returns without presenting an error when team launch is cancelled', async () => {
     const host = createHost();
-    mocks.resolveTeamLaunch.mockResolvedValue({ status: 'cancelled' });
+    mocks.resolveTeamLaunch.mockReturnValue(
+      Effect.succeed({ status: 'cancelled' }),
+    );
 
     await expect(launchTeam(host)).rejects.toMatchObject({ _tag: 'Cancelled' });
   });
@@ -129,12 +134,14 @@ describe('main-view execution launch controller', () => {
       cli: { multiAgentPresetId: 'physicist' },
     };
     const request = { agentName: 'team-root' };
-    mocks.resolveTeamLaunch.mockResolvedValue({
-      status: 'ready',
-      fields,
-      partial: true,
-      missingNames: ['writer'],
-    });
+    mocks.resolveTeamLaunch.mockReturnValue(
+      Effect.succeed({
+        status: 'ready',
+        fields,
+        partial: true,
+        missingNames: ['writer'],
+      }),
+    );
     mocks.prepareMainViewTeamExecutionRequest.mockReturnValue({
       valid: true,
       request,
@@ -142,7 +149,7 @@ describe('main-view execution launch controller', () => {
     const message = teamMessage();
 
     await expect(
-      prepareMainViewExecutionLaunch(message, host),
+      Effect.runPromise(prepareMainViewExecutionLaunch(message, host)),
     ).resolves.toEqual(request);
     expect(host.showInfoMessage).toHaveBeenCalledWith('Partial: writer');
     expect(mocks.prepareMainViewTeamExecutionRequest).toHaveBeenCalledWith(
@@ -166,7 +173,9 @@ describe('main-view execution launch controller', () => {
 
   it('surfaces catalog errors as a launch error', async () => {
     const host = createHost();
-    mocks.resolveTeamLaunch.mockRejectedValue(new Error('catalog unavailable'));
+    mocks.resolveTeamLaunch.mockReturnValue(
+      Effect.fail(new Error('catalog unavailable')),
+    );
 
     await expect(launchTeam(host)).rejects.toMatchObject({
       _tag: 'Rejected',

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { Effect, ManagedRuntime } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DefaultDesktopAgentSettingsController } from '@desktop/main/desktopAgentSettingsController';
+import { initProcessRuntime } from '@platform/processRuntime';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { assertSupported, isUnsupported } from '@shared/utils/dispatcher';
@@ -10,6 +12,7 @@ import {
   type AgentCatalog,
 } from '@test/support/agentCatalogFixtures';
 import { FakeStateStore } from '@test/support/FakePlatform';
+import { testHttpClientLayer } from '@test/support/fetchTestUtils';
 
 import { commandOf } from './desktopSettingsTestSupport';
 
@@ -20,10 +23,10 @@ interface ControllerFixtureOptions {
   readonly visibleCatalog?: AgentCatalog;
   readonly loadAgents?: (options?: {
     includeRemote?: boolean;
-  }) => Promise<void>;
+  }) => Effect.Effect<void>;
   readonly refreshAgents?: (options?: {
     includeRemote?: boolean;
-  }) => Promise<void>;
+  }) => Effect.Effect<void>;
   readonly promptText?: () => Promise<string | undefined>;
   readonly confirm?: () => Promise<boolean>;
   readonly chooseTeamAvailability?: () => Promise<
@@ -34,6 +37,10 @@ interface ControllerFixtureOptions {
   readonly getCustomAgentDirectory?: () => Promise<string>;
   readonly selectCustomAgentDirectory?: () => Promise<string | undefined>;
 }
+
+beforeEach(() => {
+  initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
+});
 
 function createControllerFixture(options: ControllerFixtureOptions = {}) {
   const workspaceState = options.workspaceState ?? new FakeStateStore();
@@ -52,18 +59,19 @@ function createControllerFixture(options: ControllerFixtureOptions = {}) {
     workspaceState,
     globalState,
     registry: {
-      loadAgents: options.loadAgents ?? (async () => undefined),
-      refreshAgents: options.refreshAgents ?? (async () => undefined),
-      loadAgentOptionsData: async () => ({
-        workflow: catalog.workflow.map((entry) => ({
-          value: `${entry.source}:${entry.name}`,
-          label: entry.name,
-        })),
-        toolUse: catalog.toolUse.map((entry) => ({
-          value: `${entry.source}:${entry.name}`,
-          label: entry.name,
-        })),
-      }),
+      loadAgents: options.loadAgents ?? (() => Effect.void),
+      refreshAgents: options.refreshAgents ?? (() => Effect.void),
+      loadAgentOptionsData: () =>
+        Effect.succeed({
+          workflow: catalog.workflow.map((entry) => ({
+            value: `${entry.source}:${entry.name}`,
+            label: entry.name,
+          })),
+          toolUse: catalog.toolUse.map((entry) => ({
+            value: `${entry.source}:${entry.name}`,
+            label: entry.name,
+          })),
+        }),
       getAgents: (category) => catalog[category],
       getVisibleAgents: (category) => visibleCatalog[category],
     },
@@ -179,7 +187,7 @@ describe('DefaultDesktopAgentSettingsController', () => {
   });
 
   it('posts startup agent data to the settings renderer', async () => {
-    const loadAgents = vi.fn(async () => undefined);
+    const loadAgents = vi.fn(() => Effect.void);
     const { controller, posted } = createControllerFixture({
       catalog: physicistCatalog(),
       loadAgents,
@@ -297,18 +305,20 @@ describe('DefaultDesktopAgentSettingsController', () => {
     const workspaceState = customTeamState(remoteTeamPreset());
     const catalog: AgentCatalog = { workflow: [], toolUse: [] };
     const order: string[] = [];
-    const refreshAgents = vi.fn(async () => {
-      order.push('refresh');
-      catalog.toolUse = [
-        {
-          source: 'remote',
-          name: 'orchestrator',
-          path: '/remote/orchestrator.yaml',
-          category: 'toolUse',
-          tools: ['delegate_agent'],
-        },
-      ];
-    });
+    const refreshAgents = vi.fn(() =>
+      Effect.sync(() => {
+        order.push('refresh');
+        catalog.toolUse = [
+          {
+            source: 'remote',
+            name: 'orchestrator',
+            path: '/remote/orchestrator.yaml',
+            category: 'toolUse',
+            tools: ['delegate_agent'],
+          },
+        ];
+      }),
+    );
     const update = vi.spyOn(workspaceState, 'update');
     const { controller } = createControllerFixture({
       workspaceState,
@@ -341,7 +351,7 @@ describe('DefaultDesktopAgentSettingsController', () => {
   it('does not write roster state when team preflight is cancelled', async () => {
     const workspaceState = customTeamState(remoteTeamPreset());
     const update = vi.spyOn(workspaceState, 'update');
-    const refreshAgents = vi.fn(async () => undefined);
+    const refreshAgents = vi.fn(() => Effect.void);
     const { controller } = createControllerFixture({
       workspaceState,
       chooseTeamAvailability: async () => 'cancel',

--- a/src/test-kernel/desktop/DesktopSettingsCapabilityMarkers.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSettingsCapabilityMarkers.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
@@ -20,6 +21,7 @@ import {
 import { repoPath } from './desktopTestPaths.ts';
 
 const noOp = async (): Promise<void> => undefined;
+const noOpEffect = (): Effect.Effect<void> => Effect.void;
 
 function statePorts() {
   return {
@@ -33,9 +35,9 @@ function realAgentController(): DefaultDesktopAgentSettingsController {
     onCatalogChanged: async () => {},
     ...statePorts(),
     registry: {
-      loadAgents: noOp,
-      refreshAgents: noOp,
-      loadAgentOptionsData: async () => ({ workflow: [], toolUse: [] }),
+      loadAgents: noOpEffect,
+      refreshAgents: noOpEffect,
+      loadAgentOptionsData: () => Effect.succeed({ workflow: [], toolUse: [] }),
       getAgents: () => [],
       getVisibleAgents: () => [],
     },

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
@@ -218,7 +218,7 @@ describe('desktop Supabase auth', () => {
     vi.spyOn(
       agentRegistry,
       'invalidateRemoteAgentsAfterSignOut',
-    ).mockResolvedValue(undefined);
+    ).mockReturnValue(Effect.void);
   });
   afterEach(() => {
     for (const auth of testAuths.splice(0)) auth.dispose();
@@ -847,7 +847,7 @@ describe('desktop Supabase auth', () => {
   it('still publishes sign-out when the local catalog rebuild fails', async () => {
     vi.mocked(
       agentRegistry.invalidateRemoteAgentsAfterSignOut,
-    ).mockRejectedValueOnce(new Error('local rebuild failed'));
+    ).mockReturnValueOnce(Effect.die(new Error('local rebuild failed')));
     const onSessionChanged = vi.fn(async () => {});
     const log = createLog();
     const { coordinator, auth } = createAuthSetup({ onSessionChanged, log });

--- a/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
+++ b/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
@@ -1,6 +1,11 @@
 import * as path from 'node:path';
 
+import { Effect, ManagedRuntime } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initProcessRuntime } from '@platform/processRuntime';
+import { AgentHandlers } from '@settingsView/handlers/agentHandlers';
+import { testHttpClientLayer } from '@test/support/fetchTestUtils';
 
 const mocks = vi.hoisted(() => ({
   deleteFile: vi.fn(async () => undefined),
@@ -99,8 +104,6 @@ vi.mock('@utils/files/absoluteFS', () => ({
   },
 }));
 
-import { AgentHandlers } from '@settingsView/handlers/agentHandlers';
-
 function createHandlers(): AgentHandlers {
   return new AgentHandlers(
     {
@@ -136,16 +139,20 @@ const APPLY_AGENT_MODE_PRESET = {
 } as const;
 
 describe('AgentHandlers custom-agent file actions', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
+  });
 
   it('logs notification failures after applying a team preset', async () => {
     mocks.showLoggedMessage.mockRejectedValueOnce(
       new Error('notification unavailable'),
     );
     mocks.applySettingsTeamRoster.mockImplementationOnce(
-      async (_presetId, { presentation }) => {
-        await presentation.showErrorMessage('Unable to apply team');
-      },
+      (_presetId, { presentation }) =>
+        Effect.promise(async () => {
+          await presentation.showErrorMessage('Unable to apply team');
+        }),
     );
 
     await createHandlers().handleApplyAgentModePreset(APPLY_AGENT_MODE_PRESET);

--- a/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
+++ b/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resetAgentCatalogAuthRefreshScopeForTests } from '@frontend/auth/agentCatalogRefreshScope';
@@ -33,8 +34,8 @@ vi.mock('vscode', async () => {
 
 const registry = vi.hoisted(() => ({
   catalog: { workflow: [], toolUse: [] } as AgentCatalog,
-  loadAgents: vi.fn(async () => undefined),
-  refreshAgents: vi.fn(async (_options?: { includeRemote?: boolean }) => {}),
+  loadAgents: vi.fn(() => Effect.void),
+  refreshAgents: vi.fn(() => Effect.void),
 }));
 
 vi.mock('@agent/index', async () => ({
@@ -139,7 +140,7 @@ const REMOTE_TEAM_STATE = {
 describe('extension settings AgentHandlers', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    registry.refreshAgents.mockImplementation(async () => {});
+    registry.refreshAgents.mockImplementation(() => Effect.void);
     isAuthenticated.mockResolvedValue(false);
     resetAgentCatalogAuthRefreshScopeForTests();
   });
@@ -199,18 +200,20 @@ describe('extension settings AgentHandlers', () => {
   it('signs in before one forced remote refresh and commits the team once', async () => {
     const workspaceState = new FakeStateStore(REMOTE_TEAM_STATE);
     const order: string[] = [];
-    registry.refreshAgents.mockImplementation(async () => {
-      order.push('refresh');
-      registry.catalog.toolUse = [
-        {
-          source: 'remote',
-          name: 'orchestrator',
-          path: '/remote/orchestrator.yaml',
-          category: 'toolUse',
-          tools: ['delegate_agent'],
-        },
-      ];
-    });
+    registry.refreshAgents.mockImplementation(() =>
+      Effect.sync(() => {
+        order.push('refresh');
+        registry.catalog.toolUse = [
+          {
+            source: 'remote',
+            name: 'orchestrator',
+            path: '/remote/orchestrator.yaml',
+            category: 'toolUse',
+            tools: ['delegate_agent'],
+          },
+        ];
+      }),
+    );
     host.executeCommand.mockImplementation(async () => {
       order.push('sign-in');
       return true;

--- a/src/test-kernel/settings/ExtensionTeamAuthRefreshScope.vitest.ts
+++ b/src/test-kernel/settings/ExtensionTeamAuthRefreshScope.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
@@ -27,53 +28,56 @@ describe('extension team auth catalog refresh scope', () => {
     };
 
     const result = await withAgentCatalogAuthRefreshDeferred(() =>
-      applyTeamRosterWithPreflight('remote-team', {
-        catalog: {
-          resolvePreset: () => ({
-            ok: true,
-            preset,
-            resolution: refreshed
-              ? {
-                  keys: {
-                    workflow: [],
-                    toolUse: ['remote:orchestrator'],
+      Effect.runPromise(
+        applyTeamRosterWithPreflight('remote-team', {
+          catalog: {
+            resolvePreset: () => ({
+              ok: true,
+              preset,
+              resolution: refreshed
+                ? {
+                    keys: {
+                      workflow: [],
+                      toolUse: ['remote:orchestrator'],
+                    },
+                    nameSlots: {
+                      workflow: [],
+                      toolUse: [],
+                    },
+                    unresolvedNames: [],
+                  }
+                : {
+                    keys: {
+                      workflow: [],
+                      toolUse: [],
+                    },
+                    nameSlots: {
+                      workflow: [],
+                      toolUse: ['orchestrator'],
+                    },
+                    unresolvedNames: ['orchestrator'],
                   },
-                  nameSlots: {
-                    workflow: [],
-                    toolUse: [],
-                  },
-                  unresolvedNames: [],
-                }
-              : {
-                  keys: {
-                    workflow: [],
-                    toolUse: [],
-                  },
-                  nameSlots: {
-                    workflow: [],
-                    toolUse: ['orchestrator'],
-                  },
-                  unresolvedNames: ['orchestrator'],
-                },
-          }),
-          commitPreset,
-        },
-        loadLocalCatalog: async () => {},
-        canAccessRemoteCatalog: async () => false,
-        choose: async () => 'sign-in',
-        signIn: async () => {
-          // Models/settings listeners run after the preflight-owned fetch and
-          // then reuse the populated cache instead of forcing another fetch.
-          runAfterAgentCatalogAuthRefresh(async () => {
-            if (!refreshed) remoteFetches += 1;
-          });
-          return true;
-        },
-        forceRefreshRemoteCatalog: async () => {
-          remoteFetches += 1;
-          refreshed = true;
-        },
-      }),
+            }),
+            commitPreset,
+          },
+          loadLocalCatalog: () => Effect.void,
+          canAccessRemoteCatalog: async () => false,
+          choose: async () => 'sign-in',
+          signIn: async () => {
+            // Models/settings listeners run after the preflight-owned fetch and
+            // then reuse the populated cache instead of forcing another fetch.
+            runAfterAgentCatalogAuthRefresh(async () => {
+              if (!refreshed) remoteFetches += 1;
+            });
+            return true;
+          },
+          forceRefreshRemoteCatalog: () =>
+            Effect.sync(() => {
+              remoteFetches += 1;
+              refreshed = true;
+            }),
+        }),
+      ),
     );
 
     expect(result.status).toBe('applied');

--- a/src/test-kernel/settings/TeamRosterApplication.vitest.ts
+++ b/src/test-kernel/settings/TeamRosterApplication.vitest.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { Effect } from 'effect';
 import {
   applyTeamRosterWithPreflight,
   type TeamRosterApplicationDeps,
@@ -55,11 +56,11 @@ function makeDeps(
       commitPreset: vi.fn(),
       ...catalog,
     },
-    loadLocalCatalog: async () => {},
+    loadLocalCatalog: () => Effect.void,
     canAccessRemoteCatalog: async () => false,
     choose: async () => 'cancel',
     signIn: async () => false,
-    forceRefreshRemoteCatalog: async () => {},
+    forceRefreshRemoteCatalog: () => Effect.void,
     ...rest,
   };
 }
@@ -72,33 +73,37 @@ describe('team roster application', () => {
       calls.push('commit');
     });
 
-    const result = await applyTeamRosterWithPreflight(
-      'research',
-      makeDeps({
-        catalog: {
-          resolvePreset: () => ({
-            ok: true,
-            preset,
-            resolution: refreshed ? resolved : unresolved,
-          }),
-          commitPreset,
-        },
-        loadLocalCatalog: async () => {
-          calls.push('local-load');
-        },
-        choose: async () => {
-          calls.push('choose');
-          return 'sign-in';
-        },
-        signIn: async () => {
-          calls.push('sign-in');
-          return true;
-        },
-        forceRefreshRemoteCatalog: async () => {
-          calls.push('forced-refresh');
-          refreshed = true;
-        },
-      }),
+    const result = await Effect.runPromise(
+      applyTeamRosterWithPreflight(
+        'research',
+        makeDeps({
+          catalog: {
+            resolvePreset: () => ({
+              ok: true,
+              preset,
+              resolution: refreshed ? resolved : unresolved,
+            }),
+            commitPreset,
+          },
+          loadLocalCatalog: () =>
+            Effect.sync(() => {
+              calls.push('local-load');
+            }),
+          choose: async () => {
+            calls.push('choose');
+            return 'sign-in';
+          },
+          signIn: async () => {
+            calls.push('sign-in');
+            return true;
+          },
+          forceRefreshRemoteCatalog: () =>
+            Effect.sync(() => {
+              calls.push('forced-refresh');
+              refreshed = true;
+            }),
+        }),
+      ),
     );
 
     expect(result).toEqual({
@@ -119,21 +124,26 @@ describe('team roster application', () => {
 
   it('cancels before refresh or roster writes', async () => {
     const commitPreset = vi.fn();
-    const forceRefreshRemoteCatalog = vi.fn();
+    let forcedRefresh = false;
     const signIn = vi.fn();
 
-    const result = await applyTeamRosterWithPreflight(
-      'research',
-      makeDeps({
-        catalog: { commitPreset },
-        signIn,
-        forceRefreshRemoteCatalog,
-      }),
+    const result = await Effect.runPromise(
+      applyTeamRosterWithPreflight(
+        'research',
+        makeDeps({
+          catalog: { commitPreset },
+          signIn,
+          forceRefreshRemoteCatalog: () =>
+            Effect.sync(() => {
+              forcedRefresh = true;
+            }),
+        }),
+      ),
     );
 
     expect(result).toEqual({ status: 'cancelled', preset });
     expect(signIn).not.toHaveBeenCalled();
-    expect(forceRefreshRemoteCatalog).not.toHaveBeenCalled();
+    expect(forcedRefresh).toBe(false);
     expect(commitPreset).not.toHaveBeenCalled();
   });
 
@@ -153,29 +163,31 @@ describe('team roster application', () => {
     );
     const commitPreset = vi.fn();
 
-    const result = await applyTeamRosterWithPreflight(
-      'legacy',
-      makeDeps({
-        catalog: {
-          resolvePreset: () => ({
-            ok: true,
-            preset: legacyPreset,
-            resolution: {
-              keys: {
-                workflow: [],
-                toolUse: ['builtInToolUse:review'],
+    const result = await Effect.runPromise(
+      applyTeamRosterWithPreflight(
+        'legacy',
+        makeDeps({
+          catalog: {
+            resolvePreset: () => ({
+              ok: true,
+              preset: legacyPreset,
+              resolution: {
+                keys: {
+                  workflow: [],
+                  toolUse: ['builtInToolUse:review'],
+                },
+                nameSlots: {
+                  workflow: [],
+                  toolUse: ['remoteSpecialist'],
+                },
+                unresolvedNames: ['remoteSpecialist'],
               },
-              nameSlots: {
-                workflow: [],
-                toolUse: ['remoteSpecialist'],
-              },
-              unresolvedNames: ['remoteSpecialist'],
-            },
-          }),
-          commitPreset,
-        },
-        choose: async (_preset, names) => choose(names),
-      }),
+            }),
+            commitPreset,
+          },
+          choose: async (_preset, names) => choose(names),
+        }),
+      ),
     );
 
     expect(result.status).toBe('cancelled');
@@ -198,28 +210,30 @@ describe('team roster application', () => {
       async (_names: readonly string[]) => 'cancel' as const,
     );
 
-    await applyTeamRosterWithPreflight(
-      'mixed-legacy',
-      makeDeps({
-        catalog: {
-          resolvePreset: () => ({
-            ok: true,
-            preset: legacyPreset,
-            resolution: {
-              keys: {
-                workflow: [],
-                toolUse: ['builtInToolUse:review'],
+    await Effect.runPromise(
+      applyTeamRosterWithPreflight(
+        'mixed-legacy',
+        makeDeps({
+          catalog: {
+            resolvePreset: () => ({
+              ok: true,
+              preset: legacyPreset,
+              resolution: {
+                keys: {
+                  workflow: [],
+                  toolUse: ['builtInToolUse:review'],
+                },
+                nameSlots: {
+                  workflow: ['generic'],
+                  toolUse: ['remoteSpecialist'],
+                },
+                unresolvedNames: ['generic', 'remoteSpecialist'],
               },
-              nameSlots: {
-                workflow: ['generic'],
-                toolUse: ['remoteSpecialist'],
-              },
-              unresolvedNames: ['generic', 'remoteSpecialist'],
-            },
-          }),
-        },
-        choose: async (_preset, names) => choose(names),
-      }),
+            }),
+          },
+          choose: async (_preset, names) => choose(names),
+        }),
+      ),
     );
 
     expect(choose).toHaveBeenCalledWith(['generic', 'remoteSpecialist']);
@@ -230,29 +244,31 @@ describe('team roster application', () => {
     const calls: string[] = [];
     const getPresetToolUseRoot = vi.fn(() => 'orchestrator');
 
-    await applySettingsTeamRoster('research', {
-      catalog: {
-        resolvePreset: () => ({ ok: true, preset, resolution: resolved }),
-        commitPreset: async () => {
-          calls.push('apply');
+    await Effect.runPromise(
+      applySettingsTeamRoster('research', {
+        catalog: {
+          resolvePreset: () => ({ ok: true, preset, resolution: resolved }),
+          commitPreset: async () => {
+            calls.push('apply');
+          },
+          getPresetToolUseRoot,
         },
-        getPresetToolUseRoot,
-      },
-      loadLocalCatalog: async () => {},
-      canAccessRemoteCatalog: async () => false,
-      signIn: async () => false,
-      forceRefreshRemoteCatalog: async () => {},
-      presentation: {
-        chooseTeamAvailability: async () => 'cancel',
-        showErrorMessage: async () => {},
-        showInfoMessage: async (message) => {
-          calls.push(`info:${message}`);
+        loadLocalCatalog: () => Effect.void,
+        canAccessRemoteCatalog: async () => false,
+        signIn: async () => false,
+        forceRefreshRemoteCatalog: () => Effect.void,
+        presentation: {
+          chooseTeamAvailability: async () => 'cancel',
+          showErrorMessage: async () => {},
+          showInfoMessage: async (message) => {
+            calls.push(`info:${message}`);
+          },
         },
-      },
-      refreshAfterApply: async (selectedToolUseAgent) => {
-        calls.push(`refresh:${selectedToolUseAgent}`);
-      },
-    });
+        refreshAfterApply: async (selectedToolUseAgent) => {
+          calls.push(`refresh:${selectedToolUseAgent}`);
+        },
+      }),
+    );
 
     expect(getPresetToolUseRoot).toHaveBeenCalledWith(
       ['orchestrator'],
@@ -269,28 +285,30 @@ describe('team roster application', () => {
     const prompts: unknown[] = [];
     const errors: string[] = [];
 
-    await applySettingsTeamRoster('research', {
-      catalog: {
-        resolvePreset: () => ({ ok: true, preset, resolution: unresolved }),
-        commitPreset: vi.fn(),
-        getPresetToolUseRoot: vi.fn(),
-      },
-      loadLocalCatalog: async () => {},
-      canAccessRemoteCatalog: async () => false,
-      signIn: async () => true,
-      forceRefreshRemoteCatalog: async () => {},
-      presentation: {
-        chooseTeamAvailability: async (prompt) => {
-          prompts.push(prompt);
-          return 'sign-in';
+    await Effect.runPromise(
+      applySettingsTeamRoster('research', {
+        catalog: {
+          resolvePreset: () => ({ ok: true, preset, resolution: unresolved }),
+          commitPreset: vi.fn(),
+          getPresetToolUseRoot: vi.fn(),
         },
-        showErrorMessage: async (message) => {
-          errors.push(message);
+        loadLocalCatalog: () => Effect.void,
+        canAccessRemoteCatalog: async () => false,
+        signIn: async () => true,
+        forceRefreshRemoteCatalog: () => Effect.void,
+        presentation: {
+          chooseTeamAvailability: async (prompt) => {
+            prompts.push(prompt);
+            return 'sign-in';
+          },
+          showErrorMessage: async (message) => {
+            errors.push(message);
+          },
+          showInfoMessage: async () => {},
         },
-        showInfoMessage: async () => {},
-      },
-      refreshAfterApply: async () => {},
-    });
+        refreshAfterApply: async () => {},
+      }),
+    );
 
     expect(prompts).toEqual([
       {
@@ -315,14 +333,16 @@ describe('team roster application', () => {
     const signIn = vi.fn();
     const commitPreset = vi.fn();
 
-    const result = await applyTeamRosterWithPreflight(
-      'research',
-      makeDeps({
-        catalog: { commitPreset },
-        providedChoice: 'continue',
-        choose,
-        signIn,
-      }),
+    const result = await Effect.runPromise(
+      applyTeamRosterWithPreflight(
+        'research',
+        makeDeps({
+          catalog: { commitPreset },
+          providedChoice: 'continue',
+          choose,
+          signIn,
+        }),
+      ),
     );
 
     expect(result).toEqual({

--- a/src/test-kernel/support/agentCatalogMock.ts
+++ b/src/test-kernel/support/agentCatalogMock.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { vi } from 'vitest';
 
 /**
@@ -25,8 +26,10 @@ const agentCatalogMock = vi.hoisted(() => ({
   getAgentsByCategory: vi.fn(),
   getVisibleAgents: vi.fn(),
   getCustomAgentScanIssues: vi.fn(() => []),
-  loadAgents: vi.fn(),
-  refresh: vi.fn(),
+  // The registry's load functions are Effect programs; the callers under
+  // test run them, so the fakes must return Effects, not promises.
+  loadAgents: vi.fn(() => Effect.void),
+  refresh: vi.fn(() => Effect.void),
   resolveAgentForLaunch: vi.fn(),
 }));
 

--- a/src/test-kernel/tools/setup/ApplyTeamTool.vitest.ts
+++ b/src/test-kernel/tools/setup/ApplyTeamTool.vitest.ts
@@ -2,6 +2,7 @@
 import { resolve } from 'node:path';
 
 // Third-party imports
+import { Effect } from 'effect';
 import {
   afterEach,
   beforeAll,
@@ -86,7 +87,7 @@ beforeAll(async () => {
       },
     },
   );
-  await refresh({ includeRemote: false });
+  await Effect.runPromise(refresh({ includeRemote: false }));
 });
 
 afterEach(() => {

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -28,6 +28,7 @@ import {
 } from '@common/teams/TeamRoster';
 import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
 import { appSignals } from '@eventBus/AppSignals';
+import { effectRuntime } from '@platform/processRuntime';
 import type { ToolResult } from '@shared/schemas';
 import {
   AGENT_MODE_PRESETS,
@@ -112,15 +113,17 @@ ${describeTeams()}`,
       },
     };
 
-    const result = await applyTeamRosterWithPreflight(input.teamId, {
-      catalog,
-      loadLocalCatalog: () => loadAgents({ includeRemote: false }),
-      canAccessRemoteCatalog: async () => authStatus.authenticated,
-      providedChoice: input.unavailableAction ?? undefined,
-      choose: async () => undefined,
-      signIn,
-      forceRefreshRemoteCatalog: () => refresh({ includeRemote: true }),
-    });
+    const result = await effectRuntime().runPromise(
+      applyTeamRosterWithPreflight(input.teamId, {
+        catalog,
+        loadLocalCatalog: () => loadAgents({ includeRemote: false }),
+        canAccessRemoteCatalog: async () => authStatus.authenticated,
+        providedChoice: input.unavailableAction ?? undefined,
+        choose: async () => undefined,
+        signIn,
+        forceRefreshRemoteCatalog: () => refresh({ includeRemote: true }),
+      }),
+    );
 
     if (result.status === 'unknown') {
       // The schema gates ids, so this only fires if the enum and the preset


### PR DESCRIPTION
## Summary

The "agent index/remote raw-catch + p-map cluster" lane of the Effect 4 migration (`.agents/docs/proposed/architecture/2026-08-26-effect-4-runtime-migration.md`, R1/R7, execution rules 1–2). The agent catalog's scanning and loading pipeline is now a genuine Effect program from the YAML glob up to the host run edges:

- **`agentYamlScanner.ts`** — the lane's `import:p-map` row. `pMap(files, read, { concurrency: 8 })` becomes `Effect.forEach(files, …, { concurrency: 8 })` (both preserve result order), and the directory scan composes `glob`/`AbsoluteFS.read` via `tryPromise`. All 3 raw catches become typed recovery over a file-local `AgentScanError`: a per-file failure still becomes an issue entry, a directory-level failure still becomes an empty scan with one issue, and the old blanket outer catch no longer swallows defects — programming errors now stay defects (R7).
- **`remoteAgentList.ts`** — both catches convert: `ky` is wrapped once with `tryPromise`; an `HTTPError` still parses into the `{ data, error }` domain value (the query-error branch is data, not a failure), and every other rejection is a typed `RemoteAgentListError` (new, homed in dependency-free `errorData.ts` so `remoteAgentMeta` can name it without statically importing the listing module — the lazy-import closure that keeps ky/auth out of generic tool modules is preserved). Signed-out, unreachable, and query-rejected listing still projects to an empty list.
- **`remoteAgentMeta.ts`** — `loadRemoteAgents` returns `Effect`; its catch (the lazy-import failure, warn + `[]`) converts in the same pass, since the file now imports `effect`.
- **`agentRegistry.ts`** — the §2.5 "single-flight with generation counter" mechanism (the `inFlight` promise chain + `epoch`) becomes one per-key lane (`withPerKeyLane`, the repo's existing Effect lane primitive) with the epoch advancing only when a refresh actually *starts*, so constructing a refresh without running it is inert. `doLoad`'s two `Promise.all` fan-outs become `Effect.all(…, { concurrency: 'unbounded' })`; directory-resolution failures are typed `AgentCatalogLoadError`; the sign-out invalidation's `.catch` becomes typed recovery with the same remove-then-warn behavior. `loadAgents` / `refresh` / `invalidateRemoteAgentsAfterSignOut` / `computeAgentOptionsData` return Effects.
- **Caller chain converted leaf to root** (execution rule 1): `teamCatalogPorts`, `TeamPlan` (`loadTeamOptions`, `resolveTeamLaunch`, `refreshRemoteCatalogForGaps` — the original `&&` short-circuit that skips the access probe on gapless plans is preserved), `TeamAvailabilityPreflight` (the `refresh` thunk splits into a `refreshRemote` program plus a synchronous `replan`, so no supplier needs a Promise→Effect union port), `TeamRosterApplication`, `SettingsTeamRosterController`, `MainViewExecutionLaunchController` (its `.catch` becomes a typed `Rejected` on the error channel), and `hostSnapshotSource` (its producers and the `Promise.allSettled` guarded fan-out become an `Effect.exit` fold; failures still report per-producer and publish the rest). Catalog ports are **lazy thunks returning Effects** — constructing a port never touches the registry or bumps the epoch.
- **Run edges land only at R1's boundaries**, all via the host-installed `effectRuntime()`: extension (`extension.ts`, `setupAssistantCommand`, `agentHandlers`, `register`, `SupabaseAuthProvider`, `ProgressViewProvider`, `extensionHostRequests`), desktop (`index`, `desktopAgentSettingsController`, `desktopSupabaseAuth`, `desktopHostRequests`), CLI (`config`, `init`, `orchestrate`, `agentRoster`, `agents`, `multiAgentRunPlan`, `AgentListForm`, `AgentRosterForm`, `runChatTui`, `supabaseAuth`, plus the `tui-harness` script), the `apply_team` tool's `execute()` (boundary kind b), and `packages/agent/src/effect/sessions.ts` (boundary kind c — its `tryPromise` wrap of `loadAgents` deletes).

`RemoteAgentLoader.ts` and `bundledPrompts.ts` are **deliberately untouched**: `loadRemoteAgent`'s only consumer is the lane-D launch path (`agentLoad` → `AgentLaunchContext`, Promise PocketFlow), and `bundledPrompts`' consumers are `ToolUseWaitNode` (same lane-D node family) and the polish path. Their baseline catch counts (1 each) stay.

## Issue acceptance gates

No issue; the governing document is the migration PRD. Lane targets:

- `import:p-map` — `src/agent/index/agentYamlScanner.ts`: **converted**, row entry removed.
- `catch:effect-importer` — `agentYamlScanner.ts` (3 sites): **converted**, row entry removed.
- `catch:effect-importer` — `src/agent/remote/remoteAgentList.ts` (2 sites): **converted**, row entry removed.
- `catch:effect-importer` — `src/agent/remote/RemoteAgentLoader.ts` (1), `src/agent/runtime/bundledPrompts.ts` (1): **kept** (blocked on lane D, see above); counts unchanged.
- One pass per file: every file that gained a runtime `effect` import had all its raw catches converted in this PR (`remoteAgentMeta`, `agentRegistry`, `MainViewExecutionLaunchController`, `hostSnapshotSource` included).
- No new `Effect.run*` below the boundary: the `Effect.run*` row is unchanged (8 files / 23 sites); `debtLanes` untouched.

## Single source of truth

- The catalog load has one serialization point: the per-key lane in `agentRegistry.ts` (replacing the `inFlight` chain), with `epoch` as the one supersession fact.
- `AgentScanError` (file-local) and `RemoteAgentListError` / `AgentCatalogLoadError` are the typed failure vocabularies; recovery lives at the same projection boundaries that owned it before (scan → issue list; listing → empty list; sign-out → remove + warn).
- `config/ratchets/effect-migration-baseline.json` records the shrinkage (`--update`, committed here).

## Duplication and abstraction budget

Removed: the `inFlight` promise chain and its `.catch(() => undefined)`/`.finally` bookkeeping (the lane's `ensuring` owns both), the scan's three hand-rolled catches, the listing's two, `packages/agent`'s `tryPromise` wrap, and the preflight `refresh` thunk (now `refreshRemote` + `replan`). Added: two error classes (one per domain, no shared error module), a per-file `hostPort` identity-catch helper in three files (2 lines each, matching the established `@controllers/effectPort` shape — a shared home is not yet warranted at three sites), and one new export (`planCurrentMultiAgentRun`, consumed by `orchestrate.ts` in this PR).

## Net elements (R6)

- Files: 61 changed (`git diff --shortstat origin/main`: +1633/−1182) — 36 production (13 under `src/`, 23 host/package run edges), 23 test suites, 1 test support mock, 1 ratchet baseline.
- Exported symbols (`^[+-]export` over the diff): 2 added (`AgentCatalogLoadError` — the registry's public error channel; `planCurrentMultiAgentRun` — consumed by `orchestrate.ts`), 0 deleted; 15 signature changes Promise → Effect on existing exports (31 `^[+-]export` lines in total).
- Classes/interfaces/enums: +2 error classes (`AgentCatalogLoadError`, `RemoteAgentListError`).
- Net LoC: +451, dominated by the caller-chain conversion (leaf-to-root rule) and test-suite adaptation; the four lane-target files themselves shrink.
- Dependencies: none added; `p-map` remains in `package.json` for the 8 importers other lanes own.

## Consumer counts (R8)

Grepped production consumers of each re-signed export (all adapted in this PR):

- `scanDirectory`: 1 (`agentRegistry.doLoad`).
- `listRemoteAgents`: 1 (`remoteAgentMeta.loadRemoteAgents`, via the preserved lazy import).
- `loadRemoteAgents`: 1 (`agentRegistry.doLoad`).
- `loadAgents`: 12 — `teamCatalogPorts`, `packages/agent` sessions, extension (`extension.ts`, `setupAssistantCommand`, `agentHandlers` ×2), desktop (`index` kickoff, `desktopAgentSettingsController` via registry), CLI (`config`, `init`, `agentRoster`, `multiAgentRunPlan` ×2, `agents` ×3), `ApplyTeamTool` deps.
- `refresh`: 9 — `teamCatalogPorts`, `ApplyTeamTool`, `agentHandlers`, `desktopAgentSettingsController`, `multiAgentRunPlan`, `orchestrate`, `ProgressViewProvider` ×2, extension `register.ts`.
- `invalidateRemoteAgentsAfterSignOut`: 3 auth hosts (extension `SupabaseAuthProvider`, desktop `desktopSupabaseAuth`, CLI `supabaseAuth`) — the `() => Promise<void>` parameter of `refreshRemoteAgentCatalogAfterSignOut` is unchanged; hosts wrap at the boundary.
- `computeAgentOptionsData`: 3 (`hostSnapshotSource`, desktop `index` registry, CLI `AgentListForm`).
- `loadTeamOptions`: 1 (`hostSnapshotSource`). `resolveTeamLaunch`: 1 (`MainViewExecutionLaunchController`). `preflightTeamAvailability`: 3 (`TeamPlan`, `TeamRosterApplication`, `orchestrate`). `applyTeamRosterWithPreflight`: 2 (`ApplyTeamTool`, `SettingsTeamRosterController`). `applySettingsTeamRoster`: 2 (`agentHandlers`, `desktopAgentSettingsController`). `prepareSurfaceLaunch`/`prepareMainViewExecutionLaunch`: 3 (`extensionHostRequests`, `desktopHostRequests`, desktop `index`).
- `HostSnapshotSource`: 3 (extension `ProgressViewProvider`, desktop `index`, desktop `desktopHostRequests`).
- `AgentSelectionPorts.loadAgents` (`src/shared/settingsView`): unchanged `() => Promise<void>` — both suppliers are boundary files that wrap once.

## Host impact

Extension: run edges only (`effectRuntime().runPromise` at the existing call sites); behavior and messages unchanged. `ProgressViewProvider.ts` has a small textual overlap with open PR #12005 — whichever lands second reapplies the one-line run-edge wrap (`effectRuntime().runPromise(this.snapshot.refresh*)`) around the moved call sites.
Desktop: same shape; `packages/desktop/src/main/index.ts` also overlaps #12005 slightly — same resolution (reapply the wrap).
CLI: run edges only; `orchestrate`'s preflight supplies `refreshRemote` + `replan` in place of the old `refresh` thunk (identical refresh-then-replan semantics). `packages/cli/src/runtime/supabaseAuth.ts` overlaps open PR #12021 (CLI auth/runtime catch cluster) by one line — whichever lands second keeps both changes (their Effect restructure plus this PR's `() => effectRuntime().runPromise(invalidateRemoteAgentsAfterSignOut())` wrap).

## Scheduled refactoring

- Convert `src/agent/remote/RemoteAgentLoader.ts` (1 catch) once lane D converts the launch path (`AgentLaunchContext`); convert `src/agent/runtime/bundledPrompts.ts` (1 catch) with it (`ToolUseWaitNode` / the polish consumer in `hostDraftRequests`, which is already Effect-native and will collapse to a plain `yield*`).
- `agentRegistry.ts`'s `platform()` rows stay with lane D (platform-port retirement).
- The three per-file `hostPort` identity-catch copies collapse into one shared helper when a fourth site appears.

## Validation

All run in the worktree on the rebased branch head (base `e7515dd68b`; rebased after #12013/#12015 landed, clean):

- `npx prettier --write` on all 55 initially changed files; `--check` clean on the final set (one test file reformatted after eslint --fix).
- `npm run typecheck:workspace`, `typecheck:test-kernel`, `typecheck:cli`, `typecheck:desktop`, `typecheck:agent` — all clean.
- `npx eslint` on every changed file — zero errors (import/order auto-fixed; final run clean).
- Targeted vitest: `AgentYamlScanner`, `AgentRegistry`, `RemoteAgentLoader`, `agentLoad`, `AgentCategoryResolution`, `AgentPackage`, `TeamPlan`, `TeamAvailabilityPreflight`, `TeamRosterApplication`, `ExtensionTeamAuthRefreshScope`, `ExtensionAgentHandlers`, `AgentHandlersDelete`, `MainViewExecutionLaunchController`, `ApplyTeamTool`, `commands/setup`, plus the settings/CLI/auth/desktop suites touching the converted callers and `src/test-kernel/progressView/` — 79 files / 561 tests, all pass; post-rebase re-run of the core set: 18 files / 207 tests, all pass. The `TeamPlan` suite caught (and now pins) the preserved `hasGaps`-before-access-probe short-circuit; the `agentLoad` suite pins the single-scan join and the typed `AgentCatalogLoadError` rejection.
- `node scripts/check-effect-migration-ratchet.mjs --update`, then without `--update` — OK: `import:p-map` loses `agentYamlScanner.ts`; `catch:effect-importer` loses `agentYamlScanner.ts` (3) and `remoteAgentList.ts` (2); no count grew; no `@adapter-until` markers.
- `npm run check:dead-code-ratchet` — OK, no new findings.
- Full `npm test -- --maxWorkers=4` — 763 files passed / 1 skipped, 9099 tests passed / 5 skipped, exit 0 (run on the rebased head; neither known parallel-load flake appeared). Two earlier full runs isolated two deterministic suite mocks that needed Effect returns (`AgentPackage`, `SetupAssistantRouting`) — fixed and re-verified.
