### PR TITLE
refactor(settings): remove memory response forwarding layers

### DIFF
--- a/src/controllers/settingsView/SettingsViewHost.ts
+++ b/src/controllers/settingsView/SettingsViewHost.ts
@@ -1,5 +1,6 @@
-import { Cause, Data, Effect, Exit } from 'effect';
+import { Cause, Effect, Exit } from 'effect';
 
+import { hostPort } from '@common/hostPort';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { SettingsMessageFor, SETTINGS_VIEW_CMD } from '@shared/schemas';
 import type {
@@ -37,14 +38,9 @@ interface SettingsViewHostOptions {
   };
 }
 
-/** The view's `respond` callback rejected while posting a memory message. */
-class SettingsPostFailed extends Data.TaggedError('SettingsPostFailed')<{
-  readonly cause: unknown;
-}> {}
-
 /**
- * Re-raise a memory failure as the cause the filesystem, the host prompt, or
- * the view's respond callback raised. The memory path has no recovery above
+ * Re-raise a memory failure as the cause the filesystem or host prompt
+ * raised. The memory path has no recovery above
  * this point — the previous `await` chain let the same error reach the host's
  * own error handling — so the host edge's `runPromise` rejects with that
  * instance rather than with a tagged wrapper nobody reads.
@@ -80,7 +76,7 @@ export class SettingsViewHost {
       const message = yield* raiseCause(
         this.memoryController.getMemoryDataMessage(),
       );
-      yield* raiseCause(this.postToRespond(message, respond));
+      yield* hostPort(() => this.post(message, respond)).pipe(Effect.orDie);
     },
   );
 
@@ -102,33 +98,24 @@ export class SettingsViewHost {
     ) {
       const posted = yield* Effect.exit(
         this.memoryController.getMemoryPreviewMessage(data.storagePath).pipe(
-          Effect.flatMap((message) =>
-            this.postToRespond(message, options.respond),
-          ),
-          // Report the filesystem or post error itself, not the tag that
-          // carried it: `Data.TaggedError`'s `message` is the tag string,
-          // and the extension formats whatever reaches `onError` with
-          // `toErrorMessage`. Unwrapping in the failure channel (rather
-          // than after `Cause.squash`) keeps a defect untouched, and is
-          // the same contract `raiseCause` gives the sibling methods.
+          // Unwrap only the memory failure; hostPort preserves the response
+          // error itself, including an error that has its own cause field.
           Effect.catch((error) => Effect.fail(error.cause)),
+          Effect.flatMap((message) =>
+            hostPort(() => this.post(message, options.respond)),
+          ),
         ),
       );
       if (Exit.isSuccess(posted)) return;
-      yield* raiseCause(
-        Effect.tryPromise({
-          try: async () => {
-            await options.onError?.(Cause.squash(posted.cause));
-          },
-          catch: (cause) => new SettingsPostFailed({ cause }),
-        }),
+      yield* hostPort(() => options.onError?.(Cause.squash(posted.cause))).pipe(
+        Effect.orDie,
       );
-      yield* raiseCause(
-        this.postToRespond(
+      yield* hostPort(() =>
+        this.post(
           this.memoryController.getMemoryPreviewErrorMessage(data.storagePath),
           options.respond,
         ),
-      );
+      ).pipe(Effect.orDie);
     },
   );
 
@@ -138,7 +125,8 @@ export class SettingsViewHost {
     respond?: SettingsRespond,
   ) {
     const message = yield* raiseCause(this.memoryController.deleteMemory(data));
-    yield* raiseCause(this.postMaybeToRespond(message, respond));
+    if (message == null) return;
+    yield* hostPort(() => this.post(message, respond)).pipe(Effect.orDie);
   });
 
   readonly setMemoryPinned = Effect.fn('SettingsViewHost.setMemoryPinned')(
@@ -151,35 +139,10 @@ export class SettingsViewHost {
       const message = yield* raiseCause(
         this.memoryController.setMemoryPinned(storagePath, pinned),
       );
-      yield* raiseCause(this.postMaybeToRespond(message, respond));
+      if (message == null) return;
+      yield* hostPort(() => this.post(message, respond)).pipe(Effect.orDie);
     },
   );
-
-  /**
-   * The memory path's one wrap of the still-Promise post helpers below, which
-   * the model-selection methods share. A rejected `respond` is a tagged
-   * failure here so the memory programs can compose it; `raiseCause` turns it
-   * back into the host's own error at the surface.
-   */
-  private postToRespond(
-    message: unknown,
-    respond?: SettingsRespond,
-  ): Effect.Effect<void, SettingsPostFailed> {
-    return Effect.tryPromise({
-      try: () => this.post(message, respond),
-      catch: (cause) => new SettingsPostFailed({ cause }),
-    });
-  }
-
-  private postMaybeToRespond(
-    message: unknown | null | undefined,
-    respond?: SettingsRespond,
-  ): Effect.Effect<void, SettingsPostFailed> {
-    return Effect.tryPromise({
-      try: () => this.postMaybe(message, respond),
-      catch: (cause) => new SettingsPostFailed({ cause }),
-    });
-  }
 
   async sendModelSelectionData(respond?: SettingsRespond): Promise<void> {
     await this.post(
@@ -219,13 +182,5 @@ export class SettingsViewHost {
       throw new Error('SettingsViewHost has no response target.');
     }
     await respond(message);
-  }
-
-  private async postMaybe(
-    message: unknown | null | undefined,
-    respond?: SettingsRespond,
-  ): Promise<void> {
-    if (message == null) return;
-    await this.post(message, respond);
   }
 }


### PR DESCRIPTION
## Summary

Remove the intermediate response methods and unused error wrapper from the
settings memory operations. These operations already return Effect programs;
they now call the existing host-port adapter directly when posting a response.

The shared response target and the model-selection methods are unchanged.
Cancelled deletion and pin-limit outcomes still post nothing. Preview failures
still reach the error callback before one placeholder response is attempted.

## Issue acceptance gates

This is a complete, independent removal of memory-response forwarding introduced
by #11953. It does not change the model package, execution, persistence, or work
in another open branch. No additional migration stage is required.

## Single source of truth

`SettingsMemoryController` continues to own memory operations. The existing
`SettingsViewHost.post` method owns response-target selection and the missing
target error. The existing `hostPort` adapter preserves host error identity.

Only memory errors are unwrapped from their domain error before posting. A
response error, even one with its own `cause` field, remains the original error.
The existing defect-channel behavior at the outer boundary is preserved.

## Duplication and abstraction budget

Delete `SettingsPostFailed`, `postToRespond`, `postMaybeToRespond`, and
`postMaybe`. No new method, helper, interface, service, or runtime entry is added.

## Net elements (R6)

- Files: 1 modified; 0 added; 0 deleted.
- Exported symbols: 0 added; 0 deleted.
- Classes: 0 added; 1 deleted. Interfaces and enums: unchanged.
- Private methods: 0 added; 3 deleted.
- Production lines: +18 / −63, net −45. Tests: unchanged.

## Consumer counts (R8)

`SettingsViewHost` has two production construction sites: the extension settings
handler and desktop settings IPC. Its public methods and their callers remain
unchanged. The deleted private methods had respectively three, two, and one
local callers; all now reach the same response operation directly. The deleted
error class had three construction sites and no external consumers.

No event key, export, subscription, or wire message is deleted or rerouted.

## Host impact

Extension: unchanged memory messages, cancellation outcomes, and failure display.

Desktop: unchanged memory messages and confirmation behavior.

CLI: no change.

## Scheduled refactoring

None.

## Validation

Formatting, all six type-check commands, the extension build, full lint, and
the Effect, dead-code, browser-safety and guidance checks passed. Full Vitest:
8,947 tests passed and six skipped; 761 files passed and one skipped. The 33
existing focused tests also passed. A temporary comparison of the original and
modified source agrees on eleven memory-response scenarios, including error
identity, preview fallback, cancelled operations, and interruption. This
diagnostic adds no permanent tests. The existing host suite covers model
selection, while the desktop suite covers cancelled memory deletion; neither is
claimed to provide comprehensive preview-error coverage.

Independent review accepted the complete one-file change and the comparison
evidence before publication. No tests or baselines were changed.
