### PR TITLE
fix(model-handlers): apply Astra's long-context pricing tier and fix the reasoning-effort clamp

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -105,6 +105,7 @@ import {
   uploadToolAttachments,
   type UploadedOpenAIResponseAttachment,
 } from './openAIResponseFileUploads';
+import type { StandardPricingConfig } from '../support/priceUtils';
 import type { AssistantTextAppendOptions } from '../ModelHandler';
 import type { BackgroundRunLifecycle } from '../support/BackgroundRunLifecycle';
 
@@ -165,6 +166,37 @@ type OpenAIResponseBaseParams = Omit<
 > & { input: ResponseInputItem[] };
 
 type ServerToolContentBlock = ResponseFunctionWebSearch | ResponseReasoningItem;
+
+/**
+ * GPT-6 Astra's long-context billing, which llm-zoo does not carry: once a
+ * request's prompt reaches 272K input tokens OpenAI bills the whole request at
+ * 2x input (cached input included) and 1.5x output. The 1.35.0 catalog entry
+ * says so in its own comment (the registry has no tier field), so the
+ * threshold and the two multipliers live here. Astra is the only OpenAI model
+ * with a published tier today; when OpenAI documents another, it needs a
+ * sibling entry here, since nothing in the catalog distinguishes a tiered
+ * model from a flat one (a 1M context window does not: GPT-5.6 has one and
+ * bills flat).
+ *
+ * Two drift traps this shape avoids. The rates are multiplied off the
+ * catalog's base prices instead of restated, so a published price change moves
+ * both tiers together rather than leaving a stale literal billing the wrong
+ * number. And the match is on the registry name, TeXRA's stable model
+ * identity, not on the `fullName` wire id, which a date pin would rename out
+ * from under a string comparison and silently drop 272K+ prompts back to flat
+ * rates.
+ *
+ * Astra's documented cached-input rate doubles along with the input rate
+ * ($1.00 to $2.00 against $10 to $20), so the catalog's cacheDiscountFactor of
+ * 0.1 holds on both sides of the threshold and the cache rebate follows the
+ * tier switch inside `computeStandardPrice` on its own.
+ */
+const ASTRA_MODEL_NAME = 'gpt6';
+const ASTRA_LONG_CONTEXT = {
+  thresholdTokens: 272_000,
+  inputMultiplier: 2,
+  outputMultiplier: 1.5,
+} as const;
 
 /**
  * store:false (stateless) content blocks: every reasoning item that carries a
@@ -1950,6 +1982,25 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     return this.config.provider === ModelProvider.OPENAI
       ? 'openai-response'
       : (this.config.provider as NormalizedUsage['provider']);
+  }
+
+  /**
+   * Catalog rates plus GPT-6 Astra's long-context tier (see
+   * {@link ASTRA_LONG_CONTEXT}). Subscription routes never reach this: they
+   * report a zero-cost provider capability profile that `normalizeUsage`
+   * prefers, because that usage is billed by plan rather than per token.
+   */
+  protected override standardPricingConfig(): StandardPricingConfig {
+    const base = super.standardPricingConfig();
+    if (this.config.name !== ASTRA_MODEL_NAME) return base;
+    return {
+      ...base,
+      longContextTier: {
+        thresholdTokens: ASTRA_LONG_CONTEXT.thresholdTokens,
+        inputPrice: base.inputPrice * ASTRA_LONG_CONTEXT.inputMultiplier,
+        outputPrice: base.outputPrice * ASTRA_LONG_CONTEXT.outputMultiplier,
+      },
+    };
   }
 
   /** Normalizes OpenAI Responses API usage data into a unified format. */

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -1469,6 +1469,26 @@ describe('ModelHandlerOpenAIResponse.normalizeUsage', () => {
     assert.equal(normalized.cachedInputTokens, 10);
   });
 
+  // #11878: Astra bills the whole request at 2x input / 1.5x output past 272K
+  // prompt tokens, and the handler priced every request at the flat catalog
+  // rates, underreporting long-context cost by up to 2x.
+  it('applies the GPT-6 Astra long-context tier past 272K prompt tokens', () => {
+    const handler = createHandler({ ...MODEL_CONFIGS.gpt6 });
+    const usageOf = (inputTokens: number): ResponseUsage =>
+      ({
+        input_tokens: inputTokens,
+        output_tokens: 1_000,
+        total_tokens: inputTokens + 1_000,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      }) as ResponseUsage;
+
+    // 300K x $20/1M + 1K x $75/1M
+    assert.equal(handler.normalizeUsage(usageOf(300_000), 0).cost, 6.075);
+    // Below the threshold the catalog rates still apply: 100K x $10/1M + 1K x $50/1M
+    assert.equal(handler.normalizeUsage(usageOf(100_000), 0).cost, 1.05);
+  });
+
   it('defaults cacheCreationTokens to undefined when cache_write_tokens is absent', () => {
     const handler = createHandler();
     const usage: ResponseUsage = {


### PR DESCRIPTION
## What was wrong

Issue #11878 reported two bugs in the GPT-6 Astra integration that landed with #11860. One is real, one is not.

**Real: Astra's long-context tier was never billed.** OpenAI bills a GPT-6 Astra request whose prompt reaches 272K input tokens at 2x input (cached input included) and 1.5x output, for the whole request. `docs/guide/models.md` says so, the CHANGELOG entry for the model says so, and the llm-zoo 1.35.0 catalog entry says so in its own comment while noting the registry has no field to carry it. The code did not. `ModelHandlerOpenAIResponse.normalizeUsage` priced through the base `standardPricingConfig()` in `ModelHandler.ts`, which returns input price, output price and cache discount factor and never a `longContextTier`. `computeStandardPrice` switches the whole rate tuple only when that field is present, and until now only `ModelHandlerXAI` set it. So every Astra request over the threshold billed flat catalog rates, underreporting cost by up to 2x on input and 1.5x on output on exactly the workload the model is sold for.

**Not real: the reasoning-effort clamp.** The issue says the `minimal` to `low` clamp, which compares `this.config.fullName === 'gpt-6-astra'`, is skipped when the user turns on "Prefer short model names", because `ModelFactory.withShortModelName` overwrites `fullName` with the short name. It does not, for this model. The rewrite lives in `applyShortModelNamePreference`, which returns the config untouched when `shortName === config.fullName`, and llm-zoo gives `gpt6` the shortName `gpt-6-astra`, identical to its fullName. No other catalog entry shares that wire id, and no other code path rewrites `config.fullName` for it. The clamp fires with the setting on or off, so this half of the issue is refuted and nothing was changed for it. Keying on `fullName` is also correct on the merits here: it is the exact string sent as `model` in the same request builder, so the predicate and the id it constrains cannot drift apart.

## How I know

The failing case is now a test, and I ran it against the unfixed handler first. A 300K-input, 1K-output Astra request reported a cost of $3.05 where OpenAI charges $6.075. With the fix it reports $6.075. For the refuted half, `MODEL_CONFIGS.gpt6` from llm-zoo 1.35.0 reports `fullName` and `shortName` both equal to `gpt-6-astra`, and exactly one entry in the catalog uses that wire id.

## What changed

`ModelHandlerOpenAIResponse` now overrides `standardPricingConfig()` and attaches the long-context tier for Astra. Two details are deliberate, because this is accounting data and a wrong number here is silent:

- The tier rates are multiplied off the catalog's own base prices rather than restated as literals, so if OpenAI republishes Astra's price both tiers move together instead of leaving a stale number in the handler.
- The match is on the registry name `gpt6`, TeXRA's stable model identity, not on the `fullName` wire id, which a date-pinned rename would change out from under a string comparison and silently drop long prompts back to flat rates.

Astra's documented cached-input rate doubles along with the input rate ($1.00 to $2.00 against $10 to $20), so the catalog's cache discount factor of 0.1 stays valid on both sides of the threshold and the existing cache rebate follows the tier switch on its own. Subscription (Codex) usage is untouched: it reports a zero-cost provider capability profile that `normalizeUsage` prefers, because that usage is billed by plan rather than per token. The OpenRouter route uses a different handler and OpenRouter's own rates.

One test was added, extending the existing `ModelHandlerOpenAIResponse.normalizeUsage` describe block rather than adding a file. It asserts the tier cost above the threshold and the flat catalog cost below it, so a future change that applies the tier unconditionally fails as well.

## Verified

- `npm run typecheck`: exit 0.
- `npx vitest run src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts src/test-kernel/agent/modelHandlers/support/priceUtils.vitest.ts`: 2 files, 49 tests passed.
- Same suite with the new override temporarily neutered: fails with `3.05 !== 6.075`, confirming the test is not vacuous.
- `node scripts/check-effect-migration-ratchet.mjs`: no count grew, no baseline headroom, no adapter markers.
- `npm run lint`: clean.
- `npm run check:dead-code-ratchet`: 282 findings against 282 baselined, no new findings. No export was added or removed; the constants are module-local and the method is a protected override.

## Deliberately left alone

The clamp, as explained above. No tripwire for a hypothetical future OpenAI model with an undocumented tier: the xAI table can use a context-window tripwire because every xAI model above 200K has a published tier, but for OpenAI nothing in the catalog separates tiered from flat (GPT-5.6 has a 1.05M window and bills flat), so the same check would cry wolf on most OpenAI entries. That limitation is written into the comment above the constant instead of guessed at in code. Cache-write tokens are still not billed by the shared inclusive-cache formula for any OpenAI model, which is pre-existing and out of scope here. No docs or CHANGELOG edit: the docs already describe this pricing and the code now matches them.

Fixes the first half of #11878; the second half is refuted above and the issue can close on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU
