### PR TITLE
refactor(agent): retire the 0.40.x continuation UUID compatibility writer

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -47,8 +47,6 @@ export type StateSlicesSnapshot = z.output<typeof StateSlicesSchema>;
  */
 export const ToolUseRunSharedSchema = z.object({
   messages: ProviderMessageArraySchema,
-  /** Written for persisted-shape compatibility; no longer read. */
-  continuationGenerationId: z.uuid(),
   /**
    * The model the run is on, mirroring the live `ModelCell`. This is the
    * resume SSOT for model identity.

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -1,6 +1,3 @@
-// Node imports
-import { randomUUID } from 'node:crypto';
-
 // Local imports
 import { logSdkError } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
@@ -430,8 +427,6 @@ export async function runToolUseFlow(
 
   let shared: ToolUseRunShared = {
     messages: [],
-    // Persisted-shape compatibility only: nothing reads this field any more.
-    continuationGenerationId: randomUUID(),
     modelId: services.modelCell.modelId,
     modelHandlerCompatibilityKey: compatibilityKey,
     shouldSkipCycle: false,

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -82,10 +82,8 @@ const TOOL_USE_SETTING = AgentToolUseSettingSchema.parse({});
 const TOOL_USE_PROMPT = AgentPromptSchema.parse({});
 const ACTIVE_COMPATIBILITY_KEY = 'ModelHandlerOpenAIResponse';
 const WAIT_NODE_CURSOR = 'start/default/default';
-const CONTINUATION_GENERATION_ID = '2c25c6a6-6c3f-4d64-9d1f-4a4f2c9b7e10';
 const VALID_TOOL_USE_SHARED = {
   messages: [],
-  continuationGenerationId: CONTINUATION_GENERATION_ID,
   shouldSkipCycle: false,
   stateSlices: null,
 };
@@ -249,7 +247,6 @@ function buildToolUseResumeData(
 ): ToolUseResumeData {
   const shared = {
     messages: [],
-    continuationGenerationId: CONTINUATION_GENERATION_ID,
     shouldSkipCycle: false,
     stateSlices: defaultStateSlices(),
   };
@@ -269,7 +266,6 @@ function buildResponseResumeData(
 ): ToolUseResumeData {
   const shared = {
     messages: [{ role: 'assistant', content: response }],
-    continuationGenerationId: CONTINUATION_GENERATION_ID,
     shouldSkipCycle: false,
     stateSlices: defaultStateSlices(),
   };
@@ -504,7 +500,6 @@ describe('retrieveSessionResumeData', () => {
   it('rejects a malformed MODEL user variable at the shared-state boundary', () => {
     const result = parseToolUseShared({
       messages: [],
-      continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
       stateSlices: defaultStateSlices('gpt54', {
         MODEL: 42,
@@ -546,10 +541,8 @@ describe('retrieveSessionResumeData', () => {
   });
 
   it('preserves structured output at the persisted shared-state boundary', () => {
-    const continuationGenerationId = '6f2051ec-5169-4fb5-9830-47aba9df665a';
     const result = parseToolUseShared({
       messages: [],
-      continuationGenerationId,
       shouldSkipCycle: false,
       stateSlices: null,
       structured: { title: 'Durable result' },
@@ -558,7 +551,6 @@ describe('retrieveSessionResumeData', () => {
     expect(result).toEqual({
       success: true,
       data: expect.objectContaining({
-        continuationGenerationId,
         structured: { title: 'Durable result' },
       }),
     });
@@ -567,7 +559,6 @@ describe('retrieveSessionResumeData', () => {
   it('does not derive a missing model id from the MODEL user variable', () => {
     const result = parseToolUseShared({
       messages: [],
-      continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
       stateSlices: defaultStateSlices('gpt54', { MODEL: 'gpt55' }),
     });
@@ -578,10 +569,8 @@ describe('retrieveSessionResumeData', () => {
   });
 
   it('keeps a persisted model id over the MODEL variable', () => {
-    const continuationGenerationId = '8439c273-d7f7-442a-9930-e63e941263d8';
     const result = parseToolUseShared({
       messages: [],
-      continuationGenerationId,
       modelId: 'gpt55',
       shouldSkipCycle: false,
       stateSlices: defaultStateSlices('gpt54', { MODEL: 'gpt54' }),
@@ -589,21 +578,8 @@ describe('retrieveSessionResumeData', () => {
 
     expect(result).toMatchObject({
       success: true,
-      data: { continuationGenerationId, modelId: 'gpt55' },
+      data: { modelId: 'gpt55' },
     });
-  });
-
-  it('rejects a record without a continuation generation', () => {
-    // The pre-fencing omission reader is retired: intermediate-era records
-    // that never persisted a generation id fail the parse loudly instead of
-    // being backfilled with a fresh UUID.
-    const result = parseToolUseShared({
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    });
-
-    expect(result.success).toBe(false);
   });
 
   it('uses the persisted model id while preserving the original stream id', async () => {
@@ -612,7 +588,6 @@ describe('retrieveSessionResumeData', () => {
     await writeFlowRecord(executionId, {
       messages: [],
       modelId: 'gpt55',
-      continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
       // A stale MODEL projection must not win over the persisted model id.
       stateSlices: defaultStateSlices('gpt54', { MODEL: 'gpt54' }),
@@ -630,7 +605,6 @@ describe('retrieveSessionResumeData', () => {
     const streamId = 'chat@gpt54#abc123-legacy-model' as StreamTabId;
     await writeFlowRecord(executionId, {
       messages: [],
-      continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
       stateSlices: defaultStateSlices('gpt54', { MODEL: 'gpt55' }),
     });
@@ -646,7 +620,6 @@ describe('retrieveSessionResumeData', () => {
     const streamId = 'chat@gpt54#abc123-no-model' as StreamTabId;
     await writeFlowRecord(executionId, {
       messages: [],
-      continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
       stateSlices: {
         runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
@@ -667,7 +640,6 @@ describe('retrieveSessionResumeData', () => {
     const parentStreamId = 'chat@gpt54#abc131-parent' as StreamTabId;
     await writeFlowRecord(executionId, {
       messages: [],
-      continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
       stateSlices: defaultStateSlices(),
     });
@@ -689,7 +661,6 @@ describe('retrieveSessionResumeData', () => {
           content: [{ type: 'text', text: 'Continue.' }],
         },
       ],
-      continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
       stateSlices: defaultStateSlices('gemini35f'),
     };
@@ -709,7 +680,6 @@ describe('retrieveSessionResumeData', () => {
     const store = getExecutionStore(executionId);
     await writeFlowRecord(executionId, {
       messages: [],
-      continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
       stateSlices: defaultStateSlices(),
     });
@@ -742,7 +712,6 @@ describe('retrieveSessionResumeData', () => {
     });
     await writeFlowRecord(executionId, {
       messages: [],
-      continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
       stateSlices: defaultStateSlices(),
     });
@@ -1757,7 +1726,6 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       executionId,
       {
         messages: [{ role: 'user', content: 'Continue.' }],
-        continuationGenerationId: '73375bdf-a9db-4d64-a702-3928784bf0e5',
         modelId: 'gpt54',
         modelHandlerCompatibilityKey: ACTIVE_COMPATIBILITY_KEY,
         shouldSkipCycle: false,
@@ -1802,7 +1770,6 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       {
         messages: [{ role: 'user', content: 'Continue.' }],
         modelHandlerCompatibilityKey: persistedCompatibilityKey,
-        continuationGenerationId: CONTINUATION_GENERATION_ID,
         shouldSkipCycle: false,
         stateSlices: defaultStateSlices(),
       },

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -177,7 +177,6 @@ export function toolUseRunShared(
 ): ToolUseRunShared {
   return {
     messages: [],
-    continuationGenerationId: '7b7f4d7e-3f60-49a5-b640-df1c8f9be302',
     shouldSkipCycle: false,
     stateSlices: null,
     ...overrides,

--- a/src/test-kernel/support/toolUseResumeTestUtils.ts
+++ b/src/test-kernel/support/toolUseResumeTestUtils.ts
@@ -10,7 +10,6 @@ export function createToolUseResumeShared(
 ): PreparedShared {
   return {
     messages: [],
-    continuationGenerationId: '9c1de2ab-58bf-4f9f-9a86-0f39be0a7c11',
     shouldSkipCycle: false,
     stateSlices: {
       runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),


### PR DESCRIPTION
## What this changes

`ToolUseRunSharedSchema` carried a required `continuationGenerationId: z.uuid()` field that no code read. It was written on every tool-use flow start purely so persisted flow records stayed schema-readable by 0.40.x builds, and its own code comment named v0.41 as the retirement condition. The repo's package.json is now 0.41.0, so the window has closed. This removes the field, its single writer, and the test fixture lines that fed it.

Closes #11731.

Concretely:

- `src/agent/implementations/flows/tooluse/nodes/types.ts` drops the schema member.
- `src/agent/implementations/flows/tooluse/runToolUseFlow.ts` drops the one write site in the initial `shared` literal, plus the `randomUUID` import from `node:crypto` that existed only for it.
- `src/test-kernel/agent/SessionResumeRetrieval.vitest.ts`, `src/test-kernel/agent/progressTestUtils.ts` and `src/test-kernel/support/toolUseResumeTestUtils.ts` drop the fixture lines. Two tests in the resume suite asserted the field round-tripped alongside their actual subject (structured output, and persisted model id beating the MODEL user variable); those assertions were trimmed and the tests kept. One test, `rejects a record without a continuation generation`, existed only to pin the field's required-ness and was deleted with it.

Net: 1 insertion, 43 deletions across 5 files. No new tests were added.

## Why no migration is needed

`ToolUseRunSharedSchema` is a plain `z.object`, deliberately not `z.strictObject`, with the strip semantics documented above it from #10641: unknown top-level keys in a persisted record are accepted and stripped at the `parseToolUseShared` boundary, and the resumed flow's first persisted step then rewrites the stripped record. So an existing record that still carries `continuationGenerationId` parses fine, the key is dropped, and the next write drops it from disk. Nothing downstream branches on it, so there is no boundary normalization to add. This is a straight drop-on-read, not a migration.

## Verification before deleting

I confirmed independently that the writer had no surviving reader. A repo-wide grep for `continuationGenerationId` across `src/` and `packages/` returned 24 hits: one schema member, one writer, and 22 test lines. There is no property access, no destructuring, no string-key or index access, and no second schema mirroring the field. A broader case-insensitive grep for `continuation` turned up only unrelated inquiry-continuation and idle-continuation code. Post-change the same grep returns nothing.

## Verified

- `npm run typecheck`: passes across root, agent, extension, cli, trace-viewer and desktop projects, no errors.
- `npx vitest run src/test-kernel/agent/SessionResumeRetrieval.vitest.ts`: 1 file passed, 51 tests passed.
- `npm test` (full suite): 763 files passed, 1 skipped; 9097 tests passed, 6 skipped; 116s.
- Effect migration ratchet: `--update` rewrote no baseline file and exits 0, and the bare run exits 0 with "no count grew, no baseline headroom". Every row is unchanged: platform() 69/156, setServices() 6/6, new AbortController( 11/12, import:p-queue 19/19, import:p-map 8/8, import:p-retry 3/3, import:p-timeout 1/1, import:p-defer 9/9, import:async-mutex 2/2, import:delay 1/1, import:neverthrow 0/0, Effect.run* 7/22, catch:effect-importer 16/51. No baseline JSON is in this diff.
- `npm run lint`: exit 0.
- `npm run check:dead-code-ratchet`: "no new findings", exit 0.
- `npx prettier --ignore-path /dev/null --write` on all five files: all unchanged.

## Not behavior-preserving

Three things to be aware of, all intended:

1. New records no longer carry the key. A pre-0.41 build reading one would fail its parse, since the field is required in the 0.40.x schema. That is precisely the compatibility guarantee this PR retires, on the condition the issue set.
2. A record written by an older build with a malformed, non-UUID value used to fail the parse loudly and now parses, because the key is stripped rather than validated. No behavior depended on that value, since nothing read it.
3. The `rejects a record without a continuation generation` test is gone. Its subject no longer exists.

## Deliberately not touched

`.agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md` lists `continuationGenerationId` among the fields a `flow.snapshot` persists, so that table is now stale by one entry. That proposal doc has a single named owner with work in flight, and editing it from here would collide with them; it needs a one-token removal by that owner.

The dead-code ratchet also reports a pre-existing stale baseline entry, `src/controllers/session/Database.ts`, which is no longer dead. It is unrelated to this change, does not fail the gate, and that file belongs to another open PR, so `config/ratchets/knip-baseline.json` is untouched here.

One honest caveat on value: both production files are on package D's deletion list, so part of this work is superseded eventually. The payoff is that it shrinks what D has to port and closes a compatibility window whose condition already expired, rather than carrying a write-only field through the port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU
