### PR TITLE
chore: sync persistence cutover with latest main

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -608,15 +608,17 @@ export class SessionHandle {
 
   /** Apply a durable fact delivered by the root's ordered table tail. */
   receiveCommittedEvent(event: SessionEvent): Effect.Effect<void> {
-    // File writers, host notifications and runtime waiters belong only to
-    // the process that authored the fact.
-    const { self } = SubscriptionRef.getUnsafe(this.graph.local);
-    if (event.ownerId == null || !self.includes(event.ownerId)) {
-      return Effect.void;
-    }
+    // The fold is this process's reading of the shared table, so every
+    // committed row enters it whoever authored it: the store's synchronous
+    // accessors would otherwise answer a cross-process run's questions from a
+    // fold that never saw its rows. The ownership fence below is on the local
+    // side effects only — file writers, host notifications and runtime waiters
+    // belong to the process that authored the fact.
     return this.applySnapshotEvent(event).pipe(
       Effect.andThen(
         Effect.sync(() => {
+          const { self } = SubscriptionRef.getUnsafe(this.graph.local);
+          if (event.ownerId == null || !self.includes(event.ownerId)) return;
           if (event.type === 'result') {
             for (const listener of [...this.resultListeners]) {
               try {

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -371,7 +371,25 @@ const sessionHandleLayer = (
         ),
         (session) =>
           Effect.sync(() => session.unwind()).pipe(
-            Effect.ensuring(Effect.promise(() => session.settlePublications())),
+            // Settlement reports what the session's own publications left
+            // behind. The release still has to finish, so that report is
+            // logged here rather than escaping `Scope.close` and failing the
+            // `invalidate` or `close` that asked for the release.
+            Effect.ensuring(
+              Effect.tryPromise({
+                try: () => session.settlePublications(),
+                catch: (error) => error,
+              }).pipe(
+                Effect.catch((error) =>
+                  Effect.sync(() => {
+                    log.warn(
+                      `Session ${key.storage} left a failed publication behind as it closed.`,
+                      { data: error },
+                    );
+                  }),
+                ),
+              ),
+            ),
           ),
       );
       yield* SubscriptionRef.set(delivered, anchor);

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -652,6 +652,71 @@ describe('Sessions owner', () => {
       }),
   );
 
+  // #12017's ownership fence must not reach the fold: the snapshot store is
+  // an in-memory reading of the shared table, and its synchronous accessors
+  // are the runtime's answer for any stream, including one another process
+  // owns.
+  it.live(
+    "folds another process's committed facts without firing local side effects",
+    () =>
+      Effect.gen(function* () {
+        const session = open('/workspace/owner/foreign-fold');
+        const onResult = vi.fn();
+        const detachResult = session.onResult(onResult);
+        const foreign = 'stream:foreign' as StreamTabId;
+        const aggregateId = qualifyAggregateId('stream', foreign);
+        const foreignExecution = 'cd34ef' as ExecutionId;
+        try {
+          yield* session.receiveCommittedEvent({
+            type: 'run.start',
+            aggregateId,
+            executionId: foreignExecution,
+            identity: { kind: 'agent', agent: 'chat' },
+            userFollowUpSupport: 'unsupported',
+            category: AgentCategory.ToolUse,
+            isRemote: false,
+            ownerId: OTHER,
+            at: 0,
+            seq: 1,
+            commit: 1,
+          });
+          yield* session.receiveCommittedEvent({
+            type: 'updateStreamDescription',
+            aggregateId,
+            description: 'a run in another process',
+            ownerId: OTHER,
+            at: 0,
+            seq: 2,
+            commit: 2,
+          });
+          yield* session.receiveCommittedEvent({
+            type: 'result',
+            aggregateId,
+            outcome: 'completed',
+            executionId: foreignExecution,
+            agentName: 'chat',
+            category: AgentCategory.ToolUse,
+            isSubagent: false,
+            ownerId: OTHER,
+            at: 0,
+            seq: 3,
+            commit: 3,
+          });
+          expect(session.snapshots.hasProvenance(foreign)).toBe(true);
+          expect(session.snapshots.getRunMetadata(foreign)).toMatchObject({
+            executionId: foreignExecution,
+            description: 'a run in another process',
+          });
+          // Host presentation of a terminal result stays with the process
+          // that authored it.
+          expect(onResult).not.toHaveBeenCalled();
+        } finally {
+          detachResult();
+          session.dispose();
+        }
+      }),
+  );
+
   it.effect(
     'close reports settled once the run ended, and releases the session',
     () =>


### PR DESCRIPTION
## Summary

Merge main at `f25e883507` into the persistence cutover branch. Keep the cutover transcript fold before the snapshot fold, with author ownership checked only for local notifications and runtime waiters. Include main's regression test proving that foreign committed facts update the local snapshot without firing local result listeners.

Session closure now logs a failed publication settlement while allowing scope release to finish, matching main's correction in #12048.

## Issue acceptance gates

Supports #11867 by keeping the cutover current with main. This synchronization completes no additional persistence stage and makes no checkpoint, importer, retention, or resume-policy decision.

## Single source of truth

The ordered committed-event consumer remains the owner of transcript and snapshot updates. Ownership fences local side effects after both folds receive the committed row.

## Duplication and abstraction budget

The conflict resolution preserves the existing cutover implementation. No parallel fold or new abstraction is introduced.

## Net elements (R6)

Two files changed, 84 lines added and 1 removed, net +83 lines. No files, exports, classes, interfaces, or enums added or removed. The added regression occupies the existing session-events suite.

## Consumer counts (R8)

Not applicable: no emitter or export is removed or rerouted. The existing local result-listener ownership fence is preserved.

## Host impact

Extension, desktop, and CLI retain the cutover fold behavior and gain main's session-close settlement correction. No public interface changes.

## Scheduled refactoring

None introduced by this synchronization. Remaining cutover work stays tracked by #11867.

## Validation

- `npm run format` and final format after build
- Full `npm run typecheck`
- `npm run compile:fast`
- Full `npm run lint`
- Session-events suite: 22 passed
- Full `npm test`, run once: 8,876 passed, 6 skipped; 760 suites passed, 1 skipped
- Dead-code and Effect migration ratchets: both passed
- `git diff --check`
