### PR TITLE
perf: record the pre-cutover runtime baseline the delivery plan makes a gate precondition

### DIFF
--- a/docs/architecture/2026-09-07-pre-cutover-runtime-baseline.md
+++ b/docs/architecture/2026-09-07-pre-cutover-runtime-baseline.md
@@ -14,9 +14,9 @@ with guessed percentage wins or a net-LOC promise."
 Nothing owned that, and the cutover is landing stage by stage, so a budget
 recorded after the fact would compare the new runtime against nothing. This
 document is the pre-cutover half of the comparison. It records what
-`scripts/measure-runtime-baseline.mjs` measured on `origin/main` at
-`854b36ee69`, the machine and datasets it measured on, and, for each metric the
-Performance gate names that is not measurable today, the exact reason.
+`scripts/measure-runtime-baseline.mjs` measured, the machine and datasets it
+measured on, and, for each metric the Performance gate names that this harness
+does not produce, what it would take to get one.
 
 No production code changed. The harness only reads and writes its own temporary
 session roots.
@@ -32,13 +32,13 @@ after the cutover and produces a back-to-back comparison on one machine.
 
 `Database` is a surviving contract: it is the substrate lane's own boundary, it
 is composed exactly once in production at
-`src/controllers/session/sessionLayer.ts:457`, the per-session layer map every
+`src/controllers/session/sessionLayer.ts:437`, the per-session layer map every
 host installs, and the delivery plan's deletion ledger does not name it.
 `appendAll`, `readAll`, `readListing`, `readInputBatch` and `currentCommit` are
 the operations the scenarios use.
 
 A scenario composes the layer exactly the way
-`src/test-kernel/controllers/session/sessionEvents.vitest.ts:819` does:
+`src/test-kernel/controllers/session/sessionEvents.vitest.ts:823` does:
 
 ```
 databaseLayer('persistent').pipe(
@@ -65,8 +65,14 @@ carries the 1-minute load average it was taken under.
 
 The script refuses to run above a 1-minute load average of 8 and says so, because
 a wall-clock number from a busy shared machine is not a smaller number, it is a
-meaningless one. `--allow-load` overrides that for an exploratory run whose
-output is not going into a budget; do not record such a run here.
+meaningless one. The ceiling is enforced twice: the driver refuses before
+spawning each scenario, and every scenario re-checks it at each record it emits,
+printing the offending record with an `aboveLoadCeiling` field and then failing
+the run. A start-only check would be systematically optimistic, because the
+harness is itself a large part of the load its later scenarios run under, so the
+reading most likely to breach the ceiling is the one taken last. `--allow-load`
+removes the ceiling for an exploratory run whose output is not going into a
+budget; do not record such a run here.
 
 Three measurement primitives are first uses in this repository: `perf_hooks`
 `monitorEventLoopDelay`, `os.loadavg`, and `process.memoryUsage`. Nothing else
@@ -92,6 +98,17 @@ the repository dies on `import { Effect } from 'effect'`.
 | Memory        | 68,719,476,736 bytes (64 GiB)                            |
 | 1-minute load | 6.83 at start, 5.29 to 7.00 across scenarios (ceiling 8) |
 | Measured at   | 2026-09-07T21:06:28Z                                     |
+
+The recorded run predates the per-record ceiling check described in section 2,
+which was added after review. The change is confined to the load gate, an
+`ENOENT` test in `databaseBytes` and the CPU read, none of which sits inside a
+timed region, and a full `--allow-load` run of the amended script reproduced
+section 4 within run-to-run variance: 100,000-row `readAll` 1451.40 ms against
+the recorded 1436.93 ms, peak heap growth 677.98 MB against 677.82 MB, settled
+on-disk bytes identical for the 1 KiB and 256 KiB shapes and 2,965,504 B
+against 2,990,080 B for `status` (2.81x against the recorded 2.84x). That run
+is deliberately not recorded here: it was taken without a ceiling, and section
+2 says such a run does not go into a budget.
 
 Datasets, all synthetic, all written through `appendAll`:
 
@@ -248,10 +265,14 @@ WAL reached 3,444,352 B, settling to 2,990,080 B on close. A long-lived session
 therefore carries its recent history in a WAL that grows until something
 checkpoints it, and on this path only closing does.
 
-## 5. Metrics the gate names that are not measurable today
+## 5. Metrics the gate names that this harness does not produce
 
-Each of these is recorded rather than dropped, with what would have to exist
-first.
+Each of these is recorded rather than dropped, with what it would take. The
+distinction that matters: none of them is an unmeasurable property of the
+system, and two of the four below are already driven by suites in this
+repository, with a third partly driven. What is missing is a vehicle that turns
+those behaviours into a number, and this harness, a spawned repo-root script
+over the `Database` contract, is not that vehicle.
 
 **Host-process cold open.** Section 4 measures the substrate half: a fresh Node
 process opening an existing session database to its first usable listing. The
@@ -264,32 +285,62 @@ drive packaged artifacts, not startup timing:
 cold open needs a launcher that reports a first-paint timestamp, which is its own
 piece of work and is not in this lane.
 
-**p95 stop latency.** Cancellation latency is a property of a run in flight:
-cancel during model call, during tool execution, during approval, during queued
-admission. Driving one needs a model handler, and the only network-free handler
-in the repository is `ModelHandlerValidation`
-(`src/agent/modelHandlers/modelHandlerValidation.ts`), reachable only through
-`shouldUseInternalValidationModelHandler`
-(`src/agent/runtime/internalValidationOverride.ts:30`), which requires all four
-of `TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL=1`, a named per-run env var set
-to `1`, `CI=1`, and an absolute flag file whose contents match a build-time
-sentinel. Any partial activation throws rather than falling through. The
-include flag is an esbuild `define` in `packages/cli/scripts/build-bundle.mjs`,
-so outside a CLI package-validation build the predicate constant-folds to
-`false`. A repository-root script cannot reach it.
+**p95 stop latency.** Cancellation is a property of a run in flight, and the
+Stop/close gate names the points: before registration, during the model call,
+during tool execution, during approval, during queued admission, during
+settlement. Two of those points are driven today, with no network anywhere:
+`src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts` builds a
+three-tool round on the real `createToolUseRoundFlow` and aborts the run's own
+`AbortController` either from inside the second tool or during tool-call
+extraction, then asserts every requested call comes back paired with a
+synthesized cancelled result. Its model handler is `roundModelHandler`
+(`src/test-kernel/agent/toolUseRoundTestUtils.ts`) wrapped in `testModelCell`
+(`src/test-kernel/agent/modelCellTestUtils.ts`): a complete handler surface
+built from `vi.fn` stubs, with no client and no request.
 
-**Tool concurrency under load.** Same gate, plus a second limit:
-`ModelHandlerValidation.createResponse`
-(`src/agent/modelHandlers/modelHandlerValidation.ts:154`) emits at most one tool
-call per turn, and only when `TEXRA_INTERNAL_VALIDATE_WORKFLOW_SCRIPT=1`. It
-cannot produce the parallel fan-out that `ToolUseDispatchNode`'s partition,
-dedup and barrier behavior exists to handle, so a concurrency number taken
-through it would describe the stub, not the product.
+Those fixtures also run outside vitest. A throwaway probe, bundling them the
+same way this harness bundles its own program, drove that round in a plain Node
+child and returned in about a millisecond between the abort and the flow
+returning with its results paired. That number is not recorded above and is not
+a stop-latency budget. Every tool in the fixture returns immediately and
+`createResponse` resolves without a request, so what the millisecond measures is
+the flow's own cancellation bookkeeping with nothing in flight to cancel. The
+budget the gate wants is dominated by what actually has to unwind: a streaming
+provider response, a running bash child, a subagent. It also needs the approval
+and queued-admission points, which the round-flow fixtures do not reach at all.
+
+Getting it therefore needs a fixture whose tools and model response take a
+controlled, non-zero time to unwind, plus coverage of the two points above.
+Either vehicle works: extend this harness to bundle the kernel fixtures (it
+can, and it would additionally have to deal with the six timers still running
+after the round returns, which keep the child alive past its last record), or
+measure inside the vitest kernel beside the suites that already drive these
+paths. The second is the smaller step and keeps the fixtures where their owners
+maintain them.
+
+**Tool concurrency under load.** The partition, dedup and barrier behaviour is
+covered: `src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts` drives
+`ToolUseDispatchNode`'s real fan-out with probe tools that count their own
+overlap through an `inFlight`/`maxInFlight` counter, and asserts that contiguous
+`parallelSafe` calls overlap, that a non-safe tool is an ordering barrier, that
+duplicates execute once and fan their result out, and that one run signal
+cancels every concurrent call.
+
+What that suite does not give is a number under load. Its probe tools sleep a
+fixed interval and do no work, and it dispatches a single round rather than a
+session under sustained tool traffic, so the overlap it proves is a scheduling
+fact, not throughput or latency. A concurrency budget needs tools that consume
+real resources at a controlled rate and a driver that keeps rounds arriving:
+the same missing vehicle as stop latency, and worth building once for both.
 
 **Representative media through the run path.** Section 4 measures 256 KiB rows
 through `appendAll`, which is the durable cost. What it does not measure is
-media arriving through the real attachment and transcript path, because that
-path needs a run, which needs the model handler above.
+media arriving through the real attachment path: a tool result's `files`
+entries becoming provider content and transcript attachments. Dispatch does
+carry that path in the kernel (`ToolUseDispatchParallel.vitest.ts` asserts a
+malformed attachment result becomes a tool error), but asserting a shape is not
+timing a payload, and the sizes that matter arrive from real tools. Same
+vehicle, again.
 
 ## 6. What to compare after the cutover
 
@@ -311,5 +362,10 @@ A regression in any of these needs a stated reason, not a percentage. A number
 that improves needs the same scrutiny: check the invariants still hold, because
 every scenario throws rather than reporting a smaller number when its contract
 breaks.
+
+Start the comparison run on a quiet machine, not merely a machine under the
+ceiling. The 100,000-row `replay-memory` scenario is the harness's own heaviest
+load, and a run begun in the low sevens has been observed carrying it past 8 and
+failing there. That is the ceiling working, but it costs the whole run.
 
 [plan]: ../../.agents/docs/proposed/architecture/2026-09-06-effect-runtime-delivery-plan.md

--- a/docs/architecture/2026-09-07-pre-cutover-runtime-baseline.md
+++ b/docs/architecture/2026-09-07-pre-cutover-runtime-baseline.md
@@ -102,8 +102,9 @@ the repository dies on `import { Effect } from 'effect'`.
 The recorded run predates the per-record ceiling check described in section 2,
 which was added after review. The change is confined to the load gate, an
 `ENOENT` test in `databaseBytes` and the CPU read, none of which sits inside a
-timed region, and a full `--allow-load` run of the amended script reproduced
-section 4 within run-to-run variance: 100,000-row `readAll` 1451.40 ms against
+timed region, and a full `--allow-load` run of the amended script, on the same
+machine with the branch rebased onto `4d538c5e40`, reproduced section 4 within
+run-to-run variance: 100,000-row `readAll` 1451.40 ms against
 the recorded 1436.93 ms, peak heap growth 677.98 MB against 677.82 MB, settled
 on-disk bytes identical for the 1 KiB and 256 KiB shapes and 2,965,504 B
 against 2,990,080 B for `status` (2.81x against the recorded 2.84x). That run

--- a/docs/architecture/2026-09-07-pre-cutover-runtime-baseline.md
+++ b/docs/architecture/2026-09-07-pre-cutover-runtime-baseline.md
@@ -111,6 +111,14 @@ against 2,990,080 B for `status` (2.81x against the recorded 2.84x). That run
 is deliberately not recorded here: it was taken without a ceiling, and section
 2 says such a run does not go into a budget.
 
+A recorded re-run was attempted three times and the ceiling refused all three,
+which is the ceiling working rather than a gap in it. Two were refused at the
+start gate, at load averages of 8.76 and 13.28. The third started at 7.05,
+passed every scenario up to the 100,000-row `replay-memory`, and failed there
+at 8.92 with the record marked `aboveLoadCeiling`. Re-take the baseline on a
+quiet machine before the post-cutover comparison, and take both halves of that
+comparison the same way.
+
 Datasets, all synthetic, all written through `appendAll`:
 
 - **Short retained session**: 1,000 `transcript.entry` rows of 240 characters

--- a/docs/architecture/2026-09-07-pre-cutover-runtime-baseline.md
+++ b/docs/architecture/2026-09-07-pre-cutover-runtime-baseline.md
@@ -1,0 +1,315 @@
+---
+created: 2026-09-07
+status: measured-baseline
+---
+
+# Pre-cutover runtime baseline
+
+Section 8 of the [Effect runtime delivery plan][plan] makes recorded budgets a
+precondition of the cutover: "Record numeric performance budgets and the
+baseline hardware/datasets in package C before the cutover implementation ...
+Budgets are not yet measured by this planning pass; do not replace measurements
+with guessed percentage wins or a net-LOC promise."
+
+Nothing owned that, and the cutover is landing stage by stage, so a budget
+recorded after the fact would compare the new runtime against nothing. This
+document is the pre-cutover half of the comparison. It records what
+`scripts/measure-runtime-baseline.mjs` measured on `origin/main` at
+`854b36ee69`, the machine and datasets it measured on, and, for each metric the
+Performance gate names that is not measurable today, the exact reason.
+
+No production code changed. The harness only reads and writes its own temporary
+session roots.
+
+## 1. What the harness measures against, and why that matters
+
+Every scenario reaches SQLite through `Database`
+(`src/shared/session/database.ts:64`) and `databaseLayer`
+(`src/controllers/session/Database.ts:219`), and through nothing else. That is
+deliberate. A harness shaped around modules package D deletes would measure
+nothing twice; the point of a baseline is that the same script runs unmodified
+after the cutover and produces a back-to-back comparison on one machine.
+
+`Database` is a surviving contract: it is the substrate lane's own boundary, it
+is composed exactly once in production at
+`src/controllers/session/sessionLayer.ts:457`, the per-session layer map every
+host installs, and the delivery plan's deletion ledger does not name it.
+`appendAll`, `readAll`, `readListing`, `readInputBatch` and `currentCommit` are
+the operations the scenarios use.
+
+A scenario composes the layer exactly the way
+`src/test-kernel/controllers/session/sessionEvents.vitest.ts:819` does:
+
+```
+databaseLayer('persistent').pipe(
+  Layer.provide(Layer.succeed(WorkspaceRoots)({ storage })),
+  Layer.provide(ProcessIdentity.layer(owner)),
+  Layer.fresh,
+)
+```
+
+Two context services and nothing more. `NEXT_SEQ`
+(`src/controllers/session/Database.ts:203`) opens a fresh aggregate owned by the
+caller on first append, so no scenario needs `acquireClaims`, `platform()`, or a
+fixture file.
+
+## 2. How to run it
+
+```
+node scripts/measure-runtime-baseline.mjs
+```
+
+It prints one JSON object per scenario on stdout, every numeric field
+unit-suffixed, and exits non-zero if any scenario's invariants fail. Each record
+carries the 1-minute load average it was taken under.
+
+The script refuses to run above a 1-minute load average of 8 and says so, because
+a wall-clock number from a busy shared machine is not a smaller number, it is a
+meaningless one. `--allow-load` overrides that for an exploratory run whose
+output is not going into a budget; do not record such a run here.
+
+Three measurement primitives are first uses in this repository: `perf_hooks`
+`monitorEventLoopDelay`, `os.loadavg`, and `process.memoryUsage`. Nothing else
+in the tree measures with them, so there is no prior convention to match.
+
+The measured program is an inline TypeScript template compiled by esbuild with
+`packages: 'external'` and run in a child process, which is the house
+measurement idiom introduced by the bounded session readers work
+([#12005](https://github.com/LionSR/TeXRA/pull/12005)); that script is not on
+this base commit, so the shape is matched rather than imported. The bundle is
+written under `node_modules/.cache/texra-measure/` and removed in a `finally`. It cannot go to `os.tmpdir()`: with external packages, Node resolves
+bare specifiers upward from the importing file's directory, and a bundle outside
+the repository dies on `import { Effect } from 'effect'`.
+
+## 3. Baseline machine and datasets
+
+| Property      | Value                                                    |
+| ------------- | -------------------------------------------------------- |
+| Commit        | `854b36ee69` (`origin/main`, 2026-09-07)                 |
+| Node          | v26.8.1                                                  |
+| Platform      | darwin arm64                                             |
+| CPU           | Apple M1 Ultra, 20 logical cores                         |
+| Memory        | 68,719,476,736 bytes (64 GiB)                            |
+| 1-minute load | 6.83 at start, 5.29 to 7.00 across scenarios (ceiling 8) |
+| Measured at   | 2026-09-07T21:06:28Z                                     |
+
+Datasets, all synthetic, all written through `appendAll`:
+
+- **Short retained session**: 1,000 `transcript.entry` rows of 240 characters
+  plus one `run.start`.
+- **Long retained session**: 100,000 `transcript.entry` rows of 240 characters
+  plus one `run.start`.
+- **Write load**: 512-character `transcript.entry` rows, appended one per
+  commit.
+- **Growth shapes**: `status` rows (about 105 payload bytes), 1 KiB
+  `transcript.entry` rows, and 256 KiB `transcript.entry` rows standing in for
+  retained media.
+
+## 4. Results
+
+### 4.1 Cold open, substrate half
+
+A fresh Node process, `databaseLayer('persistent')` over an existing file, to
+the first completed `readListing()`.
+
+| Retained history | Layer build | First listing | Open to listing | Process start to listing | Listing rows |
+| ---------------- | ----------- | ------------- | --------------- | ------------------------ | ------------ |
+| 1,000 rows       | 9.08 ms     | 2.04 ms       | 11.12 ms        | 782.06 ms                | 1            |
+| 100,000 rows     | 8.87 ms     | 2.01 ms       | 10.89 ms        | 783.50 ms                | 1            |
+
+The substrate open does not scale with retained history. `readListing`
+(`READ_LISTING`, `src/controllers/session/Database.ts:148`) selects the latest
+row per aggregate and listing type, so it is O(aggregates), not O(rows): both
+datasets are one stream, so both return one row.
+
+"Process start to listing" is `performance.now()` at that moment, so it includes
+Node boot and evaluating the bundled module graph. At about 783 ms in both runs
+it dwarfs the 11 ms of actual database work, and it is a floor any host pays
+before its first session read. Treat it as an upper bound on module-graph cost,
+not as a host startup figure: the harness bundle is not a host bundle.
+
+### 4.2 Idle memory
+
+Same fresh process, after the open and first listing, `gc()`, 400 ms settle,
+`gc()`.
+
+Memory figures below are decimal: 1 MB is 10^6 bytes.
+
+| Retained history | Heap used | RSS       | External |
+| ---------------- | --------- | --------- | -------- |
+| 1,000 rows       | 42.54 MB  | 224.25 MB | 4.33 MB  |
+| 100,000 rows     | 42.52 MB  | 225.36 MB | 4.33 MB  |
+
+Idle cost is flat in retained history, as it should be: an open connection holds
+prepared statements and pragmas, not rows.
+
+### 4.3 Replay memory
+
+`readAll(0)` over the whole history, then `readInputBatch` over the one stream,
+with heap and RSS sampled every millisecond.
+
+| Retained history | `readAll`  | `readInputBatch` | Decoded JSON | Peak heap growth | Peak RSS   | Settled heap |
+| ---------------- | ---------- | ---------------- | ------------ | ---------------- | ---------- | ------------ |
+| 1,000 rows       | 21.63 ms   | 21.74 ms         | 527,651 B    | 35.17 MB         | 229.29 MB  | 43.32 MB     |
+| 100,000 rows     | 1436.93 ms | 1569.39 ms       | 53,933,663 B | 677.82 MB        | 1008.75 MB | 42.33 MB     |
+
+This is the largest number on the page. A 100-fold increase in rows costs 66x the
+read time and 19x the transient heap, and peak heap growth runs about 12.6x the
+decoded JSON the read returns: `decodeEvent`
+(`src/controllers/session/Database.ts:187`) parses each row's JSON and then runs
+`SessionEventSchema.parse` over it, and the whole prefix is materialised as one
+array. Settled heap returns to the idle figure, so this is a transient, not a
+leak, but a 1 GB RSS peak on a single 100,000-row replay is the pre-cutover
+number the ledger design has to beat or justify.
+
+### 4.4 Commit latency
+
+Two shapes, because they answer different questions. Batched appends are what a
+seeding or import path does; single-row appends are what a live run does.
+
+| Workload                                            | Samples | p50      | p95      | p99      | Max      |
+| --------------------------------------------------- | ------- | -------- | -------- | -------- | -------- |
+| Batch of 500 rows, seeding 100,000                  | 200     | 14.87 ms | 24.01 ms | 31.33 ms | 38.80 ms |
+| One row, one paper, no contention                   | 25,197  | 0.077 ms | 0.115 ms | 0.543 ms | 8.61 ms  |
+| One row, four fibers, plus a second writing process | 34,412  | 0.079 ms | 0.123 ms | 1.744 ms | 22.10 ms |
+
+The p95 barely moves under contention; the tail does. That is what
+`BEGIN IMMEDIATE` behind one `Semaphore.make(1)` permit
+(`src/controllers/session/Database.ts:261`) with `busy_timeout = 5000`
+(`src/controllers/session/Database.ts:947`) should look like: work queues rather
+than fails, and the cost lands in p99 and max.
+
+### 4.5 Event-loop delay under SQLite contention
+
+The gate asks how much other work SQLite delays, so the reading that answers it
+is an independent 10 ms `setInterval` probe measuring its own per-tick lateness,
+with `monitorEventLoopDelay` beside it. The append loop's own latency is section
+4.4 and cannot answer this question.
+
+Load is four Effect fibers appending single rows plus a second OS process
+holding its own connection to the same file. The scenario asserts the
+cross-process part actually happened: it failed the run if the commit ordinal
+does not advance by more foreign commits than its own.
+
+| Phase                                | Probe p50 | Probe p95 | Probe p99 | Probe max | Loop mean | Loop p95 | Loop max  |
+| ------------------------------------ | --------- | --------- | --------- | --------- | --------- | -------- | --------- |
+| Idle, database open, no writes       | 0.236 ms  | 0.986 ms  | 1.251 ms  | 1.500 ms  | 1.278 ms  | 1.437 ms | 3.443 ms  |
+| 4 fibers + 1 foreign writing process | 0.108 ms  | 3.892 ms  | 7.168 ms  | 13.182 ms | 1.416 ms  | 4.276 ms | 23.167 ms |
+
+Own commits in the loaded phase: 34,416. Foreign commits observed on the same
+file in the same window: 1,250.
+
+**The budget: a process committing about 6,900 rows per second, while another
+process commits about 250 per second into the same file, delays unrelated
+event-loop work by about 2.9 ms at p95 and 5.9 ms at p99.** The median is
+unaffected, and is in fact lower under load because the loop is busy and the
+timer fires promptly. Nothing here is close to a stall, but the tail is real and
+it is entirely synchronous SQLite work: `appendAll` validates, serialises and
+commits inside `Effect.try`, on the loop.
+
+### 4.6 Two-paper concurrency
+
+Two session roots are two `databaseLayer` instances over two SQLite files. Each
+paper's own `readAll` is checked for the other's rows, and the run fails if it
+finds any. It found none.
+
+| Phase      | Rows committed in 3 s | Per paper       | Commit p95 | Probe p95 | Probe max |
+| ---------- | --------------------- | --------------- | ---------- | --------- | --------- |
+| One paper  | 25,197                | 25,197          | 0.115 ms   | 1.293 ms  | 6.88 ms   |
+| Two papers | 27,105                | 13,553 / 13,552 | 0.105 ms   | 4.429 ms  | 208.79 ms |
+
+Aggregate throughput rises 7.6% with the second paper; each paper's own rate
+falls to 53.8% of solo. Papers are isolated for correctness and share the event
+loop for throughput, which is the expected shape and the thing to re-check after
+the cutover. The 208.79 ms probe outlier is a single tick, and the
+`monitorEventLoopDelay` maximum agrees with it at 210.76 ms, so it is a real
+stall of the whole loop rather than a timer artefact; the most likely cause is a
+WAL growth or checkpoint inside one commit, and it is one sample in 281.
+
+### 4.7 Bytes written as history grows
+
+Each shape gets its own database, and the figures below are taken after the
+connection closes, because closing is what checkpoints and truncates the WAL. The
+scenario fails if any WAL survives the close.
+
+| Row shape                   | Rows   | Payload bytes | On disk    | Per row     | Amplification |
+| --------------------------- | ------ | ------------- | ---------- | ----------- | ------------- |
+| `status`, about 105 B       | 10,000 | 1,054,450     | 2,990,080  | 299.0 B     | 2.84x         |
+| `transcript.entry`, 1 KiB   | 10,000 | 12,355,568    | 15,831,040 | 1,583.1 B   | 1.28x         |
+| `transcript.entry`, 256 KiB | 100    | 26,234,964    | 26,333,184 | 263,331.8 B | 1.004x        |
+
+Small rows are where the substrate's per-row overhead shows, and a run emits far
+more small rows than large ones, so 2.84x on `status` is the number to watch.
+Large rows are essentially free of overhead.
+
+While the connection is open, small-row growth lands entirely in the WAL: the
+main file stayed at one page (4,096 B) through all 10,000 `status` rows while the
+WAL reached 3,444,352 B, settling to 2,990,080 B on close. A long-lived session
+therefore carries its recent history in a WAL that grows until something
+checkpoints it, and on this path only closing does.
+
+## 5. Metrics the gate names that are not measurable today
+
+Each of these is recorded rather than dropped, with what would have to exist
+first.
+
+**Host-process cold open.** Section 4 measures the substrate half: a fresh Node
+process opening an existing session database to its first usable listing. The
+host half (VS Code extension activation, the desktop window, the CLI's first
+paint) has no launcher harness on this commit. The nearest things in the tree
+drive packaged artifacts, not startup timing:
+`scripts/smoke-desktop-package-launch.mjs` and
+`scripts/smoke-webviews-electron.mjs` assert that a build launches, and
+`packages/cli/scripts/validate-run.mjs` drives a packaged CLI. Measuring host
+cold open needs a launcher that reports a first-paint timestamp, which is its own
+piece of work and is not in this lane.
+
+**p95 stop latency.** Cancellation latency is a property of a run in flight:
+cancel during model call, during tool execution, during approval, during queued
+admission. Driving one needs a model handler, and the only network-free handler
+in the repository is `ModelHandlerValidation`
+(`src/agent/modelHandlers/modelHandlerValidation.ts`), reachable only through
+`shouldUseInternalValidationModelHandler`
+(`src/agent/runtime/internalValidationOverride.ts:30`), which requires all four
+of `TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL=1`, a named per-run env var set
+to `1`, `CI=1`, and an absolute flag file whose contents match a build-time
+sentinel. Any partial activation throws rather than falling through. The
+include flag is an esbuild `define` in `packages/cli/scripts/build-bundle.mjs`,
+so outside a CLI package-validation build the predicate constant-folds to
+`false`. A repository-root script cannot reach it.
+
+**Tool concurrency under load.** Same gate, plus a second limit:
+`ModelHandlerValidation.createResponse`
+(`src/agent/modelHandlers/modelHandlerValidation.ts:154`) emits at most one tool
+call per turn, and only when `TEXRA_INTERNAL_VALIDATE_WORKFLOW_SCRIPT=1`. It
+cannot produce the parallel fan-out that `ToolUseDispatchNode`'s partition,
+dedup and barrier behavior exists to handle, so a concurrency number taken
+through it would describe the stub, not the product.
+
+**Representative media through the run path.** Section 4 measures 256 KiB rows
+through `appendAll`, which is the durable cost. What it does not measure is
+media arriving through the real attachment and transcript path, because that
+path needs a run, which needs the model handler above.
+
+## 6. What to compare after the cutover
+
+Run the same script on the post-cutover head, on this machine, at a load average
+below the same ceiling, and compare record for record. The scenarios that should
+be watched hardest:
+
+1. `replay-memory` heap growth at 100,000 rows. It is the largest number here and
+   the one a durable execution ledger is most likely to move, in either
+   direction.
+2. `loop-delay` probe lateness in the loaded phase. The gate's question is how
+   much other work SQLite delays, and the probe is the only reading that answers
+   it; commit latency alone cannot.
+3. `bytes-written` settled amplification for the `status` shape. Small rows are
+   where a ledger's per-row overhead shows, and a run emits far more small rows
+   than large ones.
+
+A regression in any of these needs a stated reason, not a percentage. A number
+that improves needs the same scrutiny: check the invariants still hold, because
+every scenario throws rather than reporting a smaller number when its contract
+breaks.
+
+[plan]: ../../.agents/docs/proposed/architecture/2026-09-06-effect-runtime-delivery-plan.md

--- a/scripts/measure-runtime-baseline.mjs
+++ b/scripts/measure-runtime-baseline.mjs
@@ -143,10 +143,40 @@ const startProbe = (periodMs) => {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+// The ceiling the driver refused to start under, forwarded so every record is
+// checked against it too. A start-only check is systematically optimistic:
+// the harness is itself a large part of the load its later scenarios run
+// under, so the reading most likely to breach the ceiling is the one taken
+// last. Empty means \`--allow-load\`: an exploratory run with no ceiling.
+const ceiling = process.env.TEXRA_MEASURE_LOAD_CEILING;
+if (ceiling === undefined)
+  throw new Error('TEXRA_MEASURE_LOAD_CEILING not set by the driver');
+const loadCeiling = ceiling === '' ? null : Number(ceiling);
+
 // Every record carries the load it was taken under, because a number from a
-// busy machine is not a budget.
-const emit = (record) =>
-  console.log(JSON.stringify({ ...record, loadAverage1m: loadavg()[0] }));
+// busy machine is not a budget. A record above the ceiling is printed, marked,
+// and then fails the run: it must be re-taken, never quietly kept.
+const emit = (record) => {
+  const loadAverage1m = loadavg()[0];
+  const exceeded = loadCeiling !== null && loadAverage1m > loadCeiling;
+  console.log(
+    JSON.stringify({
+      ...record,
+      loadAverage1m,
+      ...(exceeded ? { aboveLoadCeiling: loadCeiling } : {}),
+    }),
+  );
+  if (exceeded)
+    throw new Error(
+      'load average ' +
+        loadAverage1m.toFixed(2) +
+        ' exceeded the ceiling of ' +
+        loadCeiling +
+        ' while measuring ' +
+        record.scenario +
+        '; that reading is not a budget',
+    );
+};
 
 /** Append \`rows\` synthetic transcript rows and report what the batch cost. */
 const appendHistory = (db, id, rows, characters, batchSize) =>
@@ -174,10 +204,12 @@ const databaseBytes = (storage) => {
     try {
       return statSync(join(storage, 'texra.db' + suffix)).size;
     } catch (cause) {
-      // Absent only for the WAL sidecars before the first checkpoint; the
-      // main file must exist, and its absence is a real failure.
-      if (suffix === '') throw cause;
-      return 0;
+      // A sidecar that does not exist is genuinely zero bytes: SQLite creates
+      // \`-wal\`/\`-shm\` on the first write and removes them on a checkpointing
+      // close. Every other failure, and any absence of the main file, is a
+      // failed measurement rather than a small number.
+      if (suffix !== '' && cause.code === 'ENOENT') return 0;
+      throw cause;
     }
   };
   return {
@@ -501,11 +533,43 @@ if (role === 'bytes') {
 }
 `;
 
+/**
+ * Timing scenarios are wall-clock measurements on a shared desktop, so a busy
+ * machine does not produce a smaller number, it produces a meaningless one.
+ * Refuse rather than record it; `--allow-load` is for an exploratory run whose
+ * output is not going into a budget.
+ */
+const MAX_LOAD_AVERAGE = 8;
+const allowLoad = process.argv.includes('--allow-load');
+
+/** The ceiling, or `null` under `--allow-load`. Children enforce it per record. */
+const loadCeiling = allowLoad ? null : MAX_LOAD_AVERAGE;
+
+/**
+ * Refuse before spending a scenario's minutes. Children re-check at every
+ * record they emit, so a machine that gets busy mid-scenario fails there;
+ * this is only the cheap early exit.
+ */
+function refuseAboveCeiling(what) {
+  const current = os.loadavg()[0];
+  if (loadCeiling !== null && current > loadCeiling)
+    throw new Error(
+      `1-minute load average ${current.toFixed(2)} exceeds ${loadCeiling} before ${what}; ` +
+        'wait for the machine to settle, or pass --allow-load for a throwaway run.',
+    );
+}
+
 /** One scenario child. A non-zero exit is a failed measurement, never a gap. */
 function measure(label, argv) {
+  refuseAboveCeiling(label);
   const result = spawnSync(process.execPath, ['--expose-gc', output, ...argv], {
     cwd: root,
     stdio: 'inherit',
+    env: {
+      ...process.env,
+      TEXRA_MEASURE_LOAD_CEILING:
+        loadCeiling === null ? '' : String(loadCeiling),
+    },
   });
   if (result.status !== 0)
     throw new Error(
@@ -520,21 +584,7 @@ const workspace = () => {
   return directory;
 };
 
-/**
- * Timing scenarios are wall-clock measurements on a shared desktop, so a busy
- * machine does not produce a smaller number, it produces a meaningless one.
- * Refuse rather than record it; `--allow-load` is for an exploratory run whose
- * output is not going into a budget.
- */
-const MAX_LOAD_AVERAGE = 8;
-const allowLoad = process.argv.includes('--allow-load');
-if (!allowLoad && os.loadavg()[0] > MAX_LOAD_AVERAGE) {
-  console.error(
-    `1-minute load average ${os.loadavg()[0].toFixed(2)} exceeds ${MAX_LOAD_AVERAGE}; ` +
-      'wait for the machine to settle, or pass --allow-load for a throwaway run.',
-  );
-  process.exit(1);
-}
+refuseAboveCeiling('the first scenario');
 
 try {
   mkdirSync(cache, { recursive: true });
@@ -555,18 +605,25 @@ try {
   });
   writeFileSync(output, bundle.outputFiles[0].contents);
 
+  // The machine identity is the thing a baseline pins, so a missing one is a
+  // failed measurement, not the string "unknown".
+  const cpus = os.cpus();
+  const [firstCpu] = cpus;
+  if (firstCpu === undefined)
+    throw new Error('os.cpus() reported no processors');
+
   console.log(
     JSON.stringify({
       scenario: 'environment',
       nodeVersion: process.version,
       platform: process.platform,
       arch: process.arch,
-      cpus: os.cpus().length,
-      cpuModel: os.cpus()[0]?.model ?? 'unknown',
+      cpus: cpus.length,
+      cpuModel: firstCpu.model,
       totalMemoryBytes: os.totalmem(),
       loadAverage1m: os.loadavg()[0],
       loadAverage5m: os.loadavg()[1],
-      loadCeiling: allowLoad ? null : MAX_LOAD_AVERAGE,
+      loadCeiling,
       measuredAt: new Date().toISOString(),
     }),
   );

--- a/scripts/measure-runtime-baseline.mjs
+++ b/scripts/measure-runtime-baseline.mjs
@@ -1,0 +1,603 @@
+/** Pre-cutover runtime budgets against the surviving `Database` contract; synthetic events only, no model/network calls or user data. */
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import * as os from 'node:os';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+// The bundle keeps `packages: 'external'`, so Node resolves `effect` and the
+// other bare specifiers upward from the bundle's own directory. Only a path
+// inside the repository reaches the workspace `node_modules`; `os.tmpdir()`
+// would die on the first `import { Effect } from 'effect'`.
+const cache = join(root, 'node_modules/.cache/texra-measure');
+const output = join(cache, `runtime-baseline-${process.pid}.mjs`);
+
+const source = `
+import { spawn } from 'node:child_process';
+import { statSync } from 'node:fs';
+import { hostname, loadavg } from 'node:os';
+import { join } from 'node:path';
+import { monitorEventLoopDelay, performance } from 'node:perf_hooks';
+import { Effect, Layer } from 'effect';
+import { databaseLayer } from './src/controllers/session/Database';
+import { WorkspaceRoots } from './src/controllers/session/WorkspaceRoots';
+import { aggregateId } from './src/shared/schemas/sessionEvent';
+import { Database } from './src/shared/session/database';
+import { ProcessIdentity } from './src/shared/session/sessionEvents';
+
+const [role, ...args] = process.argv.slice(2);
+const owner = JSON.stringify([hostname().toLowerCase(), process.pid, 'measure']);
+
+/** Every scenario reaches SQLite through the same service the cutover keeps. */
+const substrate = (storage) =>
+  databaseLayer('persistent').pipe(
+    Layer.provide(Layer.succeed(WorkspaceRoots)({ storage })),
+    Layer.provide(ProcessIdentity.layer(owner)),
+    Layer.fresh,
+  );
+
+const withDatabase = (storage, program) =>
+  Effect.runPromise(
+    Effect.scoped(Effect.gen(program).pipe(Effect.provide(substrate(storage)))),
+  );
+
+const stream = (id) => aggregateId('stream', id);
+
+// \`run.start\` also claims \`["execution", executionId]\`, so a shared literal
+// would collide the moment two streams, or two processes on one file, start.
+let executions = 0;
+const nextExecutionId = () => {
+  executions += 1;
+  return ('00000' + process.pid.toString(16)).slice(-6) + '-' + executions.toString(16);
+};
+
+const runStart = (id) => ({
+  type: 'run.start',
+  aggregateId: stream(id),
+  executionId: nextExecutionId(),
+  identity: { kind: 'agent', agent: 'chat' },
+  userFollowUpSupport: 'unsupported',
+  category: 'toolUse',
+  isRemote: false,
+});
+
+const status = (id, cause) => ({
+  type: 'status',
+  aggregateId: stream(id),
+  phase: 'running',
+  cause,
+});
+
+const transcriptRow = (id, index, characters) => ({
+  type: 'transcript.entry',
+  aggregateId: stream(id),
+  entry: {
+    type: 'log',
+    id: 'row-' + index,
+    seqNo: index + 1,
+    timestamp: index + 1,
+    level: 'info',
+    messageType: 'modelResponse',
+    text: index + ': ' + 'x'.repeat(characters),
+  },
+});
+
+// Monotonic and zeroed at process start, so the cold-open scenario can also
+// report the wall time a fresh process spent before its first listing.
+const nowMs = () => performance.now();
+
+/** Nearest-rank percentile over a sorted-in-place copy; empty input is a defect. */
+const percentile = (values, fraction) => {
+  if (values.length === 0) throw new Error('percentile over no samples');
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.ceil(fraction * sorted.length) - 1;
+  return sorted[Math.min(Math.max(rank, 0), sorted.length - 1)];
+};
+
+const latencySummary = (samples) => ({
+  samples: samples.length,
+  p50Ms: percentile(samples, 0.5),
+  p95Ms: percentile(samples, 0.95),
+  p99Ms: percentile(samples, 0.99),
+  maxMs: Math.max(...samples),
+});
+
+/**
+ * An independent fixed-rate probe. The gate asks how much OTHER work SQLite
+ * delays, so the reported number is this probe's lateness against its own
+ * schedule, never the append loop's own latency. \`monitorEventLoopDelay\`
+ * runs beside it as a libuv-level cross-check.
+ */
+const startProbe = (periodMs) => {
+  const histogram = monitorEventLoopDelay({ resolution: 1 });
+  histogram.enable();
+  // Per-tick lateness, not lateness against an absolute schedule: Node arms
+  // the next \`setInterval\` fire after the callback returns, so an absolute
+  // schedule accumulates ordinary drift and would report it as delay.
+  let previous = nowMs();
+  const late = [];
+  const timer = setInterval(() => {
+    const tick = nowMs();
+    late.push(Math.max(tick - previous - periodMs, 0));
+    previous = tick;
+  }, periodMs);
+  return {
+    stop: () => {
+      clearInterval(timer);
+      histogram.disable();
+      if (late.length === 0) throw new Error('probe recorded no ticks');
+      return {
+        probePeriodMs: periodMs,
+        probeTicks: late.length,
+        probeLatenessMs: latencySummary(late),
+        loopDelayMeanMs: histogram.mean / 1e6,
+        loopDelayP95Ms: histogram.percentile(95) / 1e6,
+        loopDelayMaxMs: histogram.max / 1e6,
+      };
+    },
+  };
+};
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Every record carries the load it was taken under, because a number from a
+// busy machine is not a budget.
+const emit = (record) =>
+  console.log(JSON.stringify({ ...record, loadAverage1m: loadavg()[0] }));
+
+/** Append \`rows\` synthetic transcript rows and report what the batch cost. */
+const appendHistory = (db, id, rows, characters, batchSize) =>
+  Effect.gen(function* () {
+    const latencies = [];
+    let appended = 0;
+    yield* db.appendAll([runStart(id)]);
+    while (appended < rows) {
+      const size = Math.min(batchSize, rows - appended);
+      const drafts = [];
+      for (let index = 0; index < size; index += 1)
+        drafts.push(transcriptRow(id, appended + index, characters));
+      const start = nowMs();
+      const committed = yield* db.appendAll(drafts);
+      latencies.push(nowMs() - start);
+      if (committed.length !== size)
+        throw new Error('partial commit: ' + committed.length + ' / ' + size);
+      appended += size;
+    }
+    return { appended, latencies };
+  });
+
+const databaseBytes = (storage) => {
+  const sizeOf = (suffix) => {
+    try {
+      return statSync(join(storage, 'texra.db' + suffix)).size;
+    } catch (cause) {
+      // Absent only for the WAL sidecars before the first checkpoint; the
+      // main file must exist, and its absence is a real failure.
+      if (suffix === '') throw cause;
+      return 0;
+    }
+  };
+  return {
+    dbBytes: sizeOf(''),
+    walBytes: sizeOf('-wal'),
+    shmBytes: sizeOf('-shm'),
+  };
+};
+
+if (role === 'seed') {
+  const [storage, rows, characters] = [args[0], Number(args[1]), Number(args[2])];
+  const result = await withDatabase(storage, function* () {
+    const db = yield* Database;
+    const written = yield* appendHistory(db, 'seed', rows, characters, 500);
+    const commit = yield* db.currentCommit;
+    if (commit !== written.appended + 1)
+      throw new Error('commit ordinal ' + commit + ' for ' + written.appended + ' rows');
+    return { rows: written.appended, commit, latencies: written.latencies };
+  });
+  emit({
+    scenario: 'seed',
+    historyRows: result.rows,
+    historyCommit: result.commit,
+    batchRows: 500,
+    batchCommitLatencyMs: latencySummary(result.latencies),
+    ...databaseBytes(storage),
+  });
+}
+
+// Cold open: a fresh process opening an existing session database, through
+// \`databaseLayer\` and nothing else, to its first usable listing. This is the
+// substrate half of the gate's "cold open"; the host launch around it has no
+// harness in this repository and is recorded as unmeasured.
+if (role === 'open') {
+  const [storage, historyRows] = [args[0], Number(args[1])];
+  const before = nowMs();
+  const opened = await withDatabase(storage, function* () {
+    const db = yield* Database;
+    const ready = nowMs();
+    const listing = yield* db.readListing();
+    const listed = nowMs();
+    return { ready, listed, listingRows: listing.length };
+  });
+  // Includes Node boot and evaluating the bundled module graph, which is
+  // the floor any host pays before its first session read.
+  const processStartToListingMs = nowMs();
+  globalThis.gc();
+  await sleep(400);
+  globalThis.gc();
+  const idle = process.memoryUsage();
+  emit({
+    scenario: 'cold-open',
+    historyRows,
+    layerBuildMs: opened.ready - before,
+    firstListingMs: opened.listed - opened.ready,
+    openToListingMs: opened.listed - before,
+    processStartToListingMs,
+    listingRows: opened.listingRows,
+    idleHeapBytes: idle.heapUsed,
+    idleRssBytes: idle.rss,
+    idleExternalBytes: idle.external,
+  });
+}
+
+// Replay memory: the same fresh-process open, then the whole history through
+// \`readAll\`, which is what a mounting reader pays for.
+if (role === 'replay') {
+  const [storage, historyRows] = [args[0], Number(args[1])];
+  globalThis.gc();
+  const baseline = process.memoryUsage();
+  let peakHeap = baseline.heapUsed;
+  let peakRss = baseline.rss;
+  const sample = () => {
+    const memory = process.memoryUsage();
+    peakHeap = Math.max(peakHeap, memory.heapUsed);
+    peakRss = Math.max(peakRss, memory.rss);
+  };
+  const timer = setInterval(sample, 1);
+  const result = await withDatabase(storage, function* () {
+    const db = yield* Database;
+    sample();
+    const start = nowMs();
+    const events = yield* db.readAll(0);
+    const readMs = nowMs() - start;
+    sample();
+    if (events.length !== historyRows + 1)
+      throw new Error('replay read ' + events.length + ' of ' + (historyRows + 1));
+    const inputStart = nowMs();
+    const batch = yield* db.readInputBatch([stream('seed')], 0);
+    const inputBatchMs = nowMs() - inputStart;
+    sample();
+    const bytes = events.reduce((total, event) => total + JSON.stringify(event).length, 0);
+    return { rows: events.length, readMs, inputBatchMs, inputBatchRows: batch.events.length, bytes };
+  });
+  clearInterval(timer);
+  globalThis.gc();
+  const settled = process.memoryUsage();
+  emit({
+    scenario: 'replay-memory',
+    historyRows,
+    replayRows: result.rows,
+    replayMs: result.readMs,
+    readInputBatchMs: result.inputBatchMs,
+    readInputBatchRows: result.inputBatchRows,
+    decodedJsonBytes: result.bytes,
+    baselineHeapBytes: baseline.heapUsed,
+    peakHeapBytes: peakHeap,
+    heapGrowthBytes: peakHeap - baseline.heapUsed,
+    peakRssBytes: peakRss,
+    settledHeapBytes: settled.heapUsed,
+  });
+}
+
+// The contender. A second OS process holding its own connection to the same
+// file is what makes \`busy_timeout\` and the WAL writer lock real; a second
+// fiber in one process would only queue behind the single write permit.
+if (role === 'contend') {
+  const [storage, durationMs] = [args[0], Number(args[1])];
+  const committed = await withDatabase(storage, function* () {
+    const db = yield* Database;
+    const id = 'contender-' + process.pid;
+    yield* db.appendAll([runStart(id)]);
+    const deadline = nowMs() + durationMs;
+    let rows = 0;
+    while (nowMs() < deadline) {
+      yield* db.appendAll([transcriptRow(id, rows, 512)]);
+      rows += 1;
+      yield* Effect.sleep('1 millis');
+    }
+    return rows;
+  });
+  emit({ scenario: 'contender', contenderRows: committed });
+}
+
+if (role === 'loop') {
+  const [storage, writers, durationMs] = [args[0], Number(args[1]), Number(args[2])];
+  await withDatabase(storage, function* () {
+    const db = yield* Database;
+
+    const quiet = startProbe(10);
+    yield* Effect.promise(() => sleep(2000));
+    emit({ scenario: 'loop-delay', phase: 'idle', writers: 0, contender: false, ...quiet.stop() });
+
+    const contender = spawn(
+      process.execPath,
+      [process.argv[1], 'contend', storage, String(durationMs + 2000)],
+      { stdio: ['ignore', 'inherit', 'inherit'] },
+    );
+    const contenderExit = new Promise((resolve, reject) => {
+      contender.on('exit', (code) =>
+        code === 0 ? resolve() : reject(new Error('contender exited ' + code)),
+      );
+      contender.on('error', reject);
+    });
+    yield* Effect.promise(() => sleep(1500));
+
+    const commitBefore = yield* db.currentCommit;
+    const loaded = startProbe(10);
+    const deadline = nowMs() + durationMs;
+    const latencies = [];
+    const append = (writer) =>
+      Effect.gen(function* () {
+        const id = 'writer-' + writer;
+        yield* db.appendAll([runStart(id)]);
+        let rows = 0;
+        while (nowMs() < deadline) {
+          const start = nowMs();
+          yield* db.appendAll([transcriptRow(id, rows, 512)]);
+          latencies.push(nowMs() - start);
+          rows += 1;
+          yield* Effect.yieldNow;
+        }
+        return rows;
+      });
+    const written = yield* Effect.all(
+      Array.from({ length: writers }, (_, writer) => append(writer)),
+      { concurrency: 'unbounded' },
+    );
+    const under = loaded.stop();
+    const commitAfter = yield* db.currentCommit;
+    yield* Effect.promise(() => contenderExit);
+
+    const ownRows = written.reduce((total, rows) => total + rows + 1, 0);
+    const contenderRows = commitAfter - commitBefore - ownRows;
+    if (contenderRows <= 0)
+      throw new Error('no cross-process contention: ' + contenderRows + ' foreign commits');
+    emit({
+      scenario: 'loop-delay',
+      phase: 'loaded',
+      writers,
+      contender: true,
+      durationMs,
+      ownCommits: ownRows,
+      foreignCommits: contenderRows,
+      commitLatencyMs: latencySummary(latencies),
+      ...under,
+    });
+  });
+}
+
+// Two papers are two session roots, so two \`databaseLayer\` instances and two
+// SQLite files. The gate asks whether one paper's writes cost the other.
+if (role === 'twopaper') {
+  const [alone, first, second, durationMs] = [args[0], args[1], args[2], Number(args[3])];
+  const drive = (storage, id, deadline, foreignIds) =>
+    withDatabase(storage, function* () {
+      const db = yield* Database;
+      yield* db.appendAll([runStart(id)]);
+      const latencies = [];
+      let rows = 0;
+      while (nowMs() < deadline) {
+        const start = nowMs();
+        yield* db.appendAll([transcriptRow(id, rows, 512)]);
+        latencies.push(nowMs() - start);
+        rows += 1;
+        yield* Effect.yieldNow;
+      }
+      // One paper's database must not hold the other's rows. A root is a
+      // separate SQLite file, and that is the isolation the gate asks about.
+      const events = yield* db.readAll(0);
+      const leaked = events.filter((event) =>
+        foreignIds.some((foreign) => event.aggregateId === stream(foreign)),
+      );
+      if (leaked.length > 0)
+        throw new Error('paper isolation broken: ' + leaked.length + ' foreign rows');
+      return { rows, latencies, storedRows: events.length };
+    });
+
+  const soloProbe = startProbe(10);
+  const solo = await drive(alone, 'solo', nowMs() + durationMs, ['pair-a', 'pair-b']);
+  emit({
+    scenario: 'two-paper',
+    phase: 'one-paper',
+    papers: 1,
+    committedRows: solo.rows,
+    commitLatencyMs: latencySummary(solo.latencies),
+    ...soloProbe.stop(),
+  });
+
+  const pairProbe = startProbe(10);
+  const deadline = nowMs() + durationMs;
+  const [a, b] = await Promise.all([
+    drive(first, 'pair-a', deadline, ['solo', 'pair-b']),
+    drive(second, 'pair-b', deadline, ['solo', 'pair-a']),
+  ]);
+  emit({
+    scenario: 'two-paper',
+    phase: 'two-papers',
+    papers: 2,
+    committedRows: a.rows + b.rows,
+    firstPaperRows: a.rows,
+    secondPaperRows: b.rows,
+    commitLatencyMs: latencySummary([...a.latencies, ...b.latencies]),
+    ...pairProbe.stop(),
+  });
+}
+
+// Bytes written as history grows: on-disk cost per appended row, for a plain
+// status row and for a 256 KiB transcript row standing in for retained media.
+if (role === 'bytes') {
+  const [storage, tranches, perTranche] = [args[0], Number(args[1]), Number(args[2])];
+  for (const shape of [
+    { name: 'status', characters: 0, rows: perTranche },
+    { name: 'transcript-1kib', characters: 1024, rows: perTranche },
+    { name: 'transcript-256kib', characters: 256 * 1024, rows: Math.max(Math.floor(perTranche / 100), 1) },
+  ]) {
+    // One database per shape: a shared file would attribute the previous
+    // shape's pages to this one's rows.
+    const root = join(storage, shape.name);
+    const written = await withDatabase(root, function* () {
+      const db = yield* Database;
+      const id = 'bytes-' + shape.name;
+      yield* db.appendAll([runStart(id)]);
+      let payloadBytes = 0;
+      let rows = 0;
+      for (let tranche = 0; tranche < tranches; tranche += 1) {
+        const drafts = [];
+        for (let index = 0; index < shape.rows; index += 1) {
+          const draft =
+            shape.characters === 0
+              ? status(id, 'tranche-' + tranche + '-' + index)
+              : transcriptRow(id, rows + index, shape.characters);
+          payloadBytes += JSON.stringify(draft).length;
+          drafts.push(draft);
+        }
+        const committed = yield* db.appendAll(drafts);
+        if (committed.length !== drafts.length)
+          throw new Error('partial commit in bytes tranche');
+        rows += drafts.length;
+        const live = databaseBytes(root);
+        emit({
+          scenario: 'bytes-written',
+          shape: shape.name,
+          phase: 'open',
+          tranche: tranche + 1,
+          rowsSoFar: rows,
+          rowsThisTranche: drafts.length,
+          payloadBytesSoFar: payloadBytes,
+          ...live,
+          liveBytesPerRow: (live.dbBytes + live.walBytes) / rows,
+        });
+      }
+      return { rows, payloadBytes };
+    });
+    // Closing the connection is what checkpoints and truncates the WAL, so
+    // the settled figure is the one a session root actually keeps on disk.
+    const settled = databaseBytes(root);
+    if (settled.walBytes > 0)
+      throw new Error('WAL survived the close: ' + settled.walBytes + ' bytes');
+    emit({
+      scenario: 'bytes-written',
+      shape: shape.name,
+      phase: 'closed',
+      rows: written.rows,
+      payloadBytes: written.payloadBytes,
+      ...settled,
+      settledBytesPerRow: settled.dbBytes / written.rows,
+      amplification: settled.dbBytes / written.payloadBytes,
+    });
+  }
+}
+`;
+
+/** One scenario child. A non-zero exit is a failed measurement, never a gap. */
+function measure(label, argv) {
+  const result = spawnSync(process.execPath, ['--expose-gc', output, ...argv], {
+    cwd: root,
+    stdio: 'inherit',
+  });
+  if (result.status !== 0)
+    throw new Error(
+      `${label} exited ${result.status ?? 'on ' + result.signal}`,
+    );
+}
+
+const workspaces = [];
+const workspace = () => {
+  const directory = mkdtempSync(join(tmpdir(), 'texra-baseline-'));
+  workspaces.push(directory);
+  return directory;
+};
+
+/**
+ * Timing scenarios are wall-clock measurements on a shared desktop, so a busy
+ * machine does not produce a smaller number, it produces a meaningless one.
+ * Refuse rather than record it; `--allow-load` is for an exploratory run whose
+ * output is not going into a budget.
+ */
+const MAX_LOAD_AVERAGE = 8;
+const allowLoad = process.argv.includes('--allow-load');
+if (!allowLoad && os.loadavg()[0] > MAX_LOAD_AVERAGE) {
+  console.error(
+    `1-minute load average ${os.loadavg()[0].toFixed(2)} exceeds ${MAX_LOAD_AVERAGE}; ` +
+      'wait for the machine to settle, or pass --allow-load for a throwaway run.',
+  );
+  process.exit(1);
+}
+
+try {
+  mkdirSync(cache, { recursive: true });
+  const bundle = await build({
+    stdin: {
+      contents: source,
+      sourcefile: 'runtime-baseline.ts',
+      resolveDir: root,
+      loader: 'ts',
+    },
+    absWorkingDir: root,
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    packages: 'external',
+    write: false,
+    logLevel: 'silent',
+  });
+  writeFileSync(output, bundle.outputFiles[0].contents);
+
+  console.log(
+    JSON.stringify({
+      scenario: 'environment',
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      cpus: os.cpus().length,
+      cpuModel: os.cpus()[0]?.model ?? 'unknown',
+      totalMemoryBytes: os.totalmem(),
+      loadAverage1m: os.loadavg()[0],
+      loadAverage5m: os.loadavg()[1],
+      loadCeiling: allowLoad ? null : MAX_LOAD_AVERAGE,
+      measuredAt: new Date().toISOString(),
+    }),
+  );
+
+  // Short and long retained sessions, compared on the same interfaces.
+  for (const [rows, characters] of [
+    [1_000, 240],
+    [100_000, 240],
+  ]) {
+    const storage = workspace();
+    measure(`seed ${rows}`, [
+      'seed',
+      storage,
+      String(rows),
+      String(characters),
+    ]);
+    measure(`cold-open ${rows}`, ['open', storage, String(rows)]);
+    measure(`replay ${rows}`, ['replay', storage, String(rows)]);
+  }
+
+  measure('loop-delay', ['loop', workspace(), '4', '5000']);
+  measure('two-paper', [
+    'twopaper',
+    workspace(),
+    workspace(),
+    workspace(),
+    '3000',
+  ]);
+  measure('bytes-written', ['bytes', workspace(), '5', '2000']);
+} finally {
+  rmSync(output, { force: true });
+  for (const directory of workspaces)
+    rmSync(directory, { recursive: true, force: true });
+}


### PR DESCRIPTION
Section 8 of the Effect runtime delivery plan makes recorded performance budgets a precondition of the cutover, in its own words: "Record numeric performance budgets and the baseline hardware/datasets in package C before the cutover implementation ... Budgets are not yet measured by this planning pass; do not replace measurements with guessed percentage wins or a net-LOC promise."

No lane owned that, and the cutover is already landing stage by stage, so a budget recorded afterwards would compare the new runtime against nothing. This branch is the pre-cutover half of that comparison: a measurement script and a dated results document. No production code changes.

## What it delivers

`scripts/measure-runtime-baseline.mjs` compiles an inline TypeScript program with esbuild and runs each scenario in its own Node child. Every scenario reaches SQLite through the `Database` service (`src/shared/session/database.ts:64`) and `databaseLayer` (`src/controllers/session/Database.ts:219`) and through nothing else, composing the layer exactly the way the existing session-events suite does. That choice is the point: `Database` is a contract the cutover keeps, so the same script runs unmodified afterwards and produces a back-to-back comparison on one machine. A harness shaped around modules the cutover deletes would measure nothing twice.

`docs/architecture/2026-09-07-pre-cutover-runtime-baseline.md` records the readings, the machine, the datasets, and what each number does and does not mean. The path is inside the VitePress internal exclusion (`architecture/**`), so nothing here publishes to texra.ai.

## What it measured

Apple M1 Ultra, 20 logical cores, 64 GiB, Node v26.8.1, darwin arm64, at `854b36ee69`. Datasets are synthetic: a 1,000-row and a 100,000-row retained session of 240-character transcript rows, 512-character rows for write load, and three growth shapes.

The Performance gate names seven readings, counting commit and stop latency as one. Every one is recorded except stop latency, and cold open only in its substrate half:

- **Cold open, substrate half.** 11.12 ms from layer build to first listing at 1,000 retained rows, 10.89 ms at 100,000. Flat in history, because the listing query is per aggregate rather than per row.
- **Idle memory.** 42.5 MB heap and 224 to 225 MB RSS at both dataset sizes. An open connection holds statements, not rows.
- **Replay memory.** The largest number on the page. A full `readAll` over 100,000 rows takes 1436.93 ms, grows the heap by 677.82 MB transiently and peaks at 1008.75 MB RSS, then settles back to the idle figure. A hundredfold more rows costs 66 times the read time and 19 times the transient heap.
- **p95 commit latency.** Single-row appends run at p50 0.077 ms and p95 0.115 ms uncontended. With four fibers plus a second OS process writing the same file, p95 moves to 0.123 ms while p99 goes from 0.543 ms to 1.744 ms and the maximum from 8.61 ms to 22.10 ms. Contention lands in the tail, which is what one write permit plus `busy_timeout` should look like.
- **Event-loop delay under SQLite contention.** Measured by an independent 10 ms probe reporting its own lateness, with `monitorEventLoopDelay` beside it, because the append loop's own latency cannot answer this question. A process committing about 6,900 rows per second while another process commits about 250 per second into the same file delays unrelated event-loop work by about 2.9 ms at p95 and 5.9 ms at p99. The scenario fails the run if the cross-process contention did not actually happen; it observed 34,416 own commits against 1,250 foreign ones.
- **Two-paper concurrency and bytes written.** Two session roots commit 27,105 rows in three seconds against 25,197 for one, so aggregate throughput rises 7.6 percent while each paper falls to 53.8 percent of solo. Each paper's history is checked for the other's rows and has none. On disk, small `status` rows cost 2.84 times their payload, 1 KiB rows 1.28 times, and 256 KiB rows 1.004 times. Small rows are the number to watch, since a run emits far more of them.

## What it deliberately does not claim

The cold-open figure is the substrate half only. Host activation, the desktop window and the CLI's first paint have no launcher harness here, and the "process start to listing" figure of about 783 ms is an upper bound on the harness bundle's module-graph cost, not a host startup number.

p95 stop latency is not recorded. Neither is tool concurrency under load, or media through the real attachment path. Section 5 states, for each, that the behaviour is already driven by suites in this repository and that this harness is simply the wrong vehicle for turning it into a number.

## What review cut, and why

Three defects were found in review and fixed in commits on top of the original one.

**A false premise in section 5.** The first draft declared stop latency and tool concurrency unmeasurable because "the only network-free handler in the repository is `ModelHandlerValidation`", locked behind a four-way environment gate. That is wrong. `src/test-kernel/agent/toolUseRoundTestUtils.ts` exports `roundModelHandler`, a complete model-handler surface built from `vi.fn` stubs with no client and no request; `src/test-kernel/agent/modelCellTestUtils.ts` wraps it; `src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts` already aborts a real `createToolUseRoundFlow` through the run's own `AbortController` and asserts the cancelled results come back paired; and `src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts` already drives dispatch fan-out through an inFlight/maxInFlight probe, along with the barrier, dedup and one-signal cancellation cases.

Section 5 now says what is true. Those fixtures even run outside vitest: a throwaway probe bundled them the same way the harness bundles its own program and returned about a millisecond between the abort and the flow returning. That number is described in the document and deliberately not recorded, because with tools that return immediately and a `createResponse` that resolves without a request, a millisecond measures the flow's cancellation bookkeeping and not stop latency. Getting the gate's number needs a fixture whose tools and model response take a controlled, non-zero time to unwind, plus the approval and queued-admission points that the round-flow fixtures do not reach. Either extend this harness or measure inside the vitest kernel; the document names both and says the second is smaller.

**A quality gate that did not hold.** The load-average ceiling of 8 was checked once, before the first scenario spawned. The harness is itself the largest contributor to the load its later scenarios run under, so a start-only check is optimistic exactly where it matters, and review reproduced a run that started at 7.71 and then emitted a `replay-memory` record at 8.32 with no failure and no marking. The ceiling is now forwarded to every scenario child and re-checked at each record: an over-ceiling record is printed carrying an `aboveLoadCeiling` field and then fails the run. This reproduced immediately on the repaired script. A run started at load 7.05 reached the 100,000-row `replay-memory` scenario at 8.92 and failed there, which is precisely the reading the document calls its largest number.

**Two silent degradations in the harness.** `databaseBytes` caught every `statSync` failure on the `-wal` and `-shm` sidecars and returned 0, so a permissions error or a race would have become a plausible byte count in a document whose whole purpose is accurate numbers. Only `ENOENT` on a sidecar is zero now; everything else throws, and an absent main database file throws as it did before. And `os.cpus()[0]?.model ?? 'unknown'` would have recorded the baseline machine identity, the thing section 3 exists to pin, as a placeholder string. It throws instead.

## Verification

`npm run typecheck` and `npm run lint` both pass. `node docs/scripts/check-root-docs.mjs` passes, and `architecture/**` is in the VitePress `srcExclude` list, so the document's path is correct. The working tree is clean afterwards; the compiled bundle is removed in the script's `finally`.

The recorded numbers were not re-taken and are unchanged. A recorded re-run was attempted three times on a busy shared machine and the ceiling refused all three, which is the ceiling working rather than a gap in it: two were refused at the start gate at load averages of 8.76 and 13.28, and the third started at 7.05, cleared every scenario up to the 100,000-row replay, and failed there at 8.92 with the record marked. Section 3 records those attempts. What was verified instead: a full `--allow-load` run of the repaired script completed all 30 records with exit 0 and reproduced section 4 within run-to-run variance, with the 100,000-row `readAll` at 1451.40 ms against the recorded 1436.93 ms, peak heap growth at 677.98 MB against 677.82 MB, identical settled on-disk bytes for the 1 KiB and 256 KiB shapes, and 2,965,504 bytes against 2,990,080 for the `status` shape. Section 3 records that comparison and states why an `--allow-load` run is not a budget. The three changed code paths are the load gate, an `ENOENT` test and the CPU read, none of which sits inside a timed region.

Whoever takes the post-cutover comparison should start it on a quiet machine rather than merely one under the ceiling, since the 100,000-row replay is the harness's own heaviest load and has been observed carrying a run that began in the low sevens past 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU
