### PR TITLE
refactor(github): compose requests and pagination with Effect

### DIFF
--- a/src/test-kernel/tools/PRPollingSource.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSource.vitest.ts
@@ -102,7 +102,7 @@ describe('PRPollingSource annotation drain', () => {
         const run = createCheckRun(42);
         const state = createDrainState([run]);
         const rateLimit = new GitHubRateLimitError(1_800_000_000);
-        mocks.fetchAnnotations.mockRejectedValue(rateLimit);
+        mocks.fetchAnnotations.mockReturnValue(Effect.fail(rateLimit));
 
         yield* drainAccess(source).drainAnnotationQueues([
           ['owner/repo#7', state],
@@ -141,7 +141,7 @@ describe('PRPollingSource annotation drain', () => {
           createCheckRun(8),
           createCheckRun(9),
         ]);
-        mocks.fetchAnnotations.mockResolvedValue([]);
+        mocks.fetchAnnotations.mockReturnValue(Effect.succeed([]));
 
         yield* drainAccess(source).drainAnnotationQueues([
           ['first', firstState],
@@ -181,11 +181,13 @@ describe('PRPollingSource annotation drain', () => {
       );
       state.annotationLevelByListener.set(warningListener, 'warning');
       state.annotationLevelByListener.set(noticeListener, 'notice');
-      mocks.fetchAnnotations.mockResolvedValue([
-        annotation('notice', 'advisory note'),
-        annotation('warning', 'format warning'),
-        annotation('failure', 'blocking failure'),
-      ]);
+      mocks.fetchAnnotations.mockReturnValue(
+        Effect.succeed([
+          annotation('notice', 'advisory note'),
+          annotation('warning', 'format warning'),
+          annotation('failure', 'blocking failure'),
+        ]),
+      );
 
       yield* drainAccess(source).drainAnnotationQueues([
         ['owner/repo#7', state],
@@ -222,9 +224,9 @@ describe('PRPollingSource annotation drain', () => {
       const key = prKeyToString(pr);
       const state = drainAccess(source).getSubscriptionState(key);
       if (!state) throw new Error('Expected subscription state');
-      mocks.fetchAnnotations.mockResolvedValue([
-        annotation('warning', 'format warning'),
-      ]);
+      mocks.fetchAnnotations.mockReturnValue(
+        Effect.succeed([annotation('warning', 'format warning')]),
+      );
 
       state.currentShaState = createPRCurrentShaState('abcdef1234567890', {
         pendingAnnotationRuns: [createCheckRun(13)],

--- a/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
@@ -15,9 +15,6 @@ import type { GhCheckAnnotation, GhCheckRun } from '@tools/github/prTypes';
 import type { PollHookRejected } from '@tools/github/PollingSourceBase';
 import { AnnotationFetchBudget } from '@tools/github/annotationFetchBudget';
 
-// Local imports - utils
-import { ensureError } from '@utils/errors/errorMessage';
-
 // Local imports - test support
 import { mockGitHubClient } from '../support/githubClientMock';
 import {
@@ -52,7 +49,7 @@ type AnnotationFetchFn = (
   logger: AgentTrace,
   budget: AnnotationFetchBudget,
   now?: number,
-) => Promise<GhCheckAnnotation[]>;
+) => Effect.Effect<GhCheckAnnotation[], unknown>;
 
 /** Minimal logger for driving the infrastructure `fetchAnnotations` directly. */
 function testLogger(): AgentTrace {
@@ -128,20 +125,22 @@ describe('PRPollingSource annotation pagination', () => {
         createHarness(),
       );
       ghGet
-        .mockResolvedValueOnce({ status: 200, data: fullWarningPage() })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: [annotation('failure', 100)],
-        });
+        .mockReturnValueOnce(
+          Effect.succeed({ status: 200, data: fullWarningPage() }),
+        )
+        .mockReturnValueOnce(
+          Effect.succeed({
+            status: 200,
+            data: [annotation('failure', 100)],
+          }),
+        );
 
-      const annotations = yield* Effect.promise(() =>
-        fetchAnnotations(
-          'owner',
-          'repo',
-          42,
-          testLogger(),
-          new AnnotationFetchBudget(2, 60_000),
-        ),
+      const annotations = yield* fetchAnnotations(
+        'owner',
+        'repo',
+        42,
+        testLogger(),
+        new AnnotationFetchBudget(2, 60_000),
       );
 
       expect(annotations).toHaveLength(101);
@@ -159,16 +158,16 @@ describe('PRPollingSource annotation pagination', () => {
       const { ghGet, fetchAnnotations } = yield* Effect.promise(() =>
         createHarness(),
       );
-      ghGet.mockResolvedValue({ status: 200, data: fullWarningPage() });
+      ghGet.mockReturnValue(
+        Effect.succeed({ status: 200, data: fullWarningPage() }),
+      );
 
-      const annotations = yield* Effect.promise(() =>
-        fetchAnnotations(
-          'owner',
-          'repo',
-          42,
-          testLogger(),
-          new AnnotationFetchBudget(50, 60_000),
-        ),
+      const annotations = yield* fetchAnnotations(
+        'owner',
+        'repo',
+        42,
+        testLogger(),
+        new AnnotationFetchBudget(50, 60_000),
       );
 
       expect(annotations).toHaveLength(5000);
@@ -184,23 +183,23 @@ describe('PRPollingSource annotation pagination', () => {
       const { ghGet, fetchAnnotations } = yield* Effect.promise(() =>
         createHarness(),
       );
-      ghGet.mockResolvedValue({ status: 200, data: fullWarningPage() });
-
-      const error = yield* Effect.flip(
-        Effect.tryPromise({
-          try: () =>
-            fetchAnnotations(
-              'owner',
-              'repo',
-              42,
-              testLogger(),
-              new AnnotationFetchBudget(1, 60_000),
-            ),
-          catch: ensureError,
-        }),
+      ghGet.mockReturnValue(
+        Effect.succeed({ status: 200, data: fullWarningPage() }),
       );
 
-      expect(error.message).toContain('Annotation fetch budget exhausted');
+      const error = yield* Effect.flip(
+        fetchAnnotations(
+          'owner',
+          'repo',
+          42,
+          testLogger(),
+          new AnnotationFetchBudget(1, 60_000),
+        ),
+      );
+
+      expect(error).toMatchObject({
+        message: expect.stringContaining('Annotation fetch budget exhausted'),
+      });
       expect(ghGet).toHaveBeenCalledTimes(1);
     }),
   );

--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -106,11 +106,11 @@ function queuePollResponses(
   runs: GhCheckRun[],
 ): void {
   ghGet
-    .mockResolvedValueOnce(prResponse(sha))
-    .mockResolvedValueOnce({ status: 304 })
-    .mockResolvedValueOnce({ status: 304 })
-    .mockResolvedValueOnce({ status: 304 })
-    .mockResolvedValueOnce(checkRunsResponse(runs));
+    .mockReturnValueOnce(Effect.succeed(prResponse(sha)))
+    .mockReturnValueOnce(Effect.succeed({ status: 304 }))
+    .mockReturnValueOnce(Effect.succeed({ status: 304 }))
+    .mockReturnValueOnce(Effect.succeed({ status: 304 }))
+    .mockReturnValueOnce(Effect.succeed(checkRunsResponse(runs)));
 }
 
 describe('PRPollingSource CI-started events', () => {

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -14,7 +14,7 @@
  * file only owns the per-issue endpoint set and the dedup state.
  */
 
-import { Effect } from 'effect';
+import { Cause, Effect } from 'effect';
 
 import type { Disposable } from '@platform/interfaces';
 import {
@@ -32,9 +32,8 @@ import {
   dedupeComments,
   type DedupedResource,
   type PollEventListener,
-  type PollHookRejected,
+  PollHookRejected,
   PollingSourceBase,
-  pollRequest,
 } from './PollingSourceBase';
 import {
   MAX_CONCURRENT_ISSUE_SUBSCRIPTIONS,
@@ -113,7 +112,13 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
     _key: string,
     state: SubscriptionState,
   ): Effect.Effect<void, PollHookRejected> {
-    return this.pollIssue(state);
+    return this.pollIssue(state).pipe(
+      Effect.catchCause((cause) =>
+        Effect.failCause(
+          Cause.map(cause, (error) => new PollHookRejected({ cause: error })),
+        ),
+      ),
+    );
   }
 
   private readonly pollIssue = Effect.fn('IssuePollingSource.pollIssue')(
@@ -128,10 +133,8 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
       // The two endpoints are independent — fetch in parallel.
       const [issueRes, commentsRes] = yield* Effect.all(
         [
-          pollRequest(() => ghGet<GhIssue>(issuePath, state.etags.issue)),
-          pollRequest(() =>
-            ghGet<GhIssueComment[]>(commentsUrl, state.etags.comments),
-          ),
+          ghGet<GhIssue>(issuePath, state.etags.issue),
+          ghGet<GhIssueComment[]>(commentsUrl, state.etags.comments),
         ],
         { concurrency: 2 },
       );

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -11,7 +11,7 @@
  * layer above.
  */
 
-import { Clock, Effect } from 'effect';
+import { Cause, Clock, Effect } from 'effect';
 
 import type { Disposable } from '@platform/interfaces';
 import { shouldDropBotEvent } from './botFilter';
@@ -67,9 +67,8 @@ import {
   DedupedResource,
   MAX_SEEN_IDS,
   type PollEventListener,
-  type PollHookRejected,
+  PollHookRejected,
   PollingSourceBase,
-  pollRequest,
 } from './PollingSourceBase';
 import {
   MAX_CONCURRENT_PR_SUBSCRIPTIONS,
@@ -278,7 +277,13 @@ export class PRPollingSource extends PollingSourceBase<
     key: string,
     state: PRSubscriptionState,
   ): Effect.Effect<void, PollHookRejected> {
-    return this.pollPr(key, state);
+    return this.pollPr(key, state).pipe(
+      Effect.catchCause((cause) =>
+        Effect.failCause(
+          Cause.map(cause, (error) => new PollHookRejected({ cause: error })),
+        ),
+      ),
+    );
   }
 
   private readonly pollPr = Effect.fn('PRPollingSource.pollPr')(function* (
@@ -312,30 +317,19 @@ export class PRPollingSource extends PollingSourceBase<
       { response: checksRes, stagedCache: stagedCheckRunsCache },
     ] = yield* Effect.all(
       [
-        pollRequest(() =>
-          ghGet<GhIssueComment[]>(issueCommentsUrl, state.etags.issueComments),
-        ),
-        pollRequest(() =>
-          ghGet<GhReviewComment[]>(
-            reviewCommentsUrl,
-            state.etags.reviewComments,
-          ),
-        ),
-        pollRequest(() =>
-          ghGet<GhReview[]>(
-            `${prPath}/reviews?per_page=100`,
-            state.etags.reviews,
-          ),
+        ghGet<GhIssueComment[]>(issueCommentsUrl, state.etags.issueComments),
+        ghGet<GhReviewComment[]>(reviewCommentsUrl, state.etags.reviewComments),
+        ghGet<GhReview[]>(
+          `${prPath}/reviews?per_page=100`,
+          state.etags.reviews,
         ),
         state.currentShaState?.sha
-          ? pollRequest(() =>
-              fetchAllCheckRunsClient(
-                pr.owner,
-                pr.repo,
-                state.currentShaState!.sha,
-                state.currentShaState!.checkRunsCache,
-                this.logger,
-              ),
+          ? fetchAllCheckRunsClient(
+              pr.owner,
+              pr.repo,
+              state.currentShaState.sha,
+              state.currentShaState.checkRunsCache,
+              this.logger,
             )
           : Effect.succeed({
               response: { status: 304 as const },
@@ -432,9 +426,7 @@ export class PRPollingSource extends PollingSourceBase<
     prPath: string,
   ) {
     const { pr } = state;
-    const prRes = yield* pollRequest(() =>
-      ghGet<GhPullRequest>(prPath, state.etags.pr),
-    );
+    const prRes = yield* ghGet<GhPullRequest>(prPath, state.etags.pr);
     if (prRes.status !== 200) return true;
 
     // Validate the state-driving PR payload non-throwingly (never throw on
@@ -731,9 +723,12 @@ export class PRPollingSource extends PollingSourceBase<
         // typed failure here; a defect stays a defect and ends the round.
         const drained = yield* this.drainNextAnnotationRun(state, at).pipe(
           Effect.map((value) => ({ ok: true as const, value })),
-          Effect.catchTag('PollHookRejected', (failure) =>
-            Effect.succeed({ ok: false as const, failure }),
-          ),
+          Effect.catchCause((cause) => {
+            const reason = cause.reasons[0];
+            return cause.reasons.length === 1 && reason?._tag === 'Fail'
+              ? Effect.succeed({ ok: false as const, failure: reason.error })
+              : Effect.failCause(cause);
+          }),
         );
         if (!drained.ok) {
           // The failure time, not the round's start: draining can run a slow
@@ -811,20 +806,26 @@ export class PRPollingSource extends PollingSourceBase<
     const run = state.currentShaState?.pendingAnnotationRuns[0];
     if (!run) return true;
     const { pr } = state;
-    const fetched = yield* pollRequest(() =>
-      fetchAnnotationsClient(
-        pr.owner,
-        pr.repo,
-        run.id,
-        this.logger,
-        SharedAnnotationFetchBudget,
-        now,
-      ),
+    const fetched = yield* fetchAnnotationsClient(
+      pr.owner,
+      pr.repo,
+      run.id,
+      this.logger,
+      SharedAnnotationFetchBudget,
+      now,
     ).pipe(
-      Effect.map((annotations) => ({ ok: true as const, annotations })),
-      Effect.catchTag('PollHookRejected', (failure) =>
-        Effect.succeed({ ok: false as const, failure }),
+      Effect.catchCause((cause) =>
+        Effect.failCause(
+          Cause.map(cause, (error) => new PollHookRejected({ cause: error })),
+        ),
       ),
+      Effect.map((annotations) => ({ ok: true as const, annotations })),
+      Effect.catchCause((cause) => {
+        const reason = cause.reasons[0];
+        return cause.reasons.length === 1 && reason?._tag === 'Fail'
+          ? Effect.succeed({ ok: false as const, failure: reason.error })
+          : Effect.failCause(cause);
+      }),
     );
     if (fetched.ok) {
       this.removePendingAnnotationRun(state, run.id);

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -101,20 +101,6 @@ export class PollHookRejected extends Data.TaggedError('PollHookRejected')<{
   readonly cause: unknown;
 }> {}
 
-/**
- * The one wrap of the GitHub client for a poll hook: a rejected request
- * becomes a {@link PollHookRejected} carrying the error the client raised, so
- * `handleFailure`'s `instanceof` classification still sees the GitHub error
- * class itself.
- */
-export const pollRequest = <A>(
-  request: (signal: AbortSignal) => Promise<A>,
-): Effect.Effect<A, PollHookRejected> =>
-  Effect.tryPromise({
-    try: request,
-    catch: (cause) => new PollHookRejected({ cause }),
-  });
-
 interface PollingSourceConfig {
   /** Display name used in the logger and exception messages. */
   name: string;
@@ -549,10 +535,10 @@ export abstract class PollingSourceBase<
 
   /**
    * One round, with its failures contained so the poller survives them. A
-   * round only ever fails by a defect — a throwing `handleFailure` or
-   * listener — which used to reject `tick()`'s promise with nobody watching;
-   * it is logged here and the loop continues. An interrupt (shutdown, the
-   * last unsubscribe) is re-raised so the fiber ends.
+   * Single request errors are handled per subscription. Non-interrupted
+   * defects and compound failures are logged here once, retaining every reason. An
+   * interrupt is re-raised so the fiber ends. This does not recover child
+   * failures discarded by the parallel iterator during external interruption.
    */
   private readonly runRound = Effect.fn('PollingSourceBase.runRound')(
     function* (this: PollingSourceBase<K, S>) {
@@ -562,7 +548,10 @@ export abstract class PollingSourceBase<
         return yield* Effect.failCause(exit.cause);
       }
       this.logger.warn('Poll round failed; polling continues.', {
-        data: Cause.squash(exit.cause),
+        data:
+          exit.cause.reasons.length === 1
+            ? Cause.squash(exit.cause)
+            : exit.cause,
       });
     },
   );
@@ -622,30 +611,34 @@ export abstract class PollingSourceBase<
         );
       }
       yield* this.afterTick(entries, now).pipe(
-        Effect.catchTag('PollHookRejected', (rejection) =>
-          Effect.sync(() => {
+        Effect.catchCause((cause) => {
+          const reason = cause.reasons[0];
+          if (cause.reasons.length !== 1 || reason?._tag !== 'Fail') {
+            return Effect.failCause(cause);
+          }
+          return Effect.sync(() => {
             this.logger.warn('Post-poll hook failed', {
-              data: rejection.cause,
+              data: reason.error.cause,
             });
-          }),
-        ),
+          });
+        }),
       );
     },
   );
 
   /**
-   * Poll one subscription, routing every failure of that subscription through
-   * handleFailure and never past this entry.
+   * Poll one subscription, classifying its ordinary single errors here.
+   * Interruption and compound failures pass through to the round.
    *
-   * A defect is contained here, not propagated. When `pollOne` was a Promise
+   * A single defect is contained here. When `pollOne` was a Promise
    * its synchronous throws were caught by `Effect.tryPromise` and classified
    * per subscription; now that it is an Effect they would be defects, and
    * `pollRound` re-raises a failed entry before `afterTick`, so one
    * subclass's bug would skip annotation draining for every subscription in
    * the round and leave the offending one with no backoff and no path to the
-   * 24 h detach gate. Interruption is not caught (`catchDefect`, not
-   * `catchCause`), so stopping the loop still stops it, and the defect is
-   * logged rather than silently folded into the backoff.
+   * 24 h detach gate. Interruption and compound causes pass through intact;
+   * the round reports them without applying several backoff updates to one
+   * poll. An ordinary single defect is logged before applying its backoff.
    */
   private readonly pollEntry = Effect.fn('PollingSourceBase.pollEntry')(
     function* (this: PollingSourceBase<K, S>, key: K, state: S, now: number) {
@@ -657,19 +650,27 @@ export abstract class PollingSourceBase<
             state.consecutiveFailures = 0;
           }),
         ),
-        Effect.catchTag('PollHookRejected', (rejection) =>
-          Effect.flatMap(Clock.currentTimeMillis, (failedAt) =>
-            this.handleFailure(key, state, rejection.cause, failedAt),
-          ),
-        ),
-        Effect.catchDefect((defect) =>
-          Effect.flatMap(Clock.currentTimeMillis, (failedAt) =>
+        Effect.catchCause((cause) => {
+          const reason = cause.reasons[0];
+          if (cause.reasons.length !== 1 || reason?._tag !== 'Fail') {
+            return Effect.failCause(cause);
+          }
+          return Effect.flatMap(Clock.currentTimeMillis, (failedAt) =>
+            this.handleFailure(key, state, reason.error.cause, failedAt),
+          );
+        }),
+        Effect.catchCause((cause) => {
+          const reason = cause.reasons[0];
+          if (cause.reasons.length !== 1 || reason?._tag !== 'Die') {
+            return Effect.failCause(cause);
+          }
+          return Effect.flatMap(Clock.currentTimeMillis, (failedAt) =>
             Effect.suspend(() => {
-              this.logger.warn('Poll threw a defect', { data: defect });
-              return this.handleFailure(key, state, defect, failedAt);
+              this.logger.warn('Poll threw a defect', { data: reason.defect });
+              return this.handleFailure(key, state, reason.defect, failedAt);
             }),
-          ),
-        ),
+          );
+        }),
       );
     },
   );

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -34,7 +34,7 @@
  * - **CI / check-run status and inline annotations.** Per-PR by design.
  */
 
-import { Effect, Exit } from 'effect';
+import { Cause, Effect, Exit } from 'effect';
 import { LRUCache } from 'lru-cache';
 
 import type { Disposable } from '@platform/interfaces';
@@ -56,9 +56,8 @@ import {
   dedupeComments,
   type DedupedResource,
   type PollEventListener,
-  type PollHookRejected,
+  PollHookRejected,
   PollingSourceBase,
-  pollRequest,
 } from './PollingSourceBase';
 import {
   MAX_CONCURRENT_REPO_SUBSCRIPTIONS,
@@ -186,7 +185,13 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
     _key: RepoKey,
     state: SubscriptionState,
   ): Effect.Effect<void, PollHookRejected> {
-    return this.pollRepo(state);
+    return this.pollRepo(state).pipe(
+      Effect.catchCause((cause) =>
+        Effect.failCause(
+          Cause.map(cause, (error) => new PollHookRejected({ cause: error })),
+        ),
+      ),
+    );
   }
 
   private readonly pollRepo = Effect.fn('RepoPollingSource.pollRepo')(
@@ -201,9 +206,9 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
 
       const [rawIssueRes, rawReviewRes, rawPullsRes] = yield* Effect.all(
         [
-          pollRequest(() => ghGet<unknown>(issuePath)),
-          pollRequest(() => ghGet<unknown>(reviewPath)),
-          pollRequest(() => ghGet<unknown>(pullsPath)),
+          ghGet<unknown>(issuePath),
+          ghGet<unknown>(reviewPath),
+          ghGet<unknown>(pullsPath),
         ],
         { concurrency: 3 },
       );
@@ -445,7 +450,7 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
       pr: GhPullsListEntry,
     ) {
       const path = `/repos/${state.owner}/${state.repo}/pulls/${pr.number}`;
-      const res = yield* pollRequest(() => ghGet<GhPullRequest>(path));
+      const res = yield* ghGet<GhPullRequest>(path);
       if (res.status !== 200) return undefined;
       const parsed = GhPullRequestSchema.safeParse(res.data);
       if (!parsed.success) {

--- a/src/tools/github/checkRunsClient.ts
+++ b/src/tools/github/checkRunsClient.ts
@@ -9,6 +9,8 @@
  * pagination / cache-coherence reasoning be unit-tested without a live poller.
  */
 
+import { Cause, Effect } from 'effect';
+
 import type { AgentTrace } from '@agent/trace';
 
 import {
@@ -66,7 +68,7 @@ interface FetchAllCheckRunsResult {
    * itself short-circuited before fetching anything.
    *
    * Deferring the commit prevents a sibling rejection in the caller's
-   * `Promise.all` from advancing the cache while the diff branch never runs: a
+   * parallel fetch from advancing the cache while the diff branch never runs: a
    * stale cache + 304 next tick would silently swallow check-run transitions.
    */
   stagedCache?: CheckRunsCache;
@@ -124,200 +126,212 @@ interface FetchAllCheckRunsResult {
  * we log a warning and return what we have — better to under-report than
  * fan out into hundreds of GETs every 30s.
  */
-export async function fetchAllCheckRuns(
-  owner: string,
-  repo: string,
-  sha: string,
-  cache: CheckRunsCache | undefined,
-  logger: AgentTrace,
-): Promise<FetchAllCheckRunsResult> {
-  const basePath = `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=${CHECK_RUNS_PAGE_SIZE}`;
+export const fetchAllCheckRuns = Effect.fn('fetchAllCheckRuns')(
+  function* (
+    owner: string,
+    repo: string,
+    sha: string,
+    cache: CheckRunsCache | undefined,
+    logger: AgentTrace,
+  ): Effect.fn.Return<FetchAllCheckRunsResult, unknown> {
+    const basePath = `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=${CHECK_RUNS_PAGE_SIZE}`;
 
-  // Seed a scratch cache we'll stage on the return value. We rebuild from
-  // scratch each tick (rather than mutating in-place) so any pages dropped
-  // on this tick — e.g. new push reduced page count from 5 to 3 — don't
-  // leave stale entries behind.
-  const nextPages = new Map<number, CheckRunsCachePage>();
+    // Seed a scratch cache we'll stage on the return value. We rebuild from
+    // scratch each tick (rather than mutating in-place) so any pages dropped
+    // on this tick — e.g. new push reduced page count from 5 to 3 — don't
+    // leave stale entries behind.
+    const nextPages = new Map<number, CheckRunsCachePage>();
 
-  // We need a place to record whether *every* page returned 304 so we can
-  // surface a true 304 to the caller (and skip the seeding/diff work).
-  let allPagesUnchanged = true;
-  // `latestTotal` tracks the most recent 200 response's `total_count`.
-  // Crucially we do NOT carry `cache.lastTotalCount` into this — that
-  // would let a transient prior-tick inflation persist forever once page-1
-  // starts returning 304 against the unchanged content (the cached
-  // `lastTotalCount` would seed the gate every tick and `runs.length`
-  // could never catch up to an inflated, no-longer-true total).
-  let latestTotal: number | undefined;
+    // We need a place to record whether *every* page returned 304 so we can
+    // surface a true 304 to the caller (and skip the seeding/diff work).
+    let allPagesUnchanged = true;
+    // `latestTotal` tracks the most recent 200 response's `total_count`.
+    // Crucially we do NOT carry `cache.lastTotalCount` into this — that
+    // would let a transient prior-tick inflation persist forever once page-1
+    // starts returning 304 against the unchanged content (the cached
+    // `lastTotalCount` would seed the gate every tick and `runs.length`
+    // could never catch up to an inflated, no-longer-true total).
+    let latestTotal: number | undefined;
 
-  const fetchPage = async (
-    page: number,
-  ): Promise<{
-    runs: GhCheckRun[];
-    total: number | undefined;
-    was304: boolean;
-  }> => {
-    const pageEtag = cache?.pages.get(page)?.etag;
-    const res = await ghGet<{
-      total_count: number;
-      check_runs: GhCheckRun[];
-    }>(`${basePath}&page=${page}`, pageEtag);
-    if (res.status === 304) {
-      // Reuse cached page. Carry forward the ETag we sent.
-      const cachedRuns = cache?.pages.get(page)?.runs ?? [];
-      nextPages.set(page, { etag: pageEtag, runs: cachedRuns });
-      return {
-        runs: cachedRuns,
-        // total_count isn't returned on 304. We deliberately return
-        // undefined here rather than falling back to `cache.lastTotalCount`,
-        // because that cached value may itself be stale (an inflated value
-        // committed during a prior mid-walk race). The terminal `latestTotal`
-        // is derived from this tick's 200 responses; only when *every* page
-        // is 304 do we reuse the cached total below — and that case
-        // genuinely means "nothing changed since we last committed".
-        total: undefined,
-        was304: true,
-      };
-    }
-    nextPages.set(page, { etag: res.etag, runs: res.data.check_runs });
-    return {
-      runs: res.data.check_runs,
-      total: res.data.total_count,
-      was304: false,
-    };
-  };
-
-  // Page 1 always runs — we need its `total_count` (or a 304 fast-path
-  // when nothing changed).
-  const first = await fetchPage(1);
-  if (!first.was304) allPagesUnchanged = false;
-  if (first.total !== undefined) latestTotal = first.total;
-
-  // Single-page fast path. If page 1 was 304 and our last-known total fits
-  // in one page, we can short-circuit the whole call without touching any
-  // other state — this is the common steady-state for typical PRs. No
-  // staged cache: the existing `state.checkRunsCache` is still valid and
-  // we never built a replacement.
-  if (
-    first.was304 &&
-    cache &&
-    cache.lastTotalCount <= CHECK_RUNS_PAGE_SIZE &&
-    cache.pages.size === 1
-  ) {
-    return { response: { status: 304 } };
-  }
-
-  // Dedupe by run id. Pagination is not transactional on GitHub: when a
-  // new run is registered mid-walk, runs can shift across page boundaries
-  // and we'd otherwise see the same id on two different pages (or miss
-  // one entirely). A `Map<id, run>` collapses duplicates and lets the
-  // downstream `runs.length >= total_count` gate evaluate against the
-  // true unique count.
-  const runsById = new Map<number, GhCheckRun>();
-  for (const r of first.runs) runsById.set(r.id, r);
-
-  // How many pages to walk this tick. We need a starting estimate before
-  // we've seen any 200 with a non-cached total, so we fall back to the
-  // cached `lastTotalCount` when page-1 was 304 (unchanged content → the
-  // server's view almost certainly matches what we last committed). If a
-  // 200 arrives later, `latestTotal` takes precedence and we recompute.
-  const seedTotal = latestTotal ?? cache?.lastTotalCount ?? 0;
-  let totalPages = Math.max(1, Math.ceil(seedTotal / CHECK_RUNS_PAGE_SIZE));
-  if (totalPages > MAX_CHECK_RUNS_PAGES) {
-    logger.warn(
-      `Pagination cap hit for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`,
+    const fetchPage = Effect.fn('fetchAllCheckRuns.fetchPage')(function* (
+      page: number,
+    ): Effect.fn.Return<
       {
-        data: {
-          totalCount: seedTotal,
-          neededPages: totalPages,
-          cappedAt: MAX_CHECK_RUNS_PAGES,
-        },
+        runs: GhCheckRun[];
+        total: number | undefined;
+        was304: boolean;
       },
-    );
-    totalPages = MAX_CHECK_RUNS_PAGES;
-  }
-  if (totalPages > 1) {
-    logger.info(
-      `Pagination for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`,
-      {
-        data: { totalCount: seedTotal, totalPages },
-      },
-    );
-  }
-
-  let page = 2;
-  while (page <= totalPages) {
-    const result = await fetchPage(page);
-    if (!result.was304) allPagesUnchanged = false;
-    for (const r of result.runs) runsById.set(r.id, r);
-
-    // Use the LATEST observed `total_count` (from this page's 200) as the
-    // authoritative server view. Walk-length adapts to it whether it grew
-    // OR shrank: a transient inflation that has since settled back down
-    // must be allowed to take effect, otherwise a max-style monotonic
-    // tracker would strand the terminal gate forever.
-    if (result.total !== undefined) {
-      latestTotal = result.total;
-      const newTotalPages = Math.max(
-        1,
-        Math.ceil(latestTotal / CHECK_RUNS_PAGE_SIZE),
-      );
-      if (newTotalPages > MAX_CHECK_RUNS_PAGES) {
-        logger.warn(
-          `Pagination cap hit mid-walk for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`,
-          {
-            data: {
-              totalCount: latestTotal,
-              neededPages: newTotalPages,
-              cappedAt: MAX_CHECK_RUNS_PAGES,
-            },
-          },
-        );
-        totalPages = MAX_CHECK_RUNS_PAGES;
-      } else {
-        totalPages = newTotalPages;
+      unknown
+    > {
+      const pageEtag = cache?.pages.get(page)?.etag;
+      const res = yield* ghGet<{
+        total_count: number;
+        check_runs: GhCheckRun[];
+      }>(`${basePath}&page=${page}`, pageEtag);
+      if (res.status === 304) {
+        // Reuse cached page. Carry forward the ETag we sent.
+        const cachedRuns = cache?.pages.get(page)?.runs ?? [];
+        nextPages.set(page, { etag: pageEtag, runs: cachedRuns });
+        return {
+          runs: cachedRuns,
+          // total_count isn't returned on 304. We deliberately return
+          // undefined here rather than falling back to `cache.lastTotalCount`,
+          // because that cached value may itself be stale (an inflated value
+          // committed during a prior mid-walk race). The terminal `latestTotal`
+          // is derived from this tick's 200 responses; only when *every* page
+          // is 304 do we reuse the cached total below — and that case
+          // genuinely means "nothing changed since we last committed".
+          total: undefined,
+          was304: true,
+        };
       }
+      nextPages.set(page, { etag: res.etag, runs: res.data.check_runs });
+      return {
+        runs: res.data.check_runs,
+        total: res.data.total_count,
+        was304: false,
+      };
+    });
+
+    // Page 1 always runs — we need its `total_count` (or a 304 fast-path
+    // when nothing changed).
+    const first = yield* fetchPage(1);
+    if (!first.was304) allPagesUnchanged = false;
+    if (first.total !== undefined) latestTotal = first.total;
+
+    // Single-page fast path. If page 1 was 304 and our last-known total fits
+    // in one page, we can short-circuit the whole call without touching any
+    // other state — this is the common steady-state for typical PRs. No
+    // staged cache: the existing `state.checkRunsCache` is still valid and
+    // we never built a replacement.
+    if (
+      first.was304 &&
+      cache &&
+      cache.lastTotalCount <= CHECK_RUNS_PAGE_SIZE &&
+      cache.pages.size === 1
+    ) {
+      return { response: { status: 304 } };
     }
-    page += 1;
-  }
 
-  // Resolve the total we'll surface and cache. Priority order:
-  //  1. The last 200's `total_count` (current server-authoritative value).
-  //  2. If every page was 304, the previously-committed `lastTotalCount`
-  //     — nothing actually changed, so the prior commit is still correct.
-  //  3. Fall back to the deduped run count (degenerate case, no 200s and
-  //     no cache; e.g. brand-new subscription with empty results).
-  const reportedTotal = latestTotal ?? cache?.lastTotalCount ?? runsById.size;
+    // Dedupe by run id. Pagination is not transactional on GitHub: when a
+    // new run is registered mid-walk, runs can shift across page boundaries
+    // and we'd otherwise see the same id on two different pages (or miss
+    // one entirely). A `Map<id, run>` collapses duplicates and lets the
+    // downstream `runs.length >= total_count` gate evaluate against the
+    // true unique count.
+    const runsById = new Map<number, GhCheckRun>();
+    for (const r of first.runs) runsById.set(r.id, r);
 
-  // Stage the per-page caches. The caller commits to `state.checkRunsCache`
-  // only after successfully consuming the response — see the type doc above.
-  // We always overwrite on commit: any pages from a previous tick that we
-  // didn't touch this tick (e.g. page count shrank) are intentionally evicted.
-  const stagedCache: CheckRunsCache = {
-    pages: nextPages,
-    lastTotalCount: reportedTotal,
-  };
+    // How many pages to walk this tick. We need a starting estimate before
+    // we've seen any 200 with a non-cached total, so we fall back to the
+    // cached `lastTotalCount` when page-1 was 304 (unchanged content → the
+    // server's view almost certainly matches what we last committed). If a
+    // 200 arrives later, `latestTotal` takes precedence and we recompute.
+    const seedTotal = latestTotal ?? cache?.lastTotalCount ?? 0;
+    let totalPages = Math.max(1, Math.ceil(seedTotal / CHECK_RUNS_PAGE_SIZE));
+    if (totalPages > MAX_CHECK_RUNS_PAGES) {
+      logger.warn(
+        `Pagination cap hit for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`,
+        {
+          data: {
+            totalCount: seedTotal,
+            neededPages: totalPages,
+            cappedAt: MAX_CHECK_RUNS_PAGES,
+          },
+        },
+      );
+      totalPages = MAX_CHECK_RUNS_PAGES;
+    }
+    if (totalPages > 1) {
+      logger.info(
+        `Pagination for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`,
+        {
+          data: { totalCount: seedTotal, totalPages },
+        },
+      );
+    }
 
-  // True end-to-end 304: every page came back unchanged. Caller can skip
-  // the diff/seed work entirely.
-  if (allPagesUnchanged) {
-    return { response: { status: 304 }, stagedCache };
-  }
+    let page = 2;
+    while (page <= totalPages) {
+      const result = yield* fetchPage(page);
+      if (!result.was304) allPagesUnchanged = false;
+      for (const r of result.runs) runsById.set(r.id, r);
 
-  return {
-    response: {
-      status: 200,
-      data: {
-        total_count: reportedTotal,
-        check_runs: [...runsById.values()],
+      // Use the LATEST observed `total_count` (from this page's 200) as the
+      // authoritative server view. Walk-length adapts to it whether it grew
+      // OR shrank: a transient inflation that has since settled back down
+      // must be allowed to take effect, otherwise a max-style monotonic
+      // tracker would strand the terminal gate forever.
+      if (result.total !== undefined) {
+        latestTotal = result.total;
+        const newTotalPages = Math.max(
+          1,
+          Math.ceil(latestTotal / CHECK_RUNS_PAGE_SIZE),
+        );
+        if (newTotalPages > MAX_CHECK_RUNS_PAGES) {
+          logger.warn(
+            `Pagination cap hit mid-walk for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`,
+            {
+              data: {
+                totalCount: latestTotal,
+                neededPages: newTotalPages,
+                cappedAt: MAX_CHECK_RUNS_PAGES,
+              },
+            },
+          );
+          totalPages = MAX_CHECK_RUNS_PAGES;
+        } else {
+          totalPages = newTotalPages;
+        }
+      }
+      page += 1;
+    }
+
+    // Resolve the total we'll surface and cache. Priority order:
+    //  1. The last 200's `total_count` (current server-authoritative value).
+    //  2. If every page was 304, the previously-committed `lastTotalCount`
+    //     — nothing actually changed, so the prior commit is still correct.
+    //  3. Fall back to the deduped run count (degenerate case, no 200s and
+    //     no cache; e.g. brand-new subscription with empty results).
+    const reportedTotal = latestTotal ?? cache?.lastTotalCount ?? runsById.size;
+
+    // Stage the per-page caches. The caller commits to `state.checkRunsCache`
+    // only after successfully consuming the response — see the type doc above.
+    // We always overwrite on commit: any pages from a previous tick that we
+    // didn't touch this tick (e.g. page count shrank) are intentionally evicted.
+    const stagedCache: CheckRunsCache = {
+      pages: nextPages,
+      lastTotalCount: reportedTotal,
+    };
+
+    // True end-to-end 304: every page came back unchanged. Caller can skip
+    // the diff/seed work entirely.
+    if (allPagesUnchanged) {
+      return { response: { status: 304 }, stagedCache };
+    }
+
+    return {
+      response: {
+        status: 200,
+        data: {
+          total_count: reportedTotal,
+          check_runs: [...runsById.values()],
+        },
+        // No single ETag covers a multi-page response. The per-page cache on
+        // `state.checkRunsCache` is what enables conditional reuse next tick.
+        etag: undefined,
       },
-      // No single ETag covers a multi-page response. The per-page cache on
-      // `state.checkRunsCache` is what enables conditional reuse next tick.
-      etag: undefined,
-    },
-    stagedCache,
-  };
-}
+      stagedCache,
+    };
+  },
+  Effect.catchCause((cause) =>
+    // Page processing rejected the previous Promise too. Preserve that channel,
+    // without replacing an interrupted request's joined cleanup cause.
+    Cause.hasInterrupts(cause)
+      ? Effect.failCause(cause)
+      : Effect.fail(Cause.squash(cause)),
+  ),
+);
 
 /**
  * Fetch all annotations for a check-run, walking pages until a short page or
@@ -326,27 +340,36 @@ export async function fetchAllCheckRuns(
  * `AnnotationFetchBudgetExhaustedError` so the caller can defer the run rather
  * than partially emit.
  */
-export async function fetchAnnotations(
-  owner: string,
-  repo: string,
-  checkRunId: number,
-  logger: AgentTrace,
-  budget: AnnotationFetchBudget,
-  now = Date.now(),
-): Promise<GhCheckAnnotation[]> {
-  const annotations: GhCheckAnnotation[] = [];
-  for (let page = 1; page <= MAX_ANNOTATION_PAGES_PER_RUN; page += 1) {
-    if (!budget.tryClaim(now)) {
-      throw new AnnotationFetchBudgetExhaustedError();
+export const fetchAnnotations = Effect.fn('fetchAnnotations')(
+  function* (
+    owner: string,
+    repo: string,
+    checkRunId: number,
+    logger: AgentTrace,
+    budget: AnnotationFetchBudget,
+    now = Date.now(),
+  ): Effect.fn.Return<GhCheckAnnotation[], unknown> {
+    const annotations: GhCheckAnnotation[] = [];
+    for (let page = 1; page <= MAX_ANNOTATION_PAGES_PER_RUN; page += 1) {
+      if (!budget.tryClaim(now)) {
+        return yield* Effect.fail(new AnnotationFetchBudgetExhaustedError());
+      }
+      const path = `/repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=${ANNOTATIONS_PAGE_SIZE}&page=${page}`;
+      const res = yield* ghGet<GhCheckAnnotation[]>(path);
+      if (res.status !== 200) return annotations;
+      annotations.push(...res.data);
+      if (res.data.length < ANNOTATIONS_PAGE_SIZE) return annotations;
     }
-    const path = `/repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=${ANNOTATIONS_PAGE_SIZE}&page=${page}`;
-    const res = await ghGet<GhCheckAnnotation[]>(path);
-    if (res.status !== 200) return annotations;
-    annotations.push(...res.data);
-    if (res.data.length < ANNOTATIONS_PAGE_SIZE) return annotations;
-  }
-  logger.warn(
-    `Reached annotation page cap (${MAX_ANNOTATION_PAGES_PER_RUN}) for check ${checkRunId}; emitting fetched annotations only.`,
-  );
-  return annotations;
-}
+    logger.warn(
+      `Reached annotation page cap (${MAX_ANNOTATION_PAGES_PER_RUN}) for check ${checkRunId}; emitting fetched annotations only.`,
+    );
+    return annotations;
+  },
+  Effect.catchCause((cause) =>
+    // Preserve the per-run failure policy for malformed pages, and the complete
+    // cause of interruption with any joined cleanup failure.
+    Cause.hasInterrupts(cause)
+      ? Effect.failCause(cause)
+      : Effect.fail(Cause.squash(cause)),
+  ),
+);

--- a/src/tools/github/githubClient.ts
+++ b/src/tools/github/githubClient.ts
@@ -9,7 +9,9 @@
 
 import { request as octokitRequest } from '@octokit/request';
 import { RequestError } from '@octokit/request-error';
+import { Effect } from 'effect';
 import { StatusCodes } from 'http-status-codes';
+import { hostPort } from '@common/hostPort';
 import { isNonEmptyString } from '@utils/core';
 
 import { getGitHubToken } from './githubAuth';
@@ -78,11 +80,11 @@ function escapeOctokitLegacyTemplate(path: string): string {
   return path.replaceAll(/:([a-z]\w+)/g, '%3A$1');
 }
 
-export async function ghGet<T>(
+export const ghGet = Effect.fn('ghGet')(function* <T>(
   path: string,
   etag?: string,
-): Promise<ConditionalResponse<T>> {
-  const token = await getGitHubToken();
+): Effect.fn.Return<ConditionalResponse<T>, unknown> {
+  const token = yield* hostPort(() => getGitHubToken());
   const headers: Record<string, string> = {
     'X-GitHub-Api-Version': API_VERSION,
     'user-agent': 'TeXRA-Extension',
@@ -90,82 +92,120 @@ export async function ghGet<T>(
   if (token) headers.authorization = `Bearer ${token}`;
   if (etag) headers['if-none-match'] = etag;
 
-  const signal = AbortSignal.timeout(TIMEOUT_MS);
-  try {
-    const res = await octokitRequest(
-      `GET ${escapeOctokitLegacyTemplate(path)}`,
-      {
+  const timeout = AbortSignal.timeout(TIMEOUT_MS);
+  let signal: AbortSignal | undefined;
+  let pending: ReturnType<typeof octokitRequest> | undefined;
+  let primary: { error: unknown } | undefined;
+  return yield* Effect.tryPromise({
+    try: (interruption) => {
+      signal = AbortSignal.any([interruption, timeout]);
+      pending = octokitRequest(`GET ${escapeOctokitLegacyTemplate(path)}`, {
         headers,
         request: { signal },
-      },
-    );
-    return { status: 200, data: res.data as T, etag: res.headers.etag };
-  } catch (err) {
-    if (err instanceof RequestError) {
-      const status = err.status;
-      const responseHeaders = err.response?.headers;
-      const responseData = err.response?.data;
+      });
+      return pending;
+    },
+    catch: (error) => error,
+  }).pipe(
+    Effect.map((res): ConditionalResponse<T> => ({
+      status: 200,
+      data: res.data as T,
+      etag: res.headers.etag,
+    })),
+    Effect.catch((err): Effect.Effect<ConditionalResponse<T>, unknown> => {
+      primary = { error: err };
+      return Effect.try({
+        try: () => {
+          if (err instanceof RequestError) {
+            const status = err.status;
+            const responseHeaders = err.response?.headers;
+            const responseData = err.response?.data;
 
-      // 304 Not Modified comes through as an error in octokit. Surface it as
-      // the cached/unchanged response so callers can distinguish from 4xx.
-      if (status === StatusCodes.NOT_MODIFIED) return { status: 304 };
+            // 304 Not Modified comes through as an error in octokit. Surface it as
+            // the cached/unchanged response so callers can distinguish from 4xx.
+            if (status === StatusCodes.NOT_MODIFIED) {
+              return { status: 304 };
+            }
 
-      if (
-        status === StatusCodes.UNAUTHORIZED ||
-        status === StatusCodes.FORBIDDEN
-      ) {
-        // Primary rate limit: x-ratelimit-remaining hits 0 with an
-        // epoch-seconds reset timestamp. Only applies when credentials were
-        // otherwise valid.
-        const remaining = responseHeaders?.['x-ratelimit-remaining'];
-        const reset = responseHeaders?.['x-ratelimit-reset'];
-        if (remaining === '0' && typeof reset === 'string') {
-          throw new GitHubRateLimitError(Number(reset));
-        }
-        // Secondary / abuse rate limit: 403 with a Retry-After header
-        // (seconds from now). Primary-limit headers may still read
-        // "non-zero remaining". Without this branch we'd misclassify as an
-        // auth error and stop the subscription permanently.
-        const retryAfter = responseHeaders?.['retry-after'];
-        if (
-          status === StatusCodes.FORBIDDEN &&
-          typeof retryAfter === 'string'
-        ) {
-          const secs = Number(retryAfter);
-          if (Number.isFinite(secs) && secs > 0) {
-            throw new GitHubRateLimitError(
-              Math.floor(Date.now() / 1000) + Math.ceil(secs),
+            if (
+              status === StatusCodes.UNAUTHORIZED ||
+              status === StatusCodes.FORBIDDEN
+            ) {
+              // Primary rate limit: x-ratelimit-remaining hits 0 with an
+              // epoch-seconds reset timestamp. Only applies when credentials were
+              // otherwise valid.
+              const remaining = responseHeaders?.['x-ratelimit-remaining'];
+              const reset = responseHeaders?.['x-ratelimit-reset'];
+              if (remaining === '0' && typeof reset === 'string') {
+                throw new GitHubRateLimitError(Number(reset));
+              }
+              // Secondary / abuse rate limit: 403 with a Retry-After header
+              // (seconds from now). Primary-limit headers may still read
+              // "non-zero remaining". Without this branch we'd misclassify as an
+              // auth error and stop the subscription permanently.
+              const retryAfter = responseHeaders?.['retry-after'];
+              if (
+                status === StatusCodes.FORBIDDEN &&
+                typeof retryAfter === 'string'
+              ) {
+                const secs = Number(retryAfter);
+                if (Number.isFinite(secs) && secs > 0) {
+                  throw new GitHubRateLimitError(
+                    Math.floor(Date.now() / 1000) + Math.ceil(secs),
+                  );
+                }
+              }
+              throw new GitHubAuthError(
+                `GitHub returned ${status}: ${extractApiMessage(responseData, err.message)}`,
+              );
+            }
+            // Permanent HTTP failures — retrying won't help; surface immediately so
+            // callers can halt rather than burning a slot for 24 h.
+            if (
+              status === StatusCodes.NOT_FOUND ||
+              status === StatusCodes.GONE ||
+              status === StatusCodes.UNPROCESSABLE_ENTITY
+            ) {
+              throw new GitHubPermanentError(
+                status,
+                `GitHub returned ${status}: ${extractApiMessage(responseData, err.message)}`,
+              );
+            }
+          }
+          // Network-level errors (timeout, connection refused, DNS failure) reach
+          // here without a response. Re-throw a plain Error with a human-readable
+          // message so callers and the follow-up queue never see SDK internals.
+          if (timeout.aborted) {
+            throw new Error(
+              `GitHub request failed (TIMEOUT): request exceeded ${TIMEOUT_MS}ms`,
             );
           }
-        }
-        throw new GitHubAuthError(
-          `GitHub returned ${status}: ${extractApiMessage(responseData, err.message)}`,
-        );
-      }
-      // Permanent HTTP failures — retrying won't help; surface immediately so
-      // callers can halt rather than burning a slot for 24 h.
-      if (
-        status === StatusCodes.NOT_FOUND ||
-        status === StatusCodes.GONE ||
-        status === StatusCodes.UNPROCESSABLE_ENTITY
-      ) {
-        throw new GitHubPermanentError(
-          status,
-          `GitHub returned ${status}: ${extractApiMessage(responseData, err.message)}`,
-        );
-      }
-    }
-    // Network-level errors (timeout, connection refused, DNS failure) reach
-    // here without a response. Re-throw a plain Error with a human-readable
-    // message so callers and the follow-up queue never see SDK internals.
-    if (signal.aborted) {
-      throw new Error(
-        `GitHub request failed (TIMEOUT): request exceeded ${TIMEOUT_MS}ms`,
-      );
-    }
-    if (err instanceof Error) {
-      throw new Error(`GitHub request failed: ${err.message}`);
-    }
-    throw err;
-  }
-}
+          if (err instanceof Error) {
+            throw new Error(`GitHub request failed: ${err.message}`);
+          }
+          throw err;
+        },
+        catch: (error) => error,
+      });
+    }),
+    // Effect aborts the request before this uninterruptible join. Octokit's
+    // public promise includes body consumption; errors it hides stay hidden.
+    Effect.onExit(() => {
+      const request = pending;
+      return request === undefined
+        ? Effect.void
+        : Effect.tryPromise({
+            try: () => request,
+            catch: (error) => error,
+          }).pipe(
+            Effect.asVoid,
+            Effect.catch((error) =>
+              (primary !== undefined && error === primary.error) ||
+              (signal?.aborted === true && error === signal.reason)
+                ? Effect.void
+                : Effect.die(error),
+            ),
+          );
+    }),
+  );
+});

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -319,7 +319,7 @@ const resolveIssueIsPR = (
   number: number,
 ): Effect.Effect<boolean, unknown> =>
   Effect.flatMap(
-    hostPort(() => ghGet<GhIssue>(`/repos/${owner}/${repo}/issues/${number}`)),
+    ghGet<GhIssue>(`/repos/${owner}/${repo}/issues/${number}`),
     (res) =>
       res.status !== 200
         ? Effect.fail(
@@ -432,9 +432,7 @@ const getDefaultBranch = (
   repo: string,
 ): Effect.Effect<string, unknown> =>
   Effect.flatMap(
-    hostPort(() =>
-      ghGet<{ default_branch?: string }>(`/repos/${owner}/${repo}`),
-    ),
+    ghGet<{ default_branch?: string }>(`/repos/${owner}/${repo}`),
     (res) =>
       res.status !== 200
         ? Effect.fail(
@@ -463,10 +461,8 @@ const listOpenPullSuggestions = (
   repo: string,
 ): Effect.Effect<string, unknown> =>
   Effect.map(
-    hostPort(() =>
-      ghGet<OpenPullSummary[]>(
-        `/repos/${owner}/${repo}/pulls?state=open&per_page=5`,
-      ),
+    ghGet<OpenPullSummary[]>(
+      `/repos/${owner}/${repo}/pulls?state=open&per_page=5`,
     ),
     (res) => {
       if (res.status !== 200 || res.data.length === 0) {
@@ -538,9 +534,8 @@ const execFindCurrent = Effect.fn('GitHubSubscriptionTool.findCurrent')(
       );
     }
     const apiPath = `/repos/${remote.owner}/${remote.repo}/pulls?state=open&head=${remote.owner}:${encodeURIComponent(branch)}&per_page=1`;
-    const res = yield* hostPort(() =>
-      ghGet<Array<{ number: number; html_url: string }>>(apiPath),
-    );
+    const res =
+      yield* ghGet<Array<{ number: number; html_url: string }>>(apiPath);
     if (res.status !== 200) {
       return yield* Effect.fail(
         new ToolError(`Unexpected GitHub response status: ${res.status}`),


### PR DESCRIPTION
## Summary

Remove the Promise-returning request and pagination layer between the GitHub
polling programs and their HTTP library. Requests, check-run pagination, and
annotation pagination now compose directly as Effect programs.

The request boundary passes interruption to the HTTP library and waits for its
complete public request Promise to settle. The existing 15-second timeout,
authentication, error classification, conditional requests, page limits, budgets,
cache updates, and notification ordering remain unchanged for ordinary results.
When parallel requests report both an ordinary failure and a separate late
failure, the existing round logger now receives both together, once.

## Issue acceptance gates

This is a bounded part of #12025. It removes the old request adapter and converts
all of its consumers in the same change. It does not modify model execution,
session storage, other open branches, or any exclusion baseline.

## Single source of truth

`githubClient.ts` continues to own HTTP headers, URL escaping, conditional-response
handling, and GitHub error classification. `checkRunsClient.ts` continues to own
pagination and staged cache replacements. Existing polling sources retain their
subscription, backoff, event, and annotation policies.

## Duplication and abstraction budget

Delete `pollRequest`, its 12 calls, and four `hostPort` wrappers around `ghGet`.
The request, two pagination operations, and private page operation become native
Effect operations. No replacement adapter, service, compatibility branch, or
dependency is added.

Interruption aborts before the request boundary joins the public SDK Promise.
An already-reported primary error or identical abort reason is not reported twice;
a distinct exposed late failure is preserved by the request operation. Waiting
for settlement has no
promised upper bound if a foreign implementation ignores cancellation. The pinned
Octokit library hides some response-body failures internally; this change neither
recovers those hidden failures nor changes the library's response acceptance.

There is a separate existing limit in detached polling shutdown: the pinned
parallel iterator joins interrupted children but can discard their failure
causes. This change does not claim that every late child error reaches the final
poll logger, nor does it change the void disposable or stop race. Ordinary
parallel Fail+Die results that reach the poll hook are now retained through error
classification and reported together without applying several backoff updates.

## Net elements (R6)

Against base `854b36ee69d808d8db14ae96da0f169ba230317a`:

- Ten files changed; no files added or deleted.
- One exported function removed (`pollRequest`); no exported symbol added.
- No class, interface, service, or test case added or removed.
- Production: +454/-386 lines, net +68. Existing tests: +55/-54, net +1.
- Total: +509/-440 lines, net +69.

The small increase provides the HTTP abort-and-settlement ownership and preserves
the existing malformed-response failure channel and complete reported compound
causes while deleting the Promise adapter path. Most pagination diff lines
reflect indentation of the unchanged
algorithm inside the named Effect operation.

## Consumer counts (R8)

`pollRequest` had 12 production callers across the PR, issue, and repository
pollers; it now has zero. All four tool-level `hostPort` calls around `ghGet` are
also removed. No event name, emitter, listener, or notification subscription is
deleted or rerouted.

## Host impact

Extension, desktop, and CLI use the same GitHub tools and polling sources. Their
public tool results and notification policies are unchanged. No host composition
or model configuration changes.

## Scheduled refactoring

The unchanged secret-store boundary, SDK-internal body handling, and detached
poll-loop interruption limitation are outside this request-layer removal.

## Validation

The final reviewed source passed, using Node 22.23.2 and a private temporary
directory:

- Full formatting, all six typecheck components, and `compile:fast`.
- Complete lint with the unchanged 6144 MiB setting: 80.90 seconds.
- Effect, browser-safety, guidance-reference, and strict dead-code checks.
- Full Vitest with two workers: 8,947 passed, 6 skipped; 761 passing files and
  one skipped file; 754.87 seconds.
- Separate architecture check: 106 tests in 16 files passed.
- All 24 existing focused cases, including the unchanged subscription-progress
  suite; no test case was added.

Independent source review accepted the exact final ten-file snapshot. An
actual-source comparison using pinned Octokit and Effect with synthetic HTTP
responses verifies request/error behavior, pagination, malformed input, and
abort-before-joined settlement. A second comparison reaches the real issue poller
and final logger, verifying exactly-once compound reporting and silent pure
interruption, while demonstrating the external-stop limitation described above.
No live GitHub requests or credentials were used by those diagnostics. The final
source hashes remained unchanged throughout validation. Remote CI is separate
and will validate the PR combined with current main.
