### PR TITLE
fix: separate lint processes within the existing memory limit

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -544,7 +544,6 @@ export default tseslint.config(
       parserOptions: {
         project: [
           './tsconfig.json',
-          './tsconfig.test-kernel.json',
           './tsconfig.build.json',
           './packages/desktop/tsconfig.main.json',
           './packages/desktop/tsconfig.preload.json',
@@ -654,6 +653,25 @@ export default tseslint.config(
       '@typescript-eslint/no-unused-vars': 'off',
       'local/no-vscode-import-in-free-zones': 'error',
       'prefer-const': 'error',
+    },
+  },
+
+  // Tests run separately so their application-wide program is not retained
+  // alongside the production programs. Both passes keep the same rules.
+  {
+    files: ['src/test-kernel/**/*.ts'],
+    languageOptions: {
+      parserOptions: { project: ['./tsconfig.test-kernel.json'] },
+    },
+  },
+
+  // CLI scripts run in a fresh lint process so their program does not coexist
+  // with the workspace and host programs. Select it directly rather than
+  // creating every earlier project while searching for the script's owner.
+  {
+    files: ['packages/cli/scripts/**/*.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: { project: ['./packages/cli/tsconfig.scripts.json'] },
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "lint": "node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js src packages/agent/src packages/agent/scripts packages/extension/src packages/desktop/src packages/cli/src \"packages/cli/scripts/**/*.{ts,tsx}\" && node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js \"packages/desktop/design-harness/**/*.ts\" \"packages/desktop/tests/e2e/**/*.ts\"",
+    "lint": "node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js src packages/agent/src packages/agent/scripts packages/extension/src packages/desktop/src --ignore-pattern \"src/test-kernel/**\" && node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js src/test-kernel && node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js packages/cli/src && node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js \"packages/cli/scripts/**/*.{ts,tsx}\" && node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js \"packages/desktop/design-harness/**/*.ts\" \"packages/desktop/tests/e2e/**/*.ts\"",
     "test": "vitest run --config vitest.config.mjs",
     "test:watch": "vitest --config vitest.config.mjs",
     "desktop:build": "corepack pnpm --filter @texra/trace-viewer run build && corepack pnpm --filter @texra/desktop build",

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -242,10 +242,9 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
   }
 
   private async postAgentSelectionData(): Promise<void> {
+    await effectRuntime().runPromise(this.registry.loadAgents());
     this.renderer.postToRenderer(
-      await buildAgentSelectionMessage({
-        loadAgents: () =>
-          effectRuntime().runPromise(this.registry.loadAgents()),
+      buildAgentSelectionMessage({
         buildSelectionItems: () => this.catalogController.buildSelectionItems(),
         getCustomAgentScanIssues,
       }),

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -110,9 +110,9 @@ export class AgentHandlers {
   // ── Agent selection data ──
 
   async sendAgentSelectionData(webview: vscode.Webview): Promise<void> {
+    await effectRuntime().runPromise(loadAgents());
     await webview.postMessage(
-      await buildAgentSelectionMessage({
-        loadAgents: () => effectRuntime().runPromise(loadAgents()),
+      buildAgentSelectionMessage({
         buildSelectionItems: () => this.catalogController.buildSelectionItems(),
         getCustomAgentScanIssues,
       }),

--- a/src/shared/settingsView/handlers/agentSelectionHandlers.ts
+++ b/src/shared/settingsView/handlers/agentSelectionHandlers.ts
@@ -20,15 +20,13 @@ import type {
 } from '@shared/schemas';
 
 export interface AgentSelectionPorts {
-  loadAgents(): Promise<void>;
   buildSelectionItems(): ByCategory<AgentSelectionItem[]>;
   getCustomAgentScanIssues(): readonly AgentScanIssue[];
 }
 
-export async function buildAgentSelectionMessage(
+export function buildAgentSelectionMessage(
   ports: AgentSelectionPorts,
-): Promise<UpdateAgentSelectionMessage> {
-  await ports.loadAgents();
+): UpdateAgentSelectionMessage {
   return {
     command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
     agents: ports.buildSelectionItems(),

--- a/src/test-kernel/settings/settingsNotificationHandlers.vitest.ts
+++ b/src/test-kernel/settings/settingsNotificationHandlers.vitest.ts
@@ -29,20 +29,17 @@ const toolUseItem: AgentSelectionItem = {
 // hand-rolling the outbound message shape. These tests pin the exact shape
 // both hosts previously built by hand.
 describe('settingsView notification message builders', () => {
-  it('buildAgentSelectionMessage loads agents then wraps the selection items', async () => {
-    const loadAgents = vi.fn().mockResolvedValue(undefined);
+  it('buildAgentSelectionMessage wraps the selection items', () => {
     const buildSelectionItems = vi.fn().mockReturnValue({
       workflow: [workflowItem],
       toolUse: [toolUseItem],
     });
 
-    const message = await buildAgentSelectionMessage({
-      loadAgents,
+    const message = buildAgentSelectionMessage({
       buildSelectionItems,
       getCustomAgentScanIssues: () => [],
     });
 
-    expect(loadAgents).toHaveBeenCalledOnce();
     expect(buildSelectionItems).toHaveBeenCalledOnce();
     expect(message).toEqual({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
@@ -51,15 +48,14 @@ describe('settingsView notification message builders', () => {
     });
   });
 
-  it('buildAgentSelectionMessage includes custom agent scan issues', async () => {
+  it('buildAgentSelectionMessage includes custom agent scan issues', () => {
     const issues = [
       {
         path: 'retired.yaml',
         message: 'settings: unrecognized keys documentTag',
       },
     ];
-    const message = await buildAgentSelectionMessage({
-      loadAgents: vi.fn().mockResolvedValue(undefined),
+    const message = buildAgentSelectionMessage({
       buildSelectionItems: vi.fn().mockReturnValue({
         workflow: [],
         toolUse: [],


### PR DESCRIPTION
## Summary

Separate lint into five processes within the existing 6,144 MiB heap limit,
and remove the agent-selection message builder's unnecessary Promise layer.
The latter was reviewed separately in #12042 and merged into this branch.

Main `2fe503c3a776a9887598811ecbf84e27eed8fb29`, including persistence #12041,
desktop #12039 and ratchet #12038, is incorporated by a normal merge.
The startup refactor and unfinished native model package are not included.

## Issue acceptance gates

The original lint command reproducibly exhausts its unchanged heap. Separate
production, test, CLI, CLI-script and desktop-tooling processes release their
TypeScript programs between passes without weakening rules.

Both agent-selection hosts await the existing native catalogue load before
building and sending the same shared message. Load failure still prevents
sending and reaches the existing host error handling.

## Single source of truth

`eslint.config.mjs` retains the rule definitions. Existing TypeScript projects
identify each file's program. The shared agent-selection builder remains the
single message definition, and the existing native loader owns catalogue loading.

## Duplication and abstraction budget

Remove one Promise-valued interface method, the builder's asynchronous behavior
and two forwarding callbacks. No replacement abstraction, runtime entry,
dependency, compatibility path or baseline exception is introduced.

## Net elements (R6)

Six files modified: +30/−19 = **+11 lines**. The tooling correction is +18;
production agent-selection code is −3 and its existing tests are −4.
No file, exported symbol, class, interface, enum, schema or test case is added
or deleted. The positive tooling count corrects the reproduced memory failure.

## Consumer counts (R8)

The message builder has two production callers, extension and desktop; both
are converted. No event or message key changes. The original lint coverage
comparison selected the same 2,399 files exactly once with unchanged rules;
that count describes the earlier source revision, not files subsequently
added or removed by main.

## Host impact

Extension and desktop preserve load-before-build-before-send ordering, message
contents and scan-issue copying. CLI behavior is unchanged. Lint retains its
existing rules and memory limit.

## Scheduled refactoring

None for these two changes. #12033 separately tracks the missing startup
refactor; #11997 remains an unfinished model/runtime replacement.

## Validation

Both constituent changes passed independent source review and full local
validation under Node 22.23.2: formatting, all six type checks, build, full
lint and repository guards. The agent-selection run passed 9,098 tests with
six skipped, plus 106 separate architecture tests; no new test cases were added.
The lint partition was independently checked for identical file and rule coverage.

The preceding combined head `d46fc291dcaca62a8000fe3ded773892f9cdb55b` passed
CI run [34140220538](https://github.com/LionSR/TeXRA/actions/runs/34140220538).
The new main integration is `5b54e9591d86035b0e851e9a3981c851fee033a6`.
Its comparison remains the six reviewed files, independently rechecked after
integration. Fresh combined CI
[34143887129](https://github.com/LionSR/TeXRA/actions/runs/34143887129) passes:
static checks, both kernel test groups, build artifacts, macOS smoke checks
and final validation. Conditional runtime and docs jobs are skipped.

Main subsequently includes dependency PR #12032 at `b60fde893a16f82019f668277a85c2fddc754d60`.
GitHub updates the stacked head to `8579157b5f90d43d5bbdf1cb6fb1fcf0ea540e41`.
The declared-base difference remains the same six-file change; the manifest
additionally retains main's dependency update. CI run
[34144458228](https://github.com/LionSR/TeXRA/actions/runs/34144458228) passes
for this newer revision. GitHub records this PR and the empty stacked #12033
as merged at `691d9b2b251538e57540eb67c81d8a824525adb9`. The startup
implementation was not present in that merge and is being recovered separately.
