### PR TITLE
docs(effect): classify every production bare Effect.promise site

### DIFF
--- a/packages/agent/src/effect/runtime.ts
+++ b/packages/agent/src/effect/runtime.ts
@@ -152,6 +152,11 @@ export function composeProcess(platform: AgentPlatform): ProcessHold {
       if (holds > 0 || !installedHere) return Effect.void;
       installedHere = false;
       return closeOwnedSessions().pipe(
+        // A faithful round trip, not a swallowed rejection:
+        // `ManagedRuntime.disposeEffect` is `Effect<void, never>` over
+        // `Scope.close`, so the only way `disposeProcessRuntime` rejects is a
+        // layer finalizer defecting, and re-raising that as a defect is what
+        // the release above says the embedder sees.
         Effect.ensuring(Effect.promise(() => disposeProcessRuntime())),
       );
     }),

--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -133,6 +133,8 @@ export function createDesktopDiffHost(
       if (inFlightFallbacks.size === 0) {
         if (observedEmpty) return;
         observedEmpty = true;
+        // A microtask yield so a registration racing the first empty
+        // observation is seen; `Promise.resolve()` cannot reject.
         yield* Effect.promise(() => Promise.resolve());
         continue;
       }

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -401,6 +401,9 @@ export function createDesktopSupabaseAuth(
         authLanes,
         AUTH_CALLBACK_LANE,
       )(
+        // Non-rejecting: `runQueuedCallback` runs the callback through
+        // `runPromiseExit` and answers both exits itself, settling the
+        // attempt, logging the cause, and notifying the user.
         Effect.promise(() =>
           runQueuedCallback({ callback, attempt: claimedAttempt }),
         ),

--- a/src/auth/oauth/loopbackLogin.ts
+++ b/src/auth/oauth/loopbackLogin.ts
@@ -83,6 +83,10 @@ const ERROR_HTML = `<!doctype html><html><head><meta charset="utf-8"><title>Sign
 
 /** One bind attempt; resolves undefined when the port is unavailable. */
 function listenAttempt(port: number): Effect.Effect<http.Server | undefined> {
+  // Non-rejecting: the executor below resolves on `listening` or on `error`
+  // and calls no reject, and `listen` reports a bind failure through that
+  // `error` listener rather than throwing (every caller passes a fixed,
+  // in-range registered port).
   return Effect.promise(
     () =>
       new Promise((resolve) => {

--- a/src/controllers/session/SessionRequests.ts
+++ b/src/controllers/session/SessionRequests.ts
@@ -276,6 +276,10 @@ function handle(
         }
       });
     case 'followUp.send':
+      // A collaborator rejection is a handler defect by this module's
+      // contract (see the header): `Effect.promise` is what routes it there,
+      // and `SessionBridge` logs the cause under the request id and answers
+      // `Internal`.
       return Effect.promise(() =>
         submitFollowUp(
           req.streamId,
@@ -357,6 +361,8 @@ function handle(
           : Effect.fail(settled(req.streamId, 'user question')),
       );
     case 'decision.retry':
+      // A rejection from the run's client preparation is a handler defect,
+      // per the module contract above, not a `RequestError` to word.
       return Effect.promise(() =>
         session.interactions.settleRetry(
           req.approvalId,
@@ -381,6 +387,8 @@ function handle(
       );
     case 'externalInquiry.submit':
     case 'externalInquiry.drop':
+      // A rejection from the inquiry persistence is a handler defect, per the
+      // module contract above, not a `RequestError` to word.
       return Effect.promise(() =>
         handleExternalInquiryAction(
           req.kind === 'externalInquiry.submit'

--- a/src/controllers/session/SessionRequests.ts
+++ b/src/controllers/session/SessionRequests.ts
@@ -277,9 +277,10 @@ function handle(
       });
     case 'followUp.send':
       // A collaborator rejection is a handler defect by this module's
-      // contract (see the header): `Effect.promise` is what routes it there,
-      // and `SessionBridge` logs the cause under the request id and answers
-      // `Internal`.
+      // contract (see the header), and `Effect.promise` is what routes it
+      // there. Where the defect surfaces depends on the path: a bridge logs
+      // the cause under the request id and answers `Internal`; in process it
+      // reaches whatever ran the Effect.
       return Effect.promise(() =>
         submitFollowUp(
           req.streamId,

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -167,6 +167,11 @@ const ownerLiveness = Layer.effectDiscard(
       );
       const dead: OwnerId[] = [];
       for (const owner of owners) {
+        // Non-rejecting by port contract: the one thing `proveOwnerLiveness`
+        // awaits is `ProcessesPort.identity`, declared as `string | undefined`
+        // with unreadable meaning undefined, and the `kill(pid, 0)` beside it
+        // catches its own. A rejection here would end this prober's stream for
+        // the life of the process, so the contract is the thing to keep.
         const liveness = yield* Effect.promise(() =>
           proveOwnerLiveness(ownerIdentity(owner)),
         );
@@ -632,7 +637,9 @@ const closeSession = (root: string, signal?: AbortSignal) =>
         }
       }),
     );
-    // Ends at the actual settlement, or when interrupted.
+    // Ends at the actual settlement, or when interrupted. Non-rejecting:
+    // `untilSettled` awaits only `waitForAnyChange`, whose executor resolves
+    // on a registry listener or on the abort and never rejects.
     const settled = Effect.promise(
       (interrupt) =>
         runInSession(session, () =>
@@ -666,6 +673,14 @@ const closeSession = (root: string, signal?: AbortSignal) =>
     // The release is the flush's finalizer: the entry goes, or its release
     // is armed on the settlement, whatever the flush's exit, and a flush
     // that fails still fails this close.
+    //
+    // `flushArtifacts` does reject when a trace or shared artifact writer
+    // fails, and `Effect.promise` is deliberate rather than an oversight:
+    // `close` answers a `SessionCloseReport` and names no error, so the
+    // defect is the channel a failed flush travels on, and `ProcessHold.release`
+    // (packages/agent/src/effect/runtime.ts) documents the embedder seeing
+    // exactly that. Widening it into a typed failure is a contract change,
+    // not a conversion.
     yield* Effect.race(
       Effect.promise(
         () =>
@@ -718,6 +733,9 @@ export function installProcessRuntime(
       ? Layer.effect(
           ProcessIdentity,
           Effect.map(
+            // Non-rejecting by port contract: the one caller that passes a
+            // pending read passes `ProcessesPort.selfIdentity()`, declared as
+            // `string | undefined`, unreadable being undefined.
             Effect.promise(() => processStart),
             (start) => ({ ownerId: processOwnerId(start) }),
           ),

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -167,11 +167,14 @@ const ownerLiveness = Layer.effectDiscard(
       );
       const dead: OwnerId[] = [];
       for (const owner of owners) {
-        // Non-rejecting by port contract: the one thing `proveOwnerLiveness`
-        // awaits is `ProcessesPort.identity`, declared as `string | undefined`
+        // The one thing `proveOwnerLiveness` awaits is
+        // `ProcessesPort.identity`, declared `Promise<string | undefined>`
         // with unreadable meaning undefined, and the `kill(pid, 0)` beside it
-        // catches its own. A rejection here would end this prober's stream for
-        // the life of the process, so the contract is the thing to keep.
+        // catches its own throw. A rejection here would end this prober's
+        // stream for the life of the process, so that total contract is the
+        // thing to keep. Note `Database.ts` wraps the same call in
+        // `Effect.tryPromise` with a `writeFailed` catch: there the caller has
+        // an error channel to put a failure in, here it has none.
         const liveness = yield* Effect.promise(() =>
           proveOwnerLiveness(ownerIdentity(owner)),
         );

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -160,6 +160,8 @@ const awaitStatusChange = Effect.fn('ExecutionsTool.awaitStatusChange')(
       ),
       (stop) => Effect.sync(stop),
     );
+    // Non-rejecting: `waitForAnyChange`'s executor resolves on a registry
+    // listener or on the abort and never rejects.
     const statusChange = Effect.promise((signal) =>
       currentSession().executions.waitForAnyChange(executionIds, signal),
     );


### PR DESCRIPTION
## What this is

An audit, not a refactor. Every production `Effect.promise(` site was traced to its callee and the verdict written down beside it. Nothing changed behavior; the diff is 43 added lines, all comments, across seven files.

## What prompted it

`Effect.promise` documents itself as "the Promise must not reject; if it rejects, the rejection is treated as a defect, not as a typed failure. Use `tryPromise` when rejection is expected." That makes every bare `Effect.promise` a standing claim about the callee, and standing claims decay. PR #12048 found one that had: a `session.settlePublications()` in an `acquireRelease` release, where a rejection escaped `Scope.close` and failed the `invalidate` that asked for the release. This pass checks the other fourteen.

## What I found

Nine of the fourteen are provably non-rejecting once you read the callee, and the proof is not obvious from the call site, which is why it is now recorded there:

- The owner-liveness probe and the pending process-identity read (`sessionLayer.ts:170`, `:721`) bottom out in `ProcessesPort.identity` / `selfIdentity`. The port contract declares `Promise<string | undefined>` with "undefined when it cannot be read", and the sole implementation, `readIdentity` in `nodeProcesses.ts`, wraps its whole body in a catch that returns undefined. The `kill(pid, 0)` beside it catches its own throw.
- Two registry waits (`sessionLayer.ts:636`, `ExecutionsTool.ts:163`) bottom out in `ExecutionRegistry.waitForAnyChange`, whose executor resolves from a listener or from `onAbort` and never calls reject.
- `loopbackLogin.ts:86` resolves from `listening` or from `error`; `listen` reports a bind failure to that listener rather than throwing, and both callers pass fixed registered ports.
- `desktopSupabaseAuth.ts:404` wraps a function already built on `runPromiseExit` that answers both exits itself.
- `desktopDiffHost.ts:136` wraps a literal `Promise.resolve()`.
- `jsonStore.ts:32` and `leanServerPool.ts:394` already carried their proofs and are untouched. I re-checked the lean one: `runLakeCommand` runs execa with `reject: false` and returns a result object on non-zero exit, a missing binary, a timeout, and a maxBuffer overrun alike.

The other five do reject. In all five the rejection is routed to a defect on purpose, and a named boundary classifies it:

- The three `SessionRequests` arms (`:279`, `:360`, `:384`). The module header already rules on this in prose: a collaborator that rejects is a handler defect, `SessionBridge` logs the cause under the request id and answers `Internal`, and the sender's latch clears either way. `SessionBridge.defect` implements exactly that, and `requestErrors.ts` carries an `Internal` arm for precisely this case. Each arm now points back at the header.
- `sessionLayer.ts:670`, the artifact flush. `SessionOwner.close` is declared with a `never` error channel out to the SDK's `closeSession(): Promise<SessionCloseReport>`, and `ProcessHold.release` in `packages/agent/src/effect/runtime.ts` says the defect propagates so the embedder sees the failed close.
- `packages/agent/src/effect/runtime.ts:155`, the runtime disposal in the hold's release. `ManagedRuntime.disposeEffect` is typed `Effect<void, never, never>` over `Scope.close`, so the only way `dispose()` rejects is a layer finalizer defecting. Re-raising that as a defect is a faithful round trip, not a lost error.

## What I converted, and then did not

I wrote both plausible conversions first: `sessionLayer.ts:670` and `runtime.ts:155`, each to `Effect.tryPromise` plus an `Effect.catch` logging at warn, following #12048's shape exactly. I reverted both.

The disposal one reverted on evidence: I read `ManagedRuntime.ts` in the pinned rc.112 and the only rejection path is a finalizer defect, so the conversion would have downgraded a defect to a log line and fixed nothing.

The flush one reverted on a written ruling. It is the one site where an ordinary writer failure becomes a defect, and I think that is worth revisiting, but two places in the tree currently say it is deliberate, and overturning that is an owner decision rather than a lane decision. The comment at the site now names the constraint and what changing it would cost, so the next person starts from the tradeoff instead of from the grep hit.

## Two things worth a follow-up, neither in this diff

The flush question above is the first. The second falls out of the `SessionRequests` classification: `SessionBridge` catches the handler defect, but the in-process TUI path has no equivalent. `approvalQueue.ts` and `sessionCommands.ts` both do `void effectRuntime().runPromise(...)` with only an `Effect.match` `onFailure`, which handles the typed failure and not the defect, so a rejecting collaborator becomes an unhandled promise rejection and the user's approval or `/compact` silently does nothing. Those are CLI files and the sibling caller is owned by open PR #12049, so I left them alone.

## Verified

- `npm run typecheck` clean across every project.
- `npx vitest run src/test-kernel/controllers/session/ src/test-kernel/tools/ src/test-kernel/agent/`: 288 files passed, 3796 tests passed, 4 skipped. Zero tests added or changed.
- `node scripts/check-effect-migration-ratchet.mjs`: "no count grew, no baseline headroom", every row equal to baseline. The baseline JSON is untouched.
- `npm run lint` clean; prettier reports all seven files unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU

## Review round

Two site comments were hedged after review found each true on only one path:
the liveness probe's "non-rejecting by port contract" claim, which `Database.ts`
contradicts by wrapping the same call in `Effect.tryPromise`, and the
`followUp.send` arm's unconditional claim that `SessionBridge` answers
`Internal`, which holds on the bridge path but not in process.

One item is left open and needs a ruling rather than a lane decision:
`sessionLayer.ts:670`'s artifact flush stays a defect on the strength of
`ProcessHold.release`'s docblock, but `closeOwnedSessions` uses `Effect.forEach`,
so one root's failed flush aborts the sibling roots queued behind it.
