### PR TITLE
refactor: resolve stream executions from committed events

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -13,7 +13,6 @@ import {
   attachTerminalResultToast,
   describeFollowUpFailure,
   detachSubagentsOnStop,
-  lookupStreamExecutionId,
   resumeRun,
   runAgent,
   type AgentConfig,
@@ -870,9 +869,7 @@ export function createChatSessionController(
 
         await effectRuntime().runPromise(snapshotStore.preload([streamId]));
         const runMetadata = snapshotStore.getRunMetadata(streamId);
-        const executionId =
-          runMetadata.executionId ??
-          (await lookupStreamExecutionId(streamId, runtimeSession));
+        const executionId = runMetadata.executionId;
         if (!executionId) return false;
 
         const config =

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -64,6 +64,7 @@ import {
   type CodingPlanSubscriptionRuntime,
 } from '@model/codingPlanSubscriptions';
 import { platform } from '@platform/platform';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   isCodingPlanQuotaRoute,
   type QuotaFallbackRouteId,
@@ -809,11 +810,15 @@ function handleExternalInquiry(
     // Persisting the action writes the inquiry thread; nothing else owns
     // this promise, so its rejection is logged here instead of surfacing as
     // an unhandled rejection.
-    handleExternalInquiryAction(action).catch((error: unknown) => {
-      logWarning(
-        'cli.tui',
-        `External inquiry ${threadId} ${action.action} failed: ${toErrorMessage(error)}`,
-      );
-    });
+    effectRuntime()
+      .runPromise(
+        handleExternalInquiryAction(action, { session: currentSession() }),
+      )
+      .catch((error: unknown) => {
+        logWarning(
+          'cli.tui',
+          `External inquiry ${threadId} ${action.action} failed: ${toErrorMessage(error)}`,
+        );
+      });
   });
 }

--- a/packages/cli/src/runtime/approval/settleApprovals.ts
+++ b/packages/cli/src/runtime/approval/settleApprovals.ts
@@ -9,6 +9,7 @@
 
 import { defaultSession } from '@agent/runtime';
 import { warn as logWarning } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   decideHumanInputRequest,
   decideRetryApproval,
@@ -157,16 +158,23 @@ export function denyExternalInquiryIfNoHumanInput(
   // Persisting the drop writes the inquiry thread; nothing else owns this
   // promise, so its rejection is logged here instead of surfacing as an
   // unhandled rejection.
-  handleExternalInquiryAction({
-    action: 'drop',
-    threadId,
-    turnIndex,
-    reason: denial.reason,
-  }).catch((error: unknown) => {
-    logWarning(
-      'cli.approval',
-      `External inquiry ${threadId} drop failed: ${toErrorMessage(error)}`,
-    );
-  });
+  effectRuntime()
+    .runPromise(
+      handleExternalInquiryAction(
+        {
+          action: 'drop',
+          threadId,
+          turnIndex,
+          reason: denial.reason,
+        },
+        { session: defaultSession() },
+      ),
+    )
+    .catch((error: unknown) => {
+      logWarning(
+        'cli.approval',
+        `External inquiry ${threadId} drop failed: ${toErrorMessage(error)}`,
+      );
+    });
   return true;
 }

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -294,13 +294,18 @@ export function createHeadlessCliHostInteractions(
       );
     },
     async openExternalInquiry(request) {
-      await handleExternalInquiryAction({
-        action: 'drop',
-        threadId: request.threadId,
-        turnIndex: request.transcript?.at(-1)?.turnIndex ?? 1,
-        cause:
-          'External inquiry is not available in non-TUI CLI runs: inquiry answers are delivered as asynchronous continuations, and this process cannot resume them after the run finalizes. Use texra chat for the inquiry panel, or ask_user_question for synchronous CLI input.',
-      });
+      await effectRuntime().runPromise(
+        handleExternalInquiryAction(
+          {
+            action: 'drop',
+            threadId: request.threadId,
+            turnIndex: request.transcript?.at(-1)?.turnIndex ?? 1,
+            cause:
+              'External inquiry is not available in non-TUI CLI runs: inquiry answers are delivered as asynchronous continuations, and this process cannot resume them after the run finalizes. Use texra chat for the inquiry panel, or ask_user_question for synchronous CLI input.',
+          },
+          { session: defaultSession() },
+        ),
+      );
     },
     // Headless requests decide inline (policy or prompt hooks) — there is no
     // pending registry to cancel into.

--- a/packages/desktop/src/main/desktopHostRequests.ts
+++ b/packages/desktop/src/main/desktopHostRequests.ts
@@ -307,7 +307,8 @@ export function createDesktopHostRequests(
       logError: (message, error) =>
         logger.error(message, { data: toLogData(error) }),
     },
-    sendFollowUp: runActions.sendFollowUp,
+    sendFollowUp: (streamId, text) =>
+      effectRuntime().runPromise(runActions.sendFollowUp(streamId, text)),
   });
 
   async function runWorkflowDiff(request: WorkflowDiffRequest): Promise<void> {

--- a/packages/extension/src/progressView/extensionHostRequests.ts
+++ b/packages/extension/src/progressView/extensionHostRequests.ts
@@ -214,7 +214,8 @@ export function createExtensionHostRequests(
         });
       },
     },
-    sendFollowUp: runActions.sendFollowUp,
+    sendFollowUp: (streamId, text) =>
+      effectRuntime().runPromise(runActions.sendFollowUp(streamId, text)),
   });
 
   const workflowRunActions = new ProgressWorkflowRunActionsController({

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -1,9 +1,11 @@
+import { Effect } from 'effect';
+import { runInSession } from '@agent/runtime/RunContext';
 /** Tool-use follow-up routing and continuation ownership. */
+
 import {
   classifyRun,
   type RunClassification,
 } from '@agent/runtime/runClassification';
-import { listExecutionStreamReferences } from '@agent/storage/executionListing';
 import {
   currentSession,
   type SessionHandle,
@@ -16,6 +18,7 @@ import {
   streamHeldMessage,
   streamUnreadableMessage,
 } from '@shared/streams/streamStatusDisplay';
+import { ensureError } from '@utils/errors/errorMessage';
 import type { FollowUpQueueInput } from './FollowUpQueue';
 import type { FollowUpRecoveryLease } from './ToolUseFollowUpQueueManager';
 
@@ -54,7 +57,7 @@ type FollowUpPresentation =
   { severity: 'none' } | { severity: 'info' | 'warning'; message: string };
 
 interface SubmitFollowUpOptions {
-  readonly session?: SessionHandle;
+  readonly session: SessionHandle;
   readonly resumePort?: Pick<AgentResumePort, 'tryResumeStream'>;
   /**
    * Notifications never revive a persisted cursor. A child delivery is an
@@ -110,6 +113,17 @@ export function notifyFollowUpSent(
   session?: SessionHandle,
 ): void {
   (session ?? currentSession()).followUps.notifySent(streamId);
+}
+
+/** Queue transient progress using the current stream and live queue owners. */
+export function enqueueLiveFollowUp(
+  streamId: StreamTabId,
+  followUp: FollowUpQueueInput,
+  session: SessionHandle,
+): void {
+  const target = session.executions.getToolUseFollowUpTarget(streamId);
+  if (target.kind === 'no_session') return;
+  session.followUps.submit(streamId, followUp, 'live_owner');
 }
 
 interface PendingResume {
@@ -183,23 +197,13 @@ function admitFollowUp(
   return { resume, recovery };
 }
 
-/**
- * The execution a stream currently belongs to. Prefer the resident snapshot
- * record for a live session: `run.start` updates it synchronously. A stream
- * whose run metadata is not resident (after a host restart, or evicted from
- * the snapshot store) resolves through the authored `meta.streamId` index.
- */
-export async function lookupStreamExecutionId(
-  streamId: StreamTabId,
-  session: SessionHandle,
-): Promise<ExecutionId | undefined> {
-  return (
-    session.snapshots.getRunMetadata(streamId).executionId ??
-    (await listExecutionStreamReferences()).references.findLast(
-      (reference) => reference.streamId === streamId,
-    )?.executionId
-  );
-}
+/** Read the authored execution identity from the stream's committed prefix. */
+export const lookupStreamExecutionId = Effect.fn('lookupStreamExecutionId')(
+  function* (streamId: StreamTabId, session: SessionHandle) {
+    yield* session.snapshots.preload([streamId]);
+    return session.snapshots.getRunMetadata(streamId).executionId;
+  },
+);
 
 /**
  * The one mapping from a run classification to what the user's stream shows
@@ -267,57 +271,69 @@ export function recordRunRefusal(
  * the failure path; an unreadable fact is `not_resumable`. Only the one run
  * the user acted on is inspected.
  */
-async function classifyRefusal(
+const classifyRefusal = Effect.fn('classifyRefusal')(function* (
   streamId: StreamTabId,
   session: SessionHandle,
-): Promise<FollowUpFailureReason> {
-  let executionId: ExecutionId | undefined;
-  try {
-    executionId = await lookupStreamExecutionId(streamId, session);
-  } catch (error) {
-    logger.warn(
-      `Cannot classify the refusal for ${streamId}: persisted execution identity is unreadable.`,
-      { data: { streamId, error } },
-    );
-    return 'not_resumable';
-  }
+): Effect.fn.Return<FollowUpFailureReason, Error> {
+  const executionId = yield* lookupStreamExecutionId(streamId, session).pipe(
+    Effect.catch((error) =>
+      Effect.sync(() => {
+        logger.warn(
+          `Cannot classify the refusal for ${streamId}: persisted execution identity is unreadable.`,
+          { data: { streamId, error } },
+        );
+        return undefined;
+      }),
+    ),
+  );
   if (!executionId) return 'not_resumable';
-  return recordRunRefusal(streamId, session, await classifyRun(executionId));
-}
+  const classification = yield* Effect.tryPromise({
+    try: async () => runInSession(session, () => classifyRun(executionId)),
+    catch: ensureError,
+  });
+  return recordRunRefusal(streamId, session, classification);
+});
 
-export async function submitFollowUp(
+export const submitFollowUp = Effect.fn('submitFollowUp')(function* (
   streamId: StreamTabId,
   followUp: FollowUpQueueInput | string,
-  options: SubmitFollowUpOptions = {},
-): Promise<SubmitFollowUpResult> {
-  const ownerSession = options.session ?? currentSession();
+  options: SubmitFollowUpOptions,
+): Effect.fn.Return<SubmitFollowUpResult, Error> {
+  const ownerSession = options.session;
   const item = typeof followUp === 'string' ? { text: followUp } : followUp;
   // A host callback must not be able to strand the recovery lease below:
   // its failure is the host's to log, never this boundary's to propagate.
-  const notifyAdmitted = (admitted: boolean): void => {
-    try {
-      options.onAdmitted?.(admitted);
-    } catch (error) {
-      logger.warn(`onAdmitted callback failed for stream ${streamId}`, {
-        data: { streamId, error: String(error) },
-      });
-    }
-  };
+  const notifyAdmitted = (admitted: boolean) =>
+    Effect.try({
+      try: () => options.onAdmitted?.(admitted),
+      catch: ensureError,
+    }).pipe(
+      Effect.catch((error) =>
+        Effect.sync(() => {
+          logger.warn(`onAdmitted callback failed for stream ${streamId}`, {
+            data: { streamId, error: String(error) },
+          });
+        }),
+      ),
+    );
   const dispatch = admitFollowUp(streamId, item, options, ownerSession);
   if ('resume' in dispatch) {
-    notifyAdmitted(true);
-    const resumed = await dispatch.resume;
+    yield* notifyAdmitted(true);
+    const resumed = yield* Effect.tryPromise({
+      try: () => dispatch.resume,
+      catch: ensureError,
+    });
     if (resumed) return { status: 'queued' };
     ownerSession.followUps.release(dispatch.recovery, 'recoverable');
     return { status: 'queued', wake: 'failed' };
   }
   if (dispatch.status === 'no_session') {
-    notifyAdmitted(false);
+    yield* notifyAdmitted(false);
     return {
       status: 'failed',
-      reason: await classifyRefusal(streamId, ownerSession),
+      reason: yield* classifyRefusal(streamId, ownerSession),
     };
   }
-  notifyAdmitted(dispatch.status !== 'failed');
+  yield* notifyAdmitted(dispatch.status !== 'failed');
   return dispatch;
-}
+});

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -20,7 +20,6 @@ import {
 } from '@shared/streams/streamStatusDisplay';
 import { ensureError } from '@utils/errors/errorMessage';
 import type { FollowUpQueueInput } from './FollowUpQueue';
-import type { FollowUpRecoveryLease } from './ToolUseFollowUpQueueManager';
 
 /**
  * Why a submission could not be admitted, worded for the user by
@@ -128,7 +127,6 @@ export function enqueueLiveFollowUp(
 
 interface PendingResume {
   readonly resume: Promise<boolean>;
-  readonly recovery: FollowUpRecoveryLease;
 }
 
 type Admission =
@@ -190,11 +188,15 @@ function admitFollowUp(
   }
 
   const recovery = submission.lease;
-  const resume = (options.resumePort ?? platform().agentResume).tryResumeStream(
-    streamId,
-    recovery,
-  );
-  return { resume, recovery };
+  // The Promise resume port owns its settlement even if the submitting fiber
+  // stops waiting. A declined wake must release its claim for the next attempt.
+  const resume = (options.resumePort ?? platform().agentResume)
+    .tryResumeStream(streamId, recovery)
+    .then((resumed) => {
+      if (!resumed) ownerSession.followUps.release(recovery, 'recoverable');
+      return resumed;
+    });
+  return { resume };
 }
 
 /** Read the authored execution identity from the stream's committed prefix. */
@@ -324,7 +326,6 @@ export const submitFollowUp = Effect.fn('submitFollowUp')(function* (
       catch: ensureError,
     });
     if (resumed) return { status: 'queued' };
-    ownerSession.followUps.release(dispatch.recovery, 'recoverable');
     return { status: 'queued', wake: 'failed' };
   }
   if (dispatch.status === 'no_session') {

--- a/src/agent/followUp/childRunDelivery.ts
+++ b/src/agent/followUp/childRunDelivery.ts
@@ -1,4 +1,6 @@
 /** Parent-continuation delivery for child runs. */
+import { Effect } from 'effect';
+
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -10,20 +12,25 @@ type ChildRunDeliveryResult =
   | { kind: 'delivered'; wake?: 'failed' }
   | { kind: 'failed'; reason: FollowUpFailureReason };
 
-export async function deliverChildRunFollowUp(params: {
-  readonly targetStreamId: StreamTabId;
-  readonly followUp: FollowUpQueueInput;
-  readonly session: SessionHandle;
-  readonly mode?: 'live_notification' | 'child_delivery';
-}): Promise<ChildRunDeliveryResult> {
-  const result = await submitFollowUp(params.targetStreamId, params.followUp, {
-    session: params.session,
-    mode: params.mode ?? 'child_delivery',
-  });
-  if (result.status === 'failed') {
-    return { kind: 'failed', reason: result.reason };
-  }
-  return result.status === 'queued' && result.wake === 'failed'
-    ? { kind: 'delivered', wake: 'failed' }
-    : { kind: 'delivered' };
-}
+export const deliverChildRunFollowUp = Effect.fn('deliverChildRunFollowUp')(
+  function* (params: {
+    readonly targetStreamId: StreamTabId;
+    readonly followUp: FollowUpQueueInput;
+    readonly session: SessionHandle;
+  }): Effect.fn.Return<ChildRunDeliveryResult, Error> {
+    const result = yield* submitFollowUp(
+      params.targetStreamId,
+      params.followUp,
+      {
+        session: params.session,
+        mode: 'child_delivery',
+      },
+    );
+    if (result.status === 'failed') {
+      return { kind: 'failed', reason: result.reason };
+    }
+    return result.status === 'queued' && result.wake === 'failed'
+      ? { kind: 'delivered', wake: 'failed' }
+      : { kind: 'delivered' };
+  },
+);

--- a/src/agent/followUp/index.ts
+++ b/src/agent/followUp/index.ts
@@ -23,7 +23,6 @@ export {
   notifyFollowUpSent,
   presentFollowUpResult,
   submitFollowUp,
-  type SubmitFollowUpResult,
 } from './ToolUseFollowUp';
 export type { FollowUpQueueInput } from './FollowUpQueue';
 export type { FollowUpRecoveryLease } from './ToolUseFollowUpQueueManager';

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -43,6 +43,7 @@ import type {
 } from '@agent/followUp/FollowUpQueue';
 import type { FollowUpConsumerLease } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { deliverChildRunFollowUp } from '@agent/followUp/childRunDelivery';
+import { enqueueLiveFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { persistChildRunDelivery } from '@agent/storage/childRunDeliveryPersistence';
 import { classifyAgentError } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkError/errorPatterns';
@@ -724,19 +725,19 @@ const deliverTurn = Effect.fn('childRunLoop.deliverTurn')(function* <
  * Resolve a pending delivery's wake step (no-op when there is nothing to
  * wake, or the enqueue itself found no session; already logged above).
  */
-async function submitPendingDelivery(
+const submitPendingDelivery = Effect.fn('submitPendingDelivery')(function* (
   pending: PendingChildDelivery | undefined,
   session: SessionHandle,
   executionId: ExecutionId,
   logger: AgentTrace,
-): Promise<void> {
+): Effect.fn.Return<void, Error> {
   if (!pending) return;
   const targetStreamId = pending.resolveTargetStreamId();
   if (!targetStreamId) {
     warnDetachedChildDelivery(logger, executionId);
     return;
   }
-  const delivery = await deliverChildRunFollowUp({
+  const delivery = yield* deliverChildRunFollowUp({
     targetStreamId,
     followUp: pending.followUp,
     session,
@@ -758,7 +759,7 @@ async function submitPendingDelivery(
       { data: { executionId, parentStreamId: targetStreamId } },
     );
   }
-}
+});
 
 /**
  * Run pre-handoff launch work under one failure policy: if the operation
@@ -941,12 +942,11 @@ export function startChildRunLoop<TTurn>(
         );
         if (!targetStreamId) return;
         const msg = formatSubagentProgress(executionId, agentName, update);
-        void deliverChildRunFollowUp({
+        enqueueLiveFollowUp(
           targetStreamId,
-          followUp: { text: msg, origin: 'subagent_result' },
-          session: runSession,
-          mode: 'live_notification',
-        });
+          { text: msg, origin: 'subagent_result' },
+          runSession,
+        );
       },
       recordCost: (totalCostUsd) => {
         if (totalCostUsd !== undefined) {
@@ -1120,18 +1120,12 @@ export function startChildRunLoop<TTurn>(
               // the instant this turn settled); then just drain the next batch. A
               // follow-up already raced into the queue resumes immediately instead
               // of genuinely waiting.
-              yield* Effect.tryPromise({
-                try: () =>
-                  runInSession(runSession, () =>
-                    submitPendingDelivery(
-                      delivery,
-                      runSession,
-                      executionId,
-                      logger,
-                    ),
-                  ),
-                catch: ensureError,
-              });
+              yield* submitPendingDelivery(
+                delivery,
+                runSession,
+                executionId,
+                logger,
+              );
               childStream?.waitForInput();
               if (loop.isInterrupted()) break;
 
@@ -1232,18 +1226,12 @@ export function startChildRunLoop<TTurn>(
             }
           }
           // Parent wake follows the child's terminal commit and handle settlement.
-          yield* Effect.tryPromise({
-            try: () =>
-              runInSession(runSession, () =>
-                submitPendingDelivery(
-                  pendingDelivery,
-                  runSession,
-                  executionId,
-                  logger,
-                ),
-              ),
-            catch: ensureError,
-          });
+          yield* submitPendingDelivery(
+            pendingDelivery,
+            runSession,
+            executionId,
+            logger,
+          );
         }),
       );
       const released = yield* Effect.exit(

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -80,7 +80,7 @@ export {
 } from './terminalResultToast';
 
 // resumeRun
-export { lookupStreamExecutionId, resumeRun } from './resumeRun';
+export { resumeRun } from './resumeRun';
 export type { ResumeRunOptions } from './resumeRun';
 // The refusal wording a host applies to a `ResumeRunResult` failure, and the
 // stream -> execution lookup the stream-keyed host resume ports need.

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -82,8 +82,7 @@ export {
 // resumeRun
 export { resumeRun } from './resumeRun';
 export type { ResumeRunOptions } from './resumeRun';
-// The refusal wording a host applies to a `ResumeRunResult` failure, and the
-// stream -> execution lookup the stream-keyed host resume ports need.
+// The refusal wording a host applies to a `ResumeRunResult` failure.
 export { describeFollowUpFailure } from '@agent/followUp/ToolUseFollowUp';
 
 // detachSubagentsOnStop

--- a/src/agent/runtime/resumeRun.ts
+++ b/src/agent/runtime/resumeRun.ts
@@ -155,10 +155,7 @@ export const resumeStream = Effect.fn('resumeStream')(function* (
     if (recovery) session.followUps.release(recovery, 'recoverable');
     return REFUSED;
   }
-  const executionId = yield* Effect.tryPromise({
-    try: () => lookupStreamExecutionId(streamId, session),
-    catch: ensureError,
-  }).pipe(
+  const executionId = yield* lookupStreamExecutionId(streamId, session).pipe(
     Effect.onError(() =>
       Effect.sync(() =>
         releaseUnstartedRecovery(session, recovery, options.recovery == null),
@@ -175,8 +172,6 @@ export const resumeStream = Effect.fn('resumeStream')(function* (
     options.recovery == null,
   );
 }, Effect.uninterruptible);
-
-export { lookupStreamExecutionId } from '@agent/followUp/ToolUseFollowUp';
 
 const log = createLog('ResumeRun');
 

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -142,63 +142,6 @@ function listExecutionDirs(entries: [string, number][]): ExecutionId[] {
 // Public API
 // ============================================================================
 
-interface ExecutionStreamReference {
-  readonly executionId: ExecutionId;
-  readonly streamId: StreamTabId;
-}
-
-export interface ExecutionStreamReferenceListing {
-  readonly references: ExecutionStreamReference[];
-  /**
-   * Executions whose checkpoint `stat` or metadata read failed. They are not
-   * discarded: a checkpointed run whose storage cannot be read is unknown
-   * state, and the caller attributes it to a stream through its own
-   * execution-id channel rather than letting the row vanish into `ready`.
-   */
-  readonly unreadable: ReadonlyMap<ExecutionId, string>;
-}
-
-/**
- * The one walk of the executions directory that reads the authored
- * execution→stream edge (`ExecutionMeta.streamId`, stamped at registration).
- * Callers resolve a stream's execution from the resident snapshot record
- * first (a live run updates it synchronously) and fall back to this scan for
- * non-resident streams; the retired sidecar-FK and summary-mirror read
- * ladders are gone.
- *
- * This deliberately does not infer ownership for metadata without `streamId`,
- * or for malformed metadata. Those rows are retained: the sweep's only safe
- * deletion authority is the registered execution→stream edge itself. An
- * execution whose storage cannot be read is reported in `unreadable` with
- * the cause instead of being dropped.
- */
-export async function listExecutionStreamReferences(): Promise<ExecutionStreamReferenceListing> {
-  const entries = await readDirOrEmpty(RUNS_STORAGE_DIR);
-  const executionDirs = listExecutionDirs(entries);
-  const unreadable = new Map<ExecutionId, string>();
-  const results = await pMap(
-    executionDirs,
-    async (executionId): Promise<ExecutionStreamReference | null> => {
-      const store = getExecutionStore(executionId);
-      try {
-        const meta = await store.readMetaStrict();
-        if (!meta?.streamId) return null;
-        return { executionId, streamId: meta.streamId };
-      } catch (error) {
-        const cause = toErrorMessage(error);
-        unreadable.set(executionId, cause);
-        log.warn(
-          `Execution ${executionId} has unreadable storage while listing stream references: ${cause}`,
-          { data: error },
-        );
-        return null;
-      }
-    },
-    { concurrency: EXECUTION_STORAGE_CONCURRENCY },
-  );
-  return { references: results.filter(filterNotNull), unreadable };
-}
-
 /**
  * List all executions by scanning the executions/ directory.
  *

--- a/src/controllers/progressView/progressFollowUpSubmit.ts
+++ b/src/controllers/progressView/progressFollowUpSubmit.ts
@@ -1,8 +1,6 @@
-import {
-  presentFollowUpResult,
-  submitFollowUp,
-  type SubmitFollowUpResult,
-} from '@agent/followUp';
+import { Deferred, Effect } from 'effect';
+
+import { presentFollowUpResult, submitFollowUp } from '@agent/followUp';
 import type { SessionHandle } from '@agent/runtime';
 import type { FollowUpQueueInput } from '@agent/followUp';
 import { createLog } from '@logger/logUtils';
@@ -10,7 +8,7 @@ import {
   aggregateId as qualifyAggregateId,
   type StreamTabId,
 } from '@shared/schemas';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 
 const logger = createLog('ProgressFollowUpSubmit');
 
@@ -37,22 +35,44 @@ export interface ProgressFollowUpSubmitArgs {
  * admission (a recovery resume may run a whole model turn, then present its
  * outcome) runs detached so no IPC request or window close waits on it.
  */
-export function submitProgressFollowUp(
-  args: ProgressFollowUpSubmitArgs,
-): Promise<boolean> {
-  const { session, streamId, input, showInfo } = args;
-  return new Promise<boolean>((resolveAdmission) => {
-    let acknowledged = false;
+export const submitProgressFollowUp = Effect.fn('submitProgressFollowUp')(
+  function* (args: ProgressFollowUpSubmitArgs) {
+    const { session, streamId, input, showInfo } = args;
+    const admission = yield* Deferred.make<boolean>();
     const acknowledge = (accepted: boolean): void => {
-      if (acknowledged) return;
-      acknowledged = true;
-      try {
+      if (Deferred.doneUnsafe(admission, Effect.succeed(accepted))) {
         args.acknowledge(accepted);
-      } finally {
-        resolveAdmission(accepted);
       }
     };
-    const emitQueuedFollowUpsChanged = (): void => {
+    const present = (message: string) =>
+      Effect.tryPromise({
+        try: async () => {
+          await showInfo(message);
+        },
+        catch: ensureError,
+      });
+    const deliver = Effect.gen(function* () {
+      const result = yield* submitFollowUp(streamId, input, {
+        session,
+        onAdmitted: acknowledge,
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.gen(function* () {
+            acknowledge(false);
+            const message = toErrorMessage(error);
+            logger.warn(
+              `Failed to submit follow-up for stream ${streamId}: ${message}`,
+              {
+                data: { streamId, error: message },
+              },
+            );
+            yield* present(`Could not send the follow-up: ${message}`);
+            return undefined;
+          }),
+        ),
+      );
+      if (!result) return;
+      acknowledge(result.status !== 'failed');
       session.publish([
         {
           type: 'updateQueuedFollowUps',
@@ -60,40 +80,20 @@ export function submitProgressFollowUp(
           messages: session.followUps.getAll(streamId),
         },
       ]);
-    };
-
-    void (async () => {
-      let result: SubmitFollowUpResult;
-      try {
-        result = await submitFollowUp(streamId, input, {
-          session,
-          onAdmitted: acknowledge,
-        });
-      } catch (error) {
-        acknowledge(false);
-        const message = toErrorMessage(error);
-        logger.warn(
-          `Failed to submit follow-up for stream ${streamId}: ${message}`,
-          { data: { streamId, error: message } },
-        );
-        await showInfo(`Could not send the follow-up: ${message}`);
-        return;
-      }
-
-      // Anything not refused belongs to the stream, a queued input whose wake
-      // failed included. `presentFollowUpResult` is the one owner of the
-      // wording for every outcome that has any.
-      acknowledge(result.status !== 'failed');
-      emitQueuedFollowUpsChanged();
       const presentation = presentFollowUpResult(result);
-      if (presentation.severity !== 'none') {
-        await showInfo(presentation.message);
-      }
-    })().catch((error: unknown) => {
-      acknowledge(false);
-      logger.warn(
-        `Follow-up presentation failed for stream ${streamId}: ${toErrorMessage(error)}`,
-      );
-    });
-  });
-}
+      if (presentation.severity !== 'none')
+        yield* present(presentation.message);
+    }).pipe(
+      Effect.catchCause((cause) =>
+        Effect.sync(() => {
+          acknowledge(false);
+          logger.warn(
+            `Follow-up presentation failed for stream ${streamId}: ${String(cause)}`,
+          );
+        }),
+      ),
+    );
+    yield* Effect.forkDetach(deliver);
+    return yield* Deferred.await(admission);
+  },
+);

--- a/src/controllers/session/SessionRequests.ts
+++ b/src/controllers/session/SessionRequests.ts
@@ -276,19 +276,16 @@ function handle(
         }
       });
     case 'followUp.send':
-      return Effect.promise(() =>
-        submitFollowUp(
-          req.streamId,
-          {
-            text: req.text,
-            ...(req.displayText == null
-              ? {}
-              : { displayText: req.displayText }),
-            ...(req.mediaFiles == null ? {} : { mediaFiles: req.mediaFiles }),
-          },
-          { session },
-        ),
+      return submitFollowUp(
+        req.streamId,
+        {
+          text: req.text,
+          ...(req.displayText == null ? {} : { displayText: req.displayText }),
+          ...(req.mediaFiles == null ? {} : { mediaFiles: req.mediaFiles }),
+        },
+        { session },
       ).pipe(
+        Effect.orDie,
         Effect.flatMap((result) =>
           result.status === 'failed'
             ? Effect.fail(
@@ -381,27 +378,26 @@ function handle(
       );
     case 'externalInquiry.submit':
     case 'externalInquiry.drop':
-      return Effect.promise(() =>
-        handleExternalInquiryAction(
-          req.kind === 'externalInquiry.submit'
-            ? {
-                action: 'submit',
-                threadId: req.threadId,
-                turnIndex: req.turnIndex,
-                answer: req.answer,
-                ...(req.sessionLinks == null
-                  ? {}
-                  : { sessionLinks: req.sessionLinks }),
-              }
-            : {
-                action: 'drop',
-                threadId: req.threadId,
-                turnIndex: req.turnIndex,
-                ...(req.feedback == null ? {} : { feedback: req.feedback }),
-              },
-          { session },
-        ),
+      return handleExternalInquiryAction(
+        req.kind === 'externalInquiry.submit'
+          ? {
+              action: 'submit',
+              threadId: req.threadId,
+              turnIndex: req.turnIndex,
+              answer: req.answer,
+              ...(req.sessionLinks == null
+                ? {}
+                : { sessionLinks: req.sessionLinks }),
+            }
+          : {
+              action: 'drop',
+              threadId: req.threadId,
+              turnIndex: req.turnIndex,
+              ...(req.feedback == null ? {} : { feedback: req.feedback }),
+            },
+        { session },
       ).pipe(
+        Effect.orDie,
         Effect.flatMap((accepted) =>
           accepted
             ? Effect.succeed(done)

--- a/src/controllers/session/hostRunActions.ts
+++ b/src/controllers/session/hostRunActions.ts
@@ -87,7 +87,7 @@ export interface HostRunActions {
     getKnownWorkspaceOutputPaths(streamId: StreamTabId): Set<string>;
   };
   restoreProposal(proposal: unknown): AgentConfig;
-  sendFollowUp(streamId: StreamTabId, text: string): Promise<void>;
+  sendFollowUp(streamId: StreamTabId, text: string): Effect.Effect<void>;
 }
 
 export function createHostRunActions(
@@ -331,15 +331,15 @@ export function createHostRunActions(
       }
       return parsed.data;
     },
-    async sendFollowUp(streamId, text) {
-      await submitProgressFollowUp({
+    sendFollowUp(streamId, text) {
+      return submitProgressFollowUp({
         session,
         streamId,
         input: { text },
         // Programmatic file feedback has no composer to acknowledge.
         acknowledge: () => {},
         showInfo: ports.showWarning,
-      });
+      }).pipe(Effect.asVoid);
     },
     /**
      * Resume the run behind a stream: a workflow relaunches through the

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -8,9 +8,7 @@ import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 import { beforeEach, describe, expect, vi } from 'vitest';
 
-const submitFollowUpMock = vi.hoisted(() =>
-  vi.fn(async () => ({ status: 'sent' as const })),
-);
+const submitFollowUpMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
   submitFollowUp: submitFollowUpMock,
@@ -162,7 +160,9 @@ class RegistryTestSource {
 describe('GitHub subscription app signals and follow-ups', () => {
   beforeEach(() => {
     submitFollowUpMock.mockReset();
-    submitFollowUpMock.mockResolvedValue({ status: 'sent' as const });
+    submitFollowUpMock.mockReturnValue(
+      Effect.succeed({ status: 'sent' as const }),
+    );
   });
 
   it('publishes githubSubscriptionsChanged through app signals', async () => {
@@ -335,7 +335,9 @@ describe('GitHub subscription app signals and follow-ups', () => {
     };
     const registry = createTestRegistry(source, { logger });
     const unhandledRejection = vi.fn();
-    submitFollowUpMock.mockRejectedValueOnce(new Error('delivery failed'));
+    submitFollowUpMock.mockReturnValueOnce(
+      Effect.fail(new Error('delivery failed')),
+    );
 
     try {
       process.once('unhandledRejection', unhandledRejection);

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect';
+import { Effect, Fiber } from 'effect';
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 import * as resumability from '@agent/storage/resumability';
@@ -186,6 +186,30 @@ describe('submitFollowUp', () => {
 
     barrier.resolve(true);
     await expect(first).resolves.toEqual({ status: 'queued' });
+  });
+
+  it('releases declined recovery after the submitting fiber is interrupted', async () => {
+    const streamId = id('stream:interrupted-submission');
+    const session = fakeSession({ kind: 'queue' });
+    const resumed = createDeferred<boolean>();
+    const admitted = createDeferred<void>();
+    const fiber = Effect.runFork(
+      submitFollowUp(streamId, 'keep this input', {
+        session,
+        resumePort: { tryResumeStream: () => resumed.promise },
+        onAdmitted: () => admitted.resolve(),
+      }),
+    );
+    await admitted.promise;
+    await Effect.runPromise(Fiber.interrupt(fiber));
+    resumed.resolve(false);
+    await resumed.promise;
+
+    const successor = session.followUps.claimLive(streamId, 'child');
+    expect(successor).toBeDefined();
+    expect(session.followUps.queue(successor!).getAll()).toEqual([
+      'keep this input',
+    ]);
   });
 
   it('starts recovery after the child generation releases', async () => {

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 import * as resumability from '@agent/storage/resumability';
@@ -20,6 +21,7 @@ function fakeSession(target: ToolUseFollowUpTarget): SessionHandle {
     executions: { getToolUseFollowUpTarget: () => target },
     followUps: new ToolUseFollowUpQueue(),
     snapshots: {
+      preload: () => Effect.void,
       getRunMetadata: () => ({}),
     },
   } as unknown as SessionHandle;
@@ -54,10 +56,12 @@ describe('submitFollowUp', () => {
 
     for (const text of ['while waiting', 'between turns', 'during turn']) {
       await expect(
-        submitFollowUp(streamId, text, {
-          session,
-          resumePort: { tryResumeStream },
-        }),
+        Effect.runPromise(
+          submitFollowUp(streamId, text, {
+            session,
+            resumePort: { tryResumeStream },
+          }),
+        ),
       ).resolves.toMatchObject({ status: 'queued' });
     }
 
@@ -79,10 +83,12 @@ describe('submitFollowUp', () => {
     const tryResumeStream = mockTryResume();
 
     await expect(
-      submitFollowUp(streamId, 'during active turn', {
-        session,
-        resumePort: { tryResumeStream },
-      }),
+      Effect.runPromise(
+        submitFollowUp(streamId, 'during active turn', {
+          session,
+          resumePort: { tryResumeStream },
+        }),
+      ),
     ).resolves.toEqual({ status: 'sent' });
 
     expect(tryResumeStream).not.toHaveBeenCalled();
@@ -100,10 +106,12 @@ describe('submitFollowUp', () => {
     const flow = session.followUps.claimLive(streamId, 'flow')!;
 
     await expect(
-      submitFollowUp(streamId, 'child progress', {
-        session,
-        mode: 'live_notification',
-      }),
+      Effect.runPromise(
+        submitFollowUp(streamId, 'child progress', {
+          session,
+          mode: 'live_notification',
+        }),
+      ),
     ).resolves.toEqual({ status: 'queued' });
 
     expect(session.followUps.queue(flow).drainItems()).toMatchObject([
@@ -126,11 +134,13 @@ describe('submitFollowUp', () => {
 
     // live_notification on a WAITING queue without child owner should enqueue
     // without claiming recovery or triggering a stream resume.
-    const result = await submitFollowUp(streamId, 'child progress', {
-      session,
-      resumePort: { tryResumeStream },
-      mode: 'live_notification',
-    });
+    const result = await Effect.runPromise(
+      submitFollowUp(streamId, 'child progress', {
+        session,
+        resumePort: { tryResumeStream },
+        mode: 'live_notification',
+      }),
+    );
 
     expect(result).toMatchObject({ status: 'queued' });
     expect(tryResumeStream).not.toHaveBeenCalled();
@@ -147,18 +157,24 @@ describe('submitFollowUp', () => {
       return barrier.promise;
     });
 
-    const first = submitFollowUp(streamId, 'one', {
-      session,
-      resumePort: { tryResumeStream },
-    });
-    const second = submitFollowUp(streamId, 'two', {
-      session,
-      resumePort: { tryResumeStream },
-    });
-    const third = submitFollowUp(streamId, 'three', {
-      session,
-      resumePort: { tryResumeStream },
-    });
+    const first = Effect.runPromise(
+      submitFollowUp(streamId, 'one', {
+        session,
+        resumePort: { tryResumeStream },
+      }),
+    );
+    const second = Effect.runPromise(
+      submitFollowUp(streamId, 'two', {
+        session,
+        resumePort: { tryResumeStream },
+      }),
+    );
+    const third = Effect.runPromise(
+      submitFollowUp(streamId, 'three', {
+        session,
+        resumePort: { tryResumeStream },
+      }),
+    );
 
     await vi.waitFor(() => {
       expect(tryResumeStream).toHaveBeenCalledTimes(1);
@@ -180,10 +196,12 @@ describe('submitFollowUp', () => {
     const tryResumeStream = mockTryResume();
 
     await expect(
-      submitFollowUp(streamId, 'continue', {
-        session,
-        resumePort: { tryResumeStream },
-      }),
+      Effect.runPromise(
+        submitFollowUp(streamId, 'continue', {
+          session,
+          resumePort: { tryResumeStream },
+        }),
+      ),
     ).resolves.toEqual({ status: 'queued' });
     expect(tryResumeStream).toHaveBeenCalledTimes(1);
   });
@@ -197,11 +215,13 @@ describe('submitFollowUp', () => {
     session.followUps.release(child, 'recoverable');
     const tryResumeStream = mockTryResume();
 
-    const result = await submitFollowUp(streamId, 'child update', {
-      session,
-      resumePort: { tryResumeStream },
-      mode: 'live_notification',
-    });
+    const result = await Effect.runPromise(
+      submitFollowUp(streamId, 'child update', {
+        session,
+        resumePort: { tryResumeStream },
+        mode: 'live_notification',
+      }),
+    );
 
     expect(result).toMatchObject({ status: 'queued' });
     expect(tryResumeStream).not.toHaveBeenCalled();
@@ -213,10 +233,12 @@ describe('submitFollowUp', () => {
     const session = fakeSession({ kind: 'queue' });
     const tryResumeStream = mockTryResume();
 
-    await submitFollowUp(streamId, 'child result', {
-      session,
-      resumePort: { tryResumeStream },
-    });
+    await Effect.runPromise(
+      submitFollowUp(streamId, 'child result', {
+        session,
+        resumePort: { tryResumeStream },
+      }),
+    );
 
     expect(tryResumeStream).toHaveBeenCalledTimes(1);
   });
@@ -230,14 +252,16 @@ describe('submitFollowUp', () => {
     const tryResumeStream = mockTryResume();
 
     await expect(
-      submitFollowUp(
-        streamId,
-        { text: 'retained child result', origin: 'subagent_result' },
-        {
-          session,
-          resumePort: { tryResumeStream },
-          mode: 'child_delivery',
-        },
+      Effect.runPromise(
+        submitFollowUp(
+          streamId,
+          { text: 'retained child result', origin: 'subagent_result' },
+          {
+            session,
+            resumePort: { tryResumeStream },
+            mode: 'child_delivery',
+          },
+        ),
       ),
     ).resolves.toEqual({ status: 'queued' });
 
@@ -256,14 +280,16 @@ describe('submitFollowUp', () => {
     const tryResumeStream = mockTryResume();
 
     await expect(
-      submitFollowUp(
-        streamId,
-        { text: 'late child result', origin: 'subagent_result' },
-        {
-          session,
-          resumePort: { tryResumeStream },
-          mode: 'child_delivery',
-        },
+      Effect.runPromise(
+        submitFollowUp(
+          streamId,
+          { text: 'late child result', origin: 'subagent_result' },
+          {
+            session,
+            resumePort: { tryResumeStream },
+            mode: 'child_delivery',
+          },
+        ),
       ),
     ).resolves.toEqual({ status: 'failed', reason: 'not_resumable' });
     expect(tryResumeStream).not.toHaveBeenCalled();
@@ -280,11 +306,13 @@ describe('submitFollowUp', () => {
     };
 
     await expect(
-      submitFollowUp(streamId, delivery, {
-        session,
-        resumePort: { tryResumeStream },
-        mode: 'child_delivery',
-      }),
+      Effect.runPromise(
+        submitFollowUp(streamId, delivery, {
+          session,
+          resumePort: { tryResumeStream },
+          mode: 'child_delivery',
+        }),
+      ),
     ).resolves.toEqual({ status: 'queued' });
     expect(tryResumeStream).toHaveBeenCalledTimes(1);
 
@@ -292,11 +320,13 @@ describe('submitFollowUp', () => {
     // another parent message nor trigger another parent wake.
     for (let replay = 0; replay < 100; replay++) {
       await expect(
-        submitFollowUp(streamId, delivery, {
-          session,
-          resumePort: { tryResumeStream },
-          mode: 'child_delivery',
-        }),
+        Effect.runPromise(
+          submitFollowUp(streamId, delivery, {
+            session,
+            resumePort: { tryResumeStream },
+            mode: 'child_delivery',
+          }),
+        ),
       ).resolves.toEqual({ status: 'sent' });
     }
     expect(tryResumeStream).toHaveBeenCalledTimes(1);

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import '@test/support/defaultSessionTestSetup';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -104,9 +105,11 @@ describe('tool-use follow-up progress events', () => {
 
     trackToolUseFlow({ session });
 
-    const result = await submitFollowUp(streamId, 'please continue', {
-      session,
-    });
+    const result = await Effect.runPromise(
+      submitFollowUp(streamId, 'please continue', {
+        session,
+      }),
+    );
 
     expect(result).toEqual({ status: 'sent' });
     expect(session.followUps.queue(lease).drainItems()).toMatchObject([
@@ -186,7 +189,9 @@ describe('tool-use follow-up progress events', () => {
     });
     trackToolUseFlow();
 
-    const result = await submitFollowUp(streamId, 'late follow-up');
+    const result = await Effect.runPromise(
+      submitFollowUp(streamId, 'late follow-up', { session: defaultSession() }),
+    );
 
     expect(result).toEqual({ status: 'failed', reason: 'not_resumable' });
     expect(defaultSession().followUps.getAll(streamId)).toEqual([]);
@@ -196,10 +201,12 @@ describe('tool-use follow-up progress events', () => {
     const session = trackSession();
     const recorded = recordSessionEvents(session);
 
-    const result = await submitFollowUp(
-      'stream:no-follow-up-session' as StreamTabId,
-      'cannot deliver',
-      { session },
+    const result = await Effect.runPromise(
+      submitFollowUp(
+        'stream:no-follow-up-session' as StreamTabId,
+        'cannot deliver',
+        { session },
+      ),
     );
 
     expect(result).toEqual({ status: 'failed', reason: 'not_resumable' });
@@ -215,9 +222,10 @@ describe('tool-use follow-up progress events', () => {
     });
 
     try {
-      const result = await submitFollowUp(
-        resumingStreamId,
-        'queued while resuming',
+      const result = await Effect.runPromise(
+        submitFollowUp(resumingStreamId, 'queued while resuming', {
+          session: defaultSession(),
+        }),
       );
 
       // The fake platform's resume port refuses, so the input stays queued

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -286,7 +286,9 @@ beforeEach(async () => {
   mocks.finalizeRun.mockResolvedValue({ ok: true });
   mocks.persistChildRunReport.mockResolvedValue(undefined);
   mocks.persistChildRunResultMeta.mockResolvedValue(undefined);
-  mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+  mocks.deliverChildRunFollowUp.mockReturnValue(
+    Effect.succeed({ kind: 'delivered' }),
+  );
 });
 
 afterEach(() => {
@@ -559,10 +561,12 @@ describe('childRunLoop E2E fixtures', () => {
         phase: STREAM_PHASE.RUNNING,
       });
       await expect(
-        submitFollowUp(PARENT_STREAM_ID, 'active parent', {
-          session,
-          resumePort,
-        }),
+        Effect.runPromise(
+          submitFollowUp(PARENT_STREAM_ID, 'active parent', {
+            session,
+            resumePort,
+          }),
+        ),
       ).resolves.toEqual({ status: 'queued', wake: 'failed' });
 
       seedStreamStatusForTest(session.status, PARENT_STREAM_ID, {
@@ -570,18 +574,22 @@ describe('childRunLoop E2E fixtures', () => {
       });
       const userAdmission = vi.fn();
       await expect(
-        submitFollowUp(PARENT_STREAM_ID, 'restore me', {
-          session,
-          resumePort,
-          onAdmitted: userAdmission,
-        }),
+        Effect.runPromise(
+          submitFollowUp(PARENT_STREAM_ID, 'restore me', {
+            session,
+            resumePort,
+            onAdmitted: userAdmission,
+          }),
+        ),
       ).resolves.toMatchObject({ status: 'failed' });
       expect(userAdmission).toHaveBeenCalledWith(false);
       await expect(
-        submitFollowUp(
-          PARENT_STREAM_ID,
-          { text: 'late child result', origin: 'subagent_result' },
-          { session, resumePort, mode: 'child_delivery' },
+        Effect.runPromise(
+          submitFollowUp(
+            PARENT_STREAM_ID,
+            { text: 'late child result', origin: 'subagent_result' },
+            { session, resumePort, mode: 'child_delivery' },
+          ),
         ),
       ).resolves.toMatchObject({ status: 'failed' });
       expect(session.followUps.getAll(PARENT_STREAM_ID)).toEqual([
@@ -598,24 +606,28 @@ describe('childRunLoop E2E fixtures', () => {
       });
       try {
         await expect(
-          submitFollowUp(PARENT_STREAM_ID, 'native child result', {
-            session,
-            resumePort,
-            mode: 'child_delivery',
-          }),
+          Effect.runPromise(
+            submitFollowUp(PARENT_STREAM_ID, 'native child result', {
+              session,
+              resumePort,
+              mode: 'child_delivery',
+            }),
+          ),
         ).resolves.toEqual({ status: 'queued', wake: 'failed' });
       } finally {
         releaseNativeChild();
       }
 
+      const terminalQueue = session.followUps.getAll(PARENT_STREAM_ID);
       notifyProgress({ kind: 'started' });
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
-        expect.objectContaining({
-          targetStreamId: PARENT_STREAM_ID,
-          mode: 'live_notification',
-        }),
-      );
-      mocks.deliverChildRunFollowUp.mockClear();
+      expect(session.followUps.getAll(PARENT_STREAM_ID)).toEqual(terminalQueue);
+
+      seedStreamStatusForTest(session.status, PARENT_STREAM_ID, {
+        phase: STREAM_PHASE.RUNNING,
+      });
+      notifyProgress({ kind: 'started' });
+      const progressQueue = session.followUps.getAll(PARENT_STREAM_ID);
+      expect(progressQueue).toHaveLength(terminalQueue.length + 1);
 
       turn.resolve({ kind: 'terminal', value: 'done' });
       await formatStarted.promise;
@@ -624,6 +636,7 @@ describe('childRunLoop E2E fixtures', () => {
       formattedDelivery.resolve('delivered:done');
       await completion;
 
+      expect(session.followUps.getAll(PARENT_STREAM_ID)).toEqual(progressQueue);
       expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
     } finally {
       session.followUps.terminalize(PARENT_STREAM_ID);
@@ -657,18 +670,23 @@ describe('childRunLoop E2E fixtures', () => {
     const ids = loopIds('terminal-retry');
     const parentLease = session.followUps.claimLive(PARENT_STREAM_ID, 'flow')!;
     const admissions: string[] = [];
-    mocks.deliverChildRunFollowUp.mockImplementation(async (delivery) => {
-      const admission = delivery.session.followUps.submit(
-        delivery.targetStreamId,
-        delivery.followUp,
-        'live_owner',
-        delivery.expectedGenerationId,
-      );
-      admissions.push(admission.kind);
-      return admission.kind === 'duplicate' || admission.kind === 'refused'
-        ? { kind: 'dropped' as const }
-        : { kind: 'delivered' as const };
-    });
+    mocks.deliverChildRunFollowUp.mockImplementation((delivery) =>
+      Effect.tryPromise({
+        try: async () => {
+          const admission = delivery.session.followUps.submit(
+            delivery.targetStreamId,
+            delivery.followUp,
+            'live_owner',
+            delivery.expectedGenerationId,
+          );
+          admissions.push(admission.kind);
+          return admission.kind === 'duplicate' || admission.kind === 'refused'
+            ? { kind: 'dropped' as const }
+            : { kind: 'delivered' as const };
+        },
+        catch: (error) => error,
+      }),
+    );
 
     try {
       await startLoop(ids, createTerminalStrategy('First attempt'));
@@ -696,10 +714,15 @@ describe('childRunLoop E2E fixtures', () => {
     const { childStreamId, executionId } = loopIds('failed-turn-release');
     const { strategy, rejectTurn } = createFakeStrategy();
     const releaseSessionOwnership = vi.fn();
-    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
-      expect(releaseSessionOwnership).toHaveBeenCalledOnce();
-      return { kind: 'delivered' };
-    });
+    mocks.deliverChildRunFollowUp.mockImplementation(() =>
+      Effect.tryPromise({
+        try: async () => {
+          expect(releaseSessionOwnership).toHaveBeenCalledOnce();
+          return { kind: 'delivered' };
+        },
+        catch: (error) => error,
+      }),
+    );
 
     startLoop(
       { childStreamId, executionId },
@@ -744,10 +767,15 @@ describe('childRunLoop E2E fixtures', () => {
     const onTurnSuccess = vi.fn();
     const parentWake = vi.fn();
     const deliveryCompleted = pDefer<{ kind: 'delivered' }>();
-    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
-      parentWake();
-      return deliveryCompleted.promise;
-    });
+    mocks.deliverChildRunFollowUp.mockImplementation(() =>
+      Effect.tryPromise({
+        try: async () => {
+          parentWake();
+          return deliveryCompleted.promise;
+        },
+        catch: (error) => error,
+      }),
+    );
 
     startLoop(
       { childStreamId, executionId },
@@ -935,11 +963,16 @@ describe('childRunLoop E2E fixtures', () => {
       childStreamId,
     );
     let deliveryGate: DeferredPromise<void> | undefined;
-    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
-      deliveryGate = pDefer<void>();
-      await deliveryGate.promise;
-      return { kind: 'delivered' };
-    });
+    mocks.deliverChildRunFollowUp.mockImplementation(() =>
+      Effect.tryPromise({
+        try: async () => {
+          deliveryGate = pDefer<void>();
+          await deliveryGate.promise;
+          return { kind: 'delivered' };
+        },
+        catch: (error) => error,
+      }),
+    );
 
     const strategy = createTerminalStrategy('Reregister test');
 
@@ -971,15 +1004,20 @@ describe('childRunLoop E2E fixtures', () => {
 
     let releaseWake: (() => void) | undefined;
     let handleAtWakeTime: unknown;
-    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
-      // Snapshot registry state the instant the wake step is reached — the
-      // same moment a resumed parent's own turn would begin running.
-      handleAtWakeTime = session.executions.getHandle(executionId);
-      await new Promise<void>((resolve) => {
-        releaseWake = resolve;
-      });
-      return { kind: 'delivered' };
-    });
+    mocks.deliverChildRunFollowUp.mockImplementation(() =>
+      Effect.tryPromise({
+        try: async () => {
+          // Snapshot registry state the instant the wake step is reached. The
+          // same moment a resumed parent's own turn would begin running.
+          handleAtWakeTime = session.executions.getHandle(executionId);
+          await new Promise<void>((resolve) => {
+            releaseWake = resolve;
+          });
+          return { kind: 'delivered' };
+        },
+        catch: (error) => error,
+      }),
+    );
 
     const strategy = createTerminalStrategy('Finalize-before-wake test');
 

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -174,16 +174,23 @@ describe('sendFollowUp host-path session routing', () => {
       // A host-path caller (outside any run ALS, like the desktop IPC handler)
       // that passes its process session sees the live child and queues.
       await expect(
-        submitFollowUp(parentStream, 'continue', {
-          session: processSession,
-          resumePort: { tryResumeStream: async () => false },
-        }),
+        Effect.runPromise(
+          submitFollowUp(parentStream, 'continue', {
+            session: processSession,
+            resumePort: { tryResumeStream: async () => false },
+          }),
+        ),
       ).resolves.toEqual({ status: 'queued', wake: 'failed' });
 
-      // Without the session it falls back to the default session, which does
-      // not track this run — this is the dropped-follow-up regression the
-      // session parameter prevents on desktop.
-      await expect(submitFollowUp(parentStream, 'continue')).resolves.toEqual({
+      // The default session does not own this run; selecting the actual
+      // session is required for desktop follow-up delivery.
+      await expect(
+        Effect.runPromise(
+          submitFollowUp(parentStream, 'continue', {
+            session: defaultSession(),
+          }),
+        ),
+      ).resolves.toEqual({
         status: 'failed',
         reason: 'not_resumable',
       });

--- a/src/test-kernel/agent/runtime/resumeRun.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeRun.vitest.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 import { PersistedFlowStateError } from '@agent/node/persistedFlow';
 import type { ResumeToolUseFromResumeDataOptions } from '@agent/runtime/executeAgent';
 import { resumeRun, resumeStream } from '@agent/runtime/resumeRun';
-import type { ExecutionStreamReferenceListing } from '@agent/storage/executionListing';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { AgentCategory, RUN_OUTCOME } from '@shared/schemas';
 import { DatabaseReadFailed } from '@shared/session/database';
@@ -45,12 +44,6 @@ vi.mock('@agent/storage/executionLease', async (importActual) => ({
   inspectExecutionLease: inspectExecutionLeaseMock,
 }));
 
-const listExecutionStreamReferencesMock = vi.hoisted(() => vi.fn());
-vi.mock('@agent/storage/executionListing', async (importActual) => ({
-  ...(await importActual<typeof import('@agent/storage/executionListing')>()),
-  listExecutionStreamReferences: listExecutionStreamReferencesMock,
-}));
-
 const EXECUTION = 'exec:resume' as ExecutionId;
 const STREAM = 'stream:resume-ownership' as StreamTabId;
 const completed = {
@@ -86,6 +79,9 @@ function createSession(): ReturnType<typeof createTestSession> {
   const session = createTestSession();
   sessions.push(session);
   vi.spyOn(session.snapshots, 'preload').mockReturnValue(Effect.void);
+  vi.spyOn(session.snapshots, 'getRunMetadata').mockReturnValue({
+    executionId: EXECUTION,
+  });
   return session;
 }
 
@@ -103,10 +99,6 @@ describe('resumeRun tool-use queue ownership', () => {
     retrieveSessionResumeDataMock.mockReset().mockResolvedValue(snapshot());
     classifyRunMock.mockReset().mockResolvedValue({ kind: 'finished' });
     inspectExecutionLeaseMock.mockReset().mockResolvedValue({ status: 'free' });
-    listExecutionStreamReferencesMock.mockReset().mockResolvedValue({
-      references: [{ executionId: EXECUTION, streamId: STREAM }],
-      unreadable: new Map(),
-    });
     resumeToolUseFromResumeDataMock.mockReset();
     resumeToolUseFromResumeDataMock.mockImplementation(
       (_resume: unknown, options: ResumeToolUseFromResumeDataOptions) =>
@@ -123,6 +115,7 @@ describe('resumeRun tool-use queue ownership', () => {
       Effect.gen(function* () {
         const session = createSession();
         seedRecoverable(session, 'Keep this input.');
+        vi.mocked(session.snapshots.getRunMetadata).mockReturnValue({});
         const failure = new DatabaseReadFailed({
           path: ':memory:',
           cause: new Error('Corrupt stream prefix'),
@@ -140,42 +133,45 @@ describe('resumeRun tool-use queue ownership', () => {
       }),
   );
 
-  it.live('claims stream recovery before resolving the disk index', () =>
-    Effect.gen(function* () {
-      const session = createSession();
-      const index = createDeferred<ExecutionStreamReferenceListing>();
-      listExecutionStreamReferencesMock.mockReturnValueOnce(index.promise);
+  it.live(
+    'claims stream recovery before reading committed stream metadata',
+    () =>
+      Effect.gen(function* () {
+        const session = createSession();
+        const preload = createDeferred<void>();
+        vi.mocked(session.snapshots.preload).mockReturnValueOnce(
+          Effect.promise(() => preload.promise),
+        );
 
-      const resumed = yield* Effect.forkChild(
-        resumeStream(STREAM, { session, executeWorkflow }),
-        { startImmediately: true },
-      );
-      expect(
-        session.followUps.submit(STREAM, { text: 'raced' }, 'recoverable'),
-      ).toEqual({ kind: 'queued' });
+        const resumed = yield* Effect.forkChild(
+          resumeStream(STREAM, { session, executeWorkflow }),
+          { startImmediately: true },
+        );
+        expect(
+          session.followUps.submit(STREAM, { text: 'raced' }, 'recoverable'),
+        ).toEqual({ kind: 'queued' });
 
-      index.resolve({
-        references: [{ executionId: EXECUTION, streamId: STREAM }],
-        unreadable: new Map(),
-      });
-      expect(yield* Fiber.join(resumed)).toEqual({
-        started: true,
-        delivered: true,
-        outcome: RUN_OUTCOME.COMPLETED,
-      });
-      const options = resumeToolUseFromResumeDataMock.mock
-        .calls[0]?.[1] as ResumeToolUseFromResumeDataOptions;
-      expect(options.drainedFollowUps?.map((item) => item.text)).toEqual([
-        'raced',
-      ]);
-    }),
+        preload.resolve();
+        expect(yield* Fiber.join(resumed)).toEqual({
+          started: true,
+          delivered: true,
+          outcome: RUN_OUTCOME.COMPLETED,
+        });
+        const options = resumeToolUseFromResumeDataMock.mock
+          .calls[0]?.[1] as ResumeToolUseFromResumeDataOptions;
+        expect(options.drainedFollowUps?.map((item) => item.text)).toEqual([
+          'raced',
+        ]);
+      }),
   );
 
   it.live('preserves raced input when stream lookup finds no execution', () =>
     Effect.gen(function* () {
       const session = createSession();
-      const index = createDeferred<ExecutionStreamReferenceListing>();
-      listExecutionStreamReferencesMock.mockReturnValueOnce(index.promise);
+      const preload = createDeferred<void>();
+      vi.mocked(session.snapshots.preload).mockReturnValueOnce(
+        Effect.promise(() => preload.promise),
+      );
 
       const resumed = yield* Effect.forkChild(
         resumeStream(STREAM, { session, executeWorkflow }),
@@ -185,7 +181,8 @@ describe('resumeRun tool-use queue ownership', () => {
         session.followUps.submit(STREAM, { text: 'raced' }, 'recoverable'),
       ).toEqual({ kind: 'queued' });
 
-      index.resolve({ references: [], unreadable: new Map() });
+      vi.mocked(session.snapshots.getRunMetadata).mockReturnValue({});
+      preload.resolve();
       expect(yield* Fiber.join(resumed)).toEqual({ failed: 'not_resumable' });
       expect(session.followUps.getAll(STREAM)).toEqual(['raced']);
     }),

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -7,7 +7,6 @@ import {
   isUserVisibleExecution,
   listExecutions,
 } from '@agent/storage';
-import { listExecutionStreamReferences } from '@agent/storage/executionListing';
 import {
   AgentConfigSchema,
   type AgentConfig,
@@ -86,40 +85,6 @@ describe('execution listing normalization', () => {
     expect(await listExecutions()).toEqual([
       expect.objectContaining({ id, kind: 'run', checkpointPresent: false }),
     ]);
-  });
-
-  it('lists only readable execution metadata with an explicit stream reference', async () => {
-    const referenced = 'f9892001' as ExecutionId;
-    const withoutStream = 'f9892002' as ExecutionId;
-    const malformed = 'f9892003' as ExecutionId;
-    await getExecutionStore(referenced).writeMeta({
-      timestamp: '2026-08-08T00:00:00.000Z',
-      streamId: 'referenced-stream',
-    });
-    await getExecutionStore(withoutStream).writeMeta({
-      timestamp: '2026-08-08T00:00:00.000Z',
-    });
-    await getExecutionStore(malformed).write('meta', { timestamp: 42 });
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-
-    try {
-      const listing = await listExecutionStreamReferences();
-
-      expect(listing.references).toEqual([
-        { executionId: referenced, streamId: 'referenced-stream' },
-      ]);
-      // The unreadable row is reported with its cause, never dropped.
-      expect([...listing.unreadable.keys()]).toEqual([malformed]);
-      expect(warn).toHaveBeenCalledWith(
-        'ExecutionListing',
-        expect.stringContaining(
-          `Execution ${malformed} has unreadable storage`,
-        ),
-        expect.anything(),
-      );
-    } finally {
-      warn.mockRestore();
-    }
   });
 
   it('sees metadata replaced by another host after an earlier listing', async () => {

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -6,7 +6,7 @@ import { it } from '@effect/vitest';
 import { Effect, Fiber } from 'effect';
 import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
-const handleExternalInquiryActionMock = vi.hoisted(() => vi.fn(async () => {}));
+const handleExternalInquiryActionMock = vi.hoisted(() => vi.fn());
 const formatRetryRequestMessageMock = vi.hoisted(() => vi.fn());
 let detachHostInteractions = (): void => {};
 
@@ -166,6 +166,7 @@ const credentialExhaustedRetry: RetryPermission = {
 };
 
 beforeEach(async () => {
+  handleExternalInquiryActionMock.mockReturnValue(Effect.succeed(true));
   const { initPlatform: init } = await import('@platform/platform');
   const { createFakePlatform } = await import('@test/support/FakePlatform');
   init(createFakePlatform());
@@ -180,7 +181,9 @@ beforeEach(async () => {
 afterEach(() => {
   detachHostInteractions();
   detachHostInteractions = () => {};
-  handleExternalInquiryActionMock.mockClear();
+  handleExternalInquiryActionMock
+    .mockReset()
+    .mockReturnValue(Effect.succeed(true));
   formatRetryRequestMessageMock.mockReset();
   vi.restoreAllMocks();
 });
@@ -217,12 +220,15 @@ describe('human input approval policy', () => {
   it('denies external inquiry under never', () => {
     const ctx = context({ approvalPolicy: 'never' });
     expect(denyExternalInquiryIfNoHumanInput('ei_test', 1, ctx)).toBe(true);
-    expect(handleExternalInquiryActionMock).toHaveBeenCalledWith({
-      action: 'drop',
-      threadId: 'ei_test',
-      turnIndex: 1,
-      reason: texraApprovalDenialMessage('deny-policy'),
-    });
+    expect(handleExternalInquiryActionMock).toHaveBeenCalledWith(
+      {
+        action: 'drop',
+        threadId: 'ei_test',
+        turnIndex: 1,
+        reason: texraApprovalDenialMessage('deny-policy'),
+      },
+      { session: defaultSession() },
+    );
   });
 
   it.effect(
@@ -366,12 +372,15 @@ describe('approval prompt hooks', () => {
       );
 
       expect(tracker.events).toEqual([]);
-      expect(handleExternalInquiryActionMock).toHaveBeenCalledWith({
-        action: 'drop',
-        threadId: 'ei_aabbccdd0011',
-        turnIndex: 1,
-        cause: expect.stringContaining('non-TUI CLI runs'),
-      });
+      expect(handleExternalInquiryActionMock).toHaveBeenCalledWith(
+        {
+          action: 'drop',
+          threadId: 'ei_aabbccdd0011',
+          turnIndex: 1,
+          cause: expect.stringContaining('non-TUI CLI runs'),
+        },
+        { session: defaultSession() },
+      );
     }),
   );
 });

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -11,13 +11,13 @@ import {
   onTestFinished,
   vi,
 } from 'vitest';
-import { SubscriptionRef } from 'effect';
+import { Effect, SubscriptionRef } from 'effect';
 import { currentSession } from '@agent/runtime/SessionHandle';
 
 const mocks = vi.hoisted(() => ({
   apiKeyExistsUncached: vi.fn(),
   hasUsableApiKey: vi.fn(),
-  handleExternalInquiryAction: vi.fn(async () => {}),
+  handleExternalInquiryAction: vi.fn(),
   invalidateApiKeyCache: vi.fn(),
   preferSubscription: true,
   preferKimiCode: false,
@@ -424,6 +424,7 @@ async function approveOrdinaryRetryOnOldRoute(
 }
 
 beforeEach(() => {
+  mocks.handleExternalInquiryAction.mockReturnValue(Effect.succeed(true));
   mocks.preferSubscription = true;
   mocks.openRouter = false;
   mocks.apiKeyExistsUncached.mockResolvedValue(true);
@@ -465,7 +466,9 @@ afterEach(() => {
   mocks.retryCopyFailure = undefined;
   mocks.apiKeyExistsUncached.mockReset();
   mocks.hasUsableApiKey.mockReset();
-  mocks.handleExternalInquiryAction.mockClear();
+  mocks.handleExternalInquiryAction
+    .mockReset()
+    .mockReturnValue(Effect.succeed(true));
   mocks.invalidateApiKeyCache.mockReset();
   mocks.notify.mockReset();
   mocks.setCliSubscriptionPreference.mockReset();
@@ -494,12 +497,15 @@ describe('TUI retry approvals', () => {
     defaultSession().interactions.cancel({ cause: 'Session interrupted.' });
 
     await vi.waitFor(() =>
-      expect(mocks.handleExternalInquiryAction).toHaveBeenCalledWith({
-        action: 'drop',
-        threadId: 'ei_aabbccddeeff',
-        turnIndex: 1,
-        cause: 'Session interrupted.',
-      }),
+      expect(mocks.handleExternalInquiryAction).toHaveBeenCalledWith(
+        {
+          action: 'drop',
+          threadId: 'ei_aabbccddeeff',
+          turnIndex: 1,
+          cause: 'Session interrupted.',
+        },
+        { session: defaultSession() },
+      ),
     );
   });
 
@@ -522,11 +528,14 @@ describe('TUI retry approvals', () => {
     currentApproval.get()?.decide({ accepted: false });
 
     await vi.waitFor(() =>
-      expect(mocks.handleExternalInquiryAction).toHaveBeenCalledWith({
-        action: 'drop',
-        threadId: 'ei_112233445566',
-        turnIndex: 1,
-      }),
+      expect(mocks.handleExternalInquiryAction).toHaveBeenCalledWith(
+        {
+          action: 'drop',
+          threadId: 'ei_112233445566',
+          turnIndex: 1,
+        },
+        { session: defaultSession() },
+      ),
     );
   });
 

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -29,7 +29,6 @@ const mocks = vi.hoisted(() => ({
   attachTerminalResultToast: vi.fn(),
   createTuiHostInteractions: vi.fn(),
   resumeRun: vi.fn(),
-  lookupStreamExecutionId: vi.fn(),
   notify: vi.fn(),
   appendLocalAssistantTranscript: vi.fn(),
   appendLocalErrorTranscript: vi.fn(),
@@ -47,7 +46,6 @@ vi.mock('@agent/storage', () => ({
 
 vi.mock('@agent/runtime/resumeRun', () => ({
   resumeRun: mocks.resumeRun,
-  lookupStreamExecutionId: mocks.lookupStreamExecutionId,
 }));
 
 vi.mock('@agent/runtime/executeAgent', () => ({
@@ -597,7 +595,6 @@ describe('createChatSessionController', () => {
     );
     installSession();
     mocks.resumeRun.mockImplementation(defaultResumeRun);
-    mocks.lookupStreamExecutionId.mockResolvedValue('exec-1');
     installResumeExecutionStore();
     rootStreamId.set(undefined);
     rootRunPending.set(false);
@@ -1161,7 +1158,6 @@ describe('createChatSessionController', () => {
       preload: () => preload.promise,
       executionId: undefined,
     });
-    mocks.lookupStreamExecutionId.mockResolvedValueOnce(undefined);
     const ctrl = createChatSessionController(
       makeInit({ session, snapshotStore }),
     );

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -6,6 +6,7 @@ import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import pDefer from 'p-defer';
+import { Effect } from 'effect';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_MODEL_CAPABILITIES,
@@ -671,7 +672,7 @@ describe('BashTool', () => {
 
     const submitFollowUpSpy = vi
       .spyOn(toolUseFollowUp, 'submitFollowUp')
-      .mockResolvedValue({ status: 'sent' });
+      .mockReturnValue(Effect.succeed({ status: 'sent' }));
 
     const parentStreamId = 'bash-tool-bg-parent' as StreamTabId;
     const parentLease = defaultSession().followUps.claimLive(

--- a/src/test-kernel/tools/ChildRunDelivery.vitest.ts
+++ b/src/test-kernel/tools/ChildRunDelivery.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ResultMeta } from '@agent/storage';
@@ -59,14 +60,16 @@ describe('child run delivery', () => {
 
   it('submits delivery and recovery as one operation', async () => {
     const session = { tag: 'owner' };
-    mocks.submitFollowUp.mockResolvedValue({ status: 'queued' });
+    mocks.submitFollowUp.mockReturnValue(Effect.succeed({ status: 'queued' }));
 
     await expect(
-      deliverChildRunFollowUp({
-        targetStreamId: 'parent' as StreamTabId,
-        followUp: { text: 'done', origin: 'subagent_result' },
-        session: session as never,
-      }),
+      Effect.runPromise(
+        deliverChildRunFollowUp({
+          targetStreamId: 'parent' as StreamTabId,
+          followUp: { text: 'done', origin: 'subagent_result' },
+          session: session as never,
+        }),
+      ),
     ).resolves.toEqual({ kind: 'delivered' });
     expect(mocks.submitFollowUp).toHaveBeenCalledWith(
       'parent',
@@ -81,27 +84,33 @@ describe('child run delivery', () => {
   it('carries the refusal reason for a parent that did not accept delivery', async () => {
     function deliverToParent(followUp: {
       text: string;
-    }): ReturnType<typeof deliverChildRunFollowUp> {
-      return deliverChildRunFollowUp({
-        targetStreamId: 'parent' as StreamTabId,
-        followUp,
-        session: {} as never,
-      });
+    }): Promise<Effect.Success<ReturnType<typeof deliverChildRunFollowUp>>> {
+      return Effect.runPromise(
+        deliverChildRunFollowUp({
+          targetStreamId: 'parent' as StreamTabId,
+          followUp,
+          session: {} as never,
+        }),
+      );
     }
 
-    mocks.submitFollowUp.mockResolvedValueOnce({
-      status: 'failed',
-      reason: 'finished',
-    });
+    mocks.submitFollowUp.mockReturnValueOnce(
+      Effect.succeed({
+        status: 'failed',
+        reason: 'finished',
+      }),
+    );
     await expect(deliverToParent({ text: 'done' })).resolves.toEqual({
       kind: 'failed',
       reason: 'finished',
     });
 
-    mocks.submitFollowUp.mockResolvedValueOnce({
-      status: 'failed',
-      reason: 'not_resumable',
-    });
+    mocks.submitFollowUp.mockReturnValueOnce(
+      Effect.succeed({
+        status: 'failed',
+        reason: 'not_resumable',
+      }),
+    );
     await expect(deliverToParent({ text: 'late' })).resolves.toEqual({
       kind: 'failed',
       reason: 'not_resumable',

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   query: vi.fn(),
   buildClaudeAgentEnv: vi.fn(),
   findClaudeBinaryPath: vi.fn(),
-  submitFollowUp: vi.fn(async () => ({ status: 'sent' as const })),
+  submitFollowUp: vi.fn(),
 }));
 
 vi.mock('@tools/approval/bashApproval', () => ({
@@ -160,6 +160,7 @@ function captureStrategy(): { strategy?: ChildRunStrategy<unknown> } {
 
 describe('claude_agent tool launch and resume fallback', () => {
   beforeEach(() => {
+    mocks.submitFollowUp.mockReturnValue(Effect.succeed({ status: 'sent' }));
     mocks.startChildRunLoop.mockReset();
     mocks.startChildRunLoop.mockReturnValue(completedChildRunLoop());
     mocks.buildClaudeAgentEnv.mockReset();

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => ({
   importCodexClass: vi.fn(),
   findCodexBinaryPath: vi.fn(),
   resumeThread: vi.fn(),
-  submitFollowUp: vi.fn(async () => ({ status: 'sent' as const })),
+  submitFollowUp: vi.fn(),
 }));
 
 vi.mock('@tools/approval/bashApproval', () => ({
@@ -144,6 +144,7 @@ function captureRunLoopStrategy(): () => ChildRunStrategy<unknown> | undefined {
 
 describe('codex tool - atomic resume fallback', () => {
   beforeEach(() => {
+    mocks.submitFollowUp.mockReturnValue(Effect.succeed({ status: 'sent' }));
     mocks.startChildRunLoop.mockReset();
     mocks.startChildRunLoop.mockReturnValue(completedChildRunLoop());
     mocks.importCodexClass.mockReset();

--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -1,5 +1,6 @@
-// Node imports
 import * as assert from 'node:assert';
+import { Effect } from 'effect';
+// Node imports
 
 // Third-party imports
 import { describe, expect, it, afterEach, beforeEach, vi } from 'vitest';
@@ -179,11 +180,13 @@ describe('DelegateAgentTool resume ownership', () => {
     mocks.currentSession.mockReturnValue({
       executions: { getHandle: () => makeHandle() },
     } as never);
-    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+    mocks.deliverChildRunFollowUp.mockReturnValue(
+      Effect.succeed({ kind: 'delivered' }),
+    );
   });
 
   it('uses the merged submission result without a caller-local owner check', async () => {
-    mocks.submitFollowUp.mockResolvedValue({ status: 'queued' });
+    mocks.submitFollowUp.mockReturnValue(Effect.succeed({ status: 'queued' }));
 
     const result = await new DelegateAgentTool().call({
       execution_id: executionId,
@@ -196,10 +199,12 @@ describe('DelegateAgentTool resume ownership', () => {
   });
 
   it('reports a merged recovery failure to the parent', async () => {
-    mocks.submitFollowUp.mockResolvedValue({
-      status: 'queued',
-      wake: 'failed',
-    });
+    mocks.submitFollowUp.mockReturnValue(
+      Effect.succeed({
+        status: 'queued',
+        wake: 'failed',
+      }),
+    );
 
     await new DelegateAgentTool().call({
       execution_id: executionId,

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -5,6 +5,7 @@ import '@test/support/defaultSessionTestSetup';
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { beforeEach, afterEach, describe, it, vi } from 'vitest';
 
 // Local imports
@@ -82,7 +83,7 @@ async function launchBackgroundRun(
   );
   const followUp = vi
     .spyOn(toolUseFollowUp, 'submitFollowUp')
-    .mockResolvedValue({ status: 'sent' });
+    .mockReturnValue(Effect.succeed({ status: 'sent' }));
 
   const { host } = createRecordingHost();
   const recorded = recordSessionEvents(defaultSession());

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
@@ -5,6 +6,7 @@ import '@test/support/defaultSessionTestSetup';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { handleExternalInquiryAction } from '@tools/inquiry/inquiryActions';
 
 const storageMocks = vi.hoisted(() => ({
@@ -45,21 +47,33 @@ vi.mock('@tools/inquiry/externalInquiryStorage', () => storageMocks);
 
 vi.mock('@tools/inquiry/inquiryContinuation', () => continuationMocks);
 
+const session = {} as SessionHandle;
 describe('handleExternalInquiryAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    continuationMocks.injectContinuationForAnsweredThread.mockReturnValue(
+      Effect.succeed('sent'),
+    );
+    continuationMocks.injectContinuationForDroppedThread.mockReturnValue(
+      Effect.succeed('sent'),
+    );
   });
 
   it('persists and continues submit actions', async () => {
     const manifest = { status: 'answered' };
     storageMocks.recordAnswerForOpenTurn.mockResolvedValue(manifest);
 
-    await handleExternalInquiryAction({
-      action: 'submit',
-      threadId: 'thread-submit',
-      turnIndex: 1,
-      answer: 'A proof follows by compactness.',
-    });
+    await Effect.runPromise(
+      handleExternalInquiryAction(
+        {
+          action: 'submit',
+          threadId: 'thread-submit',
+          turnIndex: 1,
+          answer: 'A proof follows by compactness.',
+        },
+        { session },
+      ),
+    );
 
     expect(storageMocks.recordAnswerForOpenTurn).toHaveBeenCalledWith({
       threadId: 'thread-submit',
@@ -69,18 +83,23 @@ describe('handleExternalInquiryAction', () => {
     });
     expect(
       continuationMocks.injectContinuationForAnsweredThread,
-    ).toHaveBeenCalledWith('thread-submit', manifest, undefined);
+    ).toHaveBeenCalledWith('thread-submit', manifest, session);
   });
 
   it('persists note-free drops without synthesizing provenance', async () => {
     const manifest = { status: 'dropped' };
     storageMocks.markDropped.mockResolvedValue(manifest);
 
-    await handleExternalInquiryAction({
-      action: 'drop',
-      threadId: 'thread-drop',
-      turnIndex: 1,
-    });
+    await Effect.runPromise(
+      handleExternalInquiryAction(
+        {
+          action: 'drop',
+          threadId: 'thread-drop',
+          turnIndex: 1,
+        },
+        { session },
+      ),
+    );
 
     expect(storageMocks.markDropped).toHaveBeenCalledWith({
       threadId: 'thread-drop',
@@ -88,19 +107,24 @@ describe('handleExternalInquiryAction', () => {
     });
     expect(
       continuationMocks.injectContinuationForDroppedThread,
-    ).toHaveBeenCalledWith('thread-drop', manifest, undefined);
+    ).toHaveBeenCalledWith('thread-drop', manifest, session);
     expect(traceMocks.info).not.toHaveBeenCalled();
   });
 
   it('logs policy reasons without labeling them as feedback', async () => {
     storageMocks.markDropped.mockResolvedValue({ status: 'dropped' });
 
-    await handleExternalInquiryAction({
-      action: 'drop',
-      threadId: 'thread-denied',
-      turnIndex: 1,
-      reason: 'Human input is disabled by policy.',
-    });
+    await Effect.runPromise(
+      handleExternalInquiryAction(
+        {
+          action: 'drop',
+          threadId: 'thread-denied',
+          turnIndex: 1,
+          reason: 'Human input is disabled by policy.',
+        },
+        { session },
+      ),
+    );
 
     expect(traceMocks.info).toHaveBeenCalledWith(
       'Inquiry thread-denied denied',
@@ -111,12 +135,17 @@ describe('handleExternalInquiryAction', () => {
   it('logs lifecycle causes without labeling them as feedback', async () => {
     storageMocks.markDropped.mockResolvedValue({ status: 'dropped' });
 
-    await handleExternalInquiryAction({
-      action: 'drop',
-      threadId: 'thread-cancelled',
-      turnIndex: 1,
-      cause: 'Session interrupted.',
-    });
+    await Effect.runPromise(
+      handleExternalInquiryAction(
+        {
+          action: 'drop',
+          threadId: 'thread-cancelled',
+          turnIndex: 1,
+          cause: 'Session interrupted.',
+        },
+        { session },
+      ),
+    );
 
     expect(traceMocks.info).toHaveBeenCalledWith(
       'Inquiry thread-cancelled dropped with cause',

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -1,12 +1,9 @@
+import { Effect } from 'effect';
 import '@test/support/defaultSessionTestSetup';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const submitFollowUpMock = vi.hoisted(() =>
-  vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
-    status: 'sent' as const,
-  })),
-);
+const submitFollowUpMock = vi.hoisted(() => vi.fn());
 const getThreadSummaryMock = vi.hoisted(() => vi.fn());
 const listThreadsByStatusMock = vi.hoisted(() => vi.fn(async () => []));
 const readExternalInquiryThreadMock = vi.hoisted(() => vi.fn());
@@ -28,7 +25,6 @@ vi.mock('@tools/inquiry/externalInquiryStorage', () => ({
 }));
 
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
-import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import {
   aggregateId as qualifyAggregateId,
   type InquiryThreadId,
@@ -116,7 +112,9 @@ function answeredManifest(): ExternalInquiryThreadManifest {
 
 describe('external inquiry continuation session routing', () => {
   beforeEach(() => {
-    submitFollowUpMock.mockClear();
+    submitFollowUpMock
+      .mockReset()
+      .mockReturnValue(Effect.succeed({ status: 'sent' }));
     getThreadSummaryMock.mockResolvedValue({
       threadId: THREAD,
       parentStreamId: STREAM,
@@ -132,10 +130,8 @@ describe('external inquiry continuation session routing', () => {
   it('passes the host-provided session through to sendFollowUp', async () => {
     const session = sessionStub('desktop-session');
 
-    const outcome: InjectionOutcome = await injectContinuationForAnsweredThread(
-      THREAD,
-      answeredManifest(),
-      session,
+    const outcome: InjectionOutcome = await Effect.runPromise(
+      injectContinuationForAnsweredThread(THREAD, answeredManifest(), session),
     );
 
     expect(outcome).toBe('sent');
@@ -149,10 +145,16 @@ describe('external inquiry continuation session routing', () => {
   it('archives a turn-less manifest without dispatching a follow-up', async () => {
     // The manifest schema does not require turns; the structural guard must
     // archive (not crash) when there is no turn to fence against.
-    const outcome = await injectContinuationForAnsweredThread(THREAD, {
-      ...answeredManifest(),
-      turns: [],
-    });
+    const outcome = await Effect.runPromise(
+      injectContinuationForAnsweredThread(
+        THREAD,
+        {
+          ...answeredManifest(),
+          turns: [],
+        },
+        sessionStub(),
+      ),
+    );
 
     expect(outcome).toBe('archived');
     expect(submitFollowUpMock).not.toHaveBeenCalled();
@@ -166,10 +168,12 @@ describe('external inquiry continuation session routing', () => {
     const fallback = captureFacts(defaultSession());
 
     try {
-      await injectContinuationForAnsweredThread(
-        THREAD,
-        answeredManifest(),
-        session,
+      await Effect.runPromise(
+        injectContinuationForAnsweredThread(
+          THREAD,
+          answeredManifest(),
+          session,
+        ),
       );
       await session.settlePublications();
 
@@ -195,49 +199,18 @@ describe('external inquiry continuation session routing', () => {
     }
   });
 
-  it("emits inquiry thread updates through the active run's session when no explicit session is provided", async () => {
-    const session = createTestSession({ roots: paperRoots() });
-    publishTestRunStart(session, STREAM);
-    await session.settlePublications();
-    const run = captureFacts(session);
-    const fallback = captureFacts(defaultSession());
-
-    try {
-      await withRunContext(
-        createRunContext({
-          session,
-        }),
-        () => injectContinuationForAnsweredThread(THREAD, answeredManifest()),
-      );
-      await session.settlePublications();
-
-      await session.settlePublications();
-      expect(run.facts).toMatchObject([
-        expect.objectContaining({
-          type: 'inquiryThreadUpdated',
-          aggregateId: qualifyAggregateId('inquiry', THREAD),
-          threadId: THREAD,
-          resumeOutcome: 'sent',
-        }),
-      ]);
-      expect(fallback.facts).toEqual([]);
-    } finally {
-      run.detach();
-      fallback.detach();
-      session.dispose();
-    }
-  });
-
   it('does not emit an inquiry thread update when no summary is returned', async () => {
     const session = createTestSession();
     const { facts, detach } = captureFacts(session);
     getThreadSummaryMock.mockResolvedValueOnce(null);
 
     try {
-      await injectContinuationForAnsweredThread(
-        THREAD,
-        answeredManifest(),
-        session,
+      await Effect.runPromise(
+        injectContinuationForAnsweredThread(
+          THREAD,
+          answeredManifest(),
+          session,
+        ),
       );
 
       expect(facts).toEqual([]);
@@ -252,19 +225,19 @@ describe('external inquiry continuation session routing', () => {
       name: 'threads the provided session to the wake decision',
       session: sessionStub('desktop-session'),
     },
-    {
-      name: 'passes an undefined session when none was provided',
-      session: undefined,
-    },
   ])(
     'delegates queued wake decisions to the follow-up owner ($name)',
     async ({ session }) => {
-      submitFollowUpMock.mockResolvedValueOnce({ status: 'queued' });
+      submitFollowUpMock.mockReturnValueOnce(
+        Effect.succeed({ status: 'queued' }),
+      );
 
-      const outcome = await injectContinuationForAnsweredThread(
-        THREAD,
-        answeredManifest(),
-        session,
+      const outcome = await Effect.runPromise(
+        injectContinuationForAnsweredThread(
+          THREAD,
+          answeredManifest(),
+          session,
+        ),
       );
 
       expect(outcome).toBe('queued');
@@ -272,14 +245,19 @@ describe('external inquiry continuation session routing', () => {
   );
 
   it('archives inquiries when the follow-up owner refuses a stale queue', async () => {
-    submitFollowUpMock.mockResolvedValueOnce({
-      status: 'failed' as const,
-      reason: 'not_resumable' as const,
-    });
+    submitFollowUpMock.mockReturnValueOnce(
+      Effect.succeed({
+        status: 'failed' as const,
+        reason: 'not_resumable' as const,
+      }),
+    );
 
-    const outcome = await injectContinuationForAnsweredThread(
-      THREAD,
-      answeredManifest(),
+    const outcome = await Effect.runPromise(
+      injectContinuationForAnsweredThread(
+        THREAD,
+        answeredManifest(),
+        sessionStub(),
+      ),
     );
 
     expect(outcome).toBe('archived');

--- a/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
@@ -621,16 +621,18 @@ describe('native subagent production delivery path', { retry: 2 }, () => {
     // admission path: no additional parent message, no additional wake.
     const report = await store.readReport();
     for (let replay = 0; replay < 100; replay++) {
-      await deliverChildRunFollowUp({
-        targetStreamId: PARENT_STREAM_ID,
-        followUp: {
-          text: report!,
-          origin: 'subagent_result',
-          // Derived from the persisted turn token exactly as production does.
-          deliveryId: `${completed!.token}:delivery`,
-        },
-        session,
-      });
+      await Effect.runPromise(
+        deliverChildRunFollowUp({
+          targetStreamId: PARENT_STREAM_ID,
+          followUp: {
+            text: report!,
+            origin: 'subagent_result',
+            // Derived from the persisted turn token exactly as production does.
+            deliveryId: `${completed!.token}:delivery`,
+          },
+          session,
+        }),
+      );
     }
     await session.settlePublications();
     const afterReplay = JSON.stringify(
@@ -645,15 +647,17 @@ describe('native subagent production delivery path', { retry: 2 }, () => {
     expect(completedResumes).toEqual([PARENT_STREAM_ID]);
 
     // A distinct delivery identity with identical text is a distinct turn.
-    await deliverChildRunFollowUp({
-      targetStreamId: PARENT_STREAM_ID,
-      followUp: {
-        text: report!,
-        origin: 'subagent_result',
-        deliveryId: `${completed!.token}:delivery:other`,
-      },
-      session,
-    });
+    await Effect.runPromise(
+      deliverChildRunFollowUp({
+        targetStreamId: PARENT_STREAM_ID,
+        followUp: {
+          text: report!,
+          origin: 'subagent_result',
+          deliveryId: `${completed!.token}:delivery:other`,
+        },
+        session,
+      }),
+    );
     await waitForCompletedResumes(2);
     await session.settlePublications();
     const afterDistinct = JSON.stringify(

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -207,7 +207,9 @@ describe('NativeSubagentStrategy', () => {
     });
     mocks.throwDeliveryFormatting = false;
     mocks.throwErrorFormatting = false;
-    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+    mocks.deliverChildRunFollowUp.mockReturnValue(
+      Effect.succeed({ kind: 'delivered' }),
+    );
     mocks.persistChildRunReport.mockResolvedValue(undefined);
     mocks.persistChildRunResultMeta.mockResolvedValue(undefined);
     mocks.writeTurnState.mockResolvedValue(undefined);

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -169,11 +169,9 @@ const queueAgentCliFollowUp = Effect.fn('agentCliShared.queueAgentCliFollowUp')(
       labels,
     );
 
-    const result = yield* agentCliCall(() =>
-      submitFollowUp(stored.childStreamId, prompt, {
-        session: params.session,
-      }),
-    );
+    const result = yield* submitFollowUp(stored.childStreamId, prompt, {
+      session: params.session,
+    });
     if (result.status === 'failed') {
       return yield* Effect.fail(
         new ToolError(

--- a/src/tools/delegation/DelegationTools.ts
+++ b/src/tools/delegation/DelegationTools.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 /**
  * Tools for delegating agent executions from tool-use agents.
  * - delegate_workflow: For workflow agents (structured file I/O, fixed-round full-document rewrite)
@@ -30,6 +31,7 @@ import {
 import { deliverChildRunFollowUp } from '@agent/followUp/childRunDelivery';
 import { createLog } from '@logger/logUtils';
 import { effectRuntime } from '@platform/processRuntime';
+import type { StreamTabId } from '@shared/schemas';
 import {
   AgentCategory,
   DEFAULT_TOOL_CONFIG,
@@ -72,27 +74,29 @@ const log = createLog('delegation');
  * failure delivering THIS message is logged, not re-thrown (this already runs
  * fire-and-forget off `resumeAgent`'s own return).
  */
-async function deliverResumeWakeFailure(
-  handle: AgentExecutionHandle,
-  session: SessionHandle,
-  executionId: string,
-  err: unknown,
-): Promise<void> {
-  log.warn(
-    `Failed to wake resumed subagent '${executionId}': ${toErrorMessage(err)}`,
-  );
-  const msg = formatSubagentError(executionId, handle.agentName, err);
-  const delivery = await deliverChildRunFollowUp({
-    targetStreamId: handle.parentStreamId,
-    followUp: { text: msg, origin: 'subagent_result' },
-    session,
-  });
-  if (delivery.kind !== 'delivered') {
+const deliverResumeWakeFailure = Effect.fn('deliverResumeWakeFailure')(
+  function* (
+    handle: AgentExecutionHandle,
+    session: SessionHandle,
+    executionId: string,
+    err: unknown,
+  ): Effect.fn.Return<void, Error> {
     log.warn(
-      `Also failed to deliver the wake-failure error for '${executionId}' to the parent (${delivery.kind}).`,
+      `Failed to wake resumed subagent '${executionId}': ${toErrorMessage(err)}`,
     );
-  }
-}
+    const msg = formatSubagentError(executionId, handle.agentName, err);
+    const delivery = yield* deliverChildRunFollowUp({
+      targetStreamId: handle.parentStreamId,
+      followUp: { text: msg, origin: 'subagent_result' },
+      session,
+    });
+    if (delivery.kind !== 'delivered') {
+      log.warn(
+        `Also failed to deliver the wake-failure error for '${executionId}' to the parent (${delivery.kind}).`,
+      );
+    }
+  },
+);
 
 // ============================================================================
 // delegate_workflow tool - for document processing agents
@@ -245,7 +249,14 @@ Git worktree support: resolved from the active workspace at runtime.`,
   protected async execute(input: DelegateAgentInput): Promise<ToolResult> {
     // Resume path: execution_id is set
     if (input.execution_id) {
-      return this.resumeAgent(input.execution_id, input.instruction);
+      return effectRuntime().runPromise(
+        this.resumeAgent(
+          input.execution_id,
+          input.instruction,
+          currentSession(),
+          getRunContextStreamId(tryUseRunContext()),
+        ),
+      );
     }
 
     // New-delegation path: the schema's refine() guarantees exactly one of
@@ -290,90 +301,111 @@ Git worktree support: resolved from the active workspace at runtime.`,
   }
 
   /** Queue follow-up instructions for a tool-use subagent. */
-  private async resumeAgent(
-    executionId: string,
-    instruction: string,
-  ): Promise<ToolResult> {
-    const parentContext = tryUseRunContext();
-    const session = currentSession();
-    const handle = session.executions.getHandle(executionId);
-    if (!handle) {
-      throw new Error(
-        `Execution '${executionId}' not found. Use the executions tool to check status.`,
-      );
-    }
+  private readonly resumeAgent = Effect.fn('DelegateAgentTool.resumeAgent')(
+    function* (
+      executionId: string,
+      instruction: string,
+      session: SessionHandle,
+      callerStreamId: StreamTabId | undefined,
+    ): Effect.fn.Return<ToolResult, Error> {
+      const handle = session.executions.getHandle(executionId);
+      if (!handle) {
+        return yield* Effect.fail(
+          new Error(
+            `Execution '${executionId}' not found. Use the executions tool to check status.`,
+          ),
+        );
+      }
 
-    if (handle.category !== 'toolUse') {
-      throw new Error(
-        `Execution '${executionId}' is a workflow agent. Only tool-use subagents can be resumed.`,
-      );
-    }
+      if (handle.category !== 'toolUse') {
+        return yield* Effect.fail(
+          new Error(
+            `Execution '${executionId}' is a workflow agent. Only tool-use subagents can be resumed.`,
+          ),
+        );
+      }
 
-    // Results route to handle.parentStreamId — a detached subagent (parent ===
-    // child) delivers nowhere, and a subagent of another orchestrator reports
-    // to that orchestrator, not the caller. Fail fast instead of silently
-    // queueing instructions whose results would never come back here.
-    if (!handle.isChildExecution) {
-      throw new Error(
-        `Execution '${executionId}' was detached from its orchestrator and now runs top-level. Its results can no longer be delivered back to this session. Start a new delegation instead.`,
-      );
-    }
-    const callerStreamId = getRunContextStreamId(parentContext);
-    if (callerStreamId && !handle.isOwnedBy(callerStreamId)) {
-      throw new Error(
-        `Execution '${executionId}' belongs to a different orchestrator session. Its results would be delivered there, not here. Start a new delegation instead.`,
-      );
-    }
+      // Results route to handle.parentStreamId. A detached subagent (parent ===
+      // child) delivers nowhere, and a subagent of another orchestrator reports
+      // to that orchestrator, not the caller. Fail fast instead of silently
+      // queueing instructions whose results would never come back here.
+      if (!handle.isChildExecution) {
+        return yield* Effect.fail(
+          new Error(
+            `Execution '${executionId}' was detached from its orchestrator and now runs top-level. Its results can no longer be delivered back to this session. Start a new delegation instead.`,
+          ),
+        );
+      }
+      if (callerStreamId && !handle.isOwnedBy(callerStreamId)) {
+        return yield* Effect.fail(
+          new Error(
+            `Execution '${executionId}' belongs to a different orchestrator session. Its results would be delivered there, not here. Start a new delegation instead.`,
+          ),
+        );
+      }
 
-    const framedInstruction = formatFollowUpInstruction(instruction);
-    const result = await submitFollowUp(
-      handle.childStreamId,
-      framedInstruction,
-      {
-        session,
-      },
-    );
-    if (result.status === 'failed') {
-      throw new Error(
-        `Follow-up for '${handle.agentName}' was not accepted (${result.reason}): ${describeFollowUpFailure(result.reason)}`,
+      const framedInstruction = formatFollowUpInstruction(instruction);
+      const result = yield* submitFollowUp(
+        handle.childStreamId,
+        framedInstruction,
+        {
+          session,
+        },
       );
-    }
-    if (result.status === 'queued' && result.wake === 'failed') {
-      // The instruction is in the subagent's queue; only its wake failed.
-      // The parent learns of that through its own follow-up queue as well,
-      // the same way a child's turn failure reaches it.
-      void deliverResumeWakeFailure(
-        handle,
-        session,
-        executionId,
-        new Error(
-          'The subagent could not be resumed to process the follow-up.',
-        ),
-      );
+      if (result.status === 'failed') {
+        return yield* Effect.fail(
+          new Error(
+            `Follow-up for '${handle.agentName}' was not accepted (${result.reason}): ${describeFollowUpFailure(result.reason)}`,
+          ),
+        );
+      }
+      if (result.status === 'queued' && result.wake === 'failed') {
+        // The instruction is in the subagent's queue; only its wake failed.
+        // The parent learns of that through its own follow-up queue as well,
+        // the same way a child's turn failure reaches it.
+        yield* Effect.forkDetach(
+          deliverResumeWakeFailure(
+            handle,
+            session,
+            executionId,
+            new Error(
+              'The subagent could not be resumed to process the follow-up.',
+            ),
+          ).pipe(
+            Effect.catch((error) =>
+              Effect.sync(() => {
+                log.warn('Could not deliver the subagent wake failure.', {
+                  data: error,
+                });
+              }),
+            ),
+          ),
+        );
+        return executed(
+          [
+            `Follow-up instruction queued for '${handle.agentName}', but the subagent could not be resumed. ${FOLLOW_UP_WAKE_FAILED_MESSAGE}`,
+            `Execution ID: ${executionId}`,
+          ].join('\n'),
+          `Follow-up queued for '${handle.agentName}' (resume failed)`,
+        );
+      }
+
+      if (result.status === 'sent') {
+        return executed(
+          [
+            `Follow-up instruction sent to '${handle.agentName}'. The subagent will process it and deliver a new result automatically.`,
+            `Execution ID: ${executionId}`,
+          ].join('\n'),
+          `Follow-up sent to '${handle.agentName}'`,
+        );
+      }
       return executed(
         [
-          `Follow-up instruction queued for '${handle.agentName}', but the subagent could not be resumed. ${FOLLOW_UP_WAKE_FAILED_MESSAGE}`,
+          `Follow-up instruction queued for '${handle.agentName}'. The subagent will process it and deliver a new result automatically.`,
           `Execution ID: ${executionId}`,
         ].join('\n'),
-        `Follow-up queued for '${handle.agentName}' (resume failed)`,
+        `Follow-up queued for '${handle.agentName}'`,
       );
-    }
-
-    if (result.status === 'sent') {
-      return executed(
-        [
-          `Follow-up instruction sent to '${handle.agentName}'. The subagent will process it and deliver a new result automatically.`,
-          `Execution ID: ${executionId}`,
-        ].join('\n'),
-        `Follow-up sent to '${handle.agentName}'`,
-      );
-    }
-    return executed(
-      [
-        `Follow-up instruction queued for '${handle.agentName}'. The subagent will process it and deliver a new result automatically.`,
-        `Execution ID: ${executionId}`,
-      ].join('\n'),
-      `Follow-up queued for '${handle.agentName}'`,
-    );
-  }
+    },
+  );
 }

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -130,13 +130,9 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
               data: { key, streamId, err },
             });
           });
-        return Effect.tryPromise({
-          try: () =>
-            submitFollowUp(streamId, text, {
-              session: owner,
-              mode: 'live_notification',
-            }),
-          catch: (err) => err,
+        return submitFollowUp(streamId, text, {
+          session: owner,
+          mode: 'live_notification',
         }).pipe(
           Effect.flatMap((result) => {
             if (result.status !== 'sent' && result.status !== 'queued') {

--- a/src/tools/inquiry/inquiryActions.ts
+++ b/src/tools/inquiry/inquiryActions.ts
@@ -1,3 +1,5 @@
+import { Effect } from 'effect';
+import { runInSession } from '@agent/runtime/RunContext';
 /**
  * External-inquiry action persistence and continuation dispatch.
  *
@@ -14,6 +16,7 @@ import { createLog } from '@logger/logUtils';
 
 // Local imports - shared
 import type { InquiryActionMessage } from '@shared/schemas';
+import { ensureError } from '@utils/errors/errorMessage';
 
 // Local imports - inquiry
 import {
@@ -127,22 +130,24 @@ async function persistExternalInquiryAction(
 }
 
 /** Deliver the continuation represented by a completed durable transition. */
-async function continueExternalInquiryAction(
+const continueExternalInquiryAction = Effect.fn(
+  'continueExternalInquiryAction',
+)(function* (
   transition: ExternalInquiryTransition,
-  options: { session?: SessionHandle } = {},
-): Promise<void> {
+  options: { session: SessionHandle },
+): Effect.fn.Return<void, Error> {
   switch (transition.kind) {
     case 'answered':
       // Use the manifest just written so a concurrent follow-up cannot flip
       // storage back to `open` before this continuation observes the answer.
-      await injectContinuationForAnsweredThread(
+      yield* injectContinuationForAnsweredThread(
         transition.threadId,
         transition.manifest,
         options.session,
       );
       return;
     case 'dropped':
-      await injectContinuationForDroppedThread(
+      yield* injectContinuationForDroppedThread(
         transition.threadId,
         transition.manifest,
         options.session,
@@ -151,14 +156,22 @@ async function continueExternalInquiryAction(
     case 'stale':
       return;
   }
-}
+});
 
 /** Persist and continue an inquiry action for hosts without progress UI. */
-export async function handleExternalInquiryAction(
+export const handleExternalInquiryAction = Effect.fn(
+  'handleExternalInquiryAction',
+)(function* (
   payload: ExternalInquiryAction,
-  options: { session?: SessionHandle } = {},
-): Promise<boolean> {
-  const transition = await persistExternalInquiryAction(payload);
-  await continueExternalInquiryAction(transition, options);
+  options: { session: SessionHandle },
+): Effect.fn.Return<boolean, Error> {
+  const transition = yield* Effect.tryPromise({
+    try: async () =>
+      runInSession(options.session, () =>
+        persistExternalInquiryAction(payload),
+      ),
+    catch: ensureError,
+  });
+  yield* continueExternalInquiryAction(transition, options);
   return transition.kind !== 'stale';
-}
+});

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -1,3 +1,5 @@
+import { Effect } from 'effect';
+import { runInSession } from '@agent/runtime/RunContext';
 /**
  * Inquiry continuation injector.
  *
@@ -16,10 +18,7 @@ import {
   lookupStreamExecutionId,
   submitFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
-import {
-  currentSession,
-  type SessionHandle,
-} from '@agent/runtime/SessionHandle';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { createLog } from '@logger/logUtils';
 import {
   aggregateId as qualifyAggregateId,
@@ -29,6 +28,7 @@ import {
   type InquiryResumeOutcome,
   type StreamTabId,
 } from '@shared/schemas';
+import { ensureError } from '@utils/errors/errorMessage';
 import {
   formatRelativeTime,
   previewLabel,
@@ -109,62 +109,67 @@ export function buildContinuationText(params: {
   return lines.join('\n');
 }
 
-async function emitInquiryThreadUpdate(
+const emitInquiryThreadUpdate = Effect.fn('emitInquiryThreadUpdate')(function* (
   threadId: InquiryThreadId,
   extra: { resumeOutcome: InquiryResumeOutcome },
-  session?: SessionHandle,
-): Promise<void> {
-  const summary = await getThreadSummary(threadId);
+  session: SessionHandle,
+): Effect.fn.Return<void, Error> {
+  const summary = yield* Effect.tryPromise({
+    try: async () => runInSession(session, () => getThreadSummary(threadId)),
+    catch: ensureError,
+  });
   if (!summary) return;
   const payload: InquiryThreadUpdatedEvent = { ...summary, ...extra };
-  (session ?? currentSession()).publish([
+  session.publish([
     {
       type: 'inquiryThreadUpdated',
       aggregateId: qualifyAggregateId('inquiry', payload.threadId),
       ...payload,
     },
   ]);
-}
+});
 
 /** Archive a thread that has nothing to continue: emit the summary update. */
-async function archiveAsParentFinished(
+const archiveAsParentFinished = Effect.fn('archiveAsParentFinished')(function* (
   threadId: InquiryThreadId,
-  session?: SessionHandle,
-): Promise<InjectionOutcome> {
-  await emitInquiryThreadUpdate(
+  session: SessionHandle,
+): Effect.fn.Return<InjectionOutcome, Error> {
+  yield* emitInquiryThreadUpdate(
     threadId,
     { resumeOutcome: 'parent_finished' },
     session,
   );
   return 'archived';
-}
+});
 
-async function deliverContinuation(params: {
-  parentStreamId: StreamTabId;
-  text: string;
-  threadId: InquiryThreadId;
-  session?: SessionHandle;
-}): Promise<InjectionOutcome> {
-  const result = await submitFollowUp(params.parentStreamId, params.text, {
-    session: params.session,
-  });
+const deliverContinuation = Effect.fn('deliverContinuation')(
+  function* (params: {
+    parentStreamId: StreamTabId;
+    text: string;
+    threadId: InquiryThreadId;
+    session: SessionHandle;
+  }): Effect.fn.Return<InjectionOutcome, Error> {
+    const result = yield* submitFollowUp(params.parentStreamId, params.text, {
+      session: params.session,
+    });
 
-  // A queued continuation whose wake failed is still queued; an explicit
-  // Resume delivers it. A refusal has nothing left to continue.
-  if (result.status === 'failed') {
-    logger.warn(
-      `Inquiry continuation for ${params.threadId}: parent stream ${params.parentStreamId} refused it (${result.reason}).`,
+    // A queued continuation whose wake failed is still queued; an explicit
+    // Resume delivers it. A refusal has nothing left to continue.
+    if (result.status === 'failed') {
+      logger.warn(
+        `Inquiry continuation for ${params.threadId}: parent stream ${params.parentStreamId} refused it (${result.reason}).`,
+      );
+      return yield* archiveAsParentFinished(params.threadId, params.session);
+    }
+
+    yield* emitInquiryThreadUpdate(
+      params.threadId,
+      { resumeOutcome: result.status },
+      params.session,
     );
-    return archiveAsParentFinished(params.threadId, params.session);
-  }
-
-  await emitInquiryThreadUpdate(
-    params.threadId,
-    { resumeOutcome: result.status },
-    params.session,
-  );
-  return result.status;
-}
+    return result.status;
+  },
+);
 
 /**
  * Shared body of the answered / dropped injectors: resolve the manifest,
@@ -173,13 +178,19 @@ async function deliverContinuation(params: {
  * parent stream, or a parent stream since re-run under another execution),
  * then build and deliver the continuation.
  */
-async function injectContinuation(
+const injectContinuation = Effect.fn('injectContinuation')(function* (
   event: 'answered' | 'dropped',
   threadId: InquiryThreadId,
-  manifestHint?: ExternalInquiryThreadManifest,
-  session?: SessionHandle,
-): Promise<InjectionOutcome> {
-  const manifest = manifestHint ?? (await readExternalInquiryThread(threadId));
+  manifestHint: ExternalInquiryThreadManifest | undefined,
+  session: SessionHandle,
+): Effect.fn.Return<InjectionOutcome, Error> {
+  const manifest =
+    manifestHint ??
+    (yield* Effect.tryPromise({
+      try: async () =>
+        runInSession(session, () => readExternalInquiryThread(threadId)),
+      catch: ensureError,
+    }));
   if (!manifest) return 'archived';
 
   const lastTurn = manifest.turns.at(-1);
@@ -189,31 +200,38 @@ async function injectContinuation(
     logger.warn(
       `Inquiry continuation for ${threadId}: manifest has no turns; archiving.`,
     );
-    return archiveAsParentFinished(threadId, session);
+    return yield* archiveAsParentFinished(threadId, session);
   }
   if (event === 'answered' && lastTurn.kind !== 'answered') return 'archived';
   if (manifest.parentStreamId == null) {
-    return archiveAsParentFinished(threadId, session);
+    return yield* archiveAsParentFinished(threadId, session);
   }
   // The answer is addressed to the execution that asked. A manifest written
   // before the field existed names none and is delivered by stream alone.
   if (manifest.parentExecutionId != null) {
-    const current = await lookupStreamExecutionId(
+    const current = yield* lookupStreamExecutionId(
       manifest.parentStreamId,
-      session ?? currentSession(),
+      session,
     );
     if (current !== manifest.parentExecutionId) {
       logger.warn(
         `Inquiry continuation for ${threadId}: parent stream ${manifest.parentStreamId} now runs execution ${current ?? 'none'}, not ${manifest.parentExecutionId}; archiving.`,
       );
-      return archiveAsParentFinished(threadId, session);
+      return yield* archiveAsParentFinished(threadId, session);
     }
   }
 
-  const stillOpen = await listThreadsByStatus({
-    status: 'open',
-    scope: 'stream',
-    streamId: manifest.parentStreamId,
+  const parentStreamId = manifest.parentStreamId;
+  const stillOpen = yield* Effect.tryPromise({
+    try: async () =>
+      runInSession(session, () =>
+        listThreadsByStatus({
+          status: 'open',
+          scope: 'stream',
+          streamId: parentStreamId,
+        }),
+      ),
+    catch: ensureError,
   });
   const text = buildContinuationText({
     event,
@@ -226,13 +244,13 @@ async function injectContinuation(
     stillOpen,
   });
 
-  return deliverContinuation({
+  return yield* deliverContinuation({
     parentStreamId: manifest.parentStreamId,
     text,
     threadId,
     session,
   });
-}
+});
 
 export function injectContinuationForAnsweredThread(
   threadId: InquiryThreadId,
@@ -242,9 +260,9 @@ export function injectContinuationForAnsweredThread(
    * stream could flip `answered → open` between the write and the
    * re-read, which would otherwise drop the continuation as archived.
    */
-  manifestHint?: ExternalInquiryThreadManifest,
-  session?: SessionHandle,
-): Promise<InjectionOutcome> {
+  manifestHint: ExternalInquiryThreadManifest | undefined,
+  session: SessionHandle,
+): Effect.Effect<InjectionOutcome, Error> {
   return injectContinuation('answered', threadId, manifestHint, session);
 }
 
@@ -256,8 +274,8 @@ export function injectContinuationForDroppedThread(
    * thread from another stream could flip status away from `dropped`
    * before a fresh read, which would mislabel the continuation.
    */
-  manifestHint?: ExternalInquiryThreadManifest,
-  session?: SessionHandle,
-): Promise<InjectionOutcome> {
+  manifestHint: ExternalInquiryThreadManifest | undefined,
+  session: SessionHandle,
+): Effect.Effect<InjectionOutcome, Error> {
   return injectContinuation('dropped', threadId, manifestHint, session);
 }


### PR DESCRIPTION
Cold follow-up and resume requests now resolve the execution from the requested stream's committed `run.start` metadata through indexed snapshot preload. This removes the full execution-directory scan and its obsolete result type. The CLI also uses the execution identity it has already preloaded.

The lookup and its follow-up, inquiry, and child-delivery callers compose native Effects through the existing host and tool entry points. Transient child progress uses the current live queue owner, retaining parent routing and detachment behavior without reclassifying a parent that no longer has a live owner. This deliberately removes the old transient notification path's incidental hold-state mutation; cold user submissions and child result delivery retain their classification behavior.

This is a Stage 2 slice stacked on Stage 3. General execution listing and the existing checkpoint-based resumability decisions remain separate work; this change does not implement D4 or alter importer policy.

Review also reproduced a cancellation defect: if the submitting fiber stopped waiting before the Promise resume port declined a wake, the recovery claim remained held. Claim release now belongs to that port's settlement, so a subsequent submission can acquire it. One regression case extends the existing follow-up suite.

Validation for the final review round: format, full typecheck, compile:fast, full lint, both ratchets, and the touched follow-up, resume, and child-delivery suites (35 tests). The full suite passes: 8,875 tests, with six skipped. The final wording correction repeated every required check and the full suite, and the child-routing suite passes all 27 tests. The earlier implementation round also passed all 20 touched suites (325 tests). No test files or ratchet allowances were added.


## Net elements (R6)

Against Stage 3 commit 8a509f4789: 41 files changed, 1,024 lines added and 890 removed (net +134). No files added or deleted. Export declaration lines: seven added, nine removed (net -2). Class/interface/enum declarations: zero added, two removed. The net increase carries the indexed lookup and delivery operations through their existing callers as native Effects, with existing fixtures adapted to those operations; it adds no parallel storage or runtime.

## Consumer counts (R8)

Production searches find zero references to the deleted listExecutionStreamReferences scan and ExecutionStreamReference type. Their single lookup consumer now reads the requested stream's committed metadata. Two obsolete lookup reexports and the CLI's redundant lookup are removed. No new test files or ratchet allowances.

Tracking: #11867. Follows Stage 3 (#12046), with base cutover/persistence-substrate. This PR does not target main.
