### PR TITLE
chore: de-export six type declarations with no consumer anywhere

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -20,12 +20,6 @@
       "name": "slashPaletteWindow"
     },
     {
-      "file": "packages/cli/src/chat/tui/commands/SlashPalette.tsx",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "SlashPaletteWindow"
-    },
-    {
       "file": "packages/cli/src/chat/tui/commands/slashRegistry.ts",
       "category": "production-dead",
       "kind": "exports",
@@ -66,12 +60,6 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "createCliConfigFormProps"
-    },
-    {
-      "file": "packages/cli/src/chat/tui/forms/CliConfigForm.tsx",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "CreateCliConfigFormPropsInput"
     },
     {
       "file": "packages/cli/src/chat/tui/forms/ConfigForm.tsx",
@@ -596,12 +584,6 @@
       "name": "resolveBrowserLaunch"
     },
     {
-      "file": "packages/cli/src/runtime/browser.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "BrowserLaunchCommand"
-    },
-    {
       "file": "packages/cli/src/runtime/chatDefaults.ts",
       "category": "production-dead",
       "kind": "exports",
@@ -740,12 +722,6 @@
       "name": "resetCliUpdateNotifyLatchForTests"
     },
     {
-      "file": "packages/cli/src/runtime/updateChecker.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "InstallMethod"
-    },
-    {
       "file": "packages/cli/src/runtime/workflowInputs.ts",
       "category": "production-dead",
       "kind": "exports",
@@ -762,12 +738,6 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "workflowInputGlobOptions"
-    },
-    {
-      "file": "packages/cli/src/runtime/workflowInputs.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "StdinWorkflowInputMaterializer"
     },
     {
       "file": "packages/cli/src/runtime/workflowOutput.ts",
@@ -1122,12 +1092,6 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "resetCodexCoordinator"
-    },
-    {
-      "file": "src/auth/codex/codexDeviceLogin.ts",
-      "category": "unused",
-      "kind": "exports",
-      "name": "DeviceCodeMissing"
     },
     {
       "file": "src/auth/codex/index.ts",

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -28,7 +28,7 @@ export const SLASH_PALETTE_ROWS = 13;
 
 const COMMAND_DESCRIPTION_GAP = 2;
 
-export interface SlashPaletteWindow {
+interface SlashPaletteWindow {
   readonly start: number;
   readonly end: number;
   readonly hiddenBefore: number;

--- a/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
@@ -51,7 +51,7 @@ export interface CliConfigFormProps {
   readonly onApprovalPolicyChanged?: (policy: TexraApprovalPolicy) => void;
 }
 
-export interface CreateCliConfigFormPropsInput extends CliConfigFormProps {
+interface CreateCliConfigFormPropsInput extends CliConfigFormProps {
   readonly stores: SettingsStores;
   readonly apiKeyStatusView?: ProviderApiKeyStatusView;
   readonly markProviderApiKeySet?: (provider: ApiProvider) => void;

--- a/packages/cli/src/runtime/browser.ts
+++ b/packages/cli/src/runtime/browser.ts
@@ -2,7 +2,7 @@ import { execa } from 'execa';
 
 import { extractErrorMessage } from '@utils/errors/errorMessage';
 
-export interface BrowserLaunchCommand {
+interface BrowserLaunchCommand {
   readonly command: string;
   readonly args: string[];
 }

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -44,7 +44,7 @@ const DEFAULT_TIMEOUT_MS = 2500;
 const HOMEBREW_COMMAND_TIMEOUT_MS = 10000;
 
 /** Package manager the running binary was installed with. */
-export type InstallMethod = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'brew';
+type InstallMethod = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'brew';
 
 /**
  * Guess the package manager from the path the binary runs out of, or

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -80,7 +80,7 @@ interface PreparedWorkflowInputExpansion {
   readonly stdinInputFile?: () => Promise<string>;
 }
 
-export type StdinWorkflowInputMaterializer = (() => Promise<string>) & {
+type StdinWorkflowInputMaterializer = (() => Promise<string>) & {
   cleanup: () => Promise<void>;
 };
 

--- a/src/auth/codex/codexDeviceLogin.ts
+++ b/src/auth/codex/codexDeviceLogin.ts
@@ -31,7 +31,7 @@ import { pollDeviceToken, requestDeviceUserCode } from './codexOAuthClient';
 const DEVICE_TIMEOUT_FALLBACK_MS = 15 * 60 * 1000;
 
 /** The usercode endpoint answered without a code to show the user. */
-export class DeviceCodeMissing extends Data.TaggedError('DeviceCodeMissing')<{
+class DeviceCodeMissing extends Data.TaggedError('DeviceCodeMissing')<{
   readonly message: string;
 }> {}
 


### PR DESCRIPTION
## What this is

Six interfaces and type aliases declared with `export` but used only as internal type annotations inside their own file, with no consumer anywhere, tests included. The `export` keyword comes off and the declarations stay, because each is still doing real work where it is declared. `config/ratchets/knip-baseline.json` drops from 278 findings to 272.

No production logic changes. Every de-exported name keeps its declaration and its internal call sites.

## Why it is only six

This is the entire deletable yield of a sweep over 267 of that baseline's 278 entries, run as five independent per-area passes, each grepping every bare name across `packages`, `src`, `scripts`, `docs`, `config` and `.agents` including non-TypeScript files.

| Area | considered | deletable | de-export | false positive |
| --- | --- | --- | --- | --- |
| `packages/cli/src/chat` | 78 | 0 | 2 | 76 |
| `packages/cli/src` rest | 60 | 0 | 3 | 55 |
| `src/agent` + `src/tools` | 46 | 0 | 0 | 35 |
| `src/auth` + `src/latex` + `src/model` | 37 | 0 | 1 | 33 |
| `src/shared` + `src/controllers` + hosts | 46 | 0 | 0 | 46 |

Zero deletable across all five. The cause is structural: the `production-dead` category records findings the production knip run emits and the normal run does not, and because the `packages/cli` workspace declares one production entry while its suites live in the root workspace under `src/test-kernel/`, the production run cannot see a test consumer by construction. So `production-dead` means "not reachable from a production entry point", not "has no consumer". Filed with the measurements and the options in #12084.

The dominant real pattern is a live internal helper that a suite also imports: the name is called inside its own file by production code and imported by a `src/test-kernel/cli/*.vitest.ts` suite, so deleting breaks render logic and de-exporting breaks a live test import. Neither action applies, which is why the deletable count is zero rather than small.

## Verified

- `npm run check:dead-code-ratchet`: `272 combined vs 272 baselined. Dead-code ratchet OK: no new findings.` The combined count moved 278 to 272 in lockstep with the baseline, confirming all six are genuinely resolved.
- `tsc --noEmit -p tsconfig.json`: clean.
- The baseline diff is exactly the six removed entries. A JSON round-trip had rewritten the `semantics` header's `’` escape to a literal character; that was reverted so the only change is the entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha5vnpy67jRyC369MtxZU