### PR TITLE
fix(session): fold every committed row, fence only local side effects

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -608,15 +608,17 @@ export class SessionHandle {
 
   /** Apply a durable fact delivered by the root's ordered table tail. */
   receiveCommittedEvent(event: SessionEvent): Effect.Effect<void> {
-    // File writers, host notifications and runtime waiters belong only to
-    // the process that authored the fact.
-    const { self } = SubscriptionRef.getUnsafe(this.graph.local);
-    if (event.ownerId == null || !self.includes(event.ownerId)) {
-      return Effect.void;
-    }
+    // The fold is this process's reading of the shared table, so every
+    // committed row enters it whoever authored it: the store's synchronous
+    // accessors would otherwise answer a cross-process run's questions from a
+    // fold that never saw its rows. The ownership fence below is on the local
+    // side effects only — file writers, host notifications and runtime waiters
+    // belong to the process that authored the fact.
     return this.applySnapshotEvent(event).pipe(
       Effect.andThen(
         Effect.sync(() => {
+          const { self } = SubscriptionRef.getUnsafe(this.graph.local);
+          if (event.ownerId == null || !self.includes(event.ownerId)) return;
           if (event.type === 'result') {
             for (const listener of [...this.resultListeners]) {
               try {

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -371,7 +371,25 @@ const sessionHandleLayer = (
         ),
         (session) =>
           Effect.sync(() => session.unwind()).pipe(
-            Effect.ensuring(Effect.promise(() => session.settlePublications())),
+            // Settlement reports what the session's own publications left
+            // behind. The release still has to finish, so that report is
+            // logged here rather than escaping `Scope.close` and failing the
+            // `invalidate` or `close` that asked for the release.
+            Effect.ensuring(
+              Effect.tryPromise({
+                try: () => session.settlePublications(),
+                catch: (error) => error,
+              }).pipe(
+                Effect.catch((error) =>
+                  Effect.sync(() => {
+                    log.warn(
+                      `Session ${key.storage} left a failed publication behind as it closed.`,
+                      { data: error },
+                    );
+                  }),
+                ),
+              ),
+            ),
           ),
       );
       yield* SubscriptionRef.set(delivered, anchor);

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -652,6 +652,71 @@ describe('Sessions owner', () => {
       }),
   );
 
+  // #12017's ownership fence must not reach the fold: the snapshot store is
+  // an in-memory reading of the shared table, and its synchronous accessors
+  // are the runtime's answer for any stream, including one another process
+  // owns.
+  it.live(
+    "folds another process's committed facts without firing local side effects",
+    () =>
+      Effect.gen(function* () {
+        const session = open('/workspace/owner/foreign-fold');
+        const onResult = vi.fn();
+        const detachResult = session.onResult(onResult);
+        const foreign = 'stream:foreign' as StreamTabId;
+        const aggregateId = qualifyAggregateId('stream', foreign);
+        const foreignExecution = 'cd34ef' as ExecutionId;
+        try {
+          yield* session.receiveCommittedEvent({
+            type: 'run.start',
+            aggregateId,
+            executionId: foreignExecution,
+            identity: { kind: 'agent', agent: 'chat' },
+            userFollowUpSupport: 'unsupported',
+            category: AgentCategory.ToolUse,
+            isRemote: false,
+            ownerId: OTHER,
+            at: 0,
+            seq: 1,
+            commit: 1,
+          });
+          yield* session.receiveCommittedEvent({
+            type: 'updateStreamDescription',
+            aggregateId,
+            description: 'a run in another process',
+            ownerId: OTHER,
+            at: 0,
+            seq: 2,
+            commit: 2,
+          });
+          yield* session.receiveCommittedEvent({
+            type: 'result',
+            aggregateId,
+            outcome: 'completed',
+            executionId: foreignExecution,
+            agentName: 'chat',
+            category: AgentCategory.ToolUse,
+            isSubagent: false,
+            ownerId: OTHER,
+            at: 0,
+            seq: 3,
+            commit: 3,
+          });
+          expect(session.snapshots.hasProvenance(foreign)).toBe(true);
+          expect(session.snapshots.getRunMetadata(foreign)).toMatchObject({
+            executionId: foreignExecution,
+            description: 'a run in another process',
+          });
+          // Host presentation of a terminal result stays with the process
+          // that authored it.
+          expect(onResult).not.toHaveBeenCalled();
+        } finally {
+          detachResult();
+          session.dispose();
+        }
+      }),
+  );
+
   it.effect(
     'close reports settled once the run ended, and releases the session',
     () =>


### PR DESCRIPTION
## What was broken

`SessionHandle.receiveCommittedEvent` is the single delivery path for every row in a session's shared SQLite event table: `sessionLayer` pipes `reads.all(anchor)` (which reads the whole log, with no owner filter) into it, and nothing downstream re-applies those rows to the snapshot store. The `applySnapshotEvent` closure it calls is the store's only writer, assigned once in the constructor and used nowhere else.

That method opened with an ownership fence that returned early for any row this process did not author, so `applySnapshotEvent` never ran for a foreign row at all. `StreamSnapshotStore` used to be a file writer, and the fence was written for exactly that reason. It is now an in-memory fold of the shared table, kept in step with the log, and its synchronous accessors read that fold: `getOutputFiles`, `getMissingOutputs`, `getCompileFailures`, `getRunUsage`, `getKnownFilePaths`, `getWorkPlan`, `getRunMetadata`, `hasProvenance`, `getParentStreamId` and `getExecutionIdMap` all go through the private `current()` helper. So every one of them answered a cross-process run's question from a fold that had never seen its rows. `read`, `preload`, `load` and `listPersistedStreams` re-read the database, so full snapshots were fine; the synchronous path was not.

The history shows how it happened. The fold conversion removed the fence entirely and made both the fold and the local side effects unconditional. A later merge reintroduced the older fence on top of the new shape, which put the whole method behind it, fold included.

## How I know the fence was not protecting the fold

I checked each consumer that the fence sits in front of.

- `resultListeners`, fed by `onResult`: the consumers are `attachTerminalResultToast` and `trackTerminalResultPresentation`, wired up by the progress view, the CLI chat controller, `runExecution` and `resumeFromResumeData`. An unfenced fan-out would raise this host's error toast for another process's failed run. This is a real leak and the fence stays here.
- `statusPorts`: the only implementor is the transcript recorder's `handleStatus`, which drops any event whose `streamId` is not its own, so a foreign stream's status is already inert.
- `executions.handleStatus`: returns immediately when no handle for that stream is registered in this process, which is the case for a foreign stream.

So the narrow thing the fence genuinely guards is host presentation of a terminal result, which is what its own comment says it is for: file writers, host notifications and runtime waiters. The fold is none of those three.

## What I changed

`src/agent/runtime/SessionHandle.ts`: the fold applies unconditionally, and the ownership check moved down into the `Effect.sync` block that runs the local side effects. Reading the local snapshot inside that block also means the check sees the state at side-effect time rather than before the store's permit.

`src/controllers/session/sessionLayer.ts`: the session's `acquireRelease` release wrapped `session.settlePublications()` in a bare `Effect.promise`. A rejection there is a defect that escapes `Scope.close` and fails the `sessions.invalidate` or `closeSession` that asked for the release, turning a report about publications into a crashed close. It is now `Effect.tryPromise` with an `Effect.catch` that logs the cause at warn along with the session's storage root, so the release finishes and the failure is still loud.

`src/test-kernel/controllers/session/sessionEvents.vitest.ts`: one regression test added to the existing suite, no new file. It feeds three rows stamped with a foreign owner id straight into `receiveCommittedEvent` and asserts both halves of the contract at once: the fold has the run's provenance and description, and `onResult` never fired.

## Verification, with actual output

- `npm run typecheck`: clean across root, cli, trace-viewer and desktop projects.
- `npx vitest run src/test-kernel/controllers/session/ src/test-kernel/transcript/`: 12 files, 164 tests passed. Widening to `src/test-kernel/agent/runtime/` as well: 48 files, 599 tests passed.
- The new test run against the pre-fix `SessionHandle.ts` restored from the base commit: 1 failed, at `sessionEvents.vitest.ts:705`, `expect(session.snapshots.hasProvenance(foreign)).toBe(true)` receiving `false`. It pins the regression rather than passing vacuously.
- `node scripts/check-effect-migration-ratchet.mjs`: "Effect migration ratchet OK: no count grew, no baseline headroom", with `catch:effect-importer` still at 8 files / 17 sites and no `@adapter-until` markers. Before making the `tryPromise` change I read the row's counting logic: it counts `ts.isCatchClause` nodes and `.catch(` property-access calls other than the `Effect.catch` combinator, so neither the `catch:` property of a `tryPromise` options object nor `Effect.catch` in a pipe is counted. `sessionLayer.ts` has no catch row at all, so this mattered. The baseline JSON is untouched.
- `npm run lint`: clean.

## What I deliberately left alone

The other `Effect.promise` sites in `sessionLayer.ts`, reported rather than changed:

- The owner liveness probe around `proveOwnerLiveness` has the same unhandled-rejection shape; a rejection would kill the probe fiber inside its repeat schedule.
- The `untilSettled` promise in `closeSession` is raced against the close budget and shares the shape.
- The `flushArtifacts` promise beside it is deliberate: the surrounding comment states that a flush which fails still fails the close, so converting it would change documented behavior.
- The `processStart` promise in `installProcessRuntime` is a startup identity read, outside this subsystem.

I also left both fenced side-effect paths as they are. The status port and registry paths are inert for foreign rows by their own filters, and adding a second filter would be a duplicate guard rather than a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU
