### PR TITLE
chore(ratchet): retire the dead import:neverthrow row and fail on an empty row

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -150,7 +150,6 @@
     "import:delay": {
       "src/utils/core/index.ts": 1
     },
-    "import:neverthrow": {},
     "Effect.run*": {
       "packages/extension/src/progressView/frontend/sessionTransport.ts": 4,
       "src/agent/runtime/SessionHandle.ts": 3,

--- a/scripts/check-effect-migration-ratchet.mjs
+++ b/scripts/check-effect-migration-ratchet.mjs
@@ -56,6 +56,8 @@ const baselinePath = join(
 );
 const PRD =
   '.agents/docs/proposed/architecture/2026-08-26-effect-4-runtime-migration.md';
+/** This script, for the message that tells a reader where to retire a row. */
+const SCRIPT_REL = 'scripts/check-effect-migration-ratchet.mjs';
 
 const SUPERSEDED_PACKAGES = [
   'p-queue',
@@ -65,7 +67,6 @@ const SUPERSEDED_PACKAGES = [
   'p-defer',
   'async-mutex',
   'delay',
-  'neverthrow',
 ];
 const PLATFORM_MODULE = '@platform/platform';
 const PLATFORM_MODULE_PATH = 'src/platform/platform';
@@ -671,13 +672,17 @@ function selfTestSurvey() {
       expected: { [ROW_PLATFORM]: 1 },
     },
     {
-      text: "import PQueue from 'p-queue';\nimport type { Options } from 'delay';\nimport pd from 'p-delay';\nimport local from './delay';\nconst map = require('p-map');\nexport { retry } from 'p-retry';\nawait import('neverthrow');\n",
+      // The `await import(...)` is the only case exercising the
+      // ImportKeyword branch of moduleSpecifier, so it must always name a
+      // live row: without it, a dynamic `import('p-queue')` would dodge its
+      // row undetected, in a ratchet whose whole subject is import rows.
+      text: "import PQueue from 'p-queue';\nimport type { Options } from 'delay';\nimport pd from 'p-delay';\nimport local from './delay';\nconst map = require('p-map');\nexport { retry } from 'p-retry';\nawait import('async-mutex');\n",
       expected: {
         [importRow('p-queue')]: 1,
         [importRow('delay')]: 1,
         [importRow('p-map')]: 1,
         [importRow('p-retry')]: 1,
-        [importRow('neverthrow')]: 1,
+        [importRow('async-mutex')]: 1,
       },
     },
     {
@@ -744,7 +749,18 @@ function surveyTree(files) {
     texts.set(file, text);
     const { counts, runsOnlyInExecute } = surveySource(text, file);
     for (const [row, count] of counts) {
-      rows[row][file] = count;
+      const entries = rows[row];
+      // A row retired from ROWS whose counting site survives in surveySource
+      // would otherwise crash here on an undefined index, from a stack trace
+      // that names neither the row nor the leftover bump(). Skipping the
+      // count instead would be worse: the mechanism would go untracked in
+      // silence, which is the failure this whole script exists to prevent.
+      if (entries == null) {
+        throw new Error(
+          `Row '${row}' is counted by surveySource but absent from ROWS (first seen in ${file}). Retiring a row means deleting its counting site too: remove the bump('${row}') call in surveySource and its self-test case, or restore the row to ROWS.`,
+        );
+      }
+      entries[file] = count;
     }
     if (runsOnlyInExecute && file.startsWith(BOUNDARY_TOOL_ROOT)) {
       toolExecuteFiles.add(file);
@@ -1230,6 +1246,38 @@ function main() {
       `  ${row.id.padEnd(24)} ${Object.keys(now).length} files / ${sites(now)} sites` +
         ` (baseline ${Object.keys(was).length} files / ${sites(was)} sites)`,
     );
+  }
+
+  // "The PR that zeroes a row deletes the row" is the baseline's own stated
+  // semantics, and nothing enforced it: once a row's last file is gone,
+  // `--update` writes the row empty and every later run is green, so the row,
+  // its rule text and its counting site sit in the script forever describing
+  // a mechanism the tree no longer has. `import:neverthrow` sat that way.
+  // The gate keys on the BASELINE row being empty, not on the tree count: a
+  // tree that has fallen below a non-empty baseline is stale headroom, which
+  // the stale report below already names loudly and correctly.
+  const emptyRows = ROWS.filter(
+    (row) => Object.keys(baseline.rows[row.id]).length === 0,
+  );
+  if (emptyRows.length > 0) {
+    failed = true;
+    console.error(
+      `\nEffect migration ratchet failed: ${emptyRows.length} baseline row(s) are empty. The PR that zeroes a row deletes the row: an empty row is not a finished ratchet, it is a row nobody removed.`,
+    );
+    for (const row of emptyRows) {
+      // Import rows are generated from SUPERSEDED_PACKAGES; the other three
+      // are hand-written, with their own row-id constant, counting site and
+      // self-test case. Retiring them is not the same edit, so do not print
+      // the same instructions for both.
+      const pkg = SUPERSEDED_PACKAGES.find(
+        (name) => importRow(name) === row.id,
+      );
+      console.error(
+        pkg == null
+          ? `  - [${row.id}] Delete its row-id constant, its ROWS entry, the bump('${row.id}') site in surveySource and its case in selfTestSurvey, all in ${SCRIPT_REL}; then run --update so the row leaves the baseline.`
+          : `  - [${row.id}] Delete '${pkg}' from SUPERSEDED_PACKAGES in ${SCRIPT_REL} (the row and its rule text are generated from that list); if the dynamic-import self-test fixture in selfTestSurvey still names '${pkg}', re-point it at another superseded package rather than deleting it, since it is the only case exercising the import() branch; drop the dependency from package.json once nothing outside the scanned roots needs it; then run --update so the row leaves the baseline.`,
+      );
+    }
   }
 
   const { failures, stale } = diffRows(rows, baseline.rows);


### PR DESCRIPTION
## What this changes

The Effect migration ratchet (`scripts/check-effect-migration-ratchet.mjs`) freezes, per production file, the mechanisms the migration retires. Its baseline's stated semantics include "the PR that zeroes a row deletes the row", but nothing enforced that rule, so a row whose last file is gone simply sits in the baseline as `{}` forever while every run stays green.

One row was already in that state: `import:neverthrow`, at 0 files and 0 sites, for a package that appears in no `package.json` and not in `pnpm-lock.yaml`. This PR retires that row and turns the unenforced rule into a hard failure.

Three changes to the script:

1. `neverthrow` leaves `SUPERSEDED_PACKAGES`, which is what generates its row and its rule text. That is the whole retirement for an import row.

2. The dynamic-import self-test fixture is re-pointed from `await import('neverthrow')` to `await import('async-mutex')` rather than deleted. That one line is the only case in the file that exercises the `ts.SyntaxKind.ImportKeyword` branch of `moduleSpecifier`, so deleting it would silently make a dynamic `import('p-queue')` a way to dodge a row, in a check whose entire subject is import rows. The near-miss cases in the same fixture (`import type { Options } from 'delay'`, which must count, and `import local from './delay'`, which must not) name a row that stays, so they are untouched and keep being exercised.

3. A new gate before the row diff fails when a **baseline** row is empty, and prints row-aware instructions. Retiring an import row means deleting one entry from `SUPERSEDED_PACKAGES`; retiring `platform()`, `setServices()` or `new AbortController()` additionally means deleting a row-id constant, a hand-written counting site in `surveySource`, and a self-test case. The message says which of the two applies. Keying the gate on the baseline rather than on the current tree count is deliberate: a tree that has fallen below a non-empty baseline is stale headroom, and the existing stale-headroom report already handles that case loudly and correctly.

Plus one robustness fix that the gate makes reachable: `surveyTree` now throws a named error when `surveySource` counts a row that `ROWS` no longer carries. Without it, a future lane that follows the new message literally, deletes a row from `ROWS`, and forgets its `bump()` site would take CI down with an undefined-index TypeError naming neither the row nor the leftover call. Skipping the count instead would be the silent drop this repo forbids, so it fails loudly with the row name and the exact fix.

The baseline's `semantics` string is deliberately unchanged, so the JSON diff is exactly one deleted line while several other branches are editing this file.

## Ratchet delta

Measured by running the script. The row count goes from thirteen to twelve; every surviving row is identical.

```
  platform()             69 files / 156 sites -> 69 / 156
  setServices()           6 /   6 ->  6 /   6
  new AbortController()  11 /  12 -> 11 /  12
  import:p-queue         19 /  19 -> 19 /  19
  import:p-map            8 /   8 ->  8 /   8
  import:p-retry          3 /   3 ->  3 /   3
  import:p-timeout        1 /   1 ->  1 /   1
  import:p-defer          9 /   9 ->  9 /   9
  import:async-mutex      2 /   2 ->  2 /   2
  import:delay            1 /   1 ->  1 /   1
  import:neverthrow       0 /   0 -> row deleted
  Effect.run*             7 /  22 ->  7 /  22
  catch:effect-importer  16 /  51 -> 16 /  51
  TOTAL                 152 entries / 290 sites -> 152 / 290
```

Baseline JSON diff: 1 file changed, 1 deletion, the line `"import:neverthrow": {},`.

## Verified

- Plain run: exit 0, twelve rows, all counts as above, ending in "@adapter-until markers OK: none present." and "Effect migration ratchet OK: no count grew, no baseline headroom."
- `--update`: exit 0, and re-running it after the commit is a no-op with an empty diff.
- Negative test for the new gate: appending a never-used package name to `SUPERSEDED_PACKAGES` and regenerating makes the plain run exit 1 naming that row, with the import-row instructions. Reverted.
- Negative test for the re-pointed fixture: breaking the `callee.kind === ts.SyntaxKind.ImportKeyword` condition makes `selfTestSurvey` fail, reporting the missing `import:async-mutex` count. The fixture still guards that branch. Reverted.
- Negative test for the named throw: deleting a row from `ROWS` while leaving its `bump()` site produces the named error rather than a TypeError. Reverted.
- `npm run typecheck` passes across all workspace projects.
- `npm run lint` passes.
- `npm run format:check` passes; both changed files were formatted with prettier.
- `npm run check:dead-code-ratchet` exits 0 with "no new findings". It also reports one pre-existing stale entry, `src/controllers/session/Database.ts`, which is unrelated to this change and belongs to another open PR; the knip baseline is untouched here.
- No vitest suite references this script, so none was run. The script's two self-test functions are its coverage and run on every invocation above. Per the repo's testing budget, this behavior-preserving change adds zero new tests.

## Not behavior-preserving

Two things reviewers should know.

First, an empty baseline row is now a hard failure. No row is empty on this branch, so the check is green today, but this is a real new failure mode. `import:p-timeout` is at 1 file / 1 site, so whichever lane removes that last import will be the first to meet the gate and must delete the row in the same PR.

Second, the baseline's row key set changed. `readBaseline` rejects any drift between the JSON's rows and the script's rows, so every in-flight branch carrying a regenerated Effect migration baseline goes red the moment it rebases onto this, until it re-runs `node scripts/check-effect-migration-ratchet.mjs --update`. That is a one-command fix, and it is why this change is intended to land ahead of the other Effect conversion lanes rather than after them.

## Deliberately not touched

The `SEMANTICS` string, so the baseline diff stays at one line while other branches edit the same file.

No production TypeScript. This is a check and its baseline only.

The rows that cannot honestly reach zero. `new AbortController()` has a floor of 2 at genuine foreign boundaries: `src/tools/claudeAgent.ts`, where the Claude Agent SDK takes a controller object rather than a signal, and `src/platform/defaults/longRunningModelTransport.ts`, which feeds a fetch Request's signal. `import:async-mutex` has a floor of 1 at `src/utils/core/keyedMutex.ts`, and `import:delay` has a floor of 1 at `src/utils/core/index.ts`: both are browser-reachable modules pinned by `scripts/check-browser-safe-utils.mjs`, and the migration PRD names keyedMutex by hand when it rules that browser-reachable utility modules stay Effect-free whatever their backend callers do. The new gate fires only on a row that is already empty, so it forces nothing impossible, and its message is worded strictly as instructions for retiring an already-empty row. It never tells anyone to zero a row. What the terminal form of those three rows should be is a separate question for the owner; note that the third one, `import:delay`, has the same permanent floor as `import:async-mutex` and belongs in that discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU
