### PR TITLE
refactor(model-handlers): name the generation-time retry policy instead of repeating the literal

### DIFF
--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -63,7 +63,10 @@ import {
   estimateTokensFromText,
 } from '../contextManagementConstants';
 import { AnthropicStreamHandler } from '../support/AnthropicStreamHandler';
-import { AUXILIARY_MAX_RETRIES } from '../support/auxiliaryRetry';
+import {
+  AUXILIARY_MAX_RETRIES,
+  SDK_RETRIES_DISABLED,
+} from '../support/auxiliaryRetry';
 import {
   classifyMediaEntry,
   unknownMediaCategoryWarning,
@@ -385,7 +388,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         apiKey: credential.apiKey,
         baseURL: credential.baseUrl,
         fetch: this.longRunningModelFetch,
-        maxRetries: 0,
+        maxRetries: SDK_RETRIES_DISABLED,
       }),
       credential.route,
       credential.apiKey,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -81,6 +81,7 @@ import {
   type BackgroundTerminalVerdict,
 } from '../support/BackgroundRunLifecycle';
 import { ServerChainState } from '../support/ServerChainState';
+import { SDK_RETRIES_DISABLED } from '../support/auxiliaryRetry';
 import { CLIENT_COMPACTION_SUMMARY_MAX_TOKENS } from '../contextManagementConstants';
 import {
   DEFAULT_ATTACHMENT_MIME_TYPE,
@@ -1807,19 +1808,20 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   /**
    * Per-call options for the Speakeasy Interactions client.
    *
-   * `maxRetries: 0` keeps the node loop the single retry owner: the generated
-   * client defaults to its own 4-retry backoff, which `httpOptions`-level
-   * retry settings do not govern. Abort is wired via `fetchOptions.signal`
-   * (GoogleGenAIRequestOptions has no top-level abortSignal field). The
-   * request-local HTTP client observes native fetch response resolution and
-   * applies the shared header/body-inactivity policy without relying on
-   * non-standard RequestInit fields that the SDK drops while rebuilding.
+   * {@link SDK_RETRIES_DISABLED} keeps the node loop the single retry owner:
+   * the generated client defaults to its own 4-retry backoff, which
+   * `httpOptions`-level retry settings do not govern. Abort is wired via
+   * `fetchOptions.signal` (GoogleGenAIRequestOptions has no top-level
+   * abortSignal field). The request-local HTTP client observes native fetch
+   * response resolution and applies the shared header/body-inactivity policy
+   * without relying on non-standard RequestInit fields that the SDK drops
+   * while rebuilding.
    */
   private interactionsRequestOptions(
     signal?: AbortSignal,
   ): InteractionsRequestOptions {
     return {
-      maxRetries: 0,
+      maxRetries: SDK_RETRIES_DISABLED,
       fetchOptions: signal ? { signal } : {},
     };
   }

--- a/src/agent/modelHandlers/openai/OpenAICompatibleModelHandler.ts
+++ b/src/agent/modelHandlers/openai/OpenAICompatibleModelHandler.ts
@@ -12,6 +12,7 @@ import type {
 import { attachSdkRequestBaseURL } from '@common/errors/sdkError/sdkRequestEndpoint';
 
 // Local file imports
+import { SDK_RETRIES_DISABLED } from '../support/auxiliaryRetry';
 import { logOpenAICompatibleClientConfig } from './openAIChatHelpers';
 import { tagOpenAISdkError } from './openAISdkError';
 
@@ -72,7 +73,7 @@ export abstract class OpenAICompatibleModelHandler<
       apiKey: credential.apiKey,
       baseURL: credential.baseUrl,
       fetch: this.longRunningModelFetch,
-      maxRetries: 0,
+      maxRetries: SDK_RETRIES_DISABLED,
     });
     logOpenAICompatibleClientConfig(
       this.logger,

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -50,6 +50,7 @@ import {
 import { isPreferCodexSubscription } from '@model/codex/codexPreference';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
+import { SDK_RETRIES_DISABLED } from '../support/auxiliaryRetry';
 import { contentToText } from './openAIResponseContent';
 import { ModelHandlerOpenAIResponse } from './modelHandlerOpenAIResponse';
 import type { ResponseCreateParamsBase } from 'openai/resources/responses/responses';
@@ -300,7 +301,7 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
         baseURL: CODEX_BACKEND_BASE_URL,
         defaultHeaders,
         fetch: this.codexFetch,
-        maxRetries: 0,
+        maxRetries: SDK_RETRIES_DISABLED,
       }),
       'chatgpt-subscription',
       apiKey,

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -146,7 +146,8 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       appTitle: 'TeXRA.ai',
       ...(credential.baseUrl ? { serverURL: credential.baseUrl } : {}),
       httpClient: new HTTPClient({ fetcher: this.longRunningModelFetch }),
-      // TeXRA's session gate owns retry timing and admission.
+      // TeXRA's session gate owns retry timing and admission. Same policy as
+      // `SDK_RETRIES_DISABLED`, which this SDK spells as a strategy, not a count.
       retryConfig: { strategy: 'none' },
     });
     return this.rememberClientCredentialRoute(

--- a/src/agent/modelHandlers/support/auxiliaryRetry.ts
+++ b/src/agent/modelHandlers/support/auxiliaryRetry.ts
@@ -11,6 +11,21 @@ import { isProviderErrorAutoRetryable } from '@common/errors/sdkError/providerEr
  */
 export const AUXILIARY_MAX_RETRIES = 2;
 
+/**
+ * SDK-level retries for provider clients, disabled. `ModelInvocationNode` is
+ * the single retry owner for generation requests (an automatic `p-retry`
+ * batch, then one approved manual attempt at a time), so a provider SDK
+ * retrying underneath it would spend attempts against a budget the node
+ * cannot see. Client constructors default to this value and the auxiliary
+ * calls listed on {@link AUXILIARY_MAX_RETRIES} opt back up per request.
+ *
+ * The OpenRouter SDK expresses the same decision as
+ * `retryConfig: { strategy: 'none' }` rather than a count, so its client in
+ * `modelHandlerOpenRouterNative.getClient` states the policy in its own terms
+ * instead of importing this constant.
+ */
+export const SDK_RETRIES_DISABLED = 0;
+
 /** Run an auxiliary provider call under the shared bounded-retry policy. */
 export function auxiliaryRetry<T>(
   operation: () => Promise<T>,


### PR DESCRIPTION
## What was wrong

`src/agent/modelHandlers/support/auxiliaryRetry.ts` already names one half of this repo's retry policy: `AUXILIARY_MAX_RETRIES = 2`, the bounded retry count for auxiliary provider calls, imported at seven sites across the OpenAI, Anthropic and Kimi handlers.

The other half was never named. `ModelInvocationNode` is the single retry owner for generation requests: it runs an automatic `p-retry` batch, then one approved manual attempt at a time. For that to mean anything, the provider SDKs underneath it must not retry on their own, or attempts get spent against a budget the node cannot see. That rule existed only as a bare `maxRetries: 0` literal, copy-pasted across three provider families.

## How I know

`AUXILIARY_MAX_RETRIES`'s own docstring asserts the rule ("Generation requests run with SDK retries disabled because the node loop owns them") while the rule itself lives nowhere. Grepping `maxRetries` across `src` and `packages` found the zero at four generation sites: `OpenAICompatibleModelHandler.ts:75` (the base client shared by DashScope, DeepSeek, GLM, MiniMax and XAI), `modelHandlerCodex.ts:303`, `modelHandlerAnthropic.ts:388`, and `modelHandlerGoogleInteractions.ts:1822`. Only the Google one carried an explanation. A reader of the other three has no way to tell a deliberate policy from an arbitrary default, and someone adding a fifth provider handler has nothing to copy but the number.

## What changed

Added `SDK_RETRIES_DISABLED = 0` next to `AUXILIARY_MAX_RETRIES`, with the invariant written down once: the node loop owns generation retries, client constructors default to this value, and auxiliary calls opt back up per request. The four sites above now import it. That is the whole shape of the fix. No config object, no policy class, no options builder around a zero.

Two sites the issue listed are deliberately left as they were, because folding them in would flatten a real difference rather than express one.

`modelHandlerAnthropic.ts:276` and `:286` are per-request options on the Files API `retrieveMetadata` and `download` calls behind `estimateFileReferenceTokens`. Those are auxiliary calls, in the same token-estimation path as the `countTokens` call fifteen lines below `getClient` that passes `AUXILIARY_MAX_RETRIES = 2`. Labelling them with the generation constant would assert an invariant that does not apply to them; raising them to 2 to match their neighbour would be a behavior change and does not belong in a refactor. The inconsistency is real and worth a decision, so it is reported on the issue rather than settled quietly here.

`modelHandlerOpenRouterNative.ts:150` makes exactly the same decision, but the OpenRouter SDK spells it `retryConfig: { strategy: 'none' }`, a strategy and not a count, so no numeric constant fits. Its comment now names the shared policy and the constant's docstring points back at it, so a grep from either end reaches the other.

Behavior preserving, so no new tests. Net element count: one export added, zero deleted; six literals became four constant references plus two cross-reference comments.

## Verified

- `npm run typecheck`: clean across root, agent, extension, cli, trace-viewer and desktop.
- `npm run lint`: clean, all five eslint invocations exit 0 with no output.
- `node scripts/check-effect-migration-ratchet.mjs`: exit 0, "no count grew, no baseline headroom". `import:p-retry` stays 3 files / 3 sites and `catch:effect-importer` stays 8 files / 17 sites. The touched file gains no `effect` import, so no catch row is pulled in.
- `npm run check:dead-code-ratchet`: "no new findings", 282 combined vs 282 baselined. The new export has its four consumers in the same commit.
- `npx vitest run` over ten model-handler suites that assert client and per-request retry options: 222 passed, 4 skipped (the live-network Google suite). These include the assertions that pin the values on both sides, `client.maxRetries === 0` in ModelHandlerOpenAIClientDiagnostics, `options.maxRetries === 0` in ModelHandlerAnthropic, `{ strategy: 'none' }` in ModelHandlerOpenRouterNative, and `maxRetries: 2` in the auxiliary-path suites.

## Left alone

`packages/llm/**` and `src/model/runtimeModelRegistry.ts` are untouched; they belong to open PR #11997. If a model client is constructed there, the same constant should reach it once that lands. The module is still named `auxiliaryRetry.ts` even though it now holds both halves of the policy; renaming it would touch eight import lines and one ratchet baseline key for zero behavior, which is not worth the churn.

Closes part of #12035; the two Anthropic Files API sites are noted on the issue as an open behavior question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU
