### PR TITLE
chore(supabase): refresh edge function dependency pins

### DIFF
--- a/supabase/functions/auth-device/deno.json
+++ b/supabase/functions/auth-device/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@4.12.33",
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.111.0"
+    "@hono/hono": "jsr:@hono/hono@4.13.7",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.115.0"
   }
 }

--- a/supabase/functions/auth-device/deno.lock
+++ b/supabase/functions/auth-device/deno.lock
@@ -1,20 +1,20 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4.12.33": "4.12.33",
-    "jsr:@supabase/supabase-js@2.111.0": "2.111.0",
-    "npm:@supabase/auth-js@2.111.0": "2.111.0",
-    "npm:@supabase/functions-js@2.111.0": "2.111.0",
-    "npm:@supabase/postgrest-js@2.111.0": "2.111.0",
-    "npm:@supabase/realtime-js@2.111.0": "2.111.0",
-    "npm:@supabase/storage-js@2.111.0": "2.111.0"
+    "jsr:@hono/hono@4.13.7": "4.13.7",
+    "jsr:@supabase/supabase-js@2.115.0": "2.115.0",
+    "npm:@supabase/auth-js@2.115.0": "2.115.0",
+    "npm:@supabase/functions-js@2.115.0": "2.115.0",
+    "npm:@supabase/postgrest-js@2.115.0": "2.115.0",
+    "npm:@supabase/realtime-js@2.115.0": "2.115.0",
+    "npm:@supabase/storage-js@2.115.0": "2.115.0"
   },
   "jsr": {
-    "@hono/hono@4.12.33": {
-      "integrity": "0df9fd54840e64fd3c10455aed240ed1dbc8b2773b6d9b825e3a681378d1ba77"
+    "@hono/hono@4.13.7": {
+      "integrity": "90f83307462b2dd47c9a8028cf5e4827abedc74a53fd291a49130f1579fdcd79"
     },
-    "@supabase/supabase-js@2.111.0": {
-      "integrity": "92cd1d4c2933f6a62099f7d3b2b91908b70a9d110ee6098e1b2d3db2e6b7ef1b",
+    "@supabase/supabase-js@2.115.0": {
+      "integrity": "476e46c71a1be5754fd21c510cfeb49bde5adbcb1174cfcc1212a4002c30d4b6",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -25,14 +25,14 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.111.0": {
-      "integrity": "sha512-hbRLgyQZEX0SDyF4LYXpv94qOIQyFATfpT5SIs2V0SisHnisVRkYgiPQWzv80l4S2mO3qof78rmoH9j5zoFsYQ==",
+    "@supabase/auth-js@2.115.0": {
+      "integrity": "sha512-YNQlQWm1H0gsXHSY8Jd/xepBhjO0Zhwx04iW17A83/joQ5kFiUin6iPj9s9kZZvupnwLjXVP/diTFiLz2jUbwQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.111.0": {
-      "integrity": "sha512-RW/OCsd6MO592zU8ifzP8/f8XzxxIdpb+Up5XaOtE26Fw+3zTp475WX7+GuuktiD1WF8pFUDe6khUPbMp77RCw==",
+    "@supabase/functions-js@2.115.0": {
+      "integrity": "sha512-p97V6/YFcdp+zblFDVJaE8f9rGKTNz0PRzyJ2d1w/EYIU5lwidKuc3l/wM+u27ACmAC62albvoGiUGzLPSg7Aw==",
       "dependencies": [
         "tslib"
       ]
@@ -40,21 +40,21 @@
     "@supabase/phoenix@0.4.5": {
       "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="
     },
-    "@supabase/postgrest-js@2.111.0": {
-      "integrity": "sha512-pcqeDsnWP0lx9GawduYxNZJHeuTm53O7L0SC8RF8tniV3GWIPY6me6OTdnwzdwNUmNy1dzUVtSyIfE6+OflzPQ==",
+    "@supabase/postgrest-js@2.115.0": {
+      "integrity": "sha512-DdERcurLh5t84pgSywDg2LjLR5le7XAzl52/iQhC7FdboWDqGfDPMfaWJV3MHvhyxSlSNzbpSQG+RiQOBSn/4w==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.111.0": {
-      "integrity": "sha512-6oRf/vZyRwg8f8GbFSJkrD2w4HAu/yTvyMViHXHS+H5hNJzdXCrUR7cP5oW7daT3YlRnzRPY9LcGSJKZAmfMSg==",
+    "@supabase/realtime-js@2.115.0": {
+      "integrity": "sha512-5HyBkvlA/IUV2v8jX3uLTdy15jmTPRVXwXKoxvH2SKw5jZMNURxCxt+VpCEukscXQlY7pUpH8Cy4NH6io4iaRw==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.111.0": {
-      "integrity": "sha512-UEViNmTzVOxE8dqUA81wls+n9xgmlvSFfhfwo6QxrO4kQOytCYyw3ciYFoi4XoD4Jl95NJ3jnndHN5iIudWzqw==",
+    "@supabase/storage-js@2.115.0": {
+      "integrity": "sha512-dLyIxzbO+MCcKHhcce8rVUCQX1iyqXqQ8ytgkOVYJ7D+Zp0qKylPtQH3hamgxrGSxtDjaw47Urpzw2iK9PsKdA==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -69,8 +69,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@4.12.33",
-      "jsr:@supabase/supabase-js@2.111.0"
+      "jsr:@hono/hono@4.13.7",
+      "jsr:@supabase/supabase-js@2.115.0"
     ]
   }
 }

--- a/supabase/functions/auth-github/deno.json
+++ b/supabase/functions/auth-github/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@4.12.33",
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.111.0"
+    "@hono/hono": "jsr:@hono/hono@4.13.7",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.115.0"
   }
 }

--- a/supabase/functions/auth-github/deno.lock
+++ b/supabase/functions/auth-github/deno.lock
@@ -1,20 +1,20 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4.12.33": "4.12.33",
-    "jsr:@supabase/supabase-js@2.111.0": "2.111.0",
-    "npm:@supabase/auth-js@2.111.0": "2.111.0",
-    "npm:@supabase/functions-js@2.111.0": "2.111.0",
-    "npm:@supabase/postgrest-js@2.111.0": "2.111.0",
-    "npm:@supabase/realtime-js@2.111.0": "2.111.0",
-    "npm:@supabase/storage-js@2.111.0": "2.111.0"
+    "jsr:@hono/hono@4.13.7": "4.13.7",
+    "jsr:@supabase/supabase-js@2.115.0": "2.115.0",
+    "npm:@supabase/auth-js@2.115.0": "2.115.0",
+    "npm:@supabase/functions-js@2.115.0": "2.115.0",
+    "npm:@supabase/postgrest-js@2.115.0": "2.115.0",
+    "npm:@supabase/realtime-js@2.115.0": "2.115.0",
+    "npm:@supabase/storage-js@2.115.0": "2.115.0"
   },
   "jsr": {
-    "@hono/hono@4.12.33": {
-      "integrity": "0df9fd54840e64fd3c10455aed240ed1dbc8b2773b6d9b825e3a681378d1ba77"
+    "@hono/hono@4.13.7": {
+      "integrity": "90f83307462b2dd47c9a8028cf5e4827abedc74a53fd291a49130f1579fdcd79"
     },
-    "@supabase/supabase-js@2.111.0": {
-      "integrity": "92cd1d4c2933f6a62099f7d3b2b91908b70a9d110ee6098e1b2d3db2e6b7ef1b",
+    "@supabase/supabase-js@2.115.0": {
+      "integrity": "476e46c71a1be5754fd21c510cfeb49bde5adbcb1174cfcc1212a4002c30d4b6",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -25,14 +25,14 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.111.0": {
-      "integrity": "sha512-hbRLgyQZEX0SDyF4LYXpv94qOIQyFATfpT5SIs2V0SisHnisVRkYgiPQWzv80l4S2mO3qof78rmoH9j5zoFsYQ==",
+    "@supabase/auth-js@2.115.0": {
+      "integrity": "sha512-YNQlQWm1H0gsXHSY8Jd/xepBhjO0Zhwx04iW17A83/joQ5kFiUin6iPj9s9kZZvupnwLjXVP/diTFiLz2jUbwQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.111.0": {
-      "integrity": "sha512-RW/OCsd6MO592zU8ifzP8/f8XzxxIdpb+Up5XaOtE26Fw+3zTp475WX7+GuuktiD1WF8pFUDe6khUPbMp77RCw==",
+    "@supabase/functions-js@2.115.0": {
+      "integrity": "sha512-p97V6/YFcdp+zblFDVJaE8f9rGKTNz0PRzyJ2d1w/EYIU5lwidKuc3l/wM+u27ACmAC62albvoGiUGzLPSg7Aw==",
       "dependencies": [
         "tslib"
       ]
@@ -40,21 +40,21 @@
     "@supabase/phoenix@0.4.5": {
       "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="
     },
-    "@supabase/postgrest-js@2.111.0": {
-      "integrity": "sha512-pcqeDsnWP0lx9GawduYxNZJHeuTm53O7L0SC8RF8tniV3GWIPY6me6OTdnwzdwNUmNy1dzUVtSyIfE6+OflzPQ==",
+    "@supabase/postgrest-js@2.115.0": {
+      "integrity": "sha512-DdERcurLh5t84pgSywDg2LjLR5le7XAzl52/iQhC7FdboWDqGfDPMfaWJV3MHvhyxSlSNzbpSQG+RiQOBSn/4w==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.111.0": {
-      "integrity": "sha512-6oRf/vZyRwg8f8GbFSJkrD2w4HAu/yTvyMViHXHS+H5hNJzdXCrUR7cP5oW7daT3YlRnzRPY9LcGSJKZAmfMSg==",
+    "@supabase/realtime-js@2.115.0": {
+      "integrity": "sha512-5HyBkvlA/IUV2v8jX3uLTdy15jmTPRVXwXKoxvH2SKw5jZMNURxCxt+VpCEukscXQlY7pUpH8Cy4NH6io4iaRw==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.111.0": {
-      "integrity": "sha512-UEViNmTzVOxE8dqUA81wls+n9xgmlvSFfhfwo6QxrO4kQOytCYyw3ciYFoi4XoD4Jl95NJ3jnndHN5iIudWzqw==",
+    "@supabase/storage-js@2.115.0": {
+      "integrity": "sha512-dLyIxzbO+MCcKHhcce8rVUCQX1iyqXqQ8ytgkOVYJ7D+Zp0qKylPtQH3hamgxrGSxtDjaw47Urpzw2iK9PsKdA==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -69,8 +69,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@4.12.33",
-      "jsr:@supabase/supabase-js@2.111.0"
+      "jsr:@hono/hono@4.13.7",
+      "jsr:@supabase/supabase-js@2.115.0"
     ]
   }
 }

--- a/supabase/functions/before-user-created/deno.json
+++ b/supabase/functions/before-user-created/deno.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "standardwebhooks": "npm:standardwebhooks@1.0.0"
+    "standardwebhooks": "npm:standardwebhooks@1.1.1"
   }
 }

--- a/supabase/functions/before-user-created/deno.lock
+++ b/supabase/functions/before-user-created/deno.lock
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:standardwebhooks@1.0.0": "1.0.0"
+    "npm:standardwebhooks@1.1.1": "1.1.1"
   },
   "npm": {
     "@stablelib/base64@1.0.1": {
@@ -10,8 +10,8 @@
     "fast-sha256@1.3.0": {
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
     },
-    "standardwebhooks@1.0.0": {
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+    "standardwebhooks@1.1.1": {
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
       "dependencies": [
         "@stablelib/base64",
         "fast-sha256"
@@ -20,7 +20,7 @@
   },
   "workspace": {
     "dependencies": [
-      "npm:standardwebhooks@1.0.0"
+      "npm:standardwebhooks@1.1.1"
     ]
   }
 }

--- a/supabase/functions/get-agent-config/deno.json
+++ b/supabase/functions/get-agent-config/deno.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.111.0"
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.115.0"
   }
 }

--- a/supabase/functions/get-agent-config/deno.lock
+++ b/supabase/functions/get-agent-config/deno.lock
@@ -1,16 +1,16 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@supabase/supabase-js@2.111.0": "2.111.0",
-    "npm:@supabase/auth-js@2.111.0": "2.111.0",
-    "npm:@supabase/functions-js@2.111.0": "2.111.0",
-    "npm:@supabase/postgrest-js@2.111.0": "2.111.0",
-    "npm:@supabase/realtime-js@2.111.0": "2.111.0",
-    "npm:@supabase/storage-js@2.111.0": "2.111.0"
+    "jsr:@supabase/supabase-js@2.115.0": "2.115.0",
+    "npm:@supabase/auth-js@2.115.0": "2.115.0",
+    "npm:@supabase/functions-js@2.115.0": "2.115.0",
+    "npm:@supabase/postgrest-js@2.115.0": "2.115.0",
+    "npm:@supabase/realtime-js@2.115.0": "2.115.0",
+    "npm:@supabase/storage-js@2.115.0": "2.115.0"
   },
   "jsr": {
-    "@supabase/supabase-js@2.111.0": {
-      "integrity": "92cd1d4c2933f6a62099f7d3b2b91908b70a9d110ee6098e1b2d3db2e6b7ef1b",
+    "@supabase/supabase-js@2.115.0": {
+      "integrity": "476e46c71a1be5754fd21c510cfeb49bde5adbcb1174cfcc1212a4002c30d4b6",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -21,14 +21,14 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.111.0": {
-      "integrity": "sha512-hbRLgyQZEX0SDyF4LYXpv94qOIQyFATfpT5SIs2V0SisHnisVRkYgiPQWzv80l4S2mO3qof78rmoH9j5zoFsYQ==",
+    "@supabase/auth-js@2.115.0": {
+      "integrity": "sha512-YNQlQWm1H0gsXHSY8Jd/xepBhjO0Zhwx04iW17A83/joQ5kFiUin6iPj9s9kZZvupnwLjXVP/diTFiLz2jUbwQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.111.0": {
-      "integrity": "sha512-RW/OCsd6MO592zU8ifzP8/f8XzxxIdpb+Up5XaOtE26Fw+3zTp475WX7+GuuktiD1WF8pFUDe6khUPbMp77RCw==",
+    "@supabase/functions-js@2.115.0": {
+      "integrity": "sha512-p97V6/YFcdp+zblFDVJaE8f9rGKTNz0PRzyJ2d1w/EYIU5lwidKuc3l/wM+u27ACmAC62albvoGiUGzLPSg7Aw==",
       "dependencies": [
         "tslib"
       ]
@@ -36,21 +36,21 @@
     "@supabase/phoenix@0.4.5": {
       "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="
     },
-    "@supabase/postgrest-js@2.111.0": {
-      "integrity": "sha512-pcqeDsnWP0lx9GawduYxNZJHeuTm53O7L0SC8RF8tniV3GWIPY6me6OTdnwzdwNUmNy1dzUVtSyIfE6+OflzPQ==",
+    "@supabase/postgrest-js@2.115.0": {
+      "integrity": "sha512-DdERcurLh5t84pgSywDg2LjLR5le7XAzl52/iQhC7FdboWDqGfDPMfaWJV3MHvhyxSlSNzbpSQG+RiQOBSn/4w==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.111.0": {
-      "integrity": "sha512-6oRf/vZyRwg8f8GbFSJkrD2w4HAu/yTvyMViHXHS+H5hNJzdXCrUR7cP5oW7daT3YlRnzRPY9LcGSJKZAmfMSg==",
+    "@supabase/realtime-js@2.115.0": {
+      "integrity": "sha512-5HyBkvlA/IUV2v8jX3uLTdy15jmTPRVXwXKoxvH2SKw5jZMNURxCxt+VpCEukscXQlY7pUpH8Cy4NH6io4iaRw==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.111.0": {
-      "integrity": "sha512-UEViNmTzVOxE8dqUA81wls+n9xgmlvSFfhfwo6QxrO4kQOytCYyw3ciYFoi4XoD4Jl95NJ3jnndHN5iIudWzqw==",
+    "@supabase/storage-js@2.115.0": {
+      "integrity": "sha512-dLyIxzbO+MCcKHhcce8rVUCQX1iyqXqQ8ytgkOVYJ7D+Zp0qKylPtQH3hamgxrGSxtDjaw47Urpzw2iK9PsKdA==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -65,7 +65,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@supabase/supabase-js@2.111.0"
+      "jsr:@supabase/supabase-js@2.115.0"
     ]
   }
 }

--- a/supabase/functions/github-app-token-exchange/deno.json
+++ b/supabase/functions/github-app-token-exchange/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@octokit/auth-app": "npm:@octokit/auth-app@8.3.0",
-    "jose": "npm:jose@6.2.8"
+    "@octokit/auth-app": "npm:@octokit/auth-app@8.3.1",
+    "jose": "npm:jose@6.2.12"
   }
 }

--- a/supabase/functions/github-app-token-exchange/deno.lock
+++ b/supabase/functions/github-app-token-exchange/deno.lock
@@ -1,12 +1,12 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@octokit/auth-app@8.3.0": "8.3.0",
-    "npm:jose@6.2.8": "6.2.8"
+    "npm:@octokit/auth-app@8.3.1": "8.3.1",
+    "npm:jose@6.2.12": "6.2.12"
   },
   "npm": {
-    "@octokit/auth-app@8.3.0": {
-      "integrity": "sha512-/UaKmJCsOc5XBZwhnFiGNdLH/FkDF8lYtBn1QlKxtX7IpgaRB/XOXjixFtERAknyUZHxp3oDuoiG0En4VptJSg==",
+    "@octokit/auth-app@8.3.1": {
+      "integrity": "sha512-XHWxZsF4mvGTQCv7AOxgby9t9OjVO19FBuKq+QmyBxFrf+B2hR/P5j/MTF8g95bITf8cRtR17KIXThpFNqiKbg==",
       "dependencies": [
         "@octokit/auth-oauth-app",
         "@octokit/auth-oauth-user",
@@ -18,8 +18,8 @@
         "universal-user-agent"
       ]
     },
-    "@octokit/auth-oauth-app@9.0.4": {
-      "integrity": "sha512-Pe3du5LrC6dlv10b0RbarBlJtIT1Urq8BFoQklK8WmBw8YKnGgrANn7cQmHiA1v8AVihgi7YutV8MncP57I4og==",
+    "@octokit/auth-oauth-app@9.0.5": {
+      "integrity": "sha512-Hn2yAlIDjFLGjAz7t+CRu7e9VYoFW1W3LLyOLyahFoJGlCf4PtDkHKtRET8w/2CJpsrC0FxIF5g5Xtx9E4O78w==",
       "dependencies": [
         "@octokit/auth-oauth-device",
         "@octokit/auth-oauth-user",
@@ -28,8 +28,8 @@
         "universal-user-agent"
       ]
     },
-    "@octokit/auth-oauth-device@8.0.4": {
-      "integrity": "sha512-M/+34rmkxMvUnnTo/uqNeVRCXJoJ+5N34eNTbL1KMtIyJpedCTsu/iFL1cWdL+w5hQMlYt6xzXoyux2gn0OVnw==",
+    "@octokit/auth-oauth-device@8.0.5": {
+      "integrity": "sha512-kdJtjRhykMLJrMdcoC56XUBDfoUAuWEFKpkDxwYim+bNwYw1MreLolk+PLnwEYT8djm589YepeMuJ8+ECAIzVQ==",
       "dependencies": [
         "@octokit/oauth-methods",
         "@octokit/request",
@@ -37,8 +37,8 @@
         "universal-user-agent"
       ]
     },
-    "@octokit/auth-oauth-user@6.0.3": {
-      "integrity": "sha512-t4OKUhrI5britmpRiSzPAz1TJPyUN/Hw1HEE3Hz/uElxcmnf/YCRSKtFRNc5gy4yJFTlXgk34H1lvxiotQJQvQ==",
+    "@octokit/auth-oauth-user@6.0.4": {
+      "integrity": "sha512-eya2pMJ9pCBq1jrm1Rf6J3NI+NemEpzDMLo9J/GpRoK0KgdxIVXWX4LESIfwJ+GYeoq6QFIlUJNi1lVp5FBgmw==",
       "dependencies": [
         "@octokit/auth-oauth-device",
         "@octokit/oauth-methods",
@@ -47,8 +47,8 @@
         "universal-user-agent"
       ]
     },
-    "@octokit/endpoint@11.0.4": {
-      "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+    "@octokit/endpoint@11.0.5": {
+      "integrity": "sha512-iXa654H3yFafF/ieHkukfbgWo2rmXD2ceD0ZOtrPhw1bc3FDch1d9N/TNs0FQ1/cIbwb7kspUX8jzIs8nzb9DQ==",
       "dependencies": [
         "@octokit/types",
         "universal-user-agent"
@@ -57,8 +57,8 @@
     "@octokit/oauth-authorization-url@8.0.0": {
       "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ=="
     },
-    "@octokit/oauth-methods@6.0.3": {
-      "integrity": "sha512-t7MBs34Ja16BBZlOSAFslFh4wBMuofD83wVLG9zIuuEGMv/U12XAJ8ESOifgEcC1ptjhNA3sorLA9BCtVfgPuw==",
+    "@octokit/oauth-methods@6.0.5": {
+      "integrity": "sha512-/mAz7taDZD7DcV4zcG6TDw3Kr6TOldmYBRpvA62C3WIxRMmcgX8XxsTvVQomqKE7VEk/BgYhUao1aR2tYGyIKg==",
       "dependencies": [
         "@octokit/oauth-authorization-url",
         "@octokit/request",
@@ -66,17 +66,17 @@
         "@octokit/types"
       ]
     },
-    "@octokit/openapi-types@28.0.0": {
-      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ=="
+    "@octokit/openapi-types@29.0.1": {
+      "integrity": "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg=="
     },
-    "@octokit/request-error@7.1.1": {
-      "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
+    "@octokit/request-error@7.1.2": {
+      "integrity": "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg==",
       "dependencies": [
         "@octokit/types"
       ]
     },
-    "@octokit/request@10.0.13": {
-      "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
+    "@octokit/request@10.0.16": {
+      "integrity": "sha512-A0zWGjHzISIb+9ccG8s0dq7LKO5zVpJLRICjgUb+sJxEWqn8RUHB1rD3AE51+PECvXHIxqZ1VVvs4fHTSD9nUQ==",
       "dependencies": [
         "@octokit/endpoint",
         "@octokit/request-error",
@@ -86,20 +86,20 @@
         "universal-user-agent"
       ]
     },
-    "@octokit/types@17.0.0": {
-      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+    "@octokit/types@18.0.0": {
+      "integrity": "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA==",
       "dependencies": [
         "@octokit/openapi-types"
       ]
     },
-    "content-type@2.0.0": {
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
+    "content-type@3.0.0": {
+      "integrity": "sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw=="
     },
-    "jose@6.2.8": {
-      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="
+    "jose@6.2.12": {
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw=="
     },
-    "json-with-bigint@3.5.10": {
-      "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w=="
+    "json-with-bigint@3.5.12": {
+      "integrity": "sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w=="
     },
     "toad-cache@3.7.4": {
       "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg=="
@@ -113,8 +113,8 @@
   },
   "workspace": {
     "dependencies": [
-      "npm:@octokit/auth-app@8.3.0",
-      "npm:jose@6.2.8"
+      "npm:@octokit/auth-app@8.3.1",
+      "npm:jose@6.2.12"
     ]
   }
 }

--- a/supabase/functions/log-usage/deno.json
+++ b/supabase/functions/log-usage/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.111.0",
-    "llm-zoo": "npm:llm-zoo@^1.34.0",
-    "zod": "npm:zod@^4.4.3"
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.115.0",
+    "llm-zoo": "npm:llm-zoo@^1.35.0",
+    "zod": "npm:zod@^4.5.4"
   }
 }

--- a/supabase/functions/log-usage/deno.lock
+++ b/supabase/functions/log-usage/deno.lock
@@ -1,18 +1,18 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@supabase/supabase-js@2.111.0": "2.111.0",
-    "npm:@supabase/auth-js@2.111.0": "2.111.0",
-    "npm:@supabase/functions-js@2.111.0": "2.111.0",
-    "npm:@supabase/postgrest-js@2.111.0": "2.111.0",
-    "npm:@supabase/realtime-js@2.111.0": "2.111.0",
-    "npm:@supabase/storage-js@2.111.0": "2.111.0",
-    "npm:llm-zoo@^1.34.0": "1.34.0_zod@4.4.3",
-    "npm:zod@^4.4.3": "4.4.3"
+    "jsr:@supabase/supabase-js@2.115.0": "2.115.0",
+    "npm:@supabase/auth-js@2.115.0": "2.115.0",
+    "npm:@supabase/functions-js@2.115.0": "2.115.0",
+    "npm:@supabase/postgrest-js@2.115.0": "2.115.0",
+    "npm:@supabase/realtime-js@2.115.0": "2.115.0",
+    "npm:@supabase/storage-js@2.115.0": "2.115.0",
+    "npm:llm-zoo@^1.35.0": "1.35.0_zod@4.5.4",
+    "npm:zod@^4.5.4": "4.5.4"
   },
   "jsr": {
-    "@supabase/supabase-js@2.111.0": {
-      "integrity": "92cd1d4c2933f6a62099f7d3b2b91908b70a9d110ee6098e1b2d3db2e6b7ef1b",
+    "@supabase/supabase-js@2.115.0": {
+      "integrity": "476e46c71a1be5754fd21c510cfeb49bde5adbcb1174cfcc1212a4002c30d4b6",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -23,14 +23,14 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.111.0": {
-      "integrity": "sha512-hbRLgyQZEX0SDyF4LYXpv94qOIQyFATfpT5SIs2V0SisHnisVRkYgiPQWzv80l4S2mO3qof78rmoH9j5zoFsYQ==",
+    "@supabase/auth-js@2.115.0": {
+      "integrity": "sha512-YNQlQWm1H0gsXHSY8Jd/xepBhjO0Zhwx04iW17A83/joQ5kFiUin6iPj9s9kZZvupnwLjXVP/diTFiLz2jUbwQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.111.0": {
-      "integrity": "sha512-RW/OCsd6MO592zU8ifzP8/f8XzxxIdpb+Up5XaOtE26Fw+3zTp475WX7+GuuktiD1WF8pFUDe6khUPbMp77RCw==",
+    "@supabase/functions-js@2.115.0": {
+      "integrity": "sha512-p97V6/YFcdp+zblFDVJaE8f9rGKTNz0PRzyJ2d1w/EYIU5lwidKuc3l/wM+u27ACmAC62albvoGiUGzLPSg7Aw==",
       "dependencies": [
         "tslib"
       ]
@@ -38,21 +38,21 @@
     "@supabase/phoenix@0.4.5": {
       "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="
     },
-    "@supabase/postgrest-js@2.111.0": {
-      "integrity": "sha512-pcqeDsnWP0lx9GawduYxNZJHeuTm53O7L0SC8RF8tniV3GWIPY6me6OTdnwzdwNUmNy1dzUVtSyIfE6+OflzPQ==",
+    "@supabase/postgrest-js@2.115.0": {
+      "integrity": "sha512-DdERcurLh5t84pgSywDg2LjLR5le7XAzl52/iQhC7FdboWDqGfDPMfaWJV3MHvhyxSlSNzbpSQG+RiQOBSn/4w==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.111.0": {
-      "integrity": "sha512-6oRf/vZyRwg8f8GbFSJkrD2w4HAu/yTvyMViHXHS+H5hNJzdXCrUR7cP5oW7daT3YlRnzRPY9LcGSJKZAmfMSg==",
+    "@supabase/realtime-js@2.115.0": {
+      "integrity": "sha512-5HyBkvlA/IUV2v8jX3uLTdy15jmTPRVXwXKoxvH2SKw5jZMNURxCxt+VpCEukscXQlY7pUpH8Cy4NH6io4iaRw==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.111.0": {
-      "integrity": "sha512-UEViNmTzVOxE8dqUA81wls+n9xgmlvSFfhfwo6QxrO4kQOytCYyw3ciYFoi4XoD4Jl95NJ3jnndHN5iIudWzqw==",
+    "@supabase/storage-js@2.115.0": {
+      "integrity": "sha512-dLyIxzbO+MCcKHhcce8rVUCQX1iyqXqQ8ytgkOVYJ7D+Zp0qKylPtQH3hamgxrGSxtDjaw47Urpzw2iK9PsKdA==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -61,8 +61,8 @@
     "iceberg-js@0.8.1": {
       "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
     },
-    "llm-zoo@1.34.0_zod@4.4.3": {
-      "integrity": "sha512-a/QfJU4VMhK/oQ+TkJJJ+PZCfGncuIQ18Od33KQPdg4fFD72KM45QpODEHN8vcha4W6KV5l280Sc4NSdt+pqGg==",
+    "llm-zoo@1.35.0_zod@4.5.4": {
+      "integrity": "sha512-zHcMXttMOJFg+vuKEL/9ORLLAuo//v8oV16k5w0JvABYPb2L1v/c9FM2eV8sxBH7Q+Hg0NWM7BMjC9nWUWT+dQ==",
       "dependencies": [
         "zod"
       ],
@@ -73,15 +73,15 @@
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
-    "zod@4.4.3": {
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
+    "zod@4.5.4": {
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@supabase/supabase-js@2.111.0",
-      "npm:llm-zoo@^1.34.0",
-      "npm:zod@^4.4.3"
+      "jsr:@supabase/supabase-js@2.115.0",
+      "npm:llm-zoo@^1.35.0",
+      "npm:zod@^4.5.4"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Refreshes the per-function `deno.json` import maps to current upstream releases and regenerates the matching lockfiles.

| dep | from | to | functions |
| --- | --- | --- | --- |
| `@supabase/supabase-js` | 2.111.0 | 2.115.0 | auth-device, auth-github, get-agent-config, log-usage |
| `@hono/hono` | 4.12.33 | 4.13.7 | auth-device, auth-github |
| `standardwebhooks` | 1.0.0 | 1.1.1 | before-user-created |
| `@octokit/auth-app` | 8.3.0 | 8.3.1 | github-app-token-exchange |
| `jose` | 6.2.8 | 6.2.12 | github-app-token-exchange |
| `llm-zoo` | ^1.34.0 | ^1.35.0 | log-usage |
| `zod` | ^4.4.3 | ^4.5.4 | log-usage |

All bumps are patch or minor. `auth-bridge` has an empty import map and is unchanged.

## Verification

`deno check index.ts` passes for all seven functions (deno 2.9.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU