### PR TITLE
refactor(telemetry): send usage batches through Effect's HttpClient

### DIFF
--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -28,7 +28,10 @@ import {
   TELEMETRY_ENABLED_KEY,
 } from '@shared/schemas';
 import { CODING_PLAN_SUBSCRIPTIONS } from '@shared/codingPlanSubscriptions';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import {
+  extractErrorMessage,
+  toErrorMessage,
+} from '@utils/errors/errorMessage';
 import { isEnvFlagEnabled } from '@utils/system/envFlags';
 import { unrefSleepClock } from '@utils/system/unrefSleepClock';
 
@@ -483,7 +486,11 @@ class UsageLogServiceImpl {
         Effect.scoped,
         Effect.mapError((error) => {
           if (!HttpClientError.isHttpClientError(error)) {
-            return undelivered(toErrorMessage(error));
+            // `bodyJson` fails with `HttpBodyError`, which carries `reason`
+            // and `cause` but no message, so `toErrorMessage` renders it as
+            // the empty string — an undelivered billing batch with a blank
+            // reason. Fall back to the tag so this can never be silent.
+            return undelivered(extractErrorMessage(error) ?? String(error));
           }
           // The wrapper's message names the request that failed; only its
           // cause names the transport failure (a refused connection, a reset

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -11,7 +11,11 @@ import {
   Scope,
   Semaphore,
 } from 'effect';
-import ky from 'ky';
+import {
+  HttpClient,
+  HttpClientError,
+  HttpClientRequest,
+} from 'effect/unstable/http';
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';
@@ -254,7 +258,15 @@ class UsageLogServiceImpl {
       // Run before the sender's interruption finalizer. Closing this child on
       // dispose also removes its parent finalizer, so reinitialization neither
       // retains old shutdown callbacks nor changes the drain-before-stop order.
-      yield* Scope.addFinalizer(lifetime, this.shutdown());
+      // A scope finalizer runs with no context of its own, so the drain it
+      // performs carries the client this initialization was given.
+      const client = yield* HttpClient.HttpClient;
+      yield* Scope.addFinalizer(
+        lifetime,
+        this.shutdown().pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+        ),
+      );
     }
 
     if (isTelemetryDisabledByEnv()) {
@@ -451,25 +463,38 @@ class UsageLogServiceImpl {
         batchId: batch.batchId,
         entries: batch.entries.map(({ entry }) => entry),
       };
-      // ky's `timeout` only guards until response headers arrive (it clears
-      // the timer once fetch settles), so a server that stalls mid-body would
-      // hang the `.json()` read indefinitely, wedging the flush lane and
-      // dispose(). The body read therefore sits inside the same timed effect
-      // as the request: the timeout interrupts it, and the interruption
-      // reaches fetch through the signal.
-      const { httpResponse, data } = yield* Effect.tryPromise({
-        try: async (signal) => {
-          const httpResponse = await ky.post(USAGE_LOG_ENDPOINT, {
-            json: wire,
-            headers: { Authorization: `Bearer ${token}` },
-            timeout: false,
-            signal,
-            throwHttpErrors: false,
-          });
-          return { httpResponse, data: await httpResponse.json<unknown>() };
-        },
-        catch: (error) => undelivered(toErrorMessage(error)),
+      const client = yield* HttpClient.HttpClient;
+      // One request is one fiber. The body read sits inside the same timed
+      // effect as the request, because a server that answers headers and then
+      // stalls mid-body would otherwise hang the read indefinitely, wedging
+      // the flush lane and dispose(). The timeout interrupts the effect, and
+      // `HttpClient.withScope` turns that interruption — and a dispose that
+      // interrupts the sender — into an abort on the underlying fetch.
+      // A non-2xx status is not a failure here: the endpoint answers a
+      // rejection with a body the acknowledgement checks below read.
+      const { status, data } = yield* Effect.gen(function* () {
+        const request = yield* HttpClientRequest.post(USAGE_LOG_ENDPOINT, {
+          headers: { Authorization: `Bearer ${token}` },
+        }).pipe(HttpClientRequest.bodyJson(wire));
+        const response = yield* HttpClient.withScope(client).execute(request);
+        const data = yield* response.json;
+        return { status: response.status, data };
       }).pipe(
+        Effect.scoped,
+        Effect.mapError((error) => {
+          if (!HttpClientError.isHttpClientError(error)) {
+            return undelivered(toErrorMessage(error));
+          }
+          // The wrapper's message names the request that failed; only its
+          // cause names the transport failure (a refused connection, a reset
+          // socket). A billing warning is worth both.
+          const { cause } = error.reason;
+          return undelivered(
+            cause === undefined
+              ? error.message
+              : `${error.message}: ${toErrorMessage(cause)}`,
+          );
+        }),
         Effect.timeoutOrElse({
           duration: Duration.millis(REQUEST_TIMEOUT_MS),
           orElse: () =>
@@ -488,9 +513,9 @@ class UsageLogServiceImpl {
         if (response.retryable === false) return response;
         return yield* undelivered(response.error ?? 'Usage batch was rejected');
       }
-      if (!httpResponse.ok) {
+      if (status < 200 || status >= 300) {
         return yield* undelivered(
-          `Usage endpoint returned HTTP ${httpResponse.status} with a success acknowledgement`,
+          `Usage endpoint returned HTTP ${status} with a success acknowledgement`,
         );
       }
       if (response.accepted !== wire.entries.length) {
@@ -503,7 +528,7 @@ class UsageLogServiceImpl {
   );
 
   /** Close the active process child, draining its sender before interruption. */
-  dispose(): Effect.Effect<void> {
+  dispose(): Effect.Effect<void, never, HttpClient.HttpClient> {
     return Effect.suspend(() =>
       this.lifetime ? Scope.close(this.lifetime, Exit.void) : this.shutdown(),
     );

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -48,16 +48,17 @@ function stubAccessToken(): void {
   vi.spyOn(SupabaseClient, 'getAccessToken').mockResolvedValue('token');
 }
 
-// ky passes a Request object; read each batch body from it. `beforeRespond`
-// lets a test stall or fail a specific call before the success response.
+// The Effect fetch client passes (url, init); read each batch body from the
+// init. `beforeRespond` lets a test stall or fail a specific call before the
+// success response.
 function stubFetch(
   batches: unknown[],
   beforeRespond: (
     callCount: number,
   ) => void | Response | Promise<void | Response> = () => {},
 ): Mock {
-  const fetchMock = vi.fn(async (request: Request) => {
-    batches.push(await request.json());
+  const fetchMock = vi.fn(async (_url: URL, init: RequestInit) => {
+    batches.push(await new Response(init.body).json());
     const response = await beforeRespond(fetchMock.mock.calls.length);
     return response ?? jsonResponse({ success: true, accepted: 1 });
   });
@@ -187,7 +188,7 @@ describe('UsageLogService', () => {
 
     UsageLogService.log(usageEntry('timer'));
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    const request = fetchMock.mock.calls[0]?.[0] as Request;
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
 
     const disposal = effectRuntime().runPromise(Scope.close(owner, Exit.void));
     let disposed = false;
@@ -196,7 +197,7 @@ describe('UsageLogService', () => {
     });
     // Long enough for a dispose that abandons the send to have resolved.
     await vi.advanceTimersByTimeAsync(50);
-    expect(request.signal.aborted).toBe(false);
+    expect(init.signal?.aborted).toBe(false);
     expect(disposed).toBe(false);
 
     releaseFetch();


### PR DESCRIPTION
## Summary

`UsageLogService` was already one of the most Effect-native files in the repository — it uses `Clock`, `Data`, `Duration`, `Effect`, `Exit`, `Fiber`, `Queue`, `Scope` and `Semaphore`, and models failure as `Data.TaggedError('UsageBatchUndelivered')`. `ky` was the last foreign edge in it. This replaces that one edge with `effect/unstable/http`.

This is billing data, so the delivery contract — not the syntax — was the thing under review. Behaviour is preserved deliberately, **with one wire-level exception noted below**:

- **The body read stays inside the timed effect.** `ky`'s `timeout` only guarded until response headers arrived (it clears the timer once fetch settles), so a server that answered headers and then stalled mid-body would hang the `.json()` read indefinitely, wedging the flush lane and `dispose()`. `HttpClient.withScope` creates the `AbortController` and registers `abort` as a scope finalizer, so `Effect.timeoutOrElse` + `Effect.scoped` aborts the underlying fetch exactly as the hand-passed signal did. `raceAllFirst` awaits the loser's unwinding, so the abort is prompt.
- **A non-2xx status is still not a failure.** The endpoint answers a rejection with a body that the acknowledgement checks read, so status handling stayed below the error channel.
- **`Effect.catchTag('UsageBatchUndelivered')` still matches**, because `mapError` collapses before the timeout wrapper.
- **No hidden retry layer was removed** — `ky`'s default retry does not cover POST.
- **The opt-out path is untouched.** `TELEMETRY_ENABLED_KEY` / `usageLoggingOptOut()` gate the pipeline as before; all six consent tests pass.
- **No new event-loop holder** — setting `scopedController` skips both `responseRegistry.register` branches.

One deliberate improvement: a transport failure now reports the wrapper's message *and* its cause. The wrapper names the request that failed; only the cause names the refused connection or reset socket, and a billing warning is worth both.

The scope finalizer runs with no context of its own, so the shutdown drain is explicitly given the client this initialization received.

### The one behaviour change reviewers should decide on

`HttpClient.TracerPropagationEnabled` is a `Context.Reference` whose default is `constTrue` (`unstable/http/HttpClient.js:678`), and TeXRA installs a real `Tracer` via `effectDiagnosticsLayer` (`sessionLayer.ts:727`). **The POST therefore now carries trace-propagation headers to the Supabase usage endpoint that the `ky` version did not send.**

**Correction after review:** an earlier version of this description said "`traceparent` headers". `HttpTraceContext.toHeaders` emits **both `b3` and `traceparent`** (`HttpTraceContext.js:26-32`) — two headers, not one.

Functionally harmless — the server ignores unknown headers — but it exports internal trace/span ids to that endpoint. I did not suppress it, because doing so means adding a line that nothing in this change's validation covers. If exact prior wire parity is wanted, it is one service on the send effect: `Effect.provideService(HttpClient.TracerPropagationEnabled, false)`.

**The bearer token is not exposed.** `HttpClient.make` copies request headers into span attributes, but `Authorization` lands as `<redacted>` because `Headers.CurrentRedactedNames` defaults to `["authorization", "cookie", "set-cookie", "x-api-key"]` (`Headers.js:329`). The exported ids are not credentials. This was independently confirmed in review; an override of that Reference would nonetheless be security-relevant.

## Issue acceptance gates

**#12076, piece 1.** Three of its four items are satisfied; two are answered as negative results and one is deliberately deferred.

- [x] `ky` → `HttpClient`.
- [x] `ky` may **not** be removed from `package.json` — nine other importers.
- [ ] **`unrefSleepClock` must stay — negative result, do not attempt.** Effect's `sleepMillis` uses a ref'd `setTimeout`, and there are zero `unref` calls in `effect/dist/internal/effect.js`. The repo already pins this with a `handle.hasRef() === false` assertion. Converting it would keep the Node event loop alive, and a CLI that will not exit is a severe regression.
- [ ] **`randomUUID` → `Crypto`/`Random` — not done, deliberately.** `Crypto` is a no-default `Context.Service`; converting would widen `ProcessRuntime`'s requirements to buy test determinism the repo already gets by injection.
- [ ] **Singleton → `Layer` — deliberately out of scope.** It reaches `packages/extension/src/extension.ts`, which `cutover/persistence-substrate` and `stage/6-execution-registration` are both rewriting. Recorded as follow-up on #12076.
- [ ] **Piece 2 (`Metric`/`Tracer` instrumentation) — untouched.** Separate lane.

## Single source of truth

`HttpClient.HttpClient`, taken from context, is now the single owner of outbound HTTP for this file. It replaces a module-level `ky` import that resolved `globalThis.fetch` per call. The delivery decision (delivered / undelivered-retry / undelivered-give-up) remains owned by `UsageLogServiceImpl`'s acknowledgement checks, unchanged.

## Duplication and abstraction budget

No abstraction added. One dependency edge removed from this file. The `Effect.tryPromise` wrapper that adapted `ky`'s promise into the error channel is deleted outright rather than replaced — the client's typed `HttpClientError` reaches `mapError` directly. No pass-through layer.

## Net elements (R6)

- Files: 2 changed, +59 / −29 across two commits (net **+30** lines; the growth is comment, explaining the timeout/abort contract that was previously implicit in `ky`'s options, plus the empty-reason guard below).
- Exported symbols: `^[+-]export` over the diff = **0 added, 0 removed**.
- Classes / interfaces / enums: **0 / 0 / 0**.
- Dependencies: none added. `ky` retained (nine other importers).

## Consumer counts (R8)

`dispose()`'s signature widens from `Effect<void>` to `Effect<void, never, HttpClient.HttpClient>`. Grepped consumers of `UsageLogService.dispose()` / `.initialize()`:

- **6 production call sites**, all of which already run through `effectRuntime()`: `packages/cli/src/runtime/initPlatform.ts:386,401`, `packages/desktop/src/main/platform/index.ts:177,185`, `packages/extension/src/extension.ts:514,635`.
- **Zero host edits were required**, because `ProcessRuntime` is already `ManagedRuntime<HttpClient.HttpClient, never>`. This is the first production datapoint for open ruling **R-2** (do Platform capabilities get Effect `Context.Service` keys) and is recorded on #12073.
- No emit path or subscription key changed.

## Host impact

**Extension:** none. `extension.ts` calls `initialize`/`dispose` through `effectRuntime()`, which already provides the client. Not edited.

**Desktop:** none. Same, via `platform/index.ts`. Not edited.

**CLI:** none. Same, via `initPlatform.ts`. Not edited. The shutdown ordering comment at `initPlatform.ts:103` (lifecycle shutdown before the NDJSON stdout flush) still holds — the drain now runs against a client captured at initialize time, which is inert for the stateless `FetchHttpClient` but would matter if that layer were ever swapped for a pooled client.

## Scheduled refactoring

- #12076 — piece 1's singleton→`Layer` conversion, deferred until `extension.ts` is free.
- #12076 — piece 2, the `Metric`/`Tracer` instrumentation that #12025's Performance completion gate requires. No instrumentation currently produces those numbers in a shipped build.
- #12073 — the `TracerPropagationEnabled` and `Headers.CurrentRedactedNames` observations are recorded there as R-2 evidence.

## Validation

Run by me on a clean tree, at `1cf1a84` for the first commit and re-run in full after the second:

- `npm run typecheck` — **exit 0**, all legs (root, agent, cli, trace-viewer, desktop, extension).
- `npx vitest run src/test-kernel/telemetry` — **35 passed (35)**.
- `npx eslint src/telemetry/UsageLogService.ts` — clean. `prettier --check` — clean.
- `node scripts/check-effect-migration-ratchet.mjs` — **green**; no count grew, no baseline headroom, no `@adapter-until` marker. Baseline byte-identical.
- Pre-empting CI: ran the **12 other suites that reference `UsageLogService`, `testHttpClientLayer` or `FetchHttpClient`** — 26 files, **252 tests, all passing**.

**The two files in the first commit must land together.** `tsc` exits 0 with the production change and the *unmodified* test stub, so typecheck alone does not catch the mismatch — splitting them merges a red build (22 of 35 failing). They are one commit for that reason.

Not run: full `npm test`, `npm run lint` on the whole tree.

Provenance: implemented in an isolated worktree, reviewed by two independent adversarial passes (scope/build and semantics), then re-verified by hand before commit. Those reviews corrected three claims from the original implementation — a wrong failing-test count, an overstated typecheck result, and a "land the patch" verdict that would have shipped the production file without its test. The `review` job then found two further items, both verified and one fixed in `995966d` (see below).

### `995966d` — empty-reason guard

Review found that `sendBatch`'s non-`HttpClientError` branch could log a blank reason. `HttpClientRequest.bodyJson` fails with `HttpBodyError`, which `Data.TaggedError` builds from `{ reason, cause }` with **no message** — but it still extends `Error`, so `toErrorMessage` takes the `err instanceof Error` path and returns `err.message`, the empty string. An undelivered billing batch would have been logged with no reason at all.

Verified empirically against the pinned package: such an error gives `message === ""` and `String(err) === "HttpBodyError"`. `extractErrorMessage` returns `undefined` rather than `""`, so the fallback now yields the tag and the reason can never be blank.

Unreachable today — every `UsageLogEntry` field is a JSON-safe primitive — so this is defence for a failure mode that would otherwise be undiagnosable if the wire shape ever changed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRKNXQf68EFbEiMrsNboLo
