### PR TITLE
fix(latex): join interrupted arXiv stream operations

### DIFF
--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -4,7 +4,7 @@ import { pipeline } from 'node:stream/promises';
 import { createGunzip } from 'node:zlib';
 
 import { parse as parseContentDisposition } from 'content-disposition';
-import { Data, Duration, Effect, Random, Schedule } from 'effect';
+import { Cause, Clock, Data, Duration, Effect, Random, Schedule } from 'effect';
 import { StatusCodes } from 'http-status-codes';
 import * as tar from 'tar';
 
@@ -88,6 +88,61 @@ const permanent = <T>(
     catch: (cause) =>
       new ArxivSourcePermanentError({ message: toErrorMessage(cause) }),
   });
+
+/**
+ * Abort foreign stream work on interruption, then join its actual promise.
+ * Join outside the timeout race so a late rejection remains observable.
+ */
+function joinedStream<T, A, E>(
+  start: (signal: AbortSignal) => Promise<T>,
+  onError: (error: unknown) => Effect.Effect<A, E>,
+  timeout?: number,
+): Effect.Effect<T | A, E> {
+  return Effect.suspend(() => {
+    let pending: Promise<T> | undefined;
+    let signal: AbortSignal | undefined;
+    let primary: { error: unknown } | undefined;
+    const operation = Effect.tryPromise({
+      try: (requestSignal) => {
+        signal = requestSignal;
+        pending = start(requestSignal);
+        return pending;
+      },
+      catch: (error) => error,
+    });
+    return (
+      timeout == null
+        ? operation
+        : operation.pipe(Effect.timeout(Duration.millis(timeout)))
+    ).pipe(
+      Effect.catch((error) => {
+        primary = { error };
+        return onError(error);
+      }),
+      Effect.onExit(() =>
+        Effect.promise(
+          () =>
+            pending?.then(
+              () => {},
+              (error: unknown) => {
+                if (primary !== undefined && primary.error === error) return;
+                if (
+                  signal?.aborted &&
+                  (error === signal.reason ||
+                    (error instanceof Error &&
+                      error.name === 'AbortError' &&
+                      error.cause === signal.reason))
+                )
+                  return;
+                // A distinct late stream failure must survive interruption.
+                throw error;
+              },
+            ) ?? Promise.resolve(),
+        ),
+      ),
+    );
+  });
+}
 
 export type ArxivDownloadDestination = 'root' | 'references';
 
@@ -198,54 +253,63 @@ class ArxivSourceProcessor {
     timeout = 30000,
   ): Effect.Effect<string, ArxivSourceError> {
     const log = this.log;
-    return this.downloadFileOnce(url, destBasePath).pipe(
-      Effect.timeoutOrElse({
-        duration: Duration.millis(timeout),
-        orElse: () =>
-          Effect.fail(
-            new ArxivSourceTransientError({
-              message: `Download timed out after ${timeout} ms`,
-              cause: undefined,
-            }),
-          ),
-      }),
-      Effect.tapError((error) =>
+    return this.downloadFileOnce(url, destBasePath, timeout).pipe(
+      // Retry the whole ordinary failure, never a mixed cleanup cause. Effect's
+      // typed-error retry otherwise selects one failure and drops its siblings.
+      Effect.catchCause((cause) => Effect.fail(cause)),
+      Effect.tapError((cause) =>
         Effect.gen(function* () {
           // A permanent failure ends the retry unobserved, since it never had
           // retries left to report.
-          if (error._tag !== 'ArxivSourceTransientError') return;
+          const reason = cause.reasons[0];
+          if (
+            cause.reasons.length !== 1 ||
+            reason?._tag !== 'Fail' ||
+            reason.error._tag !== 'ArxivSourceTransientError'
+          )
+            return;
           const { attempt } = yield* Schedule.CurrentMetadata;
           log.debug(
-            `Download attempt failed (${DOWNLOAD_RETRIES - attempt} retries left): ${error.message}`,
+            `Download attempt failed (${DOWNLOAD_RETRIES - attempt} retries left): ${reason.error.message}`,
           );
         }),
       ),
       Effect.retry({
         schedule: downloadBackoff,
         times: DOWNLOAD_RETRIES,
-        while: (error) => error._tag === 'ArxivSourceTransientError',
+        while: (cause) =>
+          cause.reasons.length === 1 &&
+          cause.reasons[0]?._tag === 'Fail' &&
+          cause.reasons[0].error._tag === 'ArxivSourceTransientError',
       }),
+      Effect.catch((cause) => Effect.failCause(cause)),
     );
   }
 
   private downloadFileOnce(
     url: string,
     destBasePath: string,
+    timeout: number,
   ): Effect.Effect<string, ArxivSourceError> {
     const log = this.log;
     let destPath = destBasePath;
     return Effect.gen(function* () {
+      const deadline = (yield* Clock.currentTimeMillis) + timeout;
+      const downloadError = (cause: unknown): ArxivSourceTransientError =>
+        new ArxivSourceTransientError({
+          message: Cause.isTimeoutError(cause)
+            ? `Download timed out after ${timeout} ms`
+            : toErrorMessage(cause),
+          cause: Cause.isTimeoutError(cause) ? undefined : cause,
+        });
       // The fiber's own signal aborts the in-flight fetch when the attempt is
-      // interrupted — by the per-attempt deadline in downloadFile or by the
+      // interrupted — by the per-attempt deadline or by the
       // caller — covering connection establishment and body streaming.
-      const response = yield* Effect.tryPromise({
-        try: (signal) => fetch(url, { signal }),
-        catch: (cause) =>
-          new ArxivSourceTransientError({
-            message: toErrorMessage(cause),
-            cause,
-          }),
-      });
+      const response = yield* joinedStream(
+        (signal) => fetch(url, { signal }),
+        (cause) => Effect.fail(downloadError(cause)),
+        timeout,
+      );
 
       if (response.status === StatusCodes.NOT_FOUND) {
         return yield* Effect.fail(
@@ -320,24 +384,21 @@ class ArxivSourceProcessor {
         );
       }
 
-      yield* Effect.tryPromise({
-        try: () =>
+      yield* joinedStream(
+        (signal) =>
           pipeline(
             // response.body is a web ReadableStream; Readable.fromWeb bridges to Node streams.
             Readable.fromWeb(response.body as NodeWebReadableStream),
             AbsoluteFS.createWriteStream(destPath),
+            { signal },
           ),
-        catch: (cause) =>
-          new ArxivSourceTransientError({
-            message: toErrorMessage(cause),
-            cause,
-          }),
-      });
+        (cause) => Effect.fail(downloadError(cause)),
+        Math.max(0, deadline - (yield* Clock.currentTimeMillis)),
+      );
       return destPath;
     }).pipe(
-      // A failed attempt deletes its partial download so a retry cannot race
-      // stale bytes at the same path (the old `finally` + shouldCleanup flag;
-      // `onError`'s cleanup is uninterruptible).
+      // Failure and interruption both clean up, after the body writer settles,
+      // so neither cleanup nor a retry can race its remaining writes.
       Effect.onError(() =>
         this.cleanUpBestEffort(destPath, 'partial download'),
       ),
@@ -352,24 +413,21 @@ class ArxivSourceProcessor {
     const log = this.log;
     log.debug(`Extracting tar file: ${tarPath} to ${destDir}`);
 
-    return Effect.tryPromise({
-      try: () => tar.x({ file: tarPath, cwd: destDir }),
-      catch: toErrorMessage,
-    }).pipe(
-      options.timeout == null
-        ? (effect) => effect
-        : Effect.timeoutOrElse({
-            duration: Duration.millis(options.timeout),
-            orElse: () => Effect.fail('Extraction timed out'),
-          }),
-      Effect.as({ success: true }),
-      Effect.catch((errorMsg) =>
+    return joinedStream(
+      (signal) =>
+        // tar has no abort option. Stop admitting entries and join its public
+        // promise. This is unbounded; rejection need not mean all writes closed.
+        tar.x({ file: tarPath, cwd: destDir, filter: () => !signal.aborted }),
+      (cause) =>
         Effect.sync((): ExtractResult => {
-          log.error(`Failed to extract tar file: ${errorMsg}`);
-          return { success: false, error: errorMsg };
+          const error = Cause.isTimeoutError(cause)
+            ? 'Extraction timed out'
+            : toErrorMessage(cause);
+          log.error(`Failed to extract tar file: ${error}`);
+          return { success: false, error };
         }),
-      ),
-    );
+      options.timeout,
+    ).pipe(Effect.map((result) => result ?? { success: true }));
   }
 
   public readonly downloadSource = Effect.fn('arxivProcessor.downloadSource')(
@@ -590,12 +648,18 @@ class ArxivSourceProcessor {
       if (isGzipOnly) {
         progressCallback?.('Decompressing source file...', 60);
         const decompressedPath = downloadedPath.replace(/\.gz$/, '');
-        yield* permanent(() =>
-          pipeline(
-            AbsoluteFS.createReadStream(downloadedPath),
-            createGunzip(),
-            AbsoluteFS.createWriteStream(decompressedPath),
-          ),
+        yield* joinedStream(
+          (signal) =>
+            pipeline(
+              AbsoluteFS.createReadStream(downloadedPath),
+              createGunzip(),
+              AbsoluteFS.createWriteStream(decompressedPath),
+              { signal },
+            ),
+          (cause) =>
+            Effect.fail(
+              new ArxivSourcePermanentError({ message: toErrorMessage(cause) }),
+            ),
         );
         yield* permanent(() => AbsoluteFS.delete(downloadedPath));
         sourceFilePath = decompressedPath;

--- a/src/test-kernel/latex/ArxivProcessor.vitest.ts
+++ b/src/test-kernel/latex/ArxivProcessor.vitest.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 
 // Third-party imports
 import { it } from '@effect/vitest';
-import { Effect } from 'effect';
+import { Cause, Deferred, Effect, Exit, Fiber } from 'effect';
 import { afterEach, describe, expect, vi } from 'vitest';
 
 // Local imports
@@ -13,7 +13,10 @@ import {
   resolveArxivPaperDirectoryRelative,
 } from '@latex/arxivProcessor';
 import * as logger from '@logger/logUtils';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
+import { AbsoluteFS } from '@utils/files/absoluteFS';
 
 const tempDirs = useTempDirs();
 const SOURCE_URL = 'https://arxiv.org/src/2404.12175';
@@ -118,6 +121,84 @@ describe('arXiv processor logger channel', () => {
 });
 
 describe('arXiv source download filenames', () => {
+  setupPlatform({}, { fs: nodeFilesystem });
+
+  it.live(
+    'closes an interrupted body writer before deleting its partial download',
+    () =>
+      Effect.gen(function* () {
+        const destBasePath = yield* tempSourceBase;
+        const started = yield* Deferred.make<void>();
+        const events: string[] = [];
+        const createWriteStream = AbsoluteFS.createWriteStream.bind(AbsoluteFS);
+        vi.spyOn(AbsoluteFS, 'createWriteStream').mockImplementation(
+          (...args) => {
+            const writer = createWriteStream(...args);
+            writer.once('close', () => events.push('writer-closed'));
+            writer.once('open', () => Deferred.doneUnsafe(started, Exit.void));
+            return writer;
+          },
+        );
+        const deleteFile = AbsoluteFS.delete.bind(AbsoluteFS);
+        vi.spyOn(AbsoluteFS, 'delete').mockImplementation(async (...args) => {
+          events.push('partial-deleted');
+          return deleteFile(...args);
+        });
+        let body: ReadableStreamDefaultController<Uint8Array> | undefined;
+        vi.stubGlobal(
+          'fetch',
+          vi.fn(
+            async () =>
+              new Response(
+                new ReadableStream<Uint8Array>({
+                  start(controller) {
+                    body = controller;
+                    controller.enqueue(
+                      new TextEncoder().encode('partial source'),
+                    );
+                  },
+                  cancel() {
+                    events.push('body-cancelled');
+                  },
+                }),
+                {
+                  headers: {
+                    'content-disposition': 'attachment; filename="source"',
+                  },
+                },
+              ),
+          ),
+        );
+
+        const fiber = yield* ArxivProcessor.downloadFile(
+          SOURCE_URL,
+          destBasePath,
+        ).pipe(Effect.forkChild);
+        yield* Deferred.await(started);
+        yield* Fiber.interrupt(fiber);
+        const exit = yield* Fiber.await(fiber);
+        // End an unowned old body after observing the result, so a failing
+        // regression does not leave its original writer alive in the suite.
+        if (!events.includes('body-cancelled')) body?.close();
+        expect(
+          Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause),
+        ).toBe(true);
+        expect(events).toStrictEqual([
+          'body-cancelled',
+          'writer-closed',
+          'partial-deleted',
+        ]);
+        expect(
+          yield* Effect.promise(() =>
+            fs.access(destBasePath).then(
+              () => true,
+              () => false,
+            ),
+          ),
+        ).toBe(false);
+      }),
+  );
+
   it.effect(
     'does not infer a missing header filename when it matches the base path',
     () =>

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { Effect } from 'effect';
+import { Cause, Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
@@ -69,11 +69,16 @@ const download = Effect.fn('ArxivDownloadTool.execute')(function* (
     autoIndent: input.autoIndent,
     destination: input.destination,
   }).pipe(
-    Effect.mapError(
-      (error: ArxivSourceError) =>
-        new ToolError(`Failed to download arXiv source: ${error.message}`, {
-          cause: error,
-        }),
+    Effect.catchCause((cause) =>
+      Effect.failCause(
+        Cause.map(
+          cause,
+          (error: ArxivSourceError) =>
+            new ToolError(`Failed to download arXiv source: ${error.message}`, {
+              cause: error,
+            }),
+        ),
+      ),
     ),
   );
 


### PR DESCRIPTION
## Summary

Interrupted arXiv downloads now stop and await their body writer before removing the partial file. Gzip decompression likewise stops and awaits its streams. Tar extraction stops accepting new entries after interruption and awaits its public completion promise.

The existing download deadline, two retries, transient-error classification, filename handling, and extraction error messages remain unchanged. A timeout accompanied by a distinct late failure is preserved within the native Effect program and is not retried as an ordinary timeout.

## Issue acceptance gates

Addresses part of #11976; this PR does not close that issue.

- The body-stream regression demonstrates the original failure: partial-file deletion ran before the writer closed. The corrected implementation observes cancellation and writer closure before deletion.
- Actual Node stream diagnostics verify joined gzip cancellation, valid-tar interruption, and preservation of a distinct late rejection after interruption or a deadline.
- The pinned `Effect.onError` already includes interruption. The correction concerns unfinished foreign operations, not a missing interruption branch in that operator.
- Tar has no public abort option. On timeout, it stops accepting entries and still drains the archive; the timeout result is returned only after that public promise settles, potentially well after the nominal 30 seconds. The join cannot itself be interrupted. Its successful completion awaits pending writes, but its error promise can reject before all internal writes close. This PR does not guarantee complete quiescence after every malformed archive, or a hard return-time deadline.

## Single source of truth

The existing Effect execution supplies cancellation. `arxivProcessor.ts` owns the original operation promise and joins it before cleanup or retry. One absolute per-attempt deadline supplies the remaining time after response headers; no second timeout allowance is introduced.

## Duplication and abstraction budget

One private function applies the same abort-and-join rule at four existing boundaries: fetch, download body, tar extraction, and gzip decompression. Error conversion occurs before the final join, so it cannot erase a distinct late rejection. The existing retry schedule receives the complete failure cause and retries only an ordinary transient failure.

No service, dependency, runtime entry, public API, or compatibility layer is introduced. The tool's existing error mapping now preserves the full native cause while keeping its ordinary `ToolError` message and cause.

## Net elements (R6)

Three existing files change; no files, exported declarations, classes, interfaces, or enums are added or removed. Production is +133/−64, tests +82/−1: +150 lines overall. The increase is the cancellation/join correction and one reproduced-defect regression, not a claimed code reduction. No baseline changes are included.

## Consumer counts (R8)

No event or export is removed or rerouted. The two existing production callers of `downloadSource` remain the arXiv tool and extension command. The private join function has four actual uses.

## Host impact

Extension, desktop, and CLI tool execution retain their existing entry points. The tool already supplies the owning execution's cancellation signal. The extension command's cancel button currently only logs cancellation; changing that separate host action is not included.

Full failure causes are retained inside the native Effect program. The existing process runtime's `runPromise` still projects the first typed failure, or first defect, into a Promise rejection. This PR does not claim complete multi-error visibility at that final Promise-facing boundary.

## Scheduled refactoring

The remaining tar-error settlement and host-cancellation obligations remain under #11976. No private tar access or new extraction system is added to claim completion of those obligations.

## Validation

The exact new regression fails against the original production source and passes with the correction. The existing processor/tool suites pass all 11 cases under Node 22.23.2. Independent source review covers the pinned Effect/tar behavior, retry and timeout placement, both production callers, and the documented limitations.

Full local validation passed under actual Node 22.23.2 on base `854b36ee69` plus the three changed files:

- Full formatting, all six typecheck components, and `compile:fast`.
- Full lint with the unchanged 6144 MiB limit; peak resident memory 4,020,781,056 bytes.
- Full Vitest with two workers: 8,948 passed / 6 skipped, 761 files passed / 1 skipped, 690.56 seconds.
- Separate architecture run: 106 passed; these cases are already included in the full-suite count.
- Effect, browser-safe, guidance, and official dead-code checks; no baseline growth.

All checked source and index fingerprints remained unchanged. Subsequent main changes have no overlap with these three files and are covered separately by CI.

[CI run 34160748204](https://github.com/LionSR/TeXRA/actions/runs/34160748204) completed successfully for published head `26a4df537e`. The actual checkout was synthetic merge `77494990e29d2cceb6e4d72d3cc151c83f023a59`, combining that head with main `5484f99e4e`. Both Linux test shards passed (8,943 passed / 6 skipped on that newer-main tree), along with static checks, build, macOS smoke, guidance, and final validation. The local and CI test counts refer to their distinct recorded bases.
