### PR TITLE
refactor(settings): remove the agent-selection Promise layer

### DIFF
--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -242,10 +242,9 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
   }
 
   private async postAgentSelectionData(): Promise<void> {
+    await effectRuntime().runPromise(this.registry.loadAgents());
     this.renderer.postToRenderer(
-      await buildAgentSelectionMessage({
-        loadAgents: () =>
-          effectRuntime().runPromise(this.registry.loadAgents()),
+      buildAgentSelectionMessage({
         buildSelectionItems: () => this.catalogController.buildSelectionItems(),
         getCustomAgentScanIssues,
       }),

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -110,9 +110,9 @@ export class AgentHandlers {
   // ── Agent selection data ──
 
   async sendAgentSelectionData(webview: vscode.Webview): Promise<void> {
+    await effectRuntime().runPromise(loadAgents());
     await webview.postMessage(
-      await buildAgentSelectionMessage({
-        loadAgents: () => effectRuntime().runPromise(loadAgents()),
+      buildAgentSelectionMessage({
         buildSelectionItems: () => this.catalogController.buildSelectionItems(),
         getCustomAgentScanIssues,
       }),

--- a/src/shared/settingsView/handlers/agentSelectionHandlers.ts
+++ b/src/shared/settingsView/handlers/agentSelectionHandlers.ts
@@ -20,15 +20,13 @@ import type {
 } from '@shared/schemas';
 
 export interface AgentSelectionPorts {
-  loadAgents(): Promise<void>;
   buildSelectionItems(): ByCategory<AgentSelectionItem[]>;
   getCustomAgentScanIssues(): readonly AgentScanIssue[];
 }
 
-export async function buildAgentSelectionMessage(
+export function buildAgentSelectionMessage(
   ports: AgentSelectionPorts,
-): Promise<UpdateAgentSelectionMessage> {
-  await ports.loadAgents();
+): UpdateAgentSelectionMessage {
   return {
     command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
     agents: ports.buildSelectionItems(),

--- a/src/test-kernel/settings/settingsNotificationHandlers.vitest.ts
+++ b/src/test-kernel/settings/settingsNotificationHandlers.vitest.ts
@@ -29,20 +29,17 @@ const toolUseItem: AgentSelectionItem = {
 // hand-rolling the outbound message shape. These tests pin the exact shape
 // both hosts previously built by hand.
 describe('settingsView notification message builders', () => {
-  it('buildAgentSelectionMessage loads agents then wraps the selection items', async () => {
-    const loadAgents = vi.fn().mockResolvedValue(undefined);
+  it('buildAgentSelectionMessage wraps the selection items', () => {
     const buildSelectionItems = vi.fn().mockReturnValue({
       workflow: [workflowItem],
       toolUse: [toolUseItem],
     });
 
-    const message = await buildAgentSelectionMessage({
-      loadAgents,
+    const message = buildAgentSelectionMessage({
       buildSelectionItems,
       getCustomAgentScanIssues: () => [],
     });
 
-    expect(loadAgents).toHaveBeenCalledOnce();
     expect(buildSelectionItems).toHaveBeenCalledOnce();
     expect(message).toEqual({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
@@ -51,15 +48,14 @@ describe('settingsView notification message builders', () => {
     });
   });
 
-  it('buildAgentSelectionMessage includes custom agent scan issues', async () => {
+  it('buildAgentSelectionMessage includes custom agent scan issues', () => {
     const issues = [
       {
         path: 'retired.yaml',
         message: 'settings: unrecognized keys documentTag',
       },
     ];
-    const message = await buildAgentSelectionMessage({
-      loadAgents: vi.fn().mockResolvedValue(undefined),
+    const message = buildAgentSelectionMessage({
       buildSelectionItems: vi.fn().mockReturnValue({
         workflow: [],
         toolUse: [],


### PR DESCRIPTION
## Summary

Make the shared agent-selection message builder synchronous. Extension and
desktop hosts now await their existing native Effect catalogue load directly,
then build and send the same message. The builder no longer accepts a Promise
operation merely to run it before constructing a message.

This PR includes main `ba9f5d80296a18d3b39fdc21e22f262002cff6bf` and is based on
the separate lint correction [#12030](https://github.com/LionSR/TeXRA/pull/12030).
Its comparison with that prerequisite contains only four files. It does not
depend on the startup reconciliation, model-package or persistence changes.

## Issue acceptance gates

Remove the asynchronous forwarding layer together with both production callers.
Catalogue loading must still finish before selection items and scan issues are
read or a message is sent. A rejected load must still prevent sending and
propagate to the existing host error handling.

## Single source of truth

The shared builder remains the one definition of the agent-selection message
shape. The native catalogue loader remains the one loading implementation.
Each host retains its existing Effect execution entry and outbound transport.

## Duplication and abstraction budget

Delete `AgentSelectionPorts.loadAgents`, the builder's `async`/Promise return
and two forwarding callbacks. No replacement adapter, helper, service, runtime
entry, dependency or compatibility path is added. The custom-directory and
mode-preset builders are unchanged.

## Net elements (R6)

Four files modified; +10/−17 = **−7 lines**. Production is +6/−9 = **−3 lines**;
the existing tests are +4/−8 = **−4 lines**. One interface method and two
forwarding callbacks are deleted. One asynchronous function becomes synchronous
with the same public name. No file, exported symbol, class, interface, enum,
schema, test case or test suite is added or deleted.

Including the lint prerequisite, the cumulative comparison with main is six
files, +30/−19 = **+11 lines**. That positive total consists of the separate
18-line lint correction and this seven-line removal; the prerequisite does not
appear in this PR's declared-base comparison.

## Consumer counts (R8)

`buildAgentSelectionMessage` has exactly two production callers: extension
`AgentHandlers.sendAgentSelectionData` and desktop
`DefaultDesktopAgentSettingsController.postAgentSelectionData`. Both change
together. Its two existing direct test cases now call it synchronously. The
existing extension test substitute remains unchanged.

No event or message key, subscriber, persisted format or model policy changes.

## Host impact

Extension and desktop retain load-before-build-before-send ordering, current
message contents and scan-issue copying. Both continue to use the same native
loader and the same runtime entry. The extension still awaits `postMessage`;
desktop still uses its synchronous renderer sender. CLI behavior is unchanged.

## Scheduled refactoring

None for this removal. The obsolete Promise port and both callers are changed
in this PR; the shared message-format responsibility is preserved.

## Validation

Independent review of all four changed files found no actionable issues.
Checks used Node 22.23.2 with a dedicated temporary directory:

- Full formatting, all six type checks, extension/webview build and full lint
  passed. Lint retains the existing 6,144 MiB memory limit.
- Full Vitest passed: 9,098 tests and 763 files; six tests and one file skipped.
  The run used four workers and completed in 311.67 seconds.
- Existing focused suites passed: 39 tests in six files, plus the shared
  settings boundary test.
- A separate architecture run passed all 106 tests in 16 files.
- Effect migration, browser-safe utilities, guidance references and strict
  dead-code checks passed. No baseline was widened.

Remote CI is not yet verified. These checks establish the local refactor's
existing behavior, not a completed native runtime or model-package migration.
