### PR TITLE
docs: correct three measured factual errors in the architecture corpus

### DIFF
--- a/.agents/docs/implemented/architecture/2026-09-03-prd-one-fold-three-renderers.md
+++ b/.agents/docs/implemented/architecture/2026-09-03-prd-one-fold-three-renderers.md
@@ -1,21 +1,28 @@
 ---
 created: 2026-09-03
-updated: 2026-09-03
+updated: 2026-09-07
 status: implemented
 ---
 
 # PRD: One fold, three renderers
 
-**Status:** Proposed; requires owner ratification of the nine decisions in
-section 17 before lane 2 starts. Decision 9 is the one to read first: it
-rules that a `StreamTabId` names a run and is never reused, which is what
-lets all thirteen incarnation fences earlier drafts had accumulated be
-deleted rather than maintained. Its cost is that a relaunched workflow
-appears as a new row instead of reusing its tab, stated in full there;
-reverting is mechanical if the owner weighs that differently. Lane 1 needs
-decisions 1 **and 9** - it implements the identity change, so starting on
-decision 1 alone would ship an unratified one; lane 6 likewise needs
-decision 7, which is what it implements.
+**Status:** Partly implemented; tracked by
+[#11861](https://github.com/LionSR/TeXRA/issues/11861). Lanes 1, 2 and 3
+landed together as
+[#11881](https://github.com/LionSR/TeXRA/pull/11881), lane 4 as
+[#11911](https://github.com/LionSR/TeXRA/pull/11911) (closing issue
+[#11863](https://github.com/LionSR/TeXRA/issues/11863)), and lane 6 as
+[#11827](https://github.com/LionSR/TeXRA/pull/11827). Lanes 5, 7 and 8 are
+still open as [#11864](https://github.com/LionSR/TeXRA/issues/11864),
+[#11865](https://github.com/LionSR/TeXRA/issues/11865) and
+[#11866](https://github.com/LionSR/TeXRA/issues/11866). The nine decisions
+of section 17 no longer gate a lane start: lanes 1 and 2 implement decisions
+1 and 9, lane 6 implements decision 7, and all three have shipped. Decision
+9 is still the one to read first: it rules that a `StreamTabId` names a run
+and is never reused, which is what lets all thirteen incarnation fences
+earlier drafts had accumulated be deleted rather than maintained. Its cost
+is that a relaunched workflow appears as a new row instead of reusing its
+tab, stated in full there.
 
 **Decision in one sentence:** every process that shows a TeXRA session runs
 the same pure fold over the same events into one `SessionView`, the
@@ -42,9 +49,9 @@ classified). Where this PRD and those documents differ, this PRD governs.
 Its companion is the persistence decision
 `.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md` (the event
 table as the only persisted truth), written by the persistence cutover owner
-after two rounds of alignment with this program. That document is in flight
-in another branch and is not part of this pull request, so every "agreed
-with the substrate owner" claim below is checkable only once it lands. This
+after two rounds of alignment with this program. That document has since
+landed and sits in the tree at that path, so every "agreed with the
+substrate owner" claim below is checkable against it. This
 PRD follows the governing rules of
 `.agents/docs/proposed/architecture/2026-08-26-effect-4-runtime-migration.md` (R1 to R3, R5 to R10).
 
@@ -2885,7 +2892,7 @@ As tests:
    thirteen fences and call the question open.
 
 Already agreed with the persistence owner and recorded in the companion
-proposal (in flight in another branch, see Lineage): the eight event changes
+proposal (landed, see Lineage): the eight event changes
 of section 6; Effect Schema nowhere; the publisher
 invariants of 7.1; `WorkspaceRoots` as the `Database` layer's parameter;
 the two v4 traps.
@@ -2903,8 +2910,8 @@ Corrected in this revision after re-checking the dist: the tail names are
 `Stream.toQueue(stream, { capacity })` and `Stream.unwrap` (the v3
 `toQueueScoped` and `unwrapScoped` are gone; 7.1 no longer needs the queue
 at all); the Cause-tapping combinator
-is `tapCause`, not `tapErrorCause`; and rc.112 exports no `catch` or
-`catchAll` (the family is `catchTag`, `catchTags`, `catchCause`,
+is `tapCause`, not `tapErrorCause`; and rc.112 exports no `catchAll` (the
+family is `catch`, `catchTag`, `catchTags`, `catchCause`,
 `catchDefect`, `catchReason(s)`, `catchIf`, `catchFilter`,
 `catchNoSuchElement`, `catchCauseIf`, `catchCauseFilter`, `catchEager`).
 `Stream.mergeAll(streams, { concurrency })` and `Effect.die` are present.
@@ -2912,6 +2919,12 @@ Re-checked 2026-09-04 for the sequenced hydrate: `Stream.concat`,
 `Stream.make`, `Stream.empty`, `Stream.dropWhile`, and `Stream.mapAccum`
 are present; `mapAccum` takes a lazy initial and its function returns
 `[state, outputs]`, which is the shape 7.2 uses.
+
+Corrected 2026-09-07: an earlier revision of this section claimed rc.112
+exported neither `catch` nor `catchAll`. Half of that was wrong.
+`Effect.catch` is a function in rc.112 and 80 production call sites under
+`src` and `packages` already use it; only `catchAll` is absent. Nothing else
+in this section changed.
 
 Not verified, to confirm at lane start: the `PRAGMA data_version` poll
 interval and its cost on a laptop (contract C7; it is a trigger, not a
@@ -2948,7 +2961,7 @@ scale.
 | Resource          | `Effect.acquireRelease(acquire, release)`, `Effect.scoped`, `Scope`                                                 | `effect`         | interaction scope                                                                                                          |
 | Serialize         | `Semaphore.make(permits)`, `.withPermit`, `.withPermits(n)`                                                         | `effect`         | own module; `Effect.makeSemaphore` does not exist                                                                          |
 | Queue             | `Queue.bounded/sliding/dropping/unbounded<A, E>`, `offer`, `take`, `takeAll`                                        | `effect`         | v4 queues carry an error channel                                                                                           |
-| Errors            | `class E extends Data.TaggedError('E')<{…}> {}`                                                                     | `effect`         | yieldable; `catchTag`, `catchTags`, `orDie`, `tapCause`; no `tapErrorCause`, no `catch`/`catchAll`                         |
+| Errors            | `class E extends Data.TaggedError('E')<{…}> {}`                                                                     | `effect`         | yieldable; `catchTag`, `catchTags`, `orDie`, `tapCause`; no `tapErrorCause`, no `catchAll` (`catch` exists)                |
 | Defect            | `Effect.die(defect)`                                                                                                | `effect`         | no `Effect.dieMessage`; the transport layer's `publish` (7.1)                                                              |
 | Tracing           | `Effect.fn('X.method')(function* (…) {…})`                                                                          | `effect`         | every named service method                                                                                                 |
 | Runtime           | `ManagedRuntime.make(layer)`, `.runPromise(effect, { signal })`, `.runFork`, `.dispose()`                           | `effect`         | one per process                                                                                                            |

--- a/.agents/docs/proposed/architecture/2026-09-06-agent-architecture-study.md
+++ b/.agents/docs/proposed/architecture/2026-09-06-agent-architecture-study.md
@@ -1,7 +1,6 @@
 # TeXRA agent architecture: own the LLM package, replace the graph
 
 Status: proposed
-Archived: 2026-09-06
 
 Date: 2026-09-06. Status: research and recommended design, not an implemented migration or a change to the binding PRDs.
 

--- a/.agents/docs/proposed/architecture/2026-09-06-agent-loop-architecture-study.md
+++ b/.agents/docs/proposed/architecture/2026-09-06-agent-loop-architecture-study.md
@@ -1,7 +1,6 @@
 # Agent loops: an explicit interpreter on Effect, with one durable authority
 
 Status: proposed
-Archived: 2026-09-06
 
 Date: 2026-09-06. Research snapshot and recommendation; proposed states below are not existing production APIs. Read with the [decision document](./2026-09-06-agent-architecture-study.md) and [LLM package study](../../proposed/architecture/2026-09-06-llm-package-architecture-study.md).
 


### PR DESCRIPTION
## What was wrong

Three architecture notes carried factual errors that a reader would act on, plus one stale tracking issue.

**1. A document filed under `implemented/` told readers a combinator does not exist.** `.agents/docs/implemented/architecture/2026-09-03-prd-one-fold-three-renderers.md` stated, in its "Verified and not verified" section and again in the Appendix A vocabulary table, that Effect rc.112 "exports no `catch` or `catchAll`". That was presented as a verified correction made after re-reading the dist, so a reader has every reason to trust it and route around `Effect.catch`.

Half of it is wrong. Measured against this tree's own `node_modules`, `effect` is at 4.0.0-rc.112, `typeof Effect.catch` is `function`, `Effect.catchAll` is `undefined`, and the exported catch family is `catch, catchCause, catchCauseFilter, catchCauseIf, catchDefect, catchEager, catchFilter, catchIf, catchNoSuchElement, catchReason, catchReasons, catchTag, catchTags`. `git grep -c "Effect\.catch(" -- src packages` totals 80 call sites, and the same grep with test paths filtered out still returns 80, so all 80 are production code that already depends on the combinator the document says is absent.

**2. The same PRD's own status lines contradicted each other and the tree.** Its frontmatter said `status: implemented`; its body said "Proposed; requires owner ratification of the nine decisions in section 17 before lane 2 starts". Lane 2 merged. Per the tracker issue #11861, lanes 1, 2 and 3 landed together as #11881, lane 4 landed as #11911 (which closed issue #11863 with stateReason COMPLETED), and lane 6 landed as #11827; lanes 5, 7 and 8 are still open as #11864, #11865 and #11866. So neither "implemented" nor "awaiting ratification" describes the document. It also carried two hedges saying its persistence companion was "in flight in another branch and is not part of this pull request", making every "agreed with the substrate owner" claim uncheckable. That companion is now tracked in the tree at exactly the path the PRD cites.

**3. Two study documents each declared two statuses at once.** `.agents/docs/proposed/architecture/2026-09-06-agent-architecture-study.md` and `2026-09-06-agent-loop-architecture-study.md` both had `Status: proposed` immediately followed by `Archived: 2026-09-06`. A file cannot be both.

## What changed

In the one-fold PRD: section 18 now says rc.112 exports no `catchAll` and lists `catch` in the family, the Appendix A Errors row now reads "no `tapErrorCause`, no `catchAll` (`catch` exists)", and a dated paragraph records the re-measurement so the next reader knows the earlier claim was retracted and why. The body status line was replaced with the measured lane breakdown, linking each landing and each open lane, and noting that the section 17 decisions no longer gate a lane start because the lanes implementing decisions 1, 9 and 7 have all shipped. Decision 9's explanation, which is still the first thing a reader needs, is kept word for word. Both companion hedges now say the companion landed. The frontmatter `updated` date moved to 2026-09-07.

In the two study documents: the `Archived: 2026-09-06` line is gone from each header and `Status: proposed` stands alone. That is one deleted line per file and nothing else.

## The history behind the study-document headers

Worth recording, because it is a decision for the owner rather than for this change. Commit `b4a4b9f072` (2026-09-06, "docs: reclassify outdated proposals from the staleness audit") moved both files from `proposed/` to `archived/` and added the `Archived: 2026-09-06` marker while deliberately keeping `Status: proposed`. Commit `3e171c1575` (2026-09-07) then moved both files, and the companion `2026-09-06-agent-architecture.html`, straight back to `proposed/` as R100 renames, meaning 100 percent similarity and zero content change. So the later commit reversed the archiving by pure rename and left the marker stranded. `.agents/docs/README.md` scopes the `Archived: yyyy-mm-dd` marker to `archived/{class}/`, which makes the marker the inconsistent half given where the files live today.

This change therefore fixes only the internal contradiction. It does not move, rename, or `git mv` anything. Whether these studies belong in `archived/` is a call for the owner, and undoing someone's commit is not a factual repair.

## What I deliberately left alone

The claim that `catchAll` is absent is true and stays asserted. Nothing else in section 18 or Appendix A was touched. The PRD's frontmatter `status:` key stays `implemented`, matching the directory the owner moved it into and the closed status vocabulary in `.agents/docs/README.md`; the nuance now lives in the body `**Status:**` prose, which is the pattern other notes in `implemented/` already use. No section was restructured or deleted, and no prose was rewritten for taste.

Issue #11983, which reports a broken PRD link in `.agents/docs/proposed/architecture/2026-09-06-persistence-cutover-integration.md`, is already fixed and needs no change here. The issue quotes line 69 as `../prds/2026-08-26-effect-4-runtime-migration.md`; on this base the line reads `./2026-08-26-effect-4-runtime-migration.md#phase-2--...`, repaired by commit `5e357b75aa`. Resolving every relative markdown link in that file against the filesystem gives 3 of 3 OK and 0 broken. The issue is stale and a human can close it. I did not close it and did not edit it.

## Verification

Documentation only. No production code, no test files, no configuration.

- `npm run typecheck` exits 0 with zero error lines across the root, scripts, trace-viewer, desktop and cli projects.
- `npm run lint` exits 0 with no output from any of its five passes.
- `node scripts/check-effect-migration-ratchet.mjs` exits 0: "@adapter-until markers OK: none present." and "Effect migration ratchet OK: no count grew, no baseline headroom." No baseline was touched.
- `node scripts/check-guidance-refs.mjs` exits 0 over 58 files. None of the three edited files is in the checked set.
- `node docs/scripts/check-root-docs.mjs` exits 0. `.agents/docs/` sits outside the VitePress root, so there is no publish-allowlist exposure.
- No vitest suite was run because none was touched. A contract-restoring documentation fix earns zero new tests under the repo's test budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU
