### PR TITLE
docs(effect): record the verified Effect 4 interface findings and three corrections

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -346,10 +346,32 @@ built deliberately.
    mechanism for ambiguous external effects is unavailable at exactly the
    boundary model and tool calls would sit on.
 2. `Activity`'s default `interruptRetryPolicy` re-runs an interrupted activity
-   **up to 10 times, then dies** (`Activity.js:62-66`). TeXRA cancels model
-   calls via `AbortController`. Wrapping `ModelInvocationNode` naively turns
-   one user cancel into up to ten further provider calls. Overridable per
-   activity, but the default is backwards for this codebase.
+   **up to 10 times, then dies** (`Activity.js:62-66`). Overridable per
+   activity, but the default is backwards for a codebase whose cancellation is
+   an `AbortController`.
+
+   The cost is a defect, not provider traffic. An earlier version of this note
+   claimed a naive `ModelInvocationNode` wrapper would turn one user cancel
+   into up to ten further provider calls; that is wrong, and the mechanism
+   that makes it wrong is worth recording. The signal is run-scoped, not
+   per-attempt — bound once as `this.signal = this.services.runScope.signal`
+   (`ModelInvocationNode.ts:386`) and aborted once by
+   `interrupt: () => runAbortController.abort()`
+   (`AgentLaunchContext.ts:632`) — and `runAttempts` throws before calling
+   `exec` whenever it is already aborted (`ModelInvocationNode.ts:407-410`),
+   with the aborted run routed to `execFallback` (`:441-450`). So each re-run
+   short-circuits and reaches no provider. The schedule also only re-fires
+   `while (meta.attempt <= 10 && Cause.hasInterrupts(meta.input))`
+   (`Activity.js:62`), so a re-run that completes through `execFallback` ends
+   the retry immediately.
+
+   What remains is the real hazard: when cancellation also interrupts the
+   enclosing fiber, each re-run is interrupted again, the policy walks its
+   full schedule (exponential from 400ms, floored against a 10-second
+   spacing), and the activity ends in
+   `Effect.die('Activity "…" interrupted and retry attempts exhausted')`
+   (`Activity.js:65`). A clean user cancel becomes a defect tens of seconds
+   later. **[reproduced]** — the claim as originally written was not.
 
 **Durability is not shipped.** `WorkflowEngine` has exactly one layer in
 `unstable/workflow` — `layerMemory`. The only durable implementation is

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -150,12 +150,15 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
 - **`readDirectory` returns `Array<string>`, not `[name, type]`.** The port
   reads each entry's type off the `withFileTypes` dirent for free; Effect's
   shape forces a `stat` per entry. This is load-bearing, not tuple
-  adaptation. **Twelve production consumers** branch on the type bits:
+  adaptation. **At least twelve production consumers** branch on the type bits
+  — a floor rather than a total, since this count has grown at each of three
+  review passes (two, then eight, then twelve):
   `indentDirectory.ts:82`, `diffOperations.ts:244,266,284`,
   `memoryFileSystem.ts:252`, `runGeneratedFiles.ts:93`,
   `desktopWorkspaceIpc.ts:261-270`, `workspaceFileListing.ts:37,44`,
   `executionListing.ts:136`, `runOutputFiles.ts:70-72,126`,
-  `relativeFS.ts:74` (`cleanupOldFiles` keeps only files),
+  `relativeFS.ts:74` (`cleanupOldFiles` keeps only files — note this is a
+  **deletion** path, where a misclassification is unrecoverable),
   `ArxivDownloadTool.ts:23-42` (renders file-vs-directory identity),
   `externalInquiryStorage.ts:456` (accepts only directories), and
   `KVStore.ts:102` (accepts only `.json` files). Four of them —

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -227,7 +227,7 @@ does not control their inputs. The hole is closable for testing by handing
 `glob` a memfs instance directly. For real wiring the candidates differ:
 **candidate A can serve the five async importers directly; candidate B can
 serve them only through an adapter** that costs one extra syscall per entry
-(below). Only the three `globSync` callers are closed to both. This paragraph
+**and a run boundary for four of the five consumers** (below). Only the three `globSync` callers are closed to both. This paragraph
 has been wrong six times in six directions: two importers, then unclosable,
 then independent of R-1, then requiring synchronous methods, then B excluded on
 a correctness objection this note's own §2 disproves, then a lead still calling
@@ -265,15 +265,26 @@ traversal actually calls. So:
   as Node `Stats`. An earlier revision of this paragraph said `FSOption`
   requires synchronous methods and so overcharged A; it does not, for the
   async path.
-- **Candidate B can serve the same five, but only through an adapter.**
-  `path-scurry` wants **`lstat`**, at `:900` and `:705`, and Effect's
-  `FileSystem` has none — so B must synthesise one from the
-  `readLink`-plus-`stat` probe above. An earlier revision called that probe
-  incorrect under unrelated failures; §2 now records why that was wrong (the
-  errno survives on `reason.cause`). What is left is real but only a price:
-  a second syscall per entry on a traversal already paying one. The three
-  `globSync` callers additionally need the synchronous set, which Effect also
-  lacks — and there no adapter exists at all.
+- **Candidate B can serve the same five, but only through an adapter, and the
+  adapter needs a run boundary.** `path-scurry` wants **`lstat`**, at `:900`
+  and `:705`, and Effect's `FileSystem` has none — so B must synthesise one
+  from the `readLink`-plus-`stat` probe above. An earlier revision called that
+  probe incorrect under unrelated failures; §2 now records why that was wrong
+  (the errno survives on `reason.cause`), leaving a syscall per entry as the
+  price. **But an earlier revision also priced only that syscall, and there is
+  a second cost.** `FSOption.promises.lstat` must return a real `Promise`;
+  Effect's `readLink`/`stat`/`readDirectory` return `Effect`s. Bridging them
+  needs `runPromise` or an equivalent managed-runtime run **at each consumer**
+  — and four of the five async importers sit at non-boundary paths
+  (`src/agent/index/agentYamlScanner.ts`, `src/tools/glob.ts` — not a
+  `*Tool.ts` — `src/housekeeping/clean.ts`, `src/housekeeping/utils.ts`),
+  where the ratchet rejects a new `Effect.run*` exactly as it does for
+  `TraceEmitter.ts`. Only `packages/cli/src/runtime/workflowInputs.ts` is
+  already a boundary kind. So B needs the adapter built at an allowed boundary
+  and injected into four consumers, or a separate native seam for them — the
+  same structural cost this note found for the hub constructor, in a second
+  place. The three `globSync` callers additionally need the synchronous set,
+  which Effect also lacks — and there no adapter exists at all.
 
 So under both candidates the seam closes for the five async callers and stays
 for the three synchronous ones; B pays an extra syscall per entry that A does
@@ -388,17 +399,18 @@ So nothing here is impossible. What remains is the size of the job — and it is
 **two different sizes, because the construction finding above splits B4 into
 two candidates that earlier revisions of this note quietly averaged.**
 
-26 files touch the seam in total, of which **10 only construct** a
+26 files touch the seam in total (27 counting `TraceEmitter.ts` itself, below),
+of which **10 only construct** a
 `TraceEmitter` and 16 subscribe (directly or through
 `attachChannelSubscriber`). Whether the 10 count depends on which hub is
 adopted:
 
-- **B4-atomic — 16 files.** `makeAtomicUnbounded` is synchronous, so each
+- **B4-atomic — 17 files.** `makeAtomicUnbounded` is synchronous, so each
   constructor builds its own and the 10 are untouched. But this buys the
   storage layer: no delivery strategy, no subscriber-completion machinery.
   Most of the eight properties below then have to be re-implemented by hand on
   top of it, which is approximately what `TraceEmitter` already does.
-- **B4-hub — 26 files.** A real `PubSub` needs `PubSub.make` or
+- **B4-hub — 27 files.** A real `PubSub` needs `PubSub.make` or
   `PubSub.unbounded`, both effectful, and `TraceEmitter.ts` cannot run them
   (not a ratchet boundary kind, and the below-boundary register is not an
   intake). So the hub is built at an `Effect` boundary and injected, and all
@@ -413,12 +425,21 @@ narrow a grep, 26 counted as the union, 16 once constructor sites fell out,
 and now 16 **or** 26 depending on the route. Treat it as measured at this
 tree, not as authoritative.
 
-The composition matters more than the total. **5 of the 16 are production** —
+**Both totals exclude the file being replaced, and should not.** 26 counts
+call sites — constructors and subscribers — but either route rewrites
+`src/agent/trace/TraceEmitter.ts` itself: the `subscribers` field, `subscribe`
+and `emit`. Counting it, the churn is **17 files for B4-atomic and 27 for
+B4-hub**, across **six production files rather than five**. An estimate that
+prices a replacement while omitting the thing being replaced understates it by
+construction.
+
+The composition matters more than the total. **6 of the 17 are production** —
+`src/agent/trace/TraceEmitter.ts` itself, plus
 `packages/agent/src/effect/sessions.ts`, `ModelHandler.ts`,
-`SessionHandle.ts`, `channelTrace.ts`, `runTrace.ts` — and the other 11 are
+`SessionHandle.ts`, `channelTrace.ts`, `runTrace.ts` — and 11 are
 test-kernel, most passing a plain synchronous callback to `trace.subscribe`
 and reading events out of a local array on the next line. So the production
-blast radius is five files.
+blast radius is six files.
 
 **The eleven test files are cheaper than an earlier revision charged them.**
 That revision said each would need "a fiber, a scope and a drain". It would
@@ -431,8 +452,8 @@ subscriber file for adapter-owned infrastructure inflates the case against
 B4, which is the direction this note has now erred in three separate
 places.
 
-That is the argument against B4, and it is an economic one: **16 files of churn
-for B4-atomic or 26 for B4-hub**, mostly tests and each cheaper than first
+That is the argument against B4, and it is an economic one: **17 files of churn
+for B4-atomic or 27 for B4-hub**, mostly tests and each cheaper than first
 charged, plus the eight behavioural properties below, against the listener
 machinery being replaced — the `subscribers` field (`:47`), `subscribe`
 (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a 217-line class that
@@ -611,10 +632,21 @@ event stage-stamped on the way in, detachment stopping delivery before it
 returns, the handover cap enforced at enqueue rather than in the handler, and
 ordering preserved against the separate status plane.
 Together with the subscription and lifecycle work above, that is the real size
-of B4 — and it is **route-dependent**: the constructor sites stay untouched
-only for B4-atomic, which reproduces these eight properties by hand rather
-than inheriting them. B4-hub inherits them and changes all 26 files. The
-reason not to do it is that size, not impossibility.
+of B4 — and it is **route-dependent** in file count only: the constructor
+sites stay untouched for B4-atomic (17 files) and change for B4-hub (27).
+
+**A previous revision said B4-hub "inherits" these eight properties. It does
+not, and that sentence was the most dangerous thing in this note** — an
+implementer following it could ship a hub missing guarantees whose absence
+loses or reorders durable events. A real `PubSub` supplies exactly two of the
+eight: buffering (property 1) and, through its delivery strategy, the
+backpressure behaviour that property presumes. The other six — per-handler
+failures caught **and reported**, synchronous subscription readiness,
+synchronous mid-run detachment, every handler acknowledged before disposal,
+stage stamping on the way in, the handover cap enforced at enqueue, and
+cross-plane ordering against `StreamStatusMachine` — are **adapter work under
+both routes**. B4-hub buys a buffer and a strategy; it does not buy the
+contract. The reason not to do it is that size, not impossibility.
 
 ### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
 
@@ -764,6 +796,26 @@ free of externally visible effects, and inventory which of TeXRA's current
 between-step emissions must either become activities or acquire stable
 deduplication keys. For a run whose progress events are the user-visible
 transcript, that inventory is not small.
+
+**Determinism of the body is necessary and not sufficient, because the body
+can be replaced between suspend and resume.** `resume` runs whatever body is
+installed _now_, while the memo key is
+`` `${executionId}/${activity.name}/${attempt}` `` — it carries no identity
+for the definition that produced those rows. A deterministic body is still a
+different body after an application update. Renaming an activity orphans its
+stored exit and **re-runs an effect that already happened**; reordering or
+renumbering ordinal-named activities binds a stored exit to a _different_
+invocation, which is worse because it succeeds silently with the wrong value;
+changing control flow around an activity creates a key that never existed and
+repeats its external effect. A user updating TeXRA with a suspended run on
+disk is the ordinary case, not an exotic one.
+
+So adoption needs a **persisted definition identity** — a version or a hash of
+the activity sequence — checked on resume, with an incompatible journal
+**rejected loudly** rather than translated. Silent translation of an old
+journal onto a new body is the failure this whole section is about, arriving
+by a different route. That check does not exist in the engine; it is TeXRA's
+to add.
 
 **The Effect-Schema boundary can be held, but not by validating inside the
 activity alone.** An `Activity` with `success: Schema.Unknown` round-trips a

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -145,8 +145,15 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
 
 **Six further gaps:**
 
-- No `lstat` at all, so `isSymlink` needs a `readLink`-plus-errno probe — the
-  silent-degradation shape CLAUDE.md forbids.
+- No `lstat` at all. `isSymlink` would need a `readLink`-plus-errno probe:
+  call `readLink`, read success as "symlink" and `EINVAL` as "not one". An
+  earlier revision called that "the silent-degradation shape CLAUDE.md
+  forbids", which overstates it — this is error-as-control-flow, not a masked
+  failure. The real objection is narrower and worse: **`SystemErrorTag` has no
+  `EINVAL` member** (above), so the probe must read whatever lossy tag a layer
+  maps it to — `InvalidData` in a hand-written one — and that tag covers more
+  than `EINVAL`. An unrelated failure then reads as "not a symlink": a wrong
+  answer rather than a loud one.
 - **`readDirectory` returns `Array<string>`, not `[name, type]`.** The port
   reads each entry's type off the `withFileTypes` dirent for free; Effect's
   shape forces a `stat` per entry. This is load-bearing, not tuple
@@ -212,10 +219,11 @@ it defaults `remove` to `Effect.void` and `exists` to `false`.
 does not control their inputs. The hole is closable for testing by handing
 `glob` a memfs instance directly. For real wiring the candidates differ:
 **candidate A can serve the five async importers, candidate B none of the
-eight** — so B keeps a second filesystem seam here permanently (below). This paragraph has been
-wrong three times in three different directions: it counted two importers,
-then called the set unclosable, then called it independent of R-1. Weigh it
-accordingly.
+eight** in practice — so B keeps a second filesystem seam here (below; a
+`readLink`-based adapter exists in principle and is a bad trade). This paragraph has been wrong four times in four
+directions: two importers, then unclosable, then independent of R-1, then
+requiring synchronous methods — and its summary twice survived a correction to
+its body. Treat its claims as the least reliable in this note.
 The full set of `glob`-package importers outside the test kernel is
 `src/agent/index/agentYamlScanner.ts`, `src/tools/glob.ts`,
 `src/tools/approval/latexPreview.ts`, `src/latex/formatter/latexindentpt.ts`,
@@ -245,12 +253,16 @@ traversal actually calls. So:
   as Node `Stats`. An earlier revision of this paragraph said `FSOption`
   requires synchronous methods and so overcharged A; it does not, for the
   async path.
-- **Candidate B can serve none of them.** Not because of sync — because
-  `path-scurry` wants **`lstat`**, at `:900` and `:705`, and Effect's
-  `FileSystem` has no `lstat` in either form. The three `globSync` callers
-  additionally need the synchronous set, which Effect also lacks.
+- **Candidate B can serve none of them in practice.** Not because of sync —
+  because `path-scurry` wants **`lstat`**, at `:900` and `:705`, and Effect's
+  `FileSystem` has none. An adapter could synthesise one from the
+  `readLink`-plus-`stat` probe above, so this is a cost rather than a wall;
+  but that probe misreads unrelated failures as "not a symlink" and adds a
+  syscall per entry, which is a poor trade for a unified seam. The three
+  `globSync` callers additionally need the synchronous set, which Effect also
+  lacks — and there no adapter exists at all.
 
-So under B the repo keeps a second filesystem seam for `glob` permanently;
+So under B the repo keeps a second filesystem seam for `glob` in practice;
 under A the seam is closable for the five async callers and stays only for
 the three synchronous ones.
 
@@ -265,9 +277,17 @@ And Effect's own `glob` is not a route for any of the eight: its signature is
 
 So the honest summary: **under candidate A the five async importers can be
 adapted onto the port and only the three `globSync` callers keep separate
-wiring; under candidate B all eight keep it**, because Effect's `FileSystem`
-offers no `lstat` in either form. The second seam is a cost B carries and A
-mostly does not.
+wiring; under candidate B all eight keep it in practice**.
+
+B is not _categorically_ excluded from the five. `path-scurry` needs
+`promises.lstat`, and an adapter could synthesise one from the
+`readLink`-plus-`stat` probe described in §2. But that probe rests on an errno
+tag which does not isolate `EINVAL`, so an unrelated failure reads as "not a
+symlink"; and it adds a second syscall per entry to a traversal already paying
+one. That buys a unified seam at the price of a symlink test that is silently
+wrong under unrelated failures — a worse trade than keeping separate wiring.
+So the note prescribes separate wiring for B on cost, not on impossibility.
+The second seam is a cost B carries and A mostly does not.
 
 ### A method note, because the obvious experiment was run wrong once
 
@@ -354,12 +374,12 @@ test files that would each need a fiber, a scope and a drain to observe what
 a callback observes today.
 
 That is the argument against B4, and it is an economic one: 16 files of
-churn, mostly tests, plus the six behavioural properties below, against the
+churn, mostly tests, plus the seven behavioural properties below, against the
 listener machinery being replaced — the `subscribers` field (`:47`),
 `subscribe` (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a
 217-line class that does much else besides. Not impossibility — price.
 
-Beyond construction, six behavioural properties a replacement must reproduce.
+Beyond construction, seven behavioural properties a replacement must reproduce.
 An earlier revision listed the first two as objections that "survive even an
 unbounded hub"; review showed that overstates them, and the corrected form is
 below.
@@ -479,13 +499,27 @@ below.
    events at whole-run disposal; this is about ending one subscription early,
    mid-run.
 
-**None of these six rejects `PubSub`.** They are the contract a replacement
+7. **The handover cap counts in the subscriber callback, so async delivery
+   breaks its bound.** `sessions.ts:403-411` does
+   `if (!reading && (buffered += 1) > TRACE_HANDOVER_EVENTS)` **inside** the
+   subscribed callback, then `Queue.offerUnsafe`. Because `emit` is
+   synchronous today, that counter moves in lockstep with emission and the cap
+   fires at exactly 512. Under a hub the subscriber is a fiber taking from a
+   queue: a run emitting faster than the fiber drains accumulates arbitrarily
+   many events in the hub before `buffered` reaches the threshold, so the
+   bound this safeguard exists to enforce is already exceeded when it fires.
+   Property 6's synchronous detach does not rescue it either — the backlog
+   accrued before detachment began. A replacement needs an **enqueue-time**
+   per-subscription bound, or synchronous accounting for this sink.
+
+**None of these seven rejects `PubSub`.** They are the contract a replacement
 has to reproduce: bounded-vs-unbounded chosen deliberately, per-handler
 failures **caught and reported** (isolation alone silently consumes them),
 the subscription acquired before the first emit, **every published event's
 handler acknowledged** before disposal (an empty queue is not that), each
 event stage-stamped on the way in, and detachment stopping delivery before it
-returns. Together with the subscription and lifecycle work above — but not
+returns, and the handover cap enforced at enqueue rather than in the handler.
+Together with the subscription and lifecycle work above — but not
 the constructor sites, which can build their own hub — that is the real size
 of B4, and the reason not to do it is that size, not impossibility.
 

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -183,7 +183,13 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
   So the cost is a correctness rewrite of each walker, on top of the syscall
   cost.
 
-- No `ctime` on `File.Info`.
+- No `ctime` on `File.Info` — **a cost for candidate A only**, and arguably
+  not one at all. A repo-wide search finds `ctime` in the `FileStat`
+  declaration (`interfaces.ts:91`), the Node provider that populates it
+  (`nodeFilesystem.ts:26`), and test fakes satisfying the type. **No
+  production code reads it.** Candidate B deletes the port and so need not
+  emulate it; candidate A keeps supplying a field nobody consumes. Listing
+  this as a gap charged B for preserving dead weight.
 - `mtime` is `Option<Date>`. The natural `none → 0` default makes
   `cleanupOldFiles` delete files it should keep.
 - No `dereference` on `copy`.
@@ -456,10 +462,18 @@ built deliberately.
 **Two costs that no issue currently names:**
 
 1. `Workflow.withCompensation` — listed on #12081 as a reason to adopt — is
-   documented as registering finalizers "only for top-level effects in the
-   workflow" that "do not work for nested activities". The one framework
-   mechanism for ambiguous external effects is unavailable at exactly the
-   boundary model and tool calls would sit on.
+   **rollback for failures the live workflow observes, not protection against
+   abrupt process loss.** It registers finalizers "only for top-level effects
+   in the workflow" that "do not work for nested activities", so it is
+   unavailable at exactly the boundary model and tool calls would sit on. But
+   nesting is not the reason it cannot close the crash window: when a side
+   effect succeeds and the process dies before the result is memoized, **no
+   finalizer runs at all**, top-level or otherwise. Replay then meets an
+   ambiguous incomplete attempt and may repeat the side effect. An earlier
+   revision framed this as compensation being unavailable where it is needed;
+   the accurate framing is that compensation is the wrong tool for this
+   window, and the crash boundary needs **idempotent side effects or durable
+   deduplication** instead.
 2. `Activity`'s default `interruptRetryPolicy` re-runs an interrupted activity
    **up to 10 times, then dies** (`Activity.js:62-66`). Overridable per
    activity, but the default is backwards for a codebase whose cancellation is
@@ -518,7 +532,9 @@ read and write able to fail — malformed JSON, permissions, a full disk — and
 no error channel, an implementer's default is `Effect.orDie`, which converts
 ordinary recoverable storage failures into defects outside TeXRA's normal
 reporting path. Adoption must therefore say which operations can map a
-failure onto `Suspended` (where retrying later is the honest answer) and
+failure onto `Suspended` (where retrying later is the honest answer — though
+see below: `Suspended` must not become the answer for an incomplete attempt
+marker, or the activity parks on every replay) and
 where an outer, typed engine boundary has to surface the rest. That decision
 is not expressible inside the interface and so belongs in the adoption plan.
 
@@ -542,6 +558,19 @@ as generated output in **both** the agent-facing `/executions/{id}/files`
 listing and the CLI's history listing. The recommendation is therefore: give
 the engine an owned key prefix and register it in `isKVFile`, exactly as
 `persistedFlow` does.
+
+**The memo key collides across repeated invocations in one live workflow.**
+The key is `` `${executionId}/${activity.name}/${attempt}` ``
+(`WorkflowEngine.js:347`) and `CurrentAttempt` defaults to 1, advancing only
+under `Activity.retry`. So invoking one named `Activity` **twice in the same
+workflow** — without `Activity.retry` between them — produces the same key
+both times, and the second call returns the first's stored exit without
+executing. This is not the restart case below; it happens in a single live
+process. TeXRA's runs are repeated model and tool calls, so a generic
+activity wrapper needs a deterministic per-invocation identity in the name
+(a step index, a call ordinal), or the adoption plan has to guarantee each
+activity name occurs at most once per workflow. Neither is free, and nothing
+in the interface surfaces the hazard.
 
 **Settled: `Activity.CurrentAttempt` is in-memory, and that is deliberate —
 it is how replay works, not a collision.** `Activity.js:75` is
@@ -571,7 +600,14 @@ The real requirements are narrower and different:
   (`WorkflowEngine.js:356-360`) and falls through to execute when it finds
   one. `layerMemory` makes that moot, but a durable engine persisting the row
   must distinguish an attempt orphaned by a crash — safe to re-run — from one
-  a live process is still executing. Nothing in the interface expresses that.
+  a live process is still executing. Nothing in the interface expresses that,
+  and the distinction cannot be made by suspending: mapping every
+  start-without-completion to `Suspended` parks the activity on every replay,
+  since the marker stays incomplete and the next resume meets the same state.
+  What is needed is an **ownership or lease transition** — a live marker
+  suspends, a stale one is claimed and executed. The repo already has that
+  shape in `executionLease.ts`, which is the natural place to look rather
+  than inventing one.
 - **The interrupt-retry schedule is non-durable state, and it is a different
   counter from `CurrentAttempt`.** `makeExecute` — which reads
   `CurrentAttempt` and performs the memo lookup — wraps `executeWithoutInterrupt`

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -18,6 +18,19 @@ Claims marked **[reproduced]** were independently re-derived by a second agent
 or by hand after the run. Unmarked claims come from a single pass and should be
 re-checked before anything depends on them.
 
+**How to read every count in this note.** Each one is a **count of direct
+references** — files that name a symbol, call a function, or import a module —
+and **never includes transitive callers, factory chains, or the boundaries a
+change propagates to**. That is stated once here because it has been the single
+most repeated defect in this document: three separate corrections
+(call sites omitting the file being replaced, seam files omitting factory
+callers, leaf mentions omitting the host boundaries above them) were each fixed
+as an instance rather than as a habit. Where a fan-out has actually been
+followed, the note says so and names the files. **Everywhere else, treat a
+number as a floor whose distance from the truth is unknown**, and note that
+R-1 is the only place this was measured end to end: one converted leaf touched
+17 files.
+
 ## 1. Corrections to open issues
 
 These are the load-bearing ones. Each was asserted somewhere and is wrong.

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -75,11 +75,22 @@ own `FileSystem` service that the issue does not currently name.
 
 **The errno taxonomy is lossy.** `SystemErrorTag` has 11 members and contains
 **none** of `ENOTEMPTY`, `ENOTDIR`, `EISDIR`, `EINVAL`, `ENOSPC`, and
-`PlatformError` exposes no top-level `.code`. The four predicates in
-`src/common/errors/errorPredicates.ts`, plus the `ENOTEMPTY` branch at
-`src/agent/storage/executionLease.ts:477`, all read **false** against a raw
-`PlatformError`. A written errno mapping is a prerequisite for any code motion,
-not a follow-up.
+`PlatformError` exposes no top-level `.code`.
+
+`src/common/errors/errorPredicates.ts` holds **five** code-reading predicates,
+and the split between them is the useful part. Four read the top-level `.code`
+— `isFileNotFoundError` (`:2`), `isFileExistsError` (`:8`),
+`isNotADirectoryError` (`:14`), `isModuleNotFoundError` (`:19`) — and all four,
+along with the `ENOTEMPTY` branch at `src/agent/storage/executionLease.ts:477`,
+read **false** against a raw `PlatformError`. The fifth, `isDiskFullError`
+(`:57`), walks `causeChain(err)` instead, so it still finds `ENOSPC` on a
+wrapped cause.
+
+That fifth one is the shape the other four would need. `jsonStore.ts` already
+demonstrates the alternative at a boundary — unwrapping `error.reason.cause`
+back to the Node error identity its callers match. Either every predicate walks
+the chain, or every boundary unwraps; a written errno mapping that says which is
+a prerequisite for any code motion, not a follow-up.
 
 **`remove`'s contract is ambiguous exactly where the repo depends on it.** One
 `remove` covers both unlink and rmdir, and the interface never says which a

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -263,9 +263,11 @@ And Effect's own `glob` is not a route for any of the eight: its signature is
 `(pattern, {root?, exclude?})` and accepts none of the
 `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` options these callers pass.
 
-So the honest summary is that `glob` stays on its own filesystem wiring under
-either candidate. Under A that is unremarkable — the port is already separate
-from `glob`. Under B it is a second seam that adoption does not remove.
+So the honest summary: **under candidate A the five async importers can be
+adapted onto the port and only the three `globSync` callers keep separate
+wiring; under candidate B all eight keep it**, because Effect's `FileSystem`
+offers no `lstat` in either form. The second seam is a cost B carries and A
+mostly does not.
 
 ### A method note, because the obvious experiment was run wrong once
 
@@ -327,28 +329,31 @@ Review pointed out that the handler-construction path is reached from inside an
 `Effect.tryPromise` around `createModelHandler` — so a caller can yield
 `PubSub.unbounded()` there and pass the hub into the synchronous constructor.
 What the constructor forbids is a **drop-in field initializer**; it does not
-forbid replacing `TraceEmitter`. The honest characterisation is construction
-and injection work: threading a hub through `createModelHandler`'s `async`
-signature and into every construction site.
+forbid replacing `TraceEmitter`. And since the hub can be built in place (see
+above), threading one through `createModelHandler`'s `async` signature is not
+required either — an earlier revision prescribed that, and it is withdrawn.
 
-So nothing here is impossible. What remains is the size of the job. **26
-files** touch the seam: 19 construct `new TraceEmitter()`, 14 call
-`.subscribe(...)` on a trace, logger or emitter, and 7 do both.
+So nothing here is impossible. What remains is the size of the job, and it is
+smaller than earlier revisions of this note claimed. 26 files touch the seam
+in total, but **10 of them only construct** a `TraceEmitter` — and a
+constructor that builds its own hub leaves those unchanged. The migration
+surface is the **16 files that subscribe**, directly or through
+`attachChannelSubscriber`.
 
-This figure moved twice under review — "roughly sixteen" was an estimate, and
-a recount that reported 24 used too narrow a subscription pattern. Treat it
-as measured at this tree, not as authoritative.
+This figure has moved three times: "roughly sixteen" estimated, 24 from too
+narrow a grep, 26 counted as the union, and now 16 once constructor sites fall
+out. Treat it as measured at this tree, not as authoritative.
 
-The composition matters more than the total, and cuts both ways. **5 of the
-26 are production** — `packages/agent/src/effect/sessions.ts`,
-`ModelHandler.ts`, `SessionHandle.ts`, `channelTrace.ts`, `runTrace.ts` — and
-the other 21 are test-kernel, most passing a plain synchronous callback to
-`trace.subscribe` and reading events out of a local array on the next line.
-So the production blast radius is small, and the cost is concentrated in
-rewriting tests that would each need a fiber, a scope and a drain to observe
-what a callback observes today.
+The composition matters more than the total. **5 of the 16 are production** —
+`packages/agent/src/effect/sessions.ts`, `ModelHandler.ts`,
+`SessionHandle.ts`, `channelTrace.ts`, `runTrace.ts` — and the other 11 are
+test-kernel, most passing a plain synchronous callback to `trace.subscribe`
+and reading events out of a local array on the next line. So the production
+blast radius is five files, and the cost is concentrated in rewriting eleven
+test files that would each need a fiber, a scope and a drain to observe what
+a callback observes today.
 
-That is the argument against B4, and it is an economic one: 26 files of
+That is the argument against B4, and it is an economic one: 16 files of
 churn, mostly tests, plus the six behavioural properties below, against the
 listener machinery being replaced — the `subscribers` field (`:47`),
 `subscribe` (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a
@@ -475,11 +480,14 @@ below.
    mid-run.
 
 **None of these six rejects `PubSub`.** They are the contract a replacement
-has to reproduce: bounded-vs-unbounded chosen deliberately, per-handler fault
-isolation added explicitly, the subscription acquired before the first emit,
-its queue drained before disposal, each event stage-stamped on the way in,
-and detachment stopping delivery before it returns. Together with the injection work above, that is the real size of B4 —
-and the reason not to do it is that size, not impossibility.
+has to reproduce: bounded-vs-unbounded chosen deliberately, per-handler
+failures **caught and reported** (isolation alone silently consumes them),
+the subscription acquired before the first emit, **every published event's
+handler acknowledged** before disposal (an empty queue is not that), each
+event stage-stamped on the way in, and detachment stopping delivery before it
+returns. Together with the subscription and lifecycle work above — but not
+the constructor sites, which can build their own hub — that is the real size
+of B4, and the reason not to do it is that size, not impossibility.
 
 ### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
 
@@ -658,7 +666,7 @@ failure onto `Suspended` and
 where an outer, typed engine boundary has to surface the rest. That decision
 is not expressible inside the interface and so belongs in the adoption plan.
 
-**Classify by cause, not by operation.** Grouping malformed JSON with
+**Classify by cause _and_ by phase.** Grouping malformed JSON with
 permission and disk failures and then deciding per operation gets it wrong in
 both directions. A corrupt persisted row is _present state_, not a transient
 condition: every resume reads the same bytes and parks again, so suspending

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -146,14 +146,21 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
 **Six further gaps:**
 
 - No `lstat` at all. `isSymlink` would need a `readLink`-plus-errno probe:
-  call `readLink`, read success as "symlink" and `EINVAL` as "not one". An
-  earlier revision called that "the silent-degradation shape CLAUDE.md
-  forbids", which overstates it — this is error-as-control-flow, not a masked
-  failure. The real objection is narrower and worse: **`SystemErrorTag` has no
-  `EINVAL` member** (above), so the probe must read whatever lossy tag a layer
-  maps it to — `InvalidData` in a hand-written one — and that tag covers more
-  than `EINVAL`. An unrelated failure then reads as "not a symlink": a wrong
-  answer rather than a loud one.
+  call `readLink`, read success as "symlink" and `EINVAL` as "not one". Two
+  successive revisions overcharged this. The first called it "the
+  silent-degradation shape CLAUDE.md forbids", which overstates it — this is
+  error-as-control-flow, not a masked failure. The second said **`SystemErrorTag`
+  has no `EINVAL` member** (above) and concluded the probe must therefore read a
+  lossy tag, so an unrelated failure reads as "not a symlink". The tag fact is
+  true; the conclusion does not follow, and **§2 above disproves it**:
+  `PlatformError` preserves the Node error at `reason.cause`, which is exactly
+  how `isDiskFullError` recovers ENOSPC and how `spawnFailure`
+  (`leanServer.ts:168`) recovers an error identity the tags never carried. An
+  adapter reads `EINVAL` off the preserved cause the same way and propagates
+  every other failure loudly. So the probe is **correct but expensive**: the
+  cost is one extra syscall per entry on a traversal already paying one, plus
+  a dependency on `reason.cause` surviving whichever layer produces the error.
+  Not a correctness objection.
 - **`readDirectory` returns `Array<string>`, not `[name, type]`.** The port
   reads each entry's type off the `withFileTypes` dirent for free; Effect's
   shape forces a `stat` per entry. This is load-bearing, not tuple
@@ -218,12 +225,14 @@ it defaults `remove` to `Effect.void` and `exists` to `false`.
 **Eight production modules bypass the port entirely**, so a memfs-backed port
 does not control their inputs. The hole is closable for testing by handing
 `glob` a memfs instance directly. For real wiring the candidates differ:
-**candidate A can serve the five async importers, candidate B none of the
-eight** in practice — so B keeps a second filesystem seam here (below; a
-`readLink`-based adapter exists in principle and is a bad trade). This paragraph has been wrong four times in four
-directions: two importers, then unclosable, then independent of R-1, then
-requiring synchronous methods — and its summary twice survived a correction to
-its body. Treat its claims as the least reliable in this note.
+**candidate A can serve the five async importers directly; candidate B can
+serve them only through an adapter** that costs one extra syscall per entry
+(below). Only the three `globSync` callers are closed to both. This paragraph
+has been wrong five times in five directions: two importers, then unclosable,
+then independent of R-1, then requiring synchronous methods, then B excluded on
+a correctness objection this note's own §2 disproves — and its summary twice
+survived a correction to its body. Treat its claims as the least reliable in
+this note.
 The full set of `glob`-package importers outside the test kernel is
 `src/agent/index/agentYamlScanner.ts`, `src/tools/glob.ts`,
 `src/tools/approval/latexPreview.ts`, `src/latex/formatter/latexindentpt.ts`,
@@ -233,8 +242,8 @@ The full set of `glob`-package importers outside the test kernel is
 glob discovery with `WorkspaceFS` operations, so a memfs-backed port does not
 control their inputs today.
 
-**All eight are closable for testing with memfs; candidate A can serve five
-of them for real, candidate B none.**
+**All eight are closable for testing with memfs; five of them are servable for
+real by either candidate, A directly and B through an adapter.**
 The pinned `glob@13.0.6` takes an `fs?: FSOption` — "an fs implementation to
 override some or all of the defaults" (`glob.d.ts:231-234`) — while keeping
 the `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` behaviour these callers
@@ -253,18 +262,19 @@ traversal actually calls. So:
   as Node `Stats`. An earlier revision of this paragraph said `FSOption`
   requires synchronous methods and so overcharged A; it does not, for the
   async path.
-- **Candidate B can serve none of them in practice.** Not because of sync —
-  because `path-scurry` wants **`lstat`**, at `:900` and `:705`, and Effect's
-  `FileSystem` has none. An adapter could synthesise one from the
-  `readLink`-plus-`stat` probe above, so this is a cost rather than a wall;
-  but that probe misreads unrelated failures as "not a symlink" and adds a
-  syscall per entry, which is a poor trade for a unified seam. The three
+- **Candidate B can serve the same five, but only through an adapter.**
+  `path-scurry` wants **`lstat`**, at `:900` and `:705`, and Effect's
+  `FileSystem` has none — so B must synthesise one from the
+  `readLink`-plus-`stat` probe above. An earlier revision called that probe
+  incorrect under unrelated failures; §2 now records why that was wrong (the
+  errno survives on `reason.cause`). What is left is real but only a price:
+  a second syscall per entry on a traversal already paying one. The three
   `globSync` callers additionally need the synchronous set, which Effect also
   lacks — and there no adapter exists at all.
 
-So under B the repo keeps a second filesystem seam for `glob` in practice;
-under A the seam is closable for the five async callers and stays only for
-the three synchronous ones.
+So under both candidates the seam closes for the five async callers and stays
+for the three synchronous ones; B pays an extra syscall per entry that A does
+not.
 
 **Three of the eight are synchronous**, which compounds it:
 `latexPreview.ts:78`, `latexindentpt.ts:49` and `platformPaths.ts:47` call
@@ -275,19 +285,18 @@ And Effect's own `glob` is not a route for any of the eight: its signature is
 `(pattern, {root?, exclude?})` and accepts none of the
 `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` options these callers pass.
 
-So the honest summary: **under candidate A the five async importers can be
+So the honest summary: **under either candidate the five async importers can be
 adapted onto the port and only the three `globSync` callers keep separate
-wiring; under candidate B all eight keep it in practice**.
+wiring — B pays a per-entry syscall for the privilege, A does not**.
 
-B is not _categorically_ excluded from the five. `path-scurry` needs
-`promises.lstat`, and an adapter could synthesise one from the
-`readLink`-plus-`stat` probe described in §2. But that probe rests on an errno
-tag which does not isolate `EINVAL`, so an unrelated failure reads as "not a
-symlink"; and it adds a second syscall per entry to a traversal already paying
-one. That buys a unified seam at the price of a symlink test that is silently
-wrong under unrelated failures — a worse trade than keeping separate wiring.
-So the note prescribes separate wiring for B on cost, not on impossibility.
-The second seam is a cost B carries and A mostly does not.
+This is the third time this section has moved toward B, each time by removing
+an objection I had raised rather than by finding a new capability: first sync
+was not required for the async path, then the tag gap was not a correctness
+problem. What survives is a throughput cost, which is measurable and which R-1
+already measured on a different traversal (~8× on 3,096 files, dominated by
+exactly this per-entry `stat`). Whether that verdict transfers to `glob`'s
+workload is untested here. The note prescribes nothing about `glob` beyond
+that measurement being the thing to run.
 
 ### A method note, because the obvious experiment was run wrong once
 
@@ -374,12 +383,12 @@ test files that would each need a fiber, a scope and a drain to observe what
 a callback observes today.
 
 That is the argument against B4, and it is an economic one: 16 files of
-churn, mostly tests, plus the seven behavioural properties below, against the
+churn, mostly tests, plus the eight behavioural properties below, against the
 listener machinery being replaced — the `subscribers` field (`:47`),
 `subscribe` (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a
 217-line class that does much else besides. Not impossibility — price.
 
-Beyond construction, seven behavioural properties a replacement must reproduce.
+Beyond construction, eight behavioural properties a replacement must reproduce.
 An earlier revision listed the first two as objections that "survive even an
 unbounded hub"; review showed that overstates them, and the corrected form is
 below.
@@ -512,13 +521,35 @@ below.
    accrued before detachment began. A replacement needs an **enqueue-time**
    per-subscription bound, or synchronous accounting for this sink.
 
-**None of these seven rejects `PubSub`.** They are the contract a replacement
+8. **Ordering holds across two publication planes, and one lifecycle comment
+   depends on it.** The seven above are all within-plane; this one is not, and
+   no per-subscriber FIFO supplies it. `AgentRunLifecycle.ts:656-661` emits
+   `run.config` through `ctx.logger` — the trace plane — and `:670` then calls
+   `transitionRunStart(ctx)`, which publishes `RUNNING` through
+   `StreamStatusMachine` (`:336-348`, `session.status.transition`). Two
+   different publishers, and the comment at `:651-655` states the requirement
+   in as many words: publish the config first "so progress backends can create
+   the initial `StreamExecutionState` with the real category when the
+   transition-owned run-start side effects fire". Synchronous `emit` makes the
+   ordering free — the config has reached every subscriber before `emit`
+   returns. Under a hub, `emit` returns once the event is published, so
+   `RUNNING` can be transitioned while `run.config` is still queued, and a
+   progress backend builds its initial state with the wrong category. A
+   replacement needs a cross-plane barrier, or both facts routed through one
+   ordered path. **Note the shape**: this is the second finding in two rounds
+   where synchronous `emit` was silently supplying an ordering guarantee that
+   nothing declares. Assume there are more, and that a grep for `emit`
+   followed by a non-`emit` publish on the next few lines is the way to find
+   them, not reasoning about the contract.
+
+**None of these eight rejects `PubSub`.** They are the contract a replacement
 has to reproduce: bounded-vs-unbounded chosen deliberately, per-handler
 failures **caught and reported** (isolation alone silently consumes them),
 the subscription acquired before the first emit, **every published event's
 handler acknowledged** before disposal (an empty queue is not that), each
-event stage-stamped on the way in, and detachment stopping delivery before it
-returns, and the handover cap enforced at enqueue rather than in the handler.
+event stage-stamped on the way in, detachment stopping delivery before it
+returns, the handover cap enforced at enqueue rather than in the handler, and
+ordering preserved against the separate status plane.
 Together with the subscription and lifecycle work above — but not
 the constructor sites, which can build their own hub — that is the real size
 of B4, and the reason not to do it is that size, not impossibility.
@@ -725,6 +756,19 @@ either.
 header documents it as generic read/write for arbitrary keys, and
 `src/agent/node/persistedFlow.ts` already stores arbitrary `flow_<runId>`
 records there — not in the closed `SessionEventDraftSchema` vocabulary.
+
+**That store validates nothing, so "route storage errors to a typed failure"
+does not cover the corruption that matters.** `KVStore.read<T>`
+(`src/common/storage/KVStore.ts:55-62`) is `JSON.parse(raw) as T` — an
+unchecked cast. A missing file and unparseable JSON both fail loudly, but a
+row that is _valid JSON of the wrong shape_ — the shape contract drift
+actually produces — is returned as if it were a `T`, and the engine consumes
+it as runnable workflow state. Whatever the adoption does about storage
+failures, the marker, ownership and completion records need a runtime schema
+parsed at this boundary; the repo's own rule already says so, and says which
+way to fail (`.catch(default)` on persisted data is the anti-pattern, not the
+fix). This is the storage-side twin of the `mtime` `Option` hazard in §2: the
+loss is not the read failing, it is the read succeeding with something wrong.
 
 **But an arbitrary key is not automatically internal metadata, and the
 `flow_` precedent is precisely what shows the missing half.** `isKVFile`

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -290,13 +290,14 @@ traversal actually calls. So:
   same structural cost this note found for the hub constructor, in a second
   place.
 
-  **Generalise it, because two independent instances is a pattern and not a
+  **Generalise it, because three independent instances is a pattern and not a
   coincidence.** Anywhere candidate B meets a synchronous or Promise-shaped
   third-party contract — `path-scurry`'s `FSOption`, a class constructor, any
   callback API that must return a value rather than an `Effect` — the
   Effect-to-Promise bridge **is a `run` site**, and the ratchet decides whether
-  it may live where the consumer lives. Both instances found so far were found
-  by accident, while pricing something else. The cost is not "two places"; it
+  it may live where the consumer lives. The three instances found so far —
+  hub construction, the `glob` adapter, and the synchronous `subscribe` facade
+  (below) — were all found by accident, while pricing something else. The cost is not "two places"; it
   is one systematic cost of candidate B whose extent nobody has measured. A
   grep for B's prospective consumers against the boundary kinds is the
   measurement, and it has not been run. The three `globSync` callers additionally need the synchronous set,
@@ -491,11 +492,25 @@ test-kernel, most passing a plain synchronous callback to `trace.subscribe`
 and reading events out of a local array on the next line. So the production
 blast radius is six files.
 
+**The synchronous `subscribe` facade is itself a third run-boundary site, and
+this note had the fact 116 lines earlier without applying it.** `:382` records
+that `PubSub.subscribe` returns `Effect<Subscription<A>, never, Scope>`
+(`PubSub.d.ts:1143`). Keeping `TraceEmitter.subscribe` synchronous therefore
+means acquiring that scoped subscription and starting its consumer fiber
+**inside `TraceEmitter.ts`** — a third `Effect.run*` below the boundary, which
+`check-effect-migration-ratchet.mjs:1175-1188` rejects exactly as it rejects
+hub construction there. So B4-hub must also inject a boundary-owned
+subscription manager or runtime, or make subscription acquisition effectful
+and propagate that through every subscriber — **another injection chain the
+27 does not count**. This is the third instance of the run-boundary rule
+stated above, and the second time the note has held both halves of a fact in
+separate sections without joining them.
+
 **The eleven test files are cheaper than an earlier revision charged them.**
 That revision said each would need "a fiber, a scope and a drain". It would
-not: if `TraceEmitter.subscribe` stays a synchronous facade — which it must
-anyway, for properties 3 and 6 — the adapter owns each subscription's fiber
-and scope internally and exposes one drain barrier. What each test then needs
+not: if `TraceEmitter.subscribe` stays a synchronous facade — possible only
+with the injected runtime just described — the adapter owns each
+subscription's fiber and scope internally and exposes one drain barrier. What each test then needs
 is to _await that barrier_ before asserting on its array, not to build the
 machinery itself. Price the assertion and lifecycle change; charging every
 subscriber file for adapter-owned infrastructure inflates the case against
@@ -538,13 +553,30 @@ below.
    `PubSub.publish` on the process runtime — `effectRuntime().runFork(...)`,
    the pattern `SessionHandle.ts:679` already uses from a synchronous method.
    On a full bounded hub that fiber **waits** instead of dropping, which
-   removes the cross-subscriber loss entirely. The cost moves rather than
-   vanishing: those fibers become lifetime the adapter must track and join at
-   disposal, which is property 4 again. So bounded-with-backpressure is a
-   third option beside bounded-with-drops and unbounded-with-growth, and B4's
-   trade-off should be stated over all three. What replaces it under
-   an unbounded hub is not event loss but unbounded memory growth behind the
-   slowest subscriber — a different, arguably worse, failure for a long run.
+   removes the cross-subscriber loss.
+
+   **But calling that "backpressure" is wrong, and an earlier revision of this
+   paragraph did.** `runFork` suspends the _new fiber_; the synchronous `emit`
+   caller returns immediately and is free to emit again. Nothing propagates
+   back to the producer, so a slow subscriber does not slow the run down — it
+   accumulates **one suspended fiber per event, each retaining its event**.
+   The hub stays bounded and the memory growth simply moves outside it, which
+   is the unbounded-growth failure this option was supposed to avoid, now
+   harder to see. Property 4 (joining those fibers at disposal) is a real cost
+   on top, but it is not the main one.
+
+   So the third option is honestly named **bounded-hub-with-unbounded-pending-
+   publishers**, and it is only viable with an admission bound on pending
+   publishers — a cap with an explicit drop or block policy — or by making
+   publication awaitable, which `emit`'s `void` signature forbids without
+   changing every caller. B4's trade-off should be stated over all three, with
+   this one carrying its actual cost rather than the word "backpressure".
+
+   What replaces cross-subscriber loss under an _unbounded_ hub is not event
+   loss but unbounded memory growth behind the slowest subscriber — a
+   different, arguably worse, failure for a long run. Note that the
+   `runFork` option above collapses to the same failure by another path,
+   which is the point of renaming it.
    **And the "today they are independent" half was also wrong.**
    `TraceEmitter.emit` fans out in a synchronous sequential `for...of`
    (`src/agent/trace/TraceEmitter.ts:78-93`), so a slow or non-returning
@@ -927,15 +959,24 @@ records there — not in the closed `SessionEventDraftSchema` vocabulary.
 **That store validates nothing, so "route storage errors to a typed failure"
 does not cover the corruption that matters.** `KVStore.read<T>`
 (`src/common/storage/KVStore.ts:55-62`) is `JSON.parse(raw) as T` — an
-unchecked cast. A missing file and unparseable JSON both fail loudly, but a
-row that is _valid JSON of the wrong shape_ — the shape contract drift
-actually produces — is returned as if it were a `T`, and the engine consumes
-it as runnable workflow state. Whatever the adoption does about storage
-failures, the marker, ownership and completion records need a runtime schema
-parsed at this boundary; the repo's own rule already says so, and says which
-way to fail (`.catch(default)` on persisted data is the anti-pattern, not the
-fix). This is the storage-side twin of the `mtime` `Option` hazard in §2: the
-loss is not the read failing, it is the read succeeding with something wrong.
+unchecked cast. Three cases, and an earlier revision collapsed the first two:
+
+- **Missing is normal absence, not a failure.** `withMissingFallback` maps
+  `ENOENT` to `undefined`, and for a workflow executing a new activity the
+  memo row is _expected_ to be absent — that is the signal to run it. An
+  earlier revision said a missing file "fails loudly", which is both wrong and
+  dangerous in the opposite direction from the rest of this section: an
+  adoption that treats absence as corruption rejects every legitimate first
+  execution.
+- **Unparseable JSON does fail loudly.** `JSON.parse` throws.
+- **Valid JSON of the wrong shape does not fail at all** — the shape contract
+  drift actually produces — and is returned as if it were a `T`, so the engine
+  consumes it as runnable workflow state. Whatever the adoption does about storage
+  failures, the marker, ownership and completion records need a runtime schema
+  parsed at this boundary; the repo's own rule already says so, and says which
+  way to fail (`.catch(default)` on persisted data is the anti-pattern, not the
+  fix). This is the storage-side twin of the `mtime` `Option` hazard in §2: the
+  loss is not the read failing, it is the read succeeding with something wrong.
 
 **But an arbitrary key is not automatically internal metadata, and the
 `flow_` precedent is precisely what shows the missing half.** `isKVFile`

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -180,6 +180,16 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
   execution directory. This is a containment property, not a listing
   nicety, and it means the `lstat` gap reaches code that never calls
   `readDirectory` at all.
+
+  A second member of the same category writes rather than reads.
+  `XmlOutputManager.ts:47` guards `writeRoundOutput` with
+  `AbsoluteFS.isSymbolicLink` — `stat().type` plus `isSymlink`
+  (`baseFS.ts:223-228`) — and deletes a pre-staged symlink before writing.
+  Its comment says why: "so the write never follows the link into the
+  immutable snapshot". Under link-following `stat` the guard returns false,
+  the delete is skipped, and the write goes **through** the link into the
+  snapshot it exists to protect. So in this path the `lstat` gap is not a
+  weakened check but silent corruption of immutable state.
   So the cost is a correctness rewrite of each walker, on top of the syscall
   cost.
 
@@ -215,8 +225,8 @@ The full set of `glob`-package importers outside the test kernel is
 glob discovery with `WorkspaceFS` operations, so a memfs-backed port does not
 control their inputs today.
 
-**Five of the eight are closable without R-1, and an earlier revision wrongly
-said none were.**
+**All eight are closable for testing without R-1 — but none can use the R-1
+winner.**
 The pinned `glob@13.0.6` takes an `fs?: FSOption` — "an fs implementation to
 override some or all of the defaults" (`glob.d.ts:231-234`) — while keeping
 the `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` behaviour these callers
@@ -312,12 +322,12 @@ rewriting tests that would each need a fiber, a scope and a drain to observe
 what a callback observes today.
 
 That is the argument against B4, and it is an economic one: 26 files of
-churn, mostly tests, plus the five behavioural properties below, against the
+churn, mostly tests, plus the six behavioural properties below, against the
 listener machinery being replaced — the `subscribers` field (`:47`),
 `subscribe` (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a
 217-line class that does much else besides. Not impossibility — price.
 
-Beyond construction, five behavioural properties a replacement must reproduce.
+Beyond construction, six behavioural properties a replacement must reproduce.
 An earlier revision listed the first two as objections that "survive even an
 unbounded hub"; review showed that overstates them, and the corrected form is
 below.
@@ -409,11 +419,25 @@ below.
    misgrouped transcript entries. The adapter must hold the per-trace stage
    context and stamp before publishing.
 
-**None of these five rejects `PubSub`.** They are the contract a replacement
+6. **Detachment is synchronous too, and mid-run.** The inverse of property 3,
+   and not covered by property 4. `packages/agent/src/effect/sessions.ts`
+   holds `release()` — `detach?.(); detach = undefined;` — a plain `void`
+   function called while the run continues: by the reader's close, and by the
+   `TRACE_HANDOVER_EVENTS` cap at `:404` when nobody is reading. Both rely on
+   delivery having **stopped** by the time it returns. A hub adapter whose
+   detach merely begins an effectful scope close can keep offering events to a
+   consumer fiber that has not yet stopped, which defeats the bounded-handover
+   safeguard exactly when it matters — an unread run buffering past its cap.
+   Detach must establish a stop-delivery barrier before returning, or the
+   lifecycle must become asynchronous and await one. Property 4 drains tail
+   events at whole-run disposal; this is about ending one subscription early,
+   mid-run.
+
+**None of these six rejects `PubSub`.** They are the contract a replacement
 has to reproduce: bounded-vs-unbounded chosen deliberately, per-handler fault
 isolation added explicitly, the subscription acquired before the first emit,
-its queue drained before disposal, and each event stage-stamped on the way
-in. Together with the injection work above, that is the real size of B4 —
+its queue drained before disposal, each event stage-stamped on the way in,
+and detachment stopping delivery before it returns. Together with the injection work above, that is the real size of B4 —
 and the reason not to do it is that size, not impossibility.
 
 ### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
@@ -549,6 +573,21 @@ built deliberately.
 `ClusterWorkflowEngine` in `unstable/cluster`, which brings `Sharding`,
 `Runners`, `RunnerStorage`, `MessageStorage` and `Snowflake`. Not adoptable for
 a single-process desktop application.
+
+**Everything outside an activity replays.** `resume` re-executes the workflow
+body from the top; only activity _exits_ are memoized. So any ordinary effect
+sitting between activities — a session-progress emission, a KV update, a
+filesystem mutation — runs again on every resume, even when every model and
+tool activity short-circuits to its stored result. This is distinct from the
+crash-window discussion below, which is about an activity whose own effect may
+have completed: these are effects that never were activities and replay
+_successfully_, duplicating durable events or repeating mutations.
+
+Adoption therefore has to state that the workflow body is deterministic and
+free of externally visible effects, and inventory which of TeXRA's current
+between-step emissions must either become activities or acquire stable
+deduplication keys. For a run whose progress events are the user-visible
+transcript, that inventory is not small.
 
 **The Effect-Schema boundary can be held, but not by validating inside the
 activity alone.** An `Activity` with `success: Schema.Unknown` round-trips a

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -286,13 +286,26 @@ forbid replacing `TraceEmitter`. The honest characterisation is construction
 and injection work: threading a hub through `createModelHandler`'s `async`
 signature and into every construction site.
 
-So nothing here is impossible. What remains is the size of the job — roughly
-sixteen files, including about ten test call sites that pass plain synchronous
-callbacks to `trace.subscribe` and read events out of a local array
-immediately — against a 29-line listener set that works. That is the argument
-against B4, and it is an economic one.
+So nothing here is impossible. What remains is the size of the job. Counted
+at the measured tree rather than estimated: **24 files** touch the seam — 19
+construct `new TraceEmitter()` and 10 subscribe to a trace or attach a
+channel sink, overlapping to 24. An earlier revision said "roughly sixteen",
+which was an undercount.
 
-Beyond construction, three behavioural properties a replacement must reproduce.
+The composition matters more than the total, and cuts both ways. Only **4 of
+the 24 are production**; the other 20 are test-kernel, most of them passing a
+plain synchronous callback to `trace.subscribe` and reading events out of a
+local array on the next line. So the production blast radius is small, and
+the cost is concentrated in rewriting tests that would each need a fiber, a
+scope and a drain to observe what a callback observes today.
+
+That is the argument against B4, and it is an economic one: 24 files of
+churn, mostly tests, plus the five behavioural properties below, against the
+listener machinery being replaced — the `subscribers` field (`:47`),
+`subscribe` (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a
+217-line class that does much else besides. Not impossibility — price.
+
+Beyond construction, five behavioural properties a replacement must reproduce.
 An earlier revision listed the first two as objections that "survive even an
 unbounded hub"; review showed that overstates them, and the corrected form is
 below.
@@ -457,8 +470,10 @@ does not have.
 `cause`, `Activity.js:130-133` parks the run on it, and
 `WorkflowEngine.js:350-352` deliberately does **not** memoize a `Suspended`
 result. `Workflow.SuspendOnFailure` routes errors there too. A repo-owned
-engine writes its own start marker and maps start-without-completion to
-`Suspended`. The residual hazard is real and is the engine's to solve: on
+engine writes its own start marker, but **must not map every
+start-without-completion to `Suspended`** — that parks the activity on every
+resume, for the reason set out under the storage-error path below. Only a
+_live_ marker suspends; a stale one has to be claimed and re-run. The residual hazard is real and is the engine's to solve: on
 resume a `Suspended` activity re-runs, so double-effect protection must be
 built deliberately.
 

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -250,8 +250,10 @@ the `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` behaviour these callers
 rely on. Supplying memfs **directly** closes the testability hole for all
 eight, since memfs has the synchronous methods `glob` wants.
 
-What does _not_ work — and an earlier revision proposed it — is routing
-`glob` through Effect's `FileSystem`. `FSOption` (`path-scurry`
+What does _not_ work — and an earlier revision proposed it — is passing
+Effect's `FileSystem` **directly** as `FSOption`. Routing `glob` through it
+via an adapter does work, for both candidates; the bullets below price that.
+`FSOption` (`path-scurry`
 `index.d.ts:22-42`) carries both a synchronous set — `lstatSync`,
 `readdirSync`, `readlinkSync`, `realpathSync` — and a `promises` sub-object
 with async `lstat`, `readdir`, `readlink`, `realpath`, which is what the async
@@ -381,16 +383,34 @@ of adopting the storage layer rather than the strategy), threading one through
 `createModelHandler`'s `async` signature is not required either — an earlier
 revision prescribed that, and it is withdrawn.
 
-So nothing here is impossible. What remains is the size of the job, and it is
-smaller than earlier revisions of this note claimed. 26 files touch the seam
-in total, but **10 of them only construct** a `TraceEmitter` — and a
-constructor that builds its own hub leaves those unchanged. The migration
-surface is the **16 files that subscribe**, directly or through
-`attachChannelSubscriber`.
+So nothing here is impossible. What remains is the size of the job — and it is
+**two different sizes, because the construction finding above splits B4 into
+two candidates that earlier revisions of this note quietly averaged.**
 
-This figure has moved three times: "roughly sixteen" estimated, 24 from too
-narrow a grep, 26 counted as the union, and now 16 once constructor sites fall
-out. Treat it as measured at this tree, not as authoritative.
+26 files touch the seam in total, of which **10 only construct** a
+`TraceEmitter` and 16 subscribe (directly or through
+`attachChannelSubscriber`). Whether the 10 count depends on which hub is
+adopted:
+
+- **B4-atomic — 16 files.** `makeAtomicUnbounded` is synchronous, so each
+  constructor builds its own and the 10 are untouched. But this buys the
+  storage layer: no delivery strategy, no subscriber-completion machinery.
+  Most of the eight properties below then have to be re-implemented by hand on
+  top of it, which is approximately what `TraceEmitter` already does.
+- **B4-hub — 26 files.** A real `PubSub` needs `PubSub.make` or
+  `PubSub.unbounded`, both effectful, and `TraceEmitter.ts` cannot run them
+  (not a ratchet boundary kind, and the below-boundary register is not an
+  intake). So the hub is built at an `Effect` boundary and injected, and all
+  10 constructor sites change.
+
+An earlier revision excluded the constructors while pricing the full `PubSub`
+semantics below — combining the cheap route's file count with the expensive
+route's capabilities. That estimate was for a candidate that does not exist.
+
+This figure has moved four times: "roughly sixteen" estimated, 24 from too
+narrow a grep, 26 counted as the union, 16 once constructor sites fell out,
+and now 16 **or** 26 depending on the route. Treat it as measured at this
+tree, not as authoritative.
 
 The composition matters more than the total. **5 of the 16 are production** —
 `packages/agent/src/effect/sessions.ts`, `ModelHandler.ts`,
@@ -410,14 +430,22 @@ subscriber file for adapter-owned infrastructure inflates the case against
 B4, which is the direction this note has now erred in three separate
 places.
 
-That is the argument against B4, and it is an economic one — and it has shrunk
-in every round that examined it, which is worth stating plainly rather than
-restating the conclusion at a smaller number each time: 16 files of
-churn, mostly tests and each cheaper than first charged, plus the eight
-behavioural properties below, against the
-listener machinery being replaced — the `subscribers` field (`:47`),
-`subscribe` (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a
-217-line class that does much else besides. Not impossibility — price.
+That is the argument against B4, and it is an economic one: **16 files of churn
+for B4-atomic or 26 for B4-hub**, mostly tests and each cheaper than first
+charged, plus the eight behavioural properties below, against the listener
+machinery being replaced — the `subscribers` field (`:47`), `subscribe`
+(`:66-68`) and `emit` (`:70-94`), about 29 lines inside a 217-line class that
+does much else besides. Not impossibility — price.
+
+**A previous revision said this cost "has shrunk in every round that examined
+it" and told the reader it had only ever moved one way. That is no longer
+true, and the correction is instructive.** It had shrunk three rounds running,
+each time because an objection of mine failed. Then splitting the estimate by
+construction route moved it back **up** for B4-hub — the route that actually
+delivers the semantics the migration is for. So the earlier trend was not a
+property of B4; it was an artefact of pricing one candidate's file count
+against another candidate's capabilities. Read the two routes separately, and
+distrust any single number offered for "the cost of B4", this note's included.
 
 Beyond construction, eight behavioural properties a replacement must reproduce.
 An earlier revision listed the first two as objections that "survive even an
@@ -581,12 +609,11 @@ handler acknowledged** before disposal (an empty queue is not that), each
 event stage-stamped on the way in, detachment stopping delivery before it
 returns, the handover cap enforced at enqueue rather than in the handler, and
 ordering preserved against the separate status plane.
-Together with the subscription and lifecycle work above — but not
-the constructor sites, which can build their own storage-layer hub without
-tripping the ratchet — that is the real size of B4. The reason not to do it is
-that size, not impossibility. Read that verdict with the trend in mind: the
-size has fallen in each of the last three rounds, every time because an
-objection of mine failed rather than because a new capability appeared.
+Together with the subscription and lifecycle work above, that is the real size
+of B4 — and it is **route-dependent**: the constructor sites stay untouched
+only for B4-atomic, which reproduces these eight properties by hand rather
+than inheriting them. B4-hub inherits them and changes all 26 files. The
+reason not to do it is that size, not impossibility.
 
 ### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
 

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -77,20 +77,35 @@ own `FileSystem` service that the issue does not currently name.
 **none** of `ENOTEMPTY`, `ENOTDIR`, `EISDIR`, `EINVAL`, `ENOSPC`, and
 `PlatformError` exposes no top-level `.code`.
 
-`src/common/errors/errorPredicates.ts` holds **five** code-reading predicates,
-and the split between them is the useful part. Four read the top-level `.code`
-— `isFileNotFoundError` (`:2`), `isFileExistsError` (`:8`),
-`isNotADirectoryError` (`:14`), `isModuleNotFoundError` (`:19`) — and all four,
-along with the `ENOTEMPTY` branch at `src/agent/storage/executionLease.ts:477`,
-read **false** against a raw `PlatformError`. The fifth, `isDiskFullError`
-(`:57`), walks `causeChain(err)` instead, so it still finds `ENOSPC` on a
-wrapped cause.
+`src/common/errors/errorPredicates.ts` exports **five** code-reading predicates,
+but only **four** are filesystem ones. `isModuleNotFoundError` (`:19`) matches
+`ERR_MODULE_NOT_FOUND`/`MODULE_NOT_FOUND`, and its only two consumers
+(`src/tools/claudeAgentImport.ts:50`, `src/tools/codexImport.ts:59`) are
+dynamic-import paths that never receive a filesystem error. It is out of scope
+here and counting it inflates the exposure.
 
-That fifth one is the shape the other four would need. `jsonStore.ts` already
+Of the four filesystem predicates, the split is the useful part:
+
+- **Three read the top-level `.code` and read `false` against a raw
+  `PlatformError`**: `isFileNotFoundError` (`:2`, ENOENT),
+  `isFileExistsError` (`:8`, EEXIST), `isNotADirectoryError` (`:14`, ENOTDIR).
+  The inline `ENOTEMPTY` branch at `src/agent/storage/executionLease.ts:477`
+  is a fourth exposure of the same shape.
+- **`isDiskFullError` (`:57`) already works**, because it walks
+  `causeChain(err)` rather than reading a top-level field. A `PlatformError`
+  whose `cause` carries the underlying Node error still reports ENOSPC
+  correctly.
+
+So the exposure is three predicates plus one inline branch — not five, and
+**ENOSPC is not among them.** The prerequisite claim below should be read as
+scoped to ENOENT/EEXIST/ENOTDIR/ENOTEMPTY; ENOSPC is already recoverable
+through the existing cause-chain path.
+
+`isDiskFullError` is also the shape the other three would need. `jsonStore.ts`
 demonstrates the alternative at a boundary — unwrapping `error.reason.cause`
 back to the Node error identity its callers match. Either every predicate walks
 the chain, or every boundary unwraps; a written errno mapping that says which is
-a prerequisite for any code motion, not a follow-up.
+a prerequisite for code motion touching those four codes.
 
 **`remove`'s contract is ambiguous exactly where the repo depends on it.** One
 `remove` covers both unlink and rmdir, and the interface never says which a

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -143,10 +143,20 @@ only appears if the implementer routes to `rmdir`; `fs.rm` yields
 `ERR_FS_EISDIR`. This was demonstrated to bite: routing to `rmdir` in order to
 serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
 
-**Five further gaps:**
+**Six further gaps:**
 
 - No `lstat` at all, so `isSymlink` needs a `readLink`-plus-errno probe — the
   silent-degradation shape CLAUDE.md forbids.
+- **`readDirectory` returns `Array<string>`, not `[name, type]`.** The port
+  reads each entry's type off the `withFileTypes` dirent for free; Effect's
+  shape forces a `stat` per entry. This is load-bearing, not tuple
+  adaptation: `indentDirectory.ts:82`, `diffOperations.ts:244,266,284` and
+  `memoryFileSystem.ts:252` call `isSymlink(type)` to **reject** symlinks,
+  and `runGeneratedFiles.ts:93` branches on `isDirectory(type)`. Because
+  `stat` follows links (previous bullet), a symlink-to-file classifies as
+  `File` and those walkers would start silently following what they exist to
+  skip. So the cost is a correctness rewrite of each walker, on top of the
+  syscall cost.
 - No `ctime` on `File.Info`.
 - `mtime` is `Option<Date>`. The natural `none → 0` default makes
   `cleanupOldFiles` delete files it should keep.
@@ -156,12 +166,19 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
 **`FileSystem.makeNoop` should be banned in this repo** if adoption proceeds:
 it defaults `remove` to `Effect.void` and `exists` to `false`.
 
-**Two directory walkers bypass the port entirely** and are untestable on memfs
-under _either_ R-1 candidate: `src/agent/index/agentYamlScanner.ts` and
-`src/tools/glob.ts` both call the `glob` npm package against the real
-filesystem. `effect`'s own `glob` signature is `(pattern, {root?, exclude?})`
-and accepts none of the `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow`
-options those callers pass, so adoption does not close the hole.
+**Eight production modules bypass the port entirely** and are untestable on
+memfs under _either_ R-1 candidate. An earlier version of this note counted
+two; the full set of `glob`-package importers outside the test kernel is
+`src/agent/index/agentYamlScanner.ts`, `src/tools/glob.ts`,
+`src/tools/approval/latexPreview.ts`, `src/latex/formatter/latexindentpt.ts`,
+`src/housekeeping/clean.ts`, `src/housekeeping/utils.ts`,
+`src/utils/system/platformPaths.ts`, and
+`packages/cli/src/runtime/workflowInputs.ts`. Several combine real-filesystem
+glob discovery with `WorkspaceFS` operations, so a memfs-backed port cannot
+control their inputs either. `effect`'s own `glob` signature is
+`(pattern, {root?, exclude?})` and accepts none of the
+`cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` options those callers pass,
+so adoption does not close the hole.
 
 ### A method note, because the obvious experiment was run wrong once
 
@@ -261,10 +278,22 @@ below.
    missing from persistence, not merely from a view. A replacement must acquire
    the subscription **before the run starts** and own its scope until disposal.
 
-**None of these three rejects `PubSub`.** They are the contract a replacement
+4. **Disposal is synchronous today, and tail events depend on that too.**
+   Acquiring early is necessary but not sufficient. `AgentRunLifecycle.ts:782`
+   calls `ctx.disposeTrace()` without awaiting any subscriber work, which is
+   safe only because `emit` delivers inline — by the time disposal runs, every
+   emitted event has already reached `SessionHandle.publishRunEvent`. Under a
+   hub the consumer is asynchronous, so events published just before disposal
+   may still be sitting untaken when the scope closes, and they never reach
+   `schedulePublication` for the later persistence flush. These are a run's
+   **final** events — outcome and status — so the loss is silent and lands on
+   the durable plane. A replacement needs a drain/ack barrier at disposal, or
+   must keep the subscriber scope alive until its queue is empty.
+
+**None of these four rejects `PubSub`.** They are the contract a replacement
 has to reproduce: bounded-vs-unbounded chosen deliberately, per-handler fault
-isolation added explicitly, and the subscription acquired before the first
-emit. Together with the injection work above, that is the real size of B4 —
+isolation added explicitly, the subscription acquired before the first emit,
+and its queue drained before disposal. Together with the injection work above, that is the real size of B4 —
 and the reason not to do it is that size, not impossibility.
 
 ### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
@@ -297,11 +326,21 @@ not an argument against it.
 
 **The accumulator drain is the only real objection**, and it stands on its own.
 
-The decision is therefore narrower than the earlier revision implied, but still
-not mechanical: is the delta-emission machinery (accumulators, delta
-computation, reset flags) dead weight to remove wholesale — in which case the
-test goes with it — or a deliberately kept extension point? Either way the
-drain has to be preserved or its accumulators removed with it.
+**The delta machinery is not dead weight, and that question is now settled.**
+An earlier revision left open whether the accumulators and delta computation
+could be removed wholesale. They cannot:
+`src/shared/session/sessionFold.ts:1710` calls `indexes.source.drainEmission()`
+for every durable trace event and folds the returned `appended`/`dirtied`
+entries into the session transcript view. That is a live production consumer,
+independent of `StreamLogStore` — and `StreamLogStore.ts:455` is a _second_
+drain, over a different instance of the same class, not the only one.
+
+So the scope is smaller and unambiguous. The `onChange` **listener** and its
+store-specific suite may be retired, but the shared `StreamLog` delta
+machinery in `src/shared/session/traceEntries.ts` must stay, and
+`StreamLogStore`'s own `notify()` drain must be preserved or its accumulators
+removed with it. Removing the machinery wholesale would stop live session
+transcripts from incorporating trace entries.
 
 ## 4. `unstable/workflow` — what adoption would actually cost
 

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -228,11 +228,12 @@ does not control their inputs. The hole is closable for testing by handing
 **candidate A can serve the five async importers directly; candidate B can
 serve them only through an adapter** that costs one extra syscall per entry
 (below). Only the three `globSync` callers are closed to both. This paragraph
-has been wrong five times in five directions: two importers, then unclosable,
+has been wrong six times in six directions: two importers, then unclosable,
 then independent of R-1, then requiring synchronous methods, then B excluded on
-a correctness objection this note's own §2 disproves — and its summary twice
-survived a correction to its body. Treat its claims as the least reliable in
-this note.
+a correctness objection this note's own §2 disproves, then a lead still calling
+the adapter route impossible while the bullets beneath it priced that very
+route — and its summary twice survived a correction to its body. Treat its
+claims as the least reliable in this note.
 The full set of `glob`-package importers outside the test kernel is
 `src/agent/index/agentYamlScanner.ts`, `src/tools/glob.ts`,
 `src/tools/approval/latexPreview.ts`, `src/latex/formatter/latexindentpt.ts`,

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -142,9 +142,20 @@ ported suite still reached through `platform().fs` and still asserted Node
 errno codes, so what was measured was candidate **A** with an Effect backend.
 The seam question stayed unanswered.
 
-The experiment that would settle it is one line: change the default `fs` in
-`createFakePlatform` to an effect-backed provider and run the **full** vitest
-suite, not a chosen subset.
+**And the experiment first prescribed here repeated the same mistake.** An
+earlier revision said: change the default `fs` in `createFakePlatform` to an
+effect-backed provider and run the full suite. That is the identical error one
+level up — swapping one `FileSystemProvider` for another leaves every consumer
+reaching through `platform().fs`, so a green full suite would demonstrate only
+that candidate A tolerates an Effect backend. It cannot show that the interface
+is deletable, which is the whole of B.
+
+A settling experiment has to remove or redirect that access path, not
+re-implement behind it. The cheapest honest version: pick one leaf subsystem,
+convert its call sites to take `FileSystem` from context, delete its use of
+`platform().fs` entirely, and measure what the conversion cost and what broke
+around it. That is a real slice of B's cascade; the suite-wide swap is not a
+slice of anything.
 
 ## 3. `PubSub` cannot replace a synchronous listener set
 
@@ -161,18 +172,32 @@ is `publishUnsafe`, documented to return `false` when a bounded hub is full.
 **production class constructor** — there is no `Effect.gen` to yield in.
 (`src/transcript/runTrace.ts:34` constructs a second one, in a plain function.)
 
-Two semantic objections survive even an unbounded hub:
+Beyond the constructor problem, two behavioural differences. An earlier
+revision claimed both "survive even an unbounded hub"; review showed that
+overstates them, and the corrected form is below.
 
 1. **A `PubSub` couples subscribers into one shared buffer; a listener set
    keeps them independent.** `AgentTrace.emit` returns `void`, so the only
-   usable publish is `publishUnsafe`. If one subscriber stalls and the hub
-   fills, the event is dropped for _every_ subscriber at once — including the
-   durable event plane. Today one stalled subscriber structurally cannot affect
-   another.
-2. **Subscriber fault degrades from per-event to permanent.**
-   `TraceEmitter.emit` try/catches each subscriber and delivers the next event.
-   Under a hub each subscriber is a fiber looping on `take`; one defect kills
-   it and that sink goes dark for the rest of the run.
+   usable publish is `publishUnsafe`, which returns `false` when a bounded hub
+   is full — dropping the event for _every_ subscriber at once, including the
+   durable event plane. **This is a bounded-hub failure and does not apply to
+   `PubSub.unbounded`**, where publishing cannot fail. What replaces it under
+   an unbounded hub is not event loss but unbounded memory growth behind the
+   slowest subscriber — a different, arguably worse, failure for a long run.
+   Either way the coupling is real: today one stalled subscriber structurally
+   cannot affect another, and under any hub it can.
+2. **Per-event fault isolation becomes an adapter requirement rather than a
+   given.** `TraceEmitter.emit` try/catches each subscriber and delivers the
+   next event. Under a hub each subscriber is a fiber looping on `take`, and a
+   naïve loop dies on the first defect, taking that sink dark for the run.
+   **This is recoverable** — wrapping each handler invocation in
+   `Effect.catchAllCause` (or inspecting its `Exit`) restores exactly today's
+   isolation. So it is not an unavoidable regression; it is work the
+   replacement must do and that the current code gets for free.
+
+Neither point alone rejects `PubSub`. The constructor problem above is what
+actually blocks it for `TraceEmitter`; these two say what a replacement would
+have to reproduce.
 
 ### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
 
@@ -190,17 +215,25 @@ on unbounded accumulators for every `StreamLogStore`-owned log — converting a
 cleanup into a memory leak. The drain must survive regardless of whether any
 listener does.
 
-Furthermore, `src/test-kernel/transcript/StreamLogDelta.vitest.ts` uses
-`onChange` as the observation seam for genuinely valuable store-level
-behaviour: delta precedence (value supersedes chunks), immutability of already
-emitted payloads, and the `reset` flag. Removing the surface deletes the only
-way to observe that, and `StreamLog.vitest.ts`'s direct `drainEmission` tests
-do not cover the store-level half.
+An earlier revision offered a second argument — that
+`src/test-kernel/transcript/StreamLogDelta.vitest.ts` uses `onChange` as the
+observation seam for store-level delta behaviour (precedence, payload
+immutability, the `reset` flag), so removing the surface deletes the only way
+to observe it. **Review refuted that, correctly, against the repo's own rule.**
+AGENTS.md is explicit: "When code or a historical format is retired, delete
+tests and fixtures that exist only for that retired behavior instead of
+rewriting them around the new implementation." If `onChange` has no production
+consumer, that suite protects implementation-only machinery, not a durable or
+user-visible contract — so losing the seam is a consequence of the deletion,
+not an argument against it.
 
-The real decision is therefore larger than a deletion: is the delta-emission
-machinery itself (accumulators, delta computation, reset flags) dead weight to
-remove wholesale, or a deliberately kept extension point? That is a maintainer
-call, not a mechanical cleanup.
+**The accumulator drain is the only real objection**, and it stands on its own.
+
+The decision is therefore narrower than the earlier revision implied, but still
+not mechanical: is the delta-emission machinery (accumulators, delta
+computation, reset flags) dead weight to remove wholesale — in which case the
+test goes with it — or a deliberately kept extension point? Either way the
+drain has to be preserved or its accumulators removed with it.
 
 ## 4. `unstable/workflow` — what adoption would actually cost
 
@@ -211,13 +244,22 @@ Relevant to #12081. Prototypes typechecked at `tsc` exit 0 and ran against
 `WorkflowEngine.Encoded` is exactly ten methods, with `never` in **every**
 error channel and no pre-execution hook. The activity memo key includes the
 attempt number. `interruptUnsafe`, `resume` and `deferredDone` carry no owner
-identity, and `interruptUnsafe` requires a live in-process `Fiber` or Sharding
-routing — it is **not implementable cross-process** and degenerates into
-`interrupt`. `resume` always means full replay of the workflow body from the
-top. `Activity.make` and `Workflow.make` require Effect `Schema`.
+identity. `resume` always means full replay of the workflow body from the top.
+`Activity.make` and `Workflow.make` require Effect `Schema`.
 
-Tally for a repo-owned engine: **7 of 10 methods implementable, 2 in-process
-bookkeeping, 1 not.**
+**`interruptUnsafe` — scoped correctly.** Both shipped implementations need
+either a live in-process `Fiber` (`WorkflowEngine.js:339`) or Sharding routing.
+An earlier revision called it "not implementable cross-process"; review
+correctly pointed out that this overstates an interface limitation. Nothing in
+the signature forbids an engine from routing the execution id through its own
+worker registry or IPC — the Sharding implementation is itself proof that such
+routing works. What is unsupported is cross-process interruption **in TeXRA's
+current architecture**, which has no such routing layer and would have to build
+one. So the constraint is ours, not the interface's.
+
+Tally for a repo-owned engine, **in TeXRA as it stands today**: 7 of 10 methods
+implementable, 2 in-process bookkeeping, 1 requiring a routing layer the repo
+does not have.
 
 **The `Suspended` arm is the "not decided" channel.** It carries an optional
 `cause`, `Activity.js:130-133` parks the run on it, and

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -199,11 +199,13 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
 it defaults `remove` to `Effect.void` and `exists` to `false`.
 
 **Eight production modules bypass the port entirely**, so a memfs-backed port
-does not control their inputs. Five are closable independently of R-1; three
-are synchronous and interact with candidate B directly (both below). Earlier
-revisions of this paragraph counted two, then called the whole set
-unclosable, then called the whole set independent of R-1 — each wrong in a
-different direction.
+does not control their inputs. The hole is closable for testing by handing
+`glob` a memfs instance directly, but **none of the eight can be routed
+through whichever filesystem service wins R-1** — so candidate B keeps a
+second filesystem seam here permanently (below). This paragraph has been
+wrong three times in three different directions: it counted two importers,
+then called the set unclosable, then called it independent of R-1. Weigh it
+accordingly.
 The full set of `glob`-package importers outside the test kernel is
 `src/agent/index/agentYamlScanner.ts`, `src/tools/glob.ts`,
 `src/tools/approval/latexPreview.ts`, `src/latex/formatter/latexindentpt.ts`,
@@ -218,23 +220,29 @@ said none were.**
 The pinned `glob@13.0.6` takes an `fs?: FSOption` — "an fs implementation to
 override some or all of the defaults" (`glob.d.ts:231-234`) — while keeping
 the `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` behaviour these callers
-rely on. Supplying memfs directly, or adapting whichever filesystem service
-wins R-1 behind one shared helper, closes it for the five **async** callers
-without touching R-1.
+rely on. Supplying memfs **directly** closes the testability hole for all
+eight, since memfs has the synchronous methods `glob` wants.
 
-**Three of the eight are synchronous, and those do interact with R-1.**
+What does _not_ work — and an earlier revision proposed it — is routing
+`glob` through whichever filesystem service wins R-1. `FSOption` requires
+`lstatSync`, `readdirSync` and friends (`path-scurry` `index.d.ts:22-48`):
+**synchronous**, and **`lstat`**. Effect's `FileSystem` has neither. So under
+candidate B the repo keeps a second filesystem injection seam for `glob`
+regardless — the selected service cannot satisfy the interface. That is a
+standing cost of B, not a free independent cleanup.
+
+**Three of the eight are synchronous**, which compounds it:
 `latexPreview.ts:78`, `latexindentpt.ts:49` and `platformPaths.ts:47` call
-`globSync`, which needs synchronous filesystem methods — so no helper can
-adapt an effectful `FileSystem` service to them. Under candidate B those
-three must either become async or keep explicit synchronous wiring, and
-supplying the same memfs instance separately adds a second injection seam.
-An earlier revision of this paragraph said the hole closes "independently of
-R-1"; that is true of five callers and false of three.
-What is _not_ a route for any of the eight is Effect's own `glob`: its
-signature is `(pattern, {root?, exclude?})` and accepts none of the options
-these callers pass. So the work splits — modest and R-1-independent for the
-five async callers, part of candidate B's migration for the three
-synchronous ones.
+`globSync`, so even an async adapter is unavailable to them — they must
+become async or keep explicit synchronous wiring.
+
+And Effect's own `glob` is not a route for any of the eight: its signature is
+`(pattern, {root?, exclude?})` and accepts none of the
+`cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` options these callers pass.
+
+So the honest summary is that `glob` stays on its own filesystem wiring under
+either candidate. Under A that is unremarkable — the port is already separate
+from `glob`. Under B it is a second seam that adoption does not remove.
 
 ### A method note, because the obvious experiment was run wrong once
 
@@ -316,11 +324,22 @@ below.
 
 1. **A `PubSub` puts every subscriber behind one shared buffer, which changes
    how the existing coupling fails — it does not introduce coupling.**
-   `AgentTrace.emit` returns `void`, so the only
-   usable publish is `publishUnsafe`, which returns `false` when a bounded hub
-   is full — dropping the event for _every_ subscriber at once, including the
-   durable event plane. **This is a bounded-hub failure and does not apply to
-   `PubSub.unbounded`**, where publishing cannot fail. What replaces it under
+   `AgentTrace.emit` returns `void`, so the **simplest** publish is
+   `publishUnsafe`, which returns `false` when a bounded hub is full —
+   dropping the event for _every_ subscriber at once, including the durable
+   event plane. **This is a bounded-hub failure and does not apply to
+   `PubSub.unbounded`**, where publishing cannot fail.
+
+   A `void` signature does not force `publishUnsafe`, though, and an earlier
+   revision implied it did. An adapter can launch the ordinary effectful
+   `PubSub.publish` on the process runtime — `effectRuntime().runFork(...)`,
+   the pattern `SessionHandle.ts:679` already uses from a synchronous method.
+   On a full bounded hub that fiber **waits** instead of dropping, which
+   removes the cross-subscriber loss entirely. The cost moves rather than
+   vanishing: those fibers become lifetime the adapter must track and join at
+   disposal, which is property 4 again. So bounded-with-backpressure is a
+   third option beside bounded-with-drops and unbounded-with-growth, and B4's
+   trade-off should be stated over all three. What replaces it under
    an unbounded hub is not event loss but unbounded memory growth behind the
    slowest subscriber — a different, arguably worse, failure for a long run.
    **And the "today they are independent" half was also wrong.**
@@ -330,6 +349,7 @@ below.
    including a durable sink. Head-of-line blocking exists now. A hub changes
    the failure mode — retained backlog instead of a blocked loop — rather than
    introducing coupling where there was none.
+
 2. **Per-event fault isolation becomes an adapter requirement rather than a
    given.** `TraceEmitter.emit` try/catches each subscriber and delivers the
    next event. Under a hub each subscriber is a fiber looping on `take`, and a
@@ -554,11 +574,19 @@ read and write able to fail — malformed JSON, permissions, a full disk — and
 no error channel, an implementer's default is `Effect.orDie`, which converts
 ordinary recoverable storage failures into defects outside TeXRA's normal
 reporting path. Adoption must therefore say which operations can map a
-failure onto `Suspended` (where retrying later is the honest answer — though
-see below: `Suspended` must not become the answer for an incomplete attempt
-marker, or the activity parks on every replay) and
+failure onto `Suspended` and
 where an outer, typed engine boundary has to surface the rest. That decision
 is not expressible inside the interface and so belongs in the adoption plan.
+
+**Classify by cause, not by operation.** Grouping malformed JSON with
+permission and disk failures and then deciding per operation gets it wrong in
+both directions. A corrupt persisted row is _present state_, not a transient
+condition: every resume reads the same bytes and parks again, so suspending
+on it is a permanent hang wearing a retry's clothing. Only genuinely
+transient causes may suspend; malformed state has to reach the typed outer
+failure path where someone is told about it. The same applies to the
+incomplete-attempt marker below — `Suspended` is not the answer there
+either.
 
 **Engine records belong in `src/agent/storage/ExecutionKVStore.ts`** — its
 header documents it as generic read/write for arbitrary keys, and
@@ -621,15 +649,25 @@ The real requirements are narrower and different:
   with `exit: undefined` _before_ running the activity
   (`WorkflowEngine.js:356-360`) and falls through to execute when it finds
   one. `layerMemory` makes that moot, but a durable engine persisting the row
-  must distinguish an attempt orphaned by a crash — safe to re-run — from one
-  a live process is still executing. Nothing in the interface expresses that,
+  must distinguish an attempt orphaned by a crash from one a live process is
+  still executing. Nothing in the interface expresses that,
   and the distinction cannot be made by suspending: mapping every
   start-without-completion to `Suspended` parks the activity on every replay,
   since the marker stays incomplete and the next resume meets the same state.
   What is needed is an **ownership or lease transition** — a live marker
-  suspends, a stale one is claimed and executed. The repo already has that
-  shape in `executionLease.ts`, which is the natural place to look rather
-  than inventing one.
+  suspends, a stale one is claimed. The repo already has that shape in
+  `executionLease.ts`, which is the natural place to look rather than
+  inventing one.
+
+  **But claiming a stale marker is not the same as its work being safe to
+  re-run**, and an earlier revision of this note said "safe to re-run" as
+  though it were. A lease proves no prior owner is still live; it says
+  nothing about whether that owner's model or tool call already reached the
+  outside world before the process died. That is the same crash window
+  `withCompensation` cannot close, so reclaiming a marker requires
+  idempotency, durable deduplication, or reconciliation against the external
+  effect — the lease is the precondition, not the answer.
+
 - **The interrupt-retry schedule is non-durable state, and it is a different
   counter from `CurrentAttempt`.** `makeExecute` — which reads
   `CurrentAttempt` and performs the memo lookup — wraps `executeWithoutInterrupt`
@@ -643,6 +681,18 @@ The real requirements are narrower and different:
   An earlier revision claimed "one durable row per attempt, unbounded in the
   retry dimension." That conflated the two counters and is withdrawn — the
   interrupt schedule creates no durable rows at all.
+
+- **`Activity.retry`'s schedule replays its delays.** Distinct from the
+  interruption schedule above. On resume, prior memoized _failures_ are
+  handed back to a freshly initialised `Effect.retry` driver, so the run
+  sleeps through the earlier delays again before reaching the first
+  unmemoized attempt — and a duration-based budget restarts from zero rather
+  than accounting for time already spent. The memo result carries no
+  replay-hit flag, so an adapter cannot tell a fresh failure from a replayed
+  one. Adoption therefore needs persisted schedule state, a wrapper that
+  skips delays on memo hits, or a restriction to replay-safe (delay-free,
+  count-bounded) policies. Left alone, a workflow that crashed after eight
+  slow retries pays those delays again on every resume.
 
 This was left open in an earlier revision, answered on #12081 in the
 collision form, and corrected here after review. The correction on #12081

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -286,20 +286,24 @@ forbid replacing `TraceEmitter`. The honest characterisation is construction
 and injection work: threading a hub through `createModelHandler`'s `async`
 signature and into every construction site.
 
-So nothing here is impossible. What remains is the size of the job. Counted
-at the measured tree rather than estimated: **24 files** touch the seam — 19
-construct `new TraceEmitter()` and 10 subscribe to a trace or attach a
-channel sink, overlapping to 24. An earlier revision said "roughly sixteen",
-which was an undercount.
+So nothing here is impossible. What remains is the size of the job. **26
+files** touch the seam: 19 construct `new TraceEmitter()`, 14 call
+`.subscribe(...)` on a trace, logger or emitter, and 7 do both.
 
-The composition matters more than the total, and cuts both ways. Only **4 of
-the 24 are production**; the other 20 are test-kernel, most of them passing a
-plain synchronous callback to `trace.subscribe` and reading events out of a
-local array on the next line. So the production blast radius is small, and
-the cost is concentrated in rewriting tests that would each need a fiber, a
-scope and a drain to observe what a callback observes today.
+This figure moved twice under review — "roughly sixteen" was an estimate, and
+a recount that reported 24 used too narrow a subscription pattern. Treat it
+as measured at this tree, not as authoritative.
 
-That is the argument against B4, and it is an economic one: 24 files of
+The composition matters more than the total, and cuts both ways. **5 of the
+26 are production** — `packages/agent/src/effect/sessions.ts`,
+`ModelHandler.ts`, `SessionHandle.ts`, `channelTrace.ts`, `runTrace.ts` — and
+the other 21 are test-kernel, most passing a plain synchronous callback to
+`trace.subscribe` and reading events out of a local array on the next line.
+So the production blast radius is small, and the cost is concentrated in
+rewriting tests that would each need a fiber, a scope and a drain to observe
+what a callback observes today.
+
+That is the argument against B4, and it is an economic one: 26 files of
 churn, mostly tests, plus the five behavioural properties below, against the
 listener machinery being replaced — the `subscribers` field (`:47`),
 `subscribe` (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -52,9 +52,25 @@ Three dependencies, and `redis` is a **non-optional** peer
 `NodeChildProcessSpawner.d.ts` is a one-line re-export of
 `@effect/platform-node-shared`, which pulls `ws`.
 
-This matters beyond one issue: `cutover/native-runtime-llm-20260907` already
-adds `@effect/platform-node`, so that branch likely carries an unmet `redis`
-peer warning. Worth checking there.
+**[reproduced]** This matters beyond one issue, and an earlier revision guessed
+the failure mode wrong. It predicted an _unmet peer warning_ on
+`cutover/native-runtime-llm-20260907`. There is no warning: `pnpm-lock.yaml:4`
+sets `autoInstallPeers: true`, so pnpm silently installs the peer instead of
+complaining.
+
+What actually happens on that branch, verified in its lockfile:
+`@effect/platform-node` is declared in **`dependencies`**, `redis` is declared
+nowhere, and the lockfile nonetheless carries `redis@6.2.1(@opentelemetry/api@1.9.1)`
+with the root importer resolving
+`@effect/platform-node@4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1(...))`.
+
+So `pnpm install` pulls a full Redis client into the production install graph to
+satisfy a peer of a package that branch uses for `NodeFileSystem` and `NodePath`
+only. Nothing bundles it — esbuild includes only what is imported — so the cost
+is install weight and supply-chain surface, on a product that ships a VS Code
+extension, desktop installers and a published CLI. The cheapest escape is to take
+`FileSystem` and `Path` from `effect` core and supply the two layers directly,
+since those are the only pieces in use.
 
 **Do not generalize this to the sibling packages.** `@effect/sql-sqlite-node`
 at the same version genuinely has **zero dependencies**, one peer (`effect`),
@@ -203,13 +219,14 @@ callbacks to `trace.subscribe` and read events out of a local array
 immediately — against a 29-line listener set that works. That is the argument
 against B4, and it is an economic one.
 
-Beyond construction, two behavioural differences a replacement must reproduce.
-An earlier
-revision claimed both "survive even an unbounded hub"; review showed that
-overstates them, and the corrected form is below.
+Beyond construction, three behavioural properties a replacement must reproduce.
+An earlier revision listed the first two as objections that "survive even an
+unbounded hub"; review showed that overstates them, and the corrected form is
+below.
 
-1. **A `PubSub` couples subscribers into one shared buffer; a listener set
-   keeps them independent.** `AgentTrace.emit` returns `void`, so the only
+1. **A `PubSub` puts every subscriber behind one shared buffer, which changes
+   how the existing coupling fails — it does not introduce coupling.**
+   `AgentTrace.emit` returns `void`, so the only
    usable publish is `publishUnsafe`, which returns `false` when a bounded hub
    is full — dropping the event for _every_ subscriber at once, including the
    durable event plane. **This is a bounded-hub failure and does not apply to
@@ -232,9 +249,23 @@ overstates them, and the corrected form is below.
    isolation. So it is not an unavoidable regression; it is work the
    replacement must do and that the current code gets for free.
 
-Neither point alone rejects `PubSub`. The constructor problem above is what
-actually blocks it for `TraceEmitter`; these two say what a replacement would
-have to reproduce.
+3. **Subscription readiness is synchronous today, and two consumers depend on
+   it.** `TraceEmitter.subscribe` is `return this.subscribers.add(subscriber)` —
+   registration completes before it returns. `SessionHandle.attachRunTrace`
+   (`:496-502`) returns that detach handle directly, and
+   `packages/agent/src/effect/sessions.ts:402-413` subscribes and only then
+   signals admission via `Deferred.doneUnsafe(admitted, ...)`. `PubSub.subscribe`
+   returns a **scoped `Effect`**, so an adapter that acquires or forks the
+   subscription after exposing the trace loses every event emitted in between —
+   and for `attachRunTrace` that is the durable event plane, so those events are
+   missing from persistence, not merely from a view. A replacement must acquire
+   the subscription **before the run starts** and own its scope until disposal.
+
+**None of these three rejects `PubSub`.** They are the contract a replacement
+has to reproduce: bounded-vs-unbounded chosen deliberately, per-handler fault
+isolation added explicitly, and the subscription acquired before the first
+emit. Together with the injection work above, that is the real size of B4 —
+and the reason not to do it is that size, not impossibility.
 
 ### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
 

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -481,22 +481,37 @@ of which **10 only construct** a
 `attachChannelSubscriber`). Whether the 10 count depends on which hub is
 adopted:
 
-- **B4-atomic — 1 file.** An earlier revision charged this route 17 and was
-  importing B4-hub's cost into it. `makeAtomicUnbounded` is synchronous, and
-  so are the `Atomic`'s own `subscribe()` and `publish()` — verified by
-  running them. So `TraceEmitter` builds its own, owns the subscriptions
-  internally, and **keeps its existing synchronous `subscribe`/`emit`/detach
-  facade unchanged**. The 10 constructors are untouched _and so are the 16
-  subscribers_: they need lifecycle and assertion changes only if this route
-  separately chooses asynchronous delivery, which the `Atomic` does not
-  impose. The churn is the emitter implementation itself.
+- **B4-atomic — the cheap route does not exist.** Two revisions were wrong
+  here in sequence. The first charged it 17 files by importing B4-hub's
+  asynchronous-consumer cost. The second corrected that to 1 file, reasoning
+  that because `makeAtomicUnbounded`, `subscribe()` and `publish()` are all
+  synchronous, `TraceEmitter` could keep its facade and change nothing else.
+  **That inference was wrong, and running it shows why** [reproduced]:
 
-  **Which makes the route nearly free and nearly pointless, and those are the
-  same fact.** What it buys is the storage layer — no delivery strategy, no
-  subscriber-completion machinery — so all seven adapter-owned properties
-  below stay hand-written. That is approximately what `TraceEmitter` already
-  is. B4-atomic swaps a hand-rolled subscriber array for an upstream one and
-  changes nothing else.
+  ```
+  subscribe() -> UnboundedPubSubSubscription
+    methods: isEmpty, size, poll, pollUpTo, unsubscribe
+  publish("event-1") -> true;  pubsub size = 1;  no callback invoked
+  ```
+
+  The subscription is a **queue you pull from**, not a callback registration,
+  and the `Atomic` has no delivery strategy — `publish` enqueues and invokes
+  nothing. So `TraceEmitter.subscribe((event) => …)` cannot be served by the
+  `Atomic` alone, and the route forks into two dead ends:
+
+  - **Keep the callback registry and iterate it on `emit`.** Delivery works
+    and stays synchronous — but the `subscribers` field is still there, so
+    **the listener set has not been replaced**. The `Atomic` becomes a queue
+    nobody reads. (Polling each subscription inside `emit` collapses to the
+    same thing with extra steps: you still need the registry to know which
+    callback owns which subscription.)
+  - **Start consumers to drain the subscriptions.** Now the listener set is
+    genuinely gone — and delivery is asynchronous, which brings back the
+    subscriber lifecycle and assertion changes this route existed to avoid,
+    plus a run site to start the consumers.
+
+  **So there is no one-file B4.** The cheap number came from checking that the
+  primitives were synchronous and never checking that they _deliver_.
 
 - **B4-hub — 27 files, and that is a floor.** A real `PubSub` needs
   `PubSub.make` or `PubSub.unbounded`, both effectful, and `TraceEmitter.ts`
@@ -523,20 +538,22 @@ An earlier revision excluded the constructors while pricing the full `PubSub`
 semantics below — combining the cheap route's file count with the expensive
 route's capabilities. That estimate was for a candidate that does not exist.
 
-This figure has moved four times: "roughly sixteen" estimated, 24 from too
+This figure has moved five times: "roughly sixteen" estimated, 24 from too
 narrow a grep, 26 counted as the union, 16 once constructor sites fell out,
-and now 16 **or** 26 depending on the route. Treat it as measured at this
-tree, not as authoritative.
+16-or-26 by route, and now — once the atomic route turned out not to exist —
+**26 direct seam files plus `TraceEmitter.ts` plus an uncounted transitive
+fan-out, with no cheap alternative**. Treat it as measured at this tree, not
+as authoritative.
 
-**Both totals exclude the file being replaced, and should not.** 26 counts
-call sites — constructors and subscribers — but either route rewrites
+**The count excludes the file being replaced, and should not.** 26 counts
+call sites — constructors and subscribers — but the migration rewrites
 `src/agent/trace/TraceEmitter.ts` itself: the `subscribers` field, `subscribe`
-and `emit`. Counting it, the churn is **1 file for B4-atomic and at least 27
-for B4-hub**, across **six production files rather than five**. An estimate that
-prices a replacement while omitting the thing being replaced understates it by
-construction.
+and `emit`. Counting it, **at least 27 files**, across **six production files
+rather than five**, plus the transitive injection fan-out nobody has measured.
+An estimate that prices a replacement while omitting the thing being replaced
+understates it by construction.
 
-The composition matters more than the total. **6 of the 17 are production** —
+The composition matters more than the total. **6 of the 27 are production** —
 `src/agent/trace/TraceEmitter.ts` itself, plus
 `packages/agent/src/effect/sessions.ts`, `ModelHandler.ts`,
 `SessionHandle.ts`, `channelTrace.ts`, `runTrace.ts` — and 11 are
@@ -570,9 +587,10 @@ B4, which is the direction this note has now erred in three separate
 places.
 
 That is the argument against B4, and it is an economic one, and the two routes
-are no longer close: **1 file for B4-atomic — which buys almost nothing — or
-at least 27 for B4-hub (injection propagates up factory chains this count
-never followed)**, mostly tests and each cheaper than first
+collapse to one: **at least 27 files (injection propagates up factory chains
+this count never followed), because the cheap atomic route does not deliver to
+callbacks and so is not a replacement at all**, mostly tests and each cheaper
+than first
 charged, plus the eight behavioural properties below, against the listener
 machinery being replaced — the `subscribers` field (`:47`), `subscribe`
 (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a 217-line class that
@@ -769,8 +787,8 @@ returns, the handover cap enforced at enqueue rather than in the handler, and
 ordering preserved against the separate status plane.
 Together with the subscription and lifecycle work above, that is the real size
 of B4 — and it is **route-dependent** in file count only: the constructor
-sites stay untouched for B4-atomic (1 file, and it buys almost nothing) and
-change for B4-hub (27 at least).
+sites change: the atomic route that would have left them untouched cannot
+deliver to callbacks, so 27 at least.
 
 **A previous revision said B4-hub "inherits" these eight properties. It does
 not, and that sentence was the most dangerous thing in this note** — an

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -1,0 +1,278 @@
+# Effect 4 interface findings: what the pinned types actually say
+
+Status: proposed
+
+Measured against `effect@4.0.0-rc.112` (the repo's exact pin) and the tree at
+`1cf1a84`, by six parallel lanes each reviewed by two independent adversarial
+passes. This note exists because those facts were expensive to obtain, are
+currently scattered across six issue threads, and several of them **contradict
+what the open issues assert**.
+
+`effect-solutions` is not installed and the repository does not provision it,
+so every claim below is sourced to `node_modules/effect/dist/**` or to a
+command whose output was read. AGENTS.md's fallback rule applies: never guess a
+v4 API — v4 differs substantially from v3, and three of the corrections below
+are exactly that mistake.
+
+Claims marked **[reproduced]** were independently re-derived by a second agent
+or by hand after the run. Unmarked claims come from a single pass and should be
+re-checked before anything depends on them.
+
+## 1. Corrections to open issues
+
+These are the load-bearing ones. Each was asserted somewhere and is wrong.
+
+### `nodeChildProcessSpawner.ts` is already an `effect/unstable/process` implementation
+
+**[reproduced]** #12078 was filed on the premise that TeXRA had independently
+re-created a port that `@effect/platform-node` ships, implying a duplicate to
+convert. It is not a duplicate — it is the Node implementation _of that very
+module_. The file imports `ChildProcessSpawner` from `effect/unstable/process`,
+calls upstream's `make`, and publishes upstream's tag as a `Layer`. All three
+consumers (`leanServer.ts`, `leanServerPool.ts`, `directLspAdapter.ts`) are
+already Effect-typed against that same tag.
+
+There is also no `ChildProcessSpawner` port in `src/platform/interfaces.ts` —
+`grep` returns nothing. `effect` core contains zero `node:child_process`
+references, so `unstable/process` is interface-only by design and a repo-side
+Node implementation is the intended shape, not debt.
+
+### `@effect/platform-node` is not dependency-free
+
+**[reproduced]** Verified against the registry at `4.0.0-rc.112`:
+
+```
+deps:     {"mime":"^4.1.0","undici":"^8.10.0","@effect/platform-node-shared":"^4.0.0-rc.112"}
+peerDeps: {"redis":">=5.0.0 <7.0.0","effect":"^4.0.0-rc.112"}
+peerMeta: undefined
+```
+
+Three dependencies, and `redis` is a **non-optional** peer
+(`peerDependenciesMeta` is absent, so it is not marked optional).
+`NodeChildProcessSpawner.d.ts` is a one-line re-export of
+`@effect/platform-node-shared`, which pulls `ws`.
+
+This matters beyond one issue: `cutover/native-runtime-llm-20260907` already
+adds `@effect/platform-node`, so that branch likely carries an unmet `redis`
+peer warning. Worth checking there.
+
+**Do not generalize this to the sibling packages.** `@effect/sql-sqlite-node`
+at the same version genuinely has **zero dependencies**, one peer (`effect`),
+and is backed by `node:sqlite` — its `SqliteClient.js` imports nothing outside
+`effect/*`, and `SqliteClientConfig` documents the backend explicitly. The
+error corrected here was assuming one sibling's profile applied to the other.
+
+### `appendFile` is not a missing `FileSystem` operation
+
+`writeFile` takes an `OpenFlag`, and `'a'` is in the union. Any list of
+primitives that candidate B of R-1 would have to supply should read
+`writeFileAtomic`, `publishFile`, `removeEmptyDirectory` — three, not four.
+
+## 2. `FileSystem` — gaps that the `.d.ts` alone does not reveal
+
+Relevant to R-1 (#12073) and #12078. These are costs of standing on `effect`'s
+own `FileSystem` service that the issue does not currently name.
+
+**The errno taxonomy is lossy.** `SystemErrorTag` has 11 members and contains
+**none** of `ENOTEMPTY`, `ENOTDIR`, `EISDIR`, `EINVAL`, `ENOSPC`, and
+`PlatformError` exposes no top-level `.code`. The four predicates in
+`src/common/errors/errorPredicates.ts`, plus the `ENOTEMPTY` branch at
+`src/agent/storage/executionLease.ts:477`, all read **false** against a raw
+`PlatformError`. A written errno mapping is a prerequisite for any code motion,
+not a follow-up.
+
+**`remove`'s contract is ambiguous exactly where the repo depends on it.** One
+`remove` covers both unlink and rmdir, and the interface never says which a
+directory receives. The `ENOTEMPTY` that `executionLease.ts:477` branches on
+only appears if the implementer routes to `rmdir`; `fs.rm` yields
+`ERR_FS_EISDIR`. This was demonstrated to bite: routing to `rmdir` in order to
+serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
+
+**Five further gaps:**
+
+- No `lstat` at all, so `isSymlink` needs a `readLink`-plus-errno probe — the
+  silent-degradation shape CLAUDE.md forbids.
+- No `ctime` on `File.Info`.
+- `mtime` is `Option<Date>`. The natural `none → 0` default makes
+  `cleanupOldFiles` delete files it should keep.
+- No `dereference` on `copy`.
+- No `overwrite` on `rename`.
+
+**`FileSystem.makeNoop` should be banned in this repo** if adoption proceeds:
+it defaults `remove` to `Effect.void` and `exists` to `false`.
+
+**Two directory walkers bypass the port entirely** and are untestable on memfs
+under _either_ R-1 candidate: `src/agent/index/agentYamlScanner.ts` and
+`src/tools/glob.ts` both call the `glob` npm package against the real
+filesystem. `effect`'s own `glob` signature is `(pattern, {root?, exclude?})`
+and accepts none of the `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow`
+options those callers pass, so adoption does not close the hole.
+
+### A method note, because the obvious experiment was run wrong once
+
+A prototype built to break R-1's deadlock declared its layer
+`implements FileSystemProvider` — the interface candidate B _deletes_. Every
+ported suite still reached through `platform().fs` and still asserted Node
+errno codes, so what was measured was candidate **A** with an Effect backend.
+The seam question stayed unanswered.
+
+The experiment that would settle it is one line: change the default `fs` in
+`createFakePlatform` to an effect-backed provider and run the **full** vitest
+suite, not a chosen subset.
+
+## 3. `PubSub` cannot replace a synchronous listener set
+
+Relevant to #12074 §B4, which should be moved to that note's rejected list.
+
+**[reproduced]** `effect@4.0.0-rc.112` has **no synchronous `PubSub`
+constructor**. `make`/`bounded`/`dropping`/`sliding`/`unbounded` all return an
+`Effect`; only `makeAtomicBounded`/`makeAtomicUnbounded` are synchronous, and
+they return a bare `Atomic` requiring a hand-written `Strategy`. `subscribe`
+returns `Effect<Subscription<A>, never, Scope>`. The only synchronous publish
+is `publishUnsafe`, documented to return `false` when a bounded hub is full.
+
+`src/agent/modelHandlers/ModelHandler.ts:279` does `new TraceEmitter()` in a
+**production class constructor** — there is no `Effect.gen` to yield in.
+(`src/transcript/runTrace.ts:34` constructs a second one, in a plain function.)
+
+Two semantic objections survive even an unbounded hub:
+
+1. **A `PubSub` couples subscribers into one shared buffer; a listener set
+   keeps them independent.** `AgentTrace.emit` returns `void`, so the only
+   usable publish is `publishUnsafe`. If one subscriber stalls and the hub
+   fills, the event is dropped for _every_ subscriber at once — including the
+   durable event plane. Today one stalled subscriber structurally cannot affect
+   another.
+2. **Subscriber fault degrades from per-event to permanent.**
+   `TraceEmitter.emit` try/catches each subscriber and delivers the next event.
+   Under a hub each subscriber is a fiber looping on `take`; one defect kills
+   it and that sink goes dark for the rest of the run.
+
+### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
+
+This correction matters because the smaller claim was made twice, including by
+this author, on #12074.
+
+`onChange` has exactly one caller in the repository — a test. But it is also
+the _only_ way to populate `StreamLogStore`'s listener set, and the private
+`notify()` that fans out to that set does its work by calling
+`log.drainEmission()`, which **mutates**: it clears `pendingAppendedIds`,
+`pendingDirtiedIds` and `pendingTextChunks`.
+
+So deleting `notify()` along with the listener surface removes the only drain
+on unbounded accumulators for every `StreamLogStore`-owned log — converting a
+cleanup into a memory leak. The drain must survive regardless of whether any
+listener does.
+
+Furthermore, `src/test-kernel/transcript/StreamLogDelta.vitest.ts` uses
+`onChange` as the observation seam for genuinely valuable store-level
+behaviour: delta precedence (value supersedes chunks), immutability of already
+emitted payloads, and the `reset` flag. Removing the surface deletes the only
+way to observe that, and `StreamLog.vitest.ts`'s direct `drainEmission` tests
+do not cover the store-level half.
+
+The real decision is therefore larger than a deletion: is the delta-emission
+machinery itself (accumulators, delta computation, reset flags) dead weight to
+remove wholesale, or a deliberately kept extension point? That is a maintainer
+call, not a mechanical cleanup.
+
+## 4. `unstable/workflow` — what adoption would actually cost
+
+Relevant to #12081. Prototypes typechecked at `tsc` exit 0 and ran against
+`WorkflowEngine.layerMemory`.
+
+**[reproduced]** `Workflow.Result<A,E> = Complete | Suspended` — no third arm.
+`WorkflowEngine.Encoded` is exactly ten methods, with `never` in **every**
+error channel and no pre-execution hook. The activity memo key includes the
+attempt number. `interruptUnsafe`, `resume` and `deferredDone` carry no owner
+identity, and `interruptUnsafe` requires a live in-process `Fiber` or Sharding
+routing — it is **not implementable cross-process** and degenerates into
+`interrupt`. `resume` always means full replay of the workflow body from the
+top. `Activity.make` and `Workflow.make` require Effect `Schema`.
+
+Tally for a repo-owned engine: **7 of 10 methods implementable, 2 in-process
+bookkeeping, 1 not.**
+
+**The `Suspended` arm is the "not decided" channel.** It carries an optional
+`cause`, `Activity.js:130-133` parks the run on it, and
+`WorkflowEngine.js:350-352` deliberately does **not** memoize a `Suspended`
+result. `Workflow.SuspendOnFailure` routes errors there too. A repo-owned
+engine writes its own start marker and maps start-without-completion to
+`Suspended`. The residual hazard is real and is the engine's to solve: on
+resume a `Suspended` activity re-runs, so double-effect protection must be
+built deliberately.
+
+**Two costs that no issue currently names:**
+
+1. `Workflow.withCompensation` — listed on #12081 as a reason to adopt — is
+   documented as registering finalizers "only for top-level effects in the
+   workflow" that "do not work for nested activities". The one framework
+   mechanism for ambiguous external effects is unavailable at exactly the
+   boundary model and tool calls would sit on.
+2. `Activity`'s default `interruptRetryPolicy` re-runs an interrupted activity
+   **up to 10 times, then dies** (`Activity.js:62-66`). TeXRA cancels model
+   calls via `AbortController`. Wrapping `ModelInvocationNode` naively turns
+   one user cancel into up to ten further provider calls. Overridable per
+   activity, but the default is backwards for this codebase.
+
+**Durability is not shipped.** `WorkflowEngine` has exactly one layer in
+`unstable/workflow` — `layerMemory`. The only durable implementation is
+`ClusterWorkflowEngine` in `unstable/cluster`, which brings `Sharding`,
+`Runners`, `RunnerStorage`, `MessageStorage` and `Snowflake`. Not adoptable for
+a single-process desktop application.
+
+**The Effect-Schema boundary can be held.** An `Activity` with
+`success: Schema.Unknown` round-trips a raw provider-shaped object through
+`toCodecJson`, demonstrated running. Zod can remain the source of truth inside
+the activity, so adoption does not force the deferred Zod → `Schema` migration.
+
+**Engine records belong in `src/agent/storage/ExecutionKVStore.ts`** — its
+header documents it as generic read/write for arbitrary keys, and
+`src/agent/node/persistedFlow.ts` already stores arbitrary `flow_<runId>`
+records there — not in the closed `SessionEventDraftSchema` vocabulary.
+
+**Open and load-bearing:** whether `Activity.CurrentAttempt` survives a process
+restart. The attempt-keyed memo argument rests on it; if numbering restarts at
+1 after a crash, memo rows collide. One durable row per attempt is also
+unbounded growth in the retry dimension.
+
+## 5. `HttpClient` — two references worth knowing about
+
+**[reproduced]** `HttpClient.TracerPropagationEnabled` is a
+`Context.Reference` whose default value is `constTrue`
+(`unstable/http/HttpClient.js:678`), and TeXRA installs a real `Tracer` via
+`effectDiagnosticsLayer` (`src/controllers/session/sessionLayer.ts:727`). Any
+request issued through `HttpClient` therefore carries `traceparent` headers
+that a `fetch`- or `ky`-based call did not.
+
+`HttpClient.make` copies every request header into span attributes. For a
+request carrying `Authorization: Bearer <token>` this is safe **only** because
+`Headers.CurrentRedactedNames` defaults to include `authorization` — so any
+override of that reference is security-relevant.
+
+`FetchHttpClient.Fetch` is also a `Context.Reference`, and Effect memoizes a
+reference's default value permanently on the tag object. A process building the
+bare `FetchHttpClient.layer` captures `globalThis.fetch` at first use and never
+re-reads it, where `ky` resolved it per call. Inert in production today; it is
+the hazard the repo already works around in tests via `testHttpClientLayer`.
+
+## 6. One process finding
+
+The six lanes that produced this note **shared one checkout** rather than
+isolated worktrees. Four could not run `npm run typecheck` because borrowed
+`node_modules` symlinks triggered `ERR_PNPM_UNSAFE_TASK_RUN_STATE_PATH`; two
+mutated the shared `node_modules`; and at least one lane's `git status`
+evidence captured another lane's mid-write. Every "green" claim from that run
+is weaker than it should be.
+
+Parallel agents editing one repository need a worktree **and** their own
+`node_modules` each, or they need to be serialized. This is cheap to fix and
+expensive to discover afterwards.
+
+## References
+
+- Effect migration tracking: #12025
+- Open rulings, including R-1 and the terminal-row-form test: #12073
+- Native-feature catalogue: #12074
+- `unstable/sql` substrate lane: #12080
+- `unstable/workflow` lane: #12081

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -210,9 +210,9 @@ it defaults `remove` to `Effect.void` and `exists` to `false`.
 
 **Eight production modules bypass the port entirely**, so a memfs-backed port
 does not control their inputs. The hole is closable for testing by handing
-`glob` a memfs instance directly, but **none of the eight can be routed
-through whichever filesystem service wins R-1** — so candidate B keeps a
-second filesystem seam here permanently (below). This paragraph has been
+`glob` a memfs instance directly. For real wiring the candidates differ:
+**candidate A can serve the five async importers, candidate B none of the
+eight** — so B keeps a second filesystem seam here permanently (below). This paragraph has been
 wrong three times in three different directions: it counted two importers,
 then called the set unclosable, then called it independent of R-1. Weigh it
 accordingly.
@@ -225,8 +225,8 @@ The full set of `glob`-package importers outside the test kernel is
 glob discovery with `WorkspaceFS` operations, so a memfs-backed port does not
 control their inputs today.
 
-**All eight are closable for testing without R-1 — but none can use the R-1
-winner.**
+**All eight are closable for testing with memfs; candidate A can serve five
+of them for real, candidate B none.**
 The pinned `glob@13.0.6` takes an `fs?: FSOption` — "an fs implementation to
 override some or all of the defaults" (`glob.d.ts:231-234`) — while keeping
 the `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` behaviour these callers
@@ -234,12 +234,25 @@ rely on. Supplying memfs **directly** closes the testability hole for all
 eight, since memfs has the synchronous methods `glob` wants.
 
 What does _not_ work — and an earlier revision proposed it — is routing
-`glob` through whichever filesystem service wins R-1. `FSOption` requires
-`lstatSync`, `readdirSync` and friends (`path-scurry` `index.d.ts:22-48`):
-**synchronous**, and **`lstat`**. Effect's `FileSystem` has neither. So under
-candidate B the repo keeps a second filesystem injection seam for `glob`
-regardless — the selected service cannot satisfy the interface. That is a
-standing cost of B, not a free independent cleanup.
+`glob` through Effect's `FileSystem`. `FSOption` (`path-scurry`
+`index.d.ts:22-42`) carries both a synchronous set — `lstatSync`,
+`readdirSync`, `readlinkSync`, `realpathSync` — and a `promises` sub-object
+with async `lstat`, `readdir`, `readlink`, `realpath`, which is what the async
+traversal actually calls. So:
+
+- **Candidate A can serve the five async callers.** Its `lstat`-backed stat
+  supplies what `promises.lstat` needs, given an adapter shaping the result
+  as Node `Stats`. An earlier revision of this paragraph said `FSOption`
+  requires synchronous methods and so overcharged A; it does not, for the
+  async path.
+- **Candidate B can serve none of them.** Not because of sync — because
+  `path-scurry` wants **`lstat`**, at `:900` and `:705`, and Effect's
+  `FileSystem` has no `lstat` in either form. The three `globSync` callers
+  additionally need the synchronous set, which Effect also lacks.
+
+So under B the repo keeps a second filesystem seam for `glob` permanently;
+under A the seam is closable for the five async callers and stays only for
+the three synchronous ones.
 
 **Three of the eight are synchronous**, which compounds it:
 `latexPreview.ts:78`, `latexindentpt.ts:49` and `platformPaths.ts:47` call
@@ -293,6 +306,20 @@ is `publishUnsafe`, documented to return `false` when a bounded hub is full.
 `src/agent/modelHandlers/ModelHandler.ts:279` does `new TraceEmitter()` in a
 **production class constructor**, and `src/transcript/runTrace.ts:34`
 constructs a second one in a plain function.
+
+**And the hub need not be injected at all.** `Effect.runSync(PubSub.unbounded())`
+succeeds on rc.112 — verified by running it — so `TraceEmitter` can build its
+own hub in its constructor and none of the 19 `new TraceEmitter()` sites has
+to change. That removes most of the construction churn from the estimate
+below; the subscription and lifecycle work remains.
+
+One repo-specific cost attaches to it: `src/agent/trace/TraceEmitter.ts` is
+not one of the ratchet's boundary kinds
+(`packages/{extension,desktop,cli,agent}/src/**` or `src/tools/**/*Tool.ts`),
+so a `runSync` there lands in the `Effect.run*` row as below-boundary debt and
+`--update` refuses it without a `debtLanes` entry naming the lane that removes
+it. Workable, but it converts constructor churn into a tracked debt row rather
+than eliminating it.
 
 **An earlier revision called that constructor "the actual blocker". It is not.**
 Review pointed out that the handler-construction path is reached from inside an
@@ -364,9 +391,16 @@ below.
    given.** `TraceEmitter.emit` try/catches each subscriber and delivers the
    next event. Under a hub each subscriber is a fiber looping on `take`, and a
    naïve loop dies on the first defect, taking that sink dark for the run.
-   **This is recoverable** — wrapping each handler invocation in
-   `Effect.catchAllCause` (or inspecting its `Exit`) restores exactly today's
-   isolation. So it is not an unavoidable regression; it is work the
+   **The isolation is recoverable** — wrapping each handler invocation in
+   `Effect.catchAllCause` (or inspecting its `Exit`) keeps the fiber alive.
+   But `catchAllCause` **alone** silently consumes the failure, and today's
+   `emit` does more than survive it: its catch calls
+   `log.warn("Trace subscriber threw while handling event: …")`
+   (`TraceEmitter.ts:89-91`), with a comment recording that staying quiet
+   would be "the quiet-degradation shape the guardrail forbids". That warning
+   is the only signal when the subscriber that threw is the **durable sink**
+   and an event has therefore been lost. So a replacement must catch _and
+   report_, not merely catch. So it is not an unavoidable regression; it is work the
    replacement must do and that the current code gets for free.
 
 3. **Subscription readiness is synchronous today, and four consumers depend on
@@ -405,7 +439,14 @@ below.
    `schedulePublication` for the later persistence flush. These are a run's
    **final** events — outcome and status — so the loss is silent and lands on
    the durable plane. A replacement needs a drain/ack barrier at disposal, or
-   must keep the subscriber scope alive until its queue is empty.
+   must keep the subscriber scope alive until every published event's handler
+   has **completed**. Waiting for an empty queue is not sufficient and is not
+   a cheaper substitute: a consumer that has already taken the final outcome
+   event but is still inside `SessionHandle.publishRunEvent` leaves the queue
+   empty while the event has not yet reached `schedulePublication`, so closing
+   the scope there interrupts the in-flight handler and loses exactly the tail
+   event this property exists to protect. The barrier has to be an
+   acknowledgement, not a depth check.
 
 5. **`emit` stamps the stage before fan-out, and the transcript groups on
    it.** `TraceEmitter.emit` resolves a missing `stageId` from the emitter's
@@ -623,7 +664,18 @@ both directions. A corrupt persisted row is _present state_, not a transient
 condition: every resume reads the same bytes and parks again, so suspending
 on it is a permanent hang wearing a retry's clothing. Only genuinely
 transient causes may suspend; malformed state has to reach the typed outer
-failure path where someone is told about it. The same applies to the
+failure path where someone is told about it.
+
+**But cause alone is not sufficient either — the phase matters too.** A
+transient failure on a _read_ or a _start marker_ can suspend safely: nothing
+is lost by trying again later. A transient failure on the **completion
+write** cannot. The activity's effect has already run; suspending discards
+the only copy of its result and leaves recovery facing an incomplete marker,
+which is the ambiguous-orphan case above — so a disk-full error while
+persisting a model call's exit can cost the call itself. That phase needs the
+result retained or reconciled before any suspension, not a mapping rule. An
+earlier revision rejected per-operation classification outright; the honest
+rule is cause **and** phase. The same applies to the
 incomplete-attempt marker below — `Suspended` is not the answer there
 either.
 

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -160,7 +160,10 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
   every other failure loudly. So the probe is **correct but expensive**: the
   cost is one extra syscall per entry on a traversal already paying one, plus
   a dependency on `reason.cause` surviving whichever layer produces the error.
-  Not a correctness objection.
+  Not a correctness objection. (That is the cost of _this probe_. On the
+  `glob` path it is joined by a second per-entry call, because `FSOption`
+  wants `Dirent`s and `readDirectory` returns names — see the `glob` section.
+  Do not read "one" here as the total there.)
 - **`readDirectory` returns `Array<string>`, not `[name, type]`.** The port
   reads each entry's type off the `withFileTypes` dirent for free; Effect's
   shape forces a `stat` per entry. This is load-bearing, not tuple
@@ -226,8 +229,9 @@ it defaults `remove` to `Effect.void` and `exists` to `false`.
 does not control their inputs. The hole is closable for testing by handing
 `glob` a memfs instance directly. For real wiring the candidates differ:
 **candidate A can serve the five async importers directly; candidate B can
-serve them only through an adapter** that costs one extra syscall per entry
-**and a run boundary for four of the five consumers** (below). Only the three `globSync` callers are closed to both. This paragraph
+serve them only through an adapter** that costs **two** extra filesystem calls
+per entry — a `Dirent` probe plus the symlink test — **and a run boundary for
+four of the five consumers** (below). Only the three `globSync` callers are closed to both. This paragraph
 has been wrong six times in six directions: two importers, then unclosable,
 then independent of R-1, then requiring synchronous methods, then B excluded on
 a correctness objection this note's own §2 disproves, then a lead still calling
@@ -270,8 +274,9 @@ traversal actually calls. So:
   and `:705`, and Effect's `FileSystem` has none — so B must synthesise one
   from the `readLink`-plus-`stat` probe above. An earlier revision called that
   probe incorrect under unrelated failures; §2 now records why that was wrong
-  (the errno survives on `reason.cause`), leaving a syscall per entry as the
-  price. **But an earlier revision also priced only that syscall, and there is
+  (the errno survives on `reason.cause`), leaving the per-entry calls as the
+  price — **two of them**, since `FSOption.readdir` wants `withFileTypes` and
+  Effect's `readDirectory` returns names. **But an earlier revision also priced only that syscall, and there is
   a second cost.** `FSOption.promises.lstat` must return a real `Promise`;
   Effect's `readLink`/`stat`/`readDirectory` return `Effect`s. Bridging them
   needs `runPromise` or an equivalent managed-runtime run **at each consumer**
@@ -298,8 +303,8 @@ traversal actually calls. So:
   which Effect also lacks — and there no adapter exists at all.
 
 So under both candidates the seam closes for the five async callers and stays
-for the three synchronous ones; B pays an extra syscall per entry that A does
-not.
+for the three synchronous ones; B pays **two** extra filesystem calls per entry
+that A does not.
 
 **Three of the eight are synchronous**, which compounds it:
 `latexPreview.ts:78`, `latexindentpt.ts:49` and `platformPaths.ts:47` call
@@ -312,12 +317,31 @@ And Effect's own `glob` is not a route for any of the eight: its signature is
 
 So the honest summary: **under either candidate the five async importers can be
 adapted onto the port and only the three `globSync` callers keep separate
-wiring — B pays a per-entry syscall for the privilege, A does not**.
+wiring — but B pays three things A does not, and two of them were missing from
+earlier revisions of this very sentence**:
 
-This is the third time this section has moved toward B, each time by removing
-an objection I had raised rather than by finding a new capability: first sync
-was not required for the async path, then the tag gap was not a correctness
-problem. What survives is a throughput cost, which is measurable and which R-1
+1. **Two extra filesystem calls per entry, not one.** `FSOption.readdir`
+   demands `withFileTypes: true` and returns `Dirent[]`
+   (`path-scurry@2.0.2/dist/esm/index.d.ts:24-29`, and its own doc comment
+   says the `promises` variant is "Dirent variant only"). Effect's
+   `readDirectory` returns names — the type loss recorded in §2. So B
+   manufactures each `Dirent` by probing the child, then still runs the
+   `readLink`-plus-`stat` symlink test. A's `lstat`-backed port carries the
+   type out of the directory read and pays neither.
+2. **A run boundary.** The `promises` callbacks must return real `Promise`s,
+   so four of the five consumers need adapter construction at an allowed
+   boundary plus injection (above).
+3. The per-entry cost compounds with tree size, which is exactly the shape
+   R-1 measured at ~8×.
+
+**That reverses this section's direction.** Three consecutive revisions moved
+toward B by removing objections I had raised — sync was not required for the
+async path, then the tag gap was not a correctness problem. The last two
+rounds moved it back: the run boundary, and now the second per-entry call.
+Neither was found by re-examining B's feasibility; both were found by pricing
+what B must actually build. **The lesson is not which way the verdict lands,
+it is that feasibility questions were being answered while cost questions went
+unasked.** What survives is a throughput cost, which is measurable and which R-1
 already measured on a different traversal (~8× on 3,096 files, dominated by
 exactly this per-entry `stat`). Whether that verdict transfers to `glob`'s
 workload is untested here. The note prescribes nothing about `glob` beyond
@@ -421,11 +445,26 @@ adopted:
   storage layer: no delivery strategy, no subscriber-completion machinery.
   Most of the eight properties below then have to be re-implemented by hand on
   top of it, which is approximately what `TraceEmitter` already does.
-- **B4-hub — 27 files.** A real `PubSub` needs `PubSub.make` or
-  `PubSub.unbounded`, both effectful, and `TraceEmitter.ts` cannot run them
-  (not a ratchet boundary kind, and the below-boundary register is not an
-  intake). So the hub is built at an `Effect` boundary and injected, and all
-  10 constructor sites change.
+- **B4-hub — 27 files, and that is a floor.** A real `PubSub` needs
+  `PubSub.make` or `PubSub.unbounded`, both effectful, and `TraceEmitter.ts`
+  cannot run them (not a ratchet boundary kind, and the below-boundary
+  register is not an intake). So the hub is built at an `Effect` boundary and
+  injected, and all 10 constructor sites change.
+
+  **Injection does not stop at the constructor — it propagates up every
+  factory chain**, and none of those callers are in the 27, which counts
+  direct seam files only. `createRunTrace` (`src/transcript/runTrace.ts:30`)
+  constructs the emitter synchronously, so it must either take the injected
+  hub or become effectful; either way its callers change:
+  `src/agent/runtime/AgentLaunchContext.ts:416` and
+  `src/tools/delegation/childStream.ts:110` in production, plus
+  `sessionTestUtils.ts:134`, `SessionScope.vitest.ts:36,70` and
+  `RunTraceDispose.vitest.ts:13,29` in the kernel — and two more suites
+  (`AgentLaunchActivation.vitest.ts`, `AgentLaunchContext.vitest.ts`) that
+  _mock_ `createRunTrace` and whose mocks must match the new signature. That
+  is seven files from one factory, before looking at `ModelHandler`'s own
+  construction chain. **B4-hub's real surface has not been measured**; 27 is
+  where counting stopped, not where it ends.
 
 An earlier revision excluded the constructors while pricing the full `PubSub`
 semantics below — combining the cheap route's file count with the expensive
@@ -464,7 +503,8 @@ B4, which is the direction this note has now erred in three separate
 places.
 
 That is the argument against B4, and it is an economic one: **17 files of churn
-for B4-atomic or 27 for B4-hub**, mostly tests and each cheaper than first
+for B4-atomic or **at least** 27 for B4-hub (injection propagates up factory
+chains this count never followed)**, mostly tests and each cheaper than first
 charged, plus the eight behavioural properties below, against the listener
 machinery being replaced — the `subscribers` field (`:47`), `subscribe`
 (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a 217-line class that
@@ -649,15 +689,17 @@ sites stay untouched for B4-atomic (17 files) and change for B4-hub (27).
 **A previous revision said B4-hub "inherits" these eight properties. It does
 not, and that sentence was the most dangerous thing in this note** — an
 implementer following it could ship a hub missing guarantees whose absence
-loses or reorders durable events. A real `PubSub` supplies exactly two of the
-eight: buffering (property 1) and, through its delivery strategy, the
-backpressure behaviour that property presumes. The other six — per-handler
-failures caught **and reported**, synchronous subscription readiness,
-synchronous mid-run detachment, every handler acknowledged before disposal,
-stage stamping on the way in, the handover cap enforced at enqueue, and
-cross-plane ordering against `StreamStatusMachine` — are **adapter work under
-both routes**. B4-hub buys a buffer and a strategy; it does not buy the
-contract. The reason not to do it is that size, not impossibility.
+loses or reorders durable events. A real `PubSub` supplies **property 1 and
+nothing else**: buffering, and the backpressure behaviour its delivery
+strategy provides — both halves of that one property. **Properties 2 through
+8 — all seven — are adapter work under both routes**: per-handler failures
+caught _and reported_, synchronous subscription readiness, every handler
+acknowledged before disposal, stage stamping on the way in, synchronous
+mid-run detachment, the handover cap enforced at enqueue, and cross-plane
+ordering against `StreamStatusMachine`. An intermediate revision said "two of
+eight, six adapter-owned" while enumerating seven items directly beneath it;
+the enumeration was right and the arithmetic was wrong. B4-hub buys one
+property; it does not buy the contract. The reason not to do it is that size, not impossibility.
 
 ### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
 

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -150,13 +150,19 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
 - **`readDirectory` returns `Array<string>`, not `[name, type]`.** The port
   reads each entry's type off the `withFileTypes` dirent for free; Effect's
   shape forces a `stat` per entry. This is load-bearing, not tuple
-  adaptation: `indentDirectory.ts:82`, `diffOperations.ts:244,266,284` and
-  `memoryFileSystem.ts:252` call `isSymlink(type)` to **reject** symlinks,
-  and `runGeneratedFiles.ts:93` branches on `isDirectory(type)`. Because
-  `stat` follows links (previous bullet), a symlink-to-file classifies as
-  `File` and those walkers would start silently following what they exist to
-  skip. So the cost is a correctness rewrite of each walker, on top of the
-  syscall cost.
+  adaptation. **Eight production walkers** branch on the type bits:
+  `indentDirectory.ts:82`, `diffOperations.ts:244,266,284`,
+  `memoryFileSystem.ts:252`, `runGeneratedFiles.ts:93`,
+  `desktopWorkspaceIpc.ts:261-270`, `workspaceFileListing.ts:37,44`,
+  `executionListing.ts:136`, and `runOutputFiles.ts:70-72,126`. Four of them —
+  `indentDirectory.ts`, `diffOperations.ts`, `memoryFileSystem.ts` and
+  `desktopWorkspaceIpc.ts` — call `isSymlink(type)` to **reject** symlinks; because `stat` follows links
+  (previous bullet), a symlink-to-file classifies as `File` and those walkers
+  would silently start following what they exist to skip. Two —
+  `runOutputFiles.ts:68` and `desktopWorkspaceIpc.ts:149` — additionally call
+  the port's `isSymlink()` directly, which has no Effect equivalent at all.
+  So the cost is a correctness rewrite of each walker, on top of the syscall
+  cost.
 - No `ctime` on `File.Info`.
 - `mtime` is `Option<Date>`. The natural `none → 0` default makes
   `cleanupOldFiles` delete files it should keep.
@@ -266,7 +272,7 @@ below.
    isolation. So it is not an unavoidable regression; it is work the
    replacement must do and that the current code gets for free.
 
-3. **Subscription readiness is synchronous today, and two consumers depend on
+3. **Subscription readiness is synchronous today, and four consumers depend on
    it.** `TraceEmitter.subscribe` is `return this.subscribers.add(subscriber)` —
    registration completes before it returns. `SessionHandle.attachRunTrace`
    (`:496-502`) returns that detach handle directly, and
@@ -275,8 +281,22 @@ below.
    returns a **scoped `Effect`**, so an adapter that acquires or forks the
    subscription after exposing the trace loses every event emitted in between —
    and for `attachRunTrace` that is the durable event plane, so those events are
-   missing from persistence, not merely from a view. A replacement must acquire
-   the subscription **before the run starts** and own its scope until disposal.
+   missing from persistence, not merely from a view.
+
+   Two channel sinks depend on the same guarantee and are easy to miss because
+   they are not on the durable plane. `createRunTrace` calls
+   `attachChannelSubscriber(trace, …)` (`runTrace.ts:37`) **before returning
+   the trace**, so no caller can emit before the sink exists; and
+   `ModelHandler`'s constructor attaches its default `'Agent'` channel
+   (`ModelHandler.ts:280`) immediately after constructing the emitter —
+   deliberately, since the comment above it records that this default is
+   exercised through `createThinkingStream`/`createOutputStream` before
+   `setLogger` swaps in the real per-run trace on some paths. An adapter that
+   exposed either trace before acquiring the scoped subscriber would lose the
+   opening agent logs.
+
+   A replacement must acquire every one of these subscriptions **before the
+   run starts** and own their scopes until disposal.
 
 4. **Disposal is synchronous today, and tail events depend on that too.**
    Acquiring early is necessary but not sufficient. `AgentRunLifecycle.ts:782`
@@ -428,10 +448,18 @@ header documents it as generic read/write for arbitrary keys, and
 `src/agent/node/persistedFlow.ts` already stores arbitrary `flow_<runId>`
 records there — not in the closed `SessionEventDraftSchema` vocabulary.
 
-**Open and load-bearing:** whether `Activity.CurrentAttempt` survives a process
-restart. The attempt-keyed memo argument rests on it; if numbering restarts at
-1 after a crash, memo rows collide. One durable row per attempt is also
-unbounded growth in the retry dimension.
+**Settled, and load-bearing: `Activity.CurrentAttempt` does not survive a
+process restart.** `Activity.js:75` is `let attempt = 1` inside an in-memory
+closure, incremented per retry by
+`Effect.provideService(effect, CurrentAttempt, attempt++)`. After a crash the
+numbering restarts at 1, so attempt-keyed memo rows **collide** — a resumed
+run's first attempt reads the pre-crash first attempt's row. A durable engine
+must therefore derive the attempt from persisted state rather than from
+`CurrentAttempt`, or key its memos on something restart-stable. One durable
+row per attempt is also unbounded growth in the retry dimension.
+
+An earlier revision left this open; it was answered on #12081 and the answer
+belongs here, since this note is meant to be the citable source.
 
 ## 5. `HttpClient` — two references worth knowing about
 

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -168,8 +168,21 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
   would silently start following what they exist to skip. Two —
   `runOutputFiles.ts:68` and `desktopWorkspaceIpc.ts:149` — additionally call
   the port's `isSymlink()` directly, which has no Effect equivalent at all.
+
+  **A third category sits outside this inventory entirely: symlink checks
+  made through `stat` rather than `readDirectory`.** `inspectRunStorageEntry`
+  (`runStorageFs.ts:64-125`) resolves the root, every ancestor and the leaf
+  via `StorageFS.stat(target)).type` and rejects the `SymbolicLink` bit at
+  `:108` and `:125`. The Node provider preserves that bit by using `lstat`;
+  Effect's `stat` follows links, so under candidate B the check would
+  silently never fire and a symlinked ancestor would be accepted as an
+  ordinary directory — after which run-file reads and copies could escape the
+  execution directory. This is a containment property, not a listing
+  nicety, and it means the `lstat` gap reaches code that never calls
+  `readDirectory` at all.
   So the cost is a correctness rewrite of each walker, on top of the syscall
   cost.
+
 - No `ctime` on `File.Info`.
 - `mtime` is `Option<Date>`. The natural `none → 0` default makes
   `cleanupOldFiles` delete files it should keep.
@@ -180,9 +193,11 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
 it defaults `remove` to `Effect.void` and `exists` to `false`.
 
 **Eight production modules bypass the port entirely**, so a memfs-backed port
-does not control their inputs — a gap that is real today and separately
-closable (below), not a constraint on either R-1 candidate. An earlier
-version of this note counted two and called it unclosable; both were wrong.
+does not control their inputs. Five are closable independently of R-1; three
+are synchronous and interact with candidate B directly (both below). Earlier
+revisions of this paragraph counted two, then called the whole set
+unclosable, then called the whole set independent of R-1 — each wrong in a
+different direction.
 The full set of `glob`-package importers outside the test kernel is
 `src/agent/index/agentYamlScanner.ts`, `src/tools/glob.ts`,
 `src/tools/approval/latexPreview.ts`, `src/latex/formatter/latexindentpt.ts`,
@@ -197,11 +212,22 @@ The pinned `glob@13.0.6` takes an `fs?: FSOption` — "an fs implementation to
 override some or all of the defaults" (`glob.d.ts:231-234`) — while keeping
 the `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` behaviour these callers
 rely on. Supplying memfs directly, or adapting whichever filesystem service
-wins R-1 behind one shared helper, closes it without touching R-1 at all.
-What is _not_ a route is Effect's own `glob`: its signature is
-`(pattern, {root?, exclude?})` and accepts none of those options. So this is
-an independent piece of work with its own (modest) cost, not a constraint on
-either candidate — the previous framing overstated it.
+wins R-1 behind one shared helper, closes it for the five **async** callers
+without touching R-1.
+
+**Three of the eight are synchronous, and those do interact with R-1.**
+`latexPreview.ts:78`, `latexindentpt.ts:49` and `platformPaths.ts:47` call
+`globSync`, which needs synchronous filesystem methods — so no helper can
+adapt an effectful `FileSystem` service to them. Under candidate B those
+three must either become async or keep explicit synchronous wiring, and
+supplying the same memfs instance separately adds a second injection seam.
+An earlier revision of this paragraph said the hole closes "independently of
+R-1"; that is true of five callers and false of three.
+What is _not_ a route for any of the eight is Effect's own `glob`: its
+signature is `(pattern, {root?, exclude?})` and accepts none of the options
+these callers pass. So the work splits — modest and R-1-independent for the
+five async callers, part of candidate B's migration for the three
+synchronous ones.
 
 ### A method note, because the obvious experiment was run wrong once
 
@@ -468,10 +494,33 @@ built deliberately.
 `Runners`, `RunnerStorage`, `MessageStorage` and `Snowflake`. Not adoptable for
 a single-process desktop application.
 
-**The Effect-Schema boundary can be held.** An `Activity` with
-`success: Schema.Unknown` round-trips a raw provider-shaped object through
-`toCodecJson`, demonstrated running. Zod can remain the source of truth inside
-the activity, so adoption does not force the deferred Zod → `Schema` migration.
+**The Effect-Schema boundary can be held, but not by validating inside the
+activity alone.** An `Activity` with `success: Schema.Unknown` round-trips a
+raw provider-shaped object through `toCodecJson`, demonstrated running, so
+adoption does not force the deferred Zod → `Schema` migration.
+
+The trap is that a memo hit **does not run the activity body** — the engine
+returns the stored exit directly (`WorkflowEngine.js:354`, and the replay
+mechanics above). A Zod parse placed inside the activity therefore runs on
+first execution and is skipped on every replay, while `Schema.Unknown`
+accepts whatever was stored without inspecting it. A payload corrupted at
+rest, or one written before a contract change, would enter the resumed
+workflow unvalidated — the persisted-data failure mode CLAUDE.md's Zod rules
+exist to prevent. So Zod stays the source of truth only if the parse runs on
+**both** paths: at the memo boundary as well as on fresh execution, or by
+giving the activity an Effect schema that enforces the durable contract.
+
+**A durable engine needs a declared storage-error path, and the interface
+gives it nowhere to go.** `WorkflowEngine.Encoded` has `never` in **every**
+error channel. Replacing `layerMemory` with `ExecutionKVStore` makes every
+read and write able to fail — malformed JSON, permissions, a full disk — and
+`KVStore` deliberately propagates every failure that is not "missing". With
+no error channel, an implementer's default is `Effect.orDie`, which converts
+ordinary recoverable storage failures into defects outside TeXRA's normal
+reporting path. Adoption must therefore say which operations can map a
+failure onto `Suspended` (where retrying later is the honest answer) and
+where an outer, typed engine boundary has to surface the rest. That decision
+is not expressible inside the interface and so belongs in the adoption plan.
 
 **Engine records belong in `src/agent/storage/ExecutionKVStore.ts`** — its
 header documents it as generic read/write for arbitrary keys, and

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -213,7 +213,8 @@ The full set of `glob`-package importers outside the test kernel is
 glob discovery with `WorkspaceFS` operations, so a memfs-backed port does not
 control their inputs today.
 
-**This hole is closable, and an earlier revision wrongly said it was not.**
+**Five of the eight are closable without R-1, and an earlier revision wrongly
+said none were.**
 The pinned `glob@13.0.6` takes an `fs?: FSOption` — "an fs implementation to
 override some or all of the defaults" (`glob.d.ts:231-234`) — while keeping
 the `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` behaviour these callers
@@ -406,7 +407,9 @@ consumer, that suite protects implementation-only machinery, not a durable or
 user-visible contract — so losing the seam is a consequence of the deletion,
 not an argument against it.
 
-**The accumulator drain is the only real objection**, and it stands on its own.
+**The accumulator drain is the only objection to removing the _listener_**,
+and it stands on its own. A second and independent constraint applies to the
+machinery beneath it:
 
 **The delta machinery is not dead weight, and that question is now settled.**
 An earlier revision left open whether the accumulators and delta computation

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -448,18 +448,44 @@ header documents it as generic read/write for arbitrary keys, and
 `src/agent/node/persistedFlow.ts` already stores arbitrary `flow_<runId>`
 records there — not in the closed `SessionEventDraftSchema` vocabulary.
 
-**Settled, and load-bearing: `Activity.CurrentAttempt` does not survive a
-process restart.** `Activity.js:75` is `let attempt = 1` inside an in-memory
-closure, incremented per retry by
-`Effect.provideService(effect, CurrentAttempt, attempt++)`. After a crash the
-numbering restarts at 1, so attempt-keyed memo rows **collide** — a resumed
-run's first attempt reads the pre-crash first attempt's row. A durable engine
-must therefore derive the attempt from persisted state rather than from
-`CurrentAttempt`, or key its memos on something restart-stable. One durable
-row per attempt is also unbounded growth in the retry dimension.
+**Settled: `Activity.CurrentAttempt` is in-memory, and that is deliberate —
+it is how replay works, not a collision.** `Activity.js:75` is
+`let attempt = 1` inside a closure, incremented per retry by
+`Effect.provideService(effect, CurrentAttempt, attempt++)`, and
+`CurrentAttempt` defaults to 1. `makeExecute` passes it straight through as
+`engine.activityExecute(activity, attempt)` (`Activity.js:126,130`), and the
+engine keys on `` `${executionId}/${activity.name}/${attempt}` ``, returning a
+stored exit rather than re-executing (`WorkflowEngine.js:347,354`).
 
-An earlier revision left this open; it was answered on #12081 and the answer
-belongs here, since this note is meant to be the citable source.
+So a resumed run restarting at attempt 1 **reads its own prior result**: the
+workflow re-executes from the top, each completed activity short-circuits to
+its memoized exit, and `attempt++` walks the stored rows in order until it
+reaches the first unmemoized or suspended one. That is deterministic replay,
+and it is the mechanism a durable engine depends on.
+
+**An earlier revision of this note got that backwards**, calling the reuse a
+collision and prescribing that a durable engine derive the attempt from
+persisted state. That prescription is actively harmful: starting at attempt
+_N_ would skip rows 1…*N*−1, bypassing prior activity results and changing
+the replayed workflow's control flow.
+
+The real requirements are narrower and different:
+
+- **How an incomplete attempt is represented.** The engine inserts a state row
+  with `exit: undefined` _before_ running the activity
+  (`WorkflowEngine.js:356-360`) and falls through to execute when it finds
+  one. `layerMemory` makes that moot, but a durable engine persisting the row
+  must distinguish an attempt orphaned by a crash — safe to re-run — from one
+  a live process is still executing. Nothing in the interface expresses that.
+- **The retry budget resets across a restart.** Because the counter is
+  in-memory, an activity that had consumed eight of its ten retries before a
+  crash resumes with a fresh ten. That consequence of `Activity.js:75` does
+  survive, and it is unbounded in the retry dimension: one durable row per
+  attempt, with the ceiling reset by every restart.
+
+This was left open in an earlier revision, answered on #12081 in the
+collision form, and corrected here after review. The correction on #12081
+follows.
 
 ## 5. `HttpClient` — two references worth knowing about
 

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -101,11 +101,24 @@ So the exposure is three predicates plus one inline branch — not five, and
 scoped to ENOENT/EEXIST/ENOTDIR/ENOTEMPTY; ENOSPC is already recoverable
 through the existing cause-chain path.
 
-`isDiskFullError` is also the shape the other three would need. `jsonStore.ts`
-demonstrates the alternative at a boundary — unwrapping `error.reason.cause`
-back to the Node error identity its callers match. Either every predicate walks
-the chain, or every boundary unwraps; a written errno mapping that says which is
-a prerequisite for code motion touching those four codes.
+`isDiskFullError` is also the shape the other three would need. The alternative
+— unwrapping at the boundary — has a working example on `main` in
+`spawnFailure` (`src/tools/lean/direct/leanServer.ts:168`), which takes a
+`PlatformError` and reads `error.reason.cause ?? error` back to the Node error
+identity its callers match.
+
+**Do not look for that pattern in `jsonStore.ts`.** An earlier revision cited
+it, and on `main` it does no such thing: it wraps `node:fs/promises` calls in
+`Effect.tryPromise`, casts the failure to `NodeJS.ErrnoException`, and hands
+that raw error to `isFileNotFoundError` — there is no `PlatformError` to
+unwrap. The unwrapping version of `jsonStore.ts` exists only on
+`cutover/native-runtime-llm-20260907` (#11997), which is unmerged. Citing it
+without that qualifier sent a reader to a file that does not demonstrate the
+strategy.
+
+Either every predicate walks the chain, or every boundary unwraps; a written
+errno mapping that says which is a prerequisite for code motion touching those
+four codes.
 
 **`remove`'s contract is ambiguous exactly where the repo depends on it.** One
 `remove` covers both unlink and rmdir, and the interface never says which a
@@ -157,9 +170,11 @@ convert its call sites to take `FileSystem` from context, delete its use of
 around it. That is a real slice of B's cascade; the suite-wide swap is not a
 slice of anything.
 
-## 3. `PubSub` cannot replace a synchronous listener set
+## 3. Replacing the listener set with `PubSub` is a refactor, not a drop-in
 
-Relevant to #12074 §B4, which should be moved to that note's rejected list.
+Relevant to #12074 §B4. **This section has been corrected three times and the
+conclusion has weakened each time**; what follows is what survives, and it is
+"the cost exceeds the benefit", not "this is blocked".
 
 **[reproduced]** `effect@4.0.0-rc.112` has **no synchronous `PubSub`
 constructor**. `make`/`bounded`/`dropping`/`sliding`/`unbounded` all return an
@@ -169,10 +184,27 @@ returns `Effect<Subscription<A>, never, Scope>`. The only synchronous publish
 is `publishUnsafe`, documented to return `false` when a bounded hub is full.
 
 `src/agent/modelHandlers/ModelHandler.ts:279` does `new TraceEmitter()` in a
-**production class constructor** — there is no `Effect.gen` to yield in.
-(`src/transcript/runTrace.ts:34` constructs a second one, in a plain function.)
+**production class constructor**, and `src/transcript/runTrace.ts:34`
+constructs a second one in a plain function.
 
-Beyond the constructor problem, two behavioural differences. An earlier
+**An earlier revision called that constructor "the actual blocker". It is not.**
+Review pointed out that the handler-construction path is reached from inside an
+`Effect.gen` — `src/agent/runtime/AgentLaunchContext.ts:388` yields
+`Effect.tryPromise` around `createModelHandler` — so a caller can yield
+`PubSub.unbounded()` there and pass the hub into the synchronous constructor.
+What the constructor forbids is a **drop-in field initializer**; it does not
+forbid replacing `TraceEmitter`. The honest characterisation is construction
+and injection work: threading a hub through `createModelHandler`'s `async`
+signature and into every construction site.
+
+So nothing here is impossible. What remains is the size of the job — roughly
+sixteen files, including about ten test call sites that pass plain synchronous
+callbacks to `trace.subscribe` and read events out of a local array
+immediately — against a 29-line listener set that works. That is the argument
+against B4, and it is an economic one.
+
+Beyond construction, two behavioural differences a replacement must reproduce.
+An earlier
 revision claimed both "survive even an unbounded hub"; review showed that
 overstates them, and the corrected form is below.
 
@@ -184,8 +216,13 @@ overstates them, and the corrected form is below.
    `PubSub.unbounded`**, where publishing cannot fail. What replaces it under
    an unbounded hub is not event loss but unbounded memory growth behind the
    slowest subscriber — a different, arguably worse, failure for a long run.
-   Either way the coupling is real: today one stalled subscriber structurally
-   cannot affect another, and under any hub it can.
+   **And the "today they are independent" half was also wrong.**
+   `TraceEmitter.emit` fans out in a synchronous sequential `for...of`
+   (`src/agent/trace/TraceEmitter.ts:78-93`), so a slow or non-returning
+   synchronous subscriber already blocks every later subscriber in the loop,
+   including a durable sink. Head-of-line blocking exists now. A hub changes
+   the failure mode — retained backlog instead of a blocked loop — rather than
+   introducing coupling where there was none.
 2. **Per-event fault isolation becomes an adapter requirement rather than a
    given.** `TraceEmitter.emit` try/catches each subscriber and delivers the
    next event. Under a hub each subscriber is a fiber looping on `take`, and a

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -150,11 +150,15 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
 - **`readDirectory` returns `Array<string>`, not `[name, type]`.** The port
   reads each entry's type off the `withFileTypes` dirent for free; Effect's
   shape forces a `stat` per entry. This is load-bearing, not tuple
-  adaptation. **Eight production walkers** branch on the type bits:
+  adaptation. **Twelve production consumers** branch on the type bits:
   `indentDirectory.ts:82`, `diffOperations.ts:244,266,284`,
   `memoryFileSystem.ts:252`, `runGeneratedFiles.ts:93`,
   `desktopWorkspaceIpc.ts:261-270`, `workspaceFileListing.ts:37,44`,
-  `executionListing.ts:136`, and `runOutputFiles.ts:70-72,126`. Four of them —
+  `executionListing.ts:136`, `runOutputFiles.ts:70-72,126`,
+  `relativeFS.ts:74` (`cleanupOldFiles` keeps only files),
+  `ArxivDownloadTool.ts:23-42` (renders file-vs-directory identity),
+  `externalInquiryStorage.ts:456` (accepts only directories), and
+  `KVStore.ts:102` (accepts only `.json` files). Four of them —
   `indentDirectory.ts`, `diffOperations.ts`, `memoryFileSystem.ts` and
   `desktopWorkspaceIpc.ts` — call `isSymlink(type)` to **reject** symlinks; because `stat` follows links
   (previous bullet), a symlink-to-file classifies as `File` and those walkers
@@ -172,19 +176,29 @@ serve `removeEmptyDirectory` **corrupted `delete`** in the prototype.
 **`FileSystem.makeNoop` should be banned in this repo** if adoption proceeds:
 it defaults `remove` to `Effect.void` and `exists` to `false`.
 
-**Eight production modules bypass the port entirely** and are untestable on
-memfs under _either_ R-1 candidate. An earlier version of this note counted
-two; the full set of `glob`-package importers outside the test kernel is
+**Eight production modules bypass the port entirely**, so a memfs-backed port
+does not control their inputs — a gap that is real today and separately
+closable (below), not a constraint on either R-1 candidate. An earlier
+version of this note counted two and called it unclosable; both were wrong.
+The full set of `glob`-package importers outside the test kernel is
 `src/agent/index/agentYamlScanner.ts`, `src/tools/glob.ts`,
 `src/tools/approval/latexPreview.ts`, `src/latex/formatter/latexindentpt.ts`,
 `src/housekeeping/clean.ts`, `src/housekeeping/utils.ts`,
 `src/utils/system/platformPaths.ts`, and
 `packages/cli/src/runtime/workflowInputs.ts`. Several combine real-filesystem
-glob discovery with `WorkspaceFS` operations, so a memfs-backed port cannot
-control their inputs either. `effect`'s own `glob` signature is
-`(pattern, {root?, exclude?})` and accepts none of the
-`cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` options those callers pass,
-so adoption does not close the hole.
+glob discovery with `WorkspaceFS` operations, so a memfs-backed port does not
+control their inputs today.
+
+**This hole is closable, and an earlier revision wrongly said it was not.**
+The pinned `glob@13.0.6` takes an `fs?: FSOption` — "an fs implementation to
+override some or all of the defaults" (`glob.d.ts:231-234`) — while keeping
+the `cwd`/`dot`/`nodir`/`absolute`/`signal`/`follow` behaviour these callers
+rely on. Supplying memfs directly, or adapting whichever filesystem service
+wins R-1 behind one shared helper, closes it without touching R-1 at all.
+What is _not_ a route is Effect's own `glob`: its signature is
+`(pattern, {root?, exclude?})` and accepts none of those options. So this is
+an independent piece of work with its own (modest) cost, not a constraint on
+either candidate — the previous framing overstated it.
 
 ### A method note, because the obvious experiment was run wrong once
 
@@ -310,10 +324,23 @@ below.
    the durable plane. A replacement needs a drain/ack barrier at disposal, or
    must keep the subscriber scope alive until its queue is empty.
 
-**None of these four rejects `PubSub`.** They are the contract a replacement
+5. **`emit` stamps the stage before fan-out, and the transcript groups on
+   it.** `TraceEmitter.emit` resolves a missing `stageId` from the emitter's
+   own scope stack before delivering — `event.stageId !== undefined ? event :
+{ ...event, stageId: this.currentStageStack().at(-1) }`
+   (`TraceEmitter.ts:70-76`) — and `traceFold.ts` uses that value as the
+   transcript entry's `groupId`. The stamp is per-emitter context, not part
+   of the event a caller publishes. An adapter that puts the caller's raw
+   event into a hub loses grouping for everything emitted inside a
+   `StageHandle` scope without an explicit id, producing orphaned or
+   misgrouped transcript entries. The adapter must hold the per-trace stage
+   context and stamp before publishing.
+
+**None of these five rejects `PubSub`.** They are the contract a replacement
 has to reproduce: bounded-vs-unbounded chosen deliberately, per-handler fault
 isolation added explicitly, the subscription acquired before the first emit,
-and its queue drained before disposal. Together with the injection work above, that is the real size of B4 —
+its queue drained before disposal, and each event stage-stamped on the way
+in. Together with the injection work above, that is the real size of B4 —
 and the reason not to do it is that size, not impossibility.
 
 ### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
@@ -448,6 +475,22 @@ header documents it as generic read/write for arbitrary keys, and
 `src/agent/node/persistedFlow.ts` already stores arbitrary `flow_<runId>`
 records there — not in the closed `SessionEventDraftSchema` vocabulary.
 
+**But an arbitrary key is not automatically internal metadata, and the
+`flow_` precedent is precisely what shows the missing half.** `isKVFile`
+(`src/tools/executions/executionKvFiles.ts:25`) recognises a key only by
+deferring to each owning subsystem: `isReservedKvKeyName`, `FLOW_KEY_PREFIX`,
+`isWorkflowScriptCheckpointKvKey`, `isStableSubagentStateKvKey`.
+`isReservedKvKeyName` itself knows only the store's fixed vocabulary and the
+`child-` prefix — it returns **false** for `flow_abc123`, which the existing
+suite pins (`ExecutionKVStore.vitest.ts:102`). `runGeneratedFiles.ts:89`
+skips an entry only when `isKVFile` says so.
+
+So an engine that writes rows under an unregistered key surfaces its own JSON
+as generated output in **both** the agent-facing `/executions/{id}/files`
+listing and the CLI's history listing. The recommendation is therefore: give
+the engine an owned key prefix and register it in `isKVFile`, exactly as
+`persistedFlow` does.
+
 **Settled: `Activity.CurrentAttempt` is in-memory, and that is deliberate —
 it is how replay works, not a collision.** `Activity.js:75` is
 `let attempt = 1` inside a closure, incremented per retry by
@@ -477,11 +520,19 @@ The real requirements are narrower and different:
   one. `layerMemory` makes that moot, but a durable engine persisting the row
   must distinguish an attempt orphaned by a crash — safe to re-run — from one
   a live process is still executing. Nothing in the interface expresses that.
-- **The retry budget resets across a restart.** Because the counter is
-  in-memory, an activity that had consumed eight of its ten retries before a
-  crash resumes with a fresh ten. That consequence of `Activity.js:75` does
-  survive, and it is unbounded in the retry dimension: one durable row per
-  attempt, with the ceiling reset by every restart.
+- **The interrupt-retry schedule is non-durable state, and it is a different
+  counter from `CurrentAttempt`.** `makeExecute` — which reads
+  `CurrentAttempt` and performs the memo lookup — wraps `executeWithoutInterrupt`
+  from _outside_ (`Activity.js:26,53,59`), so all ten interruption retries run
+  **inside a single memo key**, re-running that invocation's effect rather than
+  allocating a row each. `CurrentAttempt` advances only through the separate
+  `Activity.retry` helper (`Activity.js:74-77`). What a crash resets is the
+  in-memory schedule: an activity eight interruption-retries deep resumes
+  against the existing `exit: undefined` row with a fresh ten-step budget.
+
+  An earlier revision claimed "one durable row per attempt, unbounded in the
+  retry dimension." That conflated the two counters and is withdrawn — the
+  interrupt schedule creates no durable rows at all.
 
 This was left open in an earlier revision, answered on #12081 in the
 collision form, and corrected here after review. The correction on #12081

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -297,10 +297,33 @@ traversal actually calls. So:
   Effect-to-Promise bridge **is a `run` site**, and the ratchet decides whether
   it may live where the consumer lives. The three instances found so far —
   hub construction, the `glob` adapter, and the synchronous `subscribe` facade
-  (below) — were all found by accident, while pricing something else. The cost is not "two places"; it
-  is one systematic cost of candidate B whose extent nobody has measured. A
-  grep for B's prospective consumers against the boundary kinds is the
-  measurement, and it has not been run. The three `globSync` callers additionally need the synchronous set,
+  (below) — were all found by accident, while pricing something else.
+
+  **The deferred grep has now been run, and it bounds the exposure rather than
+  counting it** [reproduced]. 22 files consume `platform().fs`. Exactly **one**
+  sits at a ratchet boundary — `packages/desktop/src/main/desktopWorkspaceIpc.ts`.
+  The other **21 do not**: 9 production
+  (`compiledPdfArtifacts.ts`, `platformAgentDirectories.ts`,
+  `workspaceFileOptions.ts`, `runDirOps.ts`, `LatexMediaManager.ts`,
+  `tempFileManager.ts`, `claudeAgentConfig.ts`, `leanServer.ts`,
+  `baseFS.ts`) and 12 test-kernel.
+
+  **Read that as an upper bound, not an answer, and the distinction is the
+  whole point.** A non-boundary consumer needs a `run` site only if it must
+  hand a _value_ to something that cannot accept an `Effect`; otherwise the
+  `Effect` propagates upward until it reaches a boundary that can run it. So
+  21 is the ceiling on new run sites, and the floor is however far propagation
+  travels. R-1 supplies the only real datum on that: converting **one** leaf
+  (`workspaceFileOptions.ts`, on this list) touched **17 files**. The likely
+  shape is therefore few run sites and a great deal of propagation — which is
+  a different cost from the one this section was worried about, and worse in a
+  way the ratchet does not measure.
+
+  What the grep does settle: the exposure is **21 files, not "unknown"**, and
+  every one is named above. The cost is not "two places"; it
+  is one systematic cost of candidate B, and its extent is now bounded rather
+  than unknown: 22 `platform().fs` consumers, 21 of them off-boundary, all
+  named above. The three `globSync` callers additionally need the synchronous set,
   which Effect also lacks — and there no adapter exists at all.
 
 So under both candidates the seam closes for the five async callers and stays

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -741,7 +741,8 @@ The real requirements are narrower and different:
   (`WorkflowEngine.js:356-360`) and falls through to execute when it finds
   one. `layerMemory` makes that moot, but a durable engine persisting the row
   must distinguish an attempt orphaned by a crash from one a live process is
-  still executing. Nothing in the interface expresses that,
+  still executing. (One way such a marker is created: a completion write that
+  failed transiently and suspended — see the storage-error path above.) Nothing in the interface expresses that,
   and the distinction cannot be made by suspending: mapping every
   start-without-completion to `Suspended` parks the activity on every replay,
   since the marker stays incomplete and the next resume meets the same state.

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -283,7 +283,18 @@ traversal actually calls. So:
   already a boundary kind. So B needs the adapter built at an allowed boundary
   and injected into four consumers, or a separate native seam for them — the
   same structural cost this note found for the hub constructor, in a second
-  place. The three `globSync` callers additionally need the synchronous set,
+  place.
+
+  **Generalise it, because two independent instances is a pattern and not a
+  coincidence.** Anywhere candidate B meets a synchronous or Promise-shaped
+  third-party contract — `path-scurry`'s `FSOption`, a class constructor, any
+  callback API that must return a value rather than an `Effect` — the
+  Effect-to-Promise bridge **is a `run` site**, and the ratchet decides whether
+  it may live where the consumer lives. Both instances found so far were found
+  by accident, while pricing something else. The cost is not "two places"; it
+  is one systematic cost of candidate B whose extent nobody has measured. A
+  grep for B's prospective consumers against the boundary kinds is the
+  measurement, and it has not been run. The three `globSync` callers additionally need the synchronous set,
   which Effect also lacks — and there no adapter exists at all.
 
 So under both candidates the seam closes for the five async callers and stays

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -338,19 +338,36 @@ is `publishUnsafe`, documented to return `false` when a bounded hub is full.
 **production class constructor**, and `src/transcript/runTrace.ts:34`
 constructs a second one in a plain function.
 
-**And the hub need not be injected at all.** `Effect.runSync(PubSub.unbounded())`
-succeeds on rc.112 — verified by running it — so `TraceEmitter` can build its
-own hub in its constructor and none of the 19 `new TraceEmitter()` sites has
-to change. That removes most of the construction churn from the estimate
-below; the subscription and lifecycle work remains.
-
-One repo-specific cost attaches to it: `src/agent/trace/TraceEmitter.ts` is
-not one of the ratchet's boundary kinds
+**The hub need not be injected — but not by the route this note first gave.**
+`Effect.runSync(PubSub.unbounded())` does succeed on rc.112. It is
+nonetheless **barred here**, and a `debtLanes` entry does not rescue it:
+`src/agent/trace/TraceEmitter.ts` is not one of the ratchet's boundary kinds
 (`packages/{extension,desktop,cli,agent}/src/**` or `src/tools/**/*Tool.ts`),
-so a `runSync` there lands in the `Effect.run*` row as below-boundary debt and
-`--update` refuses it without a `debtLanes` entry naming the lane that removes
-it. Workable, but it converts constructor churn into a tracked debt row rather
-than eliminating it.
+and `check-effect-migration-ratchet.mjs:1175-1188` refuses **any** file
+entering the below-boundary register that the committed baseline does not
+already name — "the register records the debt that already existed when it was
+written; it is not an intake" — then exits 1. An earlier revision of this
+paragraph called that "workable, a tracked debt row". It is not workable; it
+is rejected.
+
+**The route that does work is `PubSub.makeAtomicUnbounded`, and it is
+synchronous end to end** [reproduced]. It returns an `UnboundedPubSub` value
+rather than an `Effect`, and on that value `subscribe()` returns a
+subscription object and `publish(x)` returns a boolean — all verified by
+running them. No `Effect.run*`, so no ratchet row at all. `PubSub.make`, which
+wraps an atomic in a delivery strategy, _is_ effectful
+(`Effect.Effect<PubSub<A>>`) and would land back on `runSync`.
+
+**But notice what that buys, because it cuts against the conclusion it
+rescues.** `Atomic` is the low-level storage layer: no delivery strategy, no
+subscriber-completion machinery, none of the semantics `PubSub` layers on top.
+A `TraceEmitter` holding an `Atomic` and calling its synchronous
+`publish`/`subscribe` is **closer to the hand-rolled listener set B4 exists to
+replace** than to the hub whose semantics justified replacing it. So the
+ratchet-legal in-place construction is available, and taking it gives up most
+of the reason to migrate. Either the hub is built at an existing `Effect`
+boundary — which is injection, the thing this paragraph set out to avoid — or
+B4 adopts a queue and calls it a hub.
 
 **An earlier revision called that constructor "the actual blocker". It is not.**
 Review pointed out that the handler-construction path is reached from inside an
@@ -358,9 +375,11 @@ Review pointed out that the handler-construction path is reached from inside an
 `Effect.tryPromise` around `createModelHandler` — so a caller can yield
 `PubSub.unbounded()` there and pass the hub into the synchronous constructor.
 What the constructor forbids is a **drop-in field initializer**; it does not
-forbid replacing `TraceEmitter`. And since the hub can be built in place (see
-above), threading one through `createModelHandler`'s `async` signature is not
-required either — an earlier revision prescribed that, and it is withdrawn.
+forbid replacing `TraceEmitter`. And since a hub can be built in place (see
+above — via `makeAtomicUnbounded`, the only ratchet-legal route, at the price
+of adopting the storage layer rather than the strategy), threading one through
+`createModelHandler`'s `async` signature is not required either — an earlier
+revision prescribed that, and it is withdrawn.
 
 So nothing here is impossible. What remains is the size of the job, and it is
 smaller than earlier revisions of this note claimed. 26 files touch the seam
@@ -378,12 +397,24 @@ The composition matters more than the total. **5 of the 16 are production** —
 `SessionHandle.ts`, `channelTrace.ts`, `runTrace.ts` — and the other 11 are
 test-kernel, most passing a plain synchronous callback to `trace.subscribe`
 and reading events out of a local array on the next line. So the production
-blast radius is five files, and the cost is concentrated in rewriting eleven
-test files that would each need a fiber, a scope and a drain to observe what
-a callback observes today.
+blast radius is five files.
 
-That is the argument against B4, and it is an economic one: 16 files of
-churn, mostly tests, plus the eight behavioural properties below, against the
+**The eleven test files are cheaper than an earlier revision charged them.**
+That revision said each would need "a fiber, a scope and a drain". It would
+not: if `TraceEmitter.subscribe` stays a synchronous facade — which it must
+anyway, for properties 3 and 6 — the adapter owns each subscription's fiber
+and scope internally and exposes one drain barrier. What each test then needs
+is to _await that barrier_ before asserting on its array, not to build the
+machinery itself. Price the assertion and lifecycle change; charging every
+subscriber file for adapter-owned infrastructure inflates the case against
+B4, which is the direction this note has now erred in three separate
+places.
+
+That is the argument against B4, and it is an economic one — and it has shrunk
+in every round that examined it, which is worth stating plainly rather than
+restating the conclusion at a smaller number each time: 16 files of
+churn, mostly tests and each cheaper than first charged, plus the eight
+behavioural properties below, against the
 listener machinery being replaced — the `subscribers` field (`:47`),
 `subscribe` (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a
 217-line class that does much else besides. Not impossibility — price.
@@ -551,8 +582,11 @@ event stage-stamped on the way in, detachment stopping delivery before it
 returns, the handover cap enforced at enqueue rather than in the handler, and
 ordering preserved against the separate status plane.
 Together with the subscription and lifecycle work above — but not
-the constructor sites, which can build their own hub — that is the real size
-of B4, and the reason not to do it is that size, not impossibility.
+the constructor sites, which can build their own storage-layer hub without
+tripping the ratchet — that is the real size of B4. The reason not to do it is
+that size, not impossibility. Read that verdict with the trend in mind: the
+size has fallen in each of the last three rounds, every time because an
+objection of mine failed rather than because a new capability appeared.
 
 ### `StreamLogStore.onChange` is dead in production but is **not** a three-file deletion
 

--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -299,31 +299,48 @@ traversal actually calls. So:
   hub construction, the `glob` adapter, and the synchronous `subscribe` facade
   (below) — were all found by accident, while pricing something else.
 
-  **The deferred grep has now been run, and it bounds the exposure rather than
-  counting it** [reproduced]. 22 files consume `platform().fs`. Exactly **one**
-  sits at a ratchet boundary — `packages/desktop/src/main/desktopWorkspaceIpc.ts`.
-  The other **21 do not**: 9 production
-  (`compiledPdfArtifacts.ts`, `platformAgentDirectories.ts`,
-  `workspaceFileOptions.ts`, `runDirOps.ts`, `LatexMediaManager.ts`,
-  `tempFileManager.ts`, `claudeAgentConfig.ts`, `leanServer.ts`,
-  `baseFS.ts`) and 12 test-kernel.
+  **The deferred grep was run and then corrected twice; both corrections
+  matter more than the number.**
 
-  **Read that as an upper bound, not an answer, and the distinction is the
-  whole point.** A non-boundary consumer needs a `run` site only if it must
-  hand a _value_ to something that cannot accept an `Effect`; otherwise the
-  `Effect` propagates upward until it reaches a boundary that can run it. So
-  21 is the ceiling on new run sites, and the floor is however far propagation
-  travels. R-1 supplies the only real datum on that: converting **one** leaf
-  (`workspaceFileOptions.ts`, on this list) touched **17 files**. The likely
-  shape is therefore few run sites and a great deal of propagation — which is
-  a different cost from the one this section was worried about, and worse in a
-  way the ratchet does not measure.
+  The raw grep found 22 files mentioning `platform().fs`, and an earlier
+  revision reported 21 off-boundary — 9 production, 12 test-kernel — as a
+  measured exposure. Both halves were wrong:
 
-  What the grep does settle: the exposure is **21 files, not "unknown"**, and
-  every one is named above. The cost is not "two places"; it
-  is one systematic cost of candidate B, and its extent is now bounded rather
-  than unknown: 22 `platform().fs` consumers, 21 of them off-boundary, all
-  named above. The three `globSync` callers additionally need the synchronous set,
+  - **Three of the nine "production consumers" are comment-only, and the
+    comments say the opposite of what the count assumed.**
+    `tempFileManager.ts:14`, `claudeAgentConfig.ts:111` and
+    `leanServer.ts:428` each mention `platform().fs` only to explain why the
+    file deliberately uses `node:fs/promises` **instead**. They are documented
+    non-consumers. The grep counted textual mentions and the prose called them
+    consumers. **Six** off-boundary production consumers, not nine:
+    `compiledPdfArtifacts.ts`, `platformAgentDirectories.ts`,
+    `workspaceFileOptions.ts`, `runDirOps.ts`, `LatexMediaManager.ts`,
+    `baseFS.ts` — plus the one boundary consumer,
+    `packages/desktop/src/main/desktopWorkspaceIpc.ts`. (The 12 `test-kernel`
+    matches are excluded from a production tally by the ratchet's own
+    `productionFiles()`.)
+  - **"A ceiling on run sites" was the wrong shape entirely.** A converted
+    leaf does not propagate to _one_ boundary; it fans out to **every**
+    independent host boundary above it, each needing its own bridge.
+    `workspaceFileOptions.ts` alone feeds
+    `packages/desktop/src/main/desktopFileSelection.ts:89` and
+    `packages/extension/src/progressView/ProgressViewProvider.ts:156` through
+    `workspaceFileOptions`, and
+    `packages/desktop/src/main/desktopHostRequests.ts:34` through
+    `listWorkspaceFilesOfType` — three files across **two host packages**,
+    none of them on the list. A leaf count cannot bound a fan-out.
+
+  So the honest statement is narrower than the one it replaces: **six
+  off-boundary production consumers are the leaves**, the run sites are at
+  their transitive host boundaries, and **that fan-out is still unmeasured**.
+  R-1 remains the only datum — converting `workspaceFileOptions.ts` alone
+  touched 17 files.
+
+  **The lesson is the one this note keeps relearning.** A grep returns
+  matches; calling them consumers is an inference, and I published the
+  inference as a measurement one round after writing that verified premises do
+  not license unverified steps. Any count here should be treated as a leaf
+  count and nothing more. The three `globSync` callers additionally need the synchronous set,
   which Effect also lacks — and there no adapter exists at all.
 
 So under both candidates the seam closes for the five async callers and stays
@@ -464,11 +481,23 @@ of which **10 only construct** a
 `attachChannelSubscriber`). Whether the 10 count depends on which hub is
 adopted:
 
-- **B4-atomic — 17 files.** `makeAtomicUnbounded` is synchronous, so each
-  constructor builds its own and the 10 are untouched. But this buys the
-  storage layer: no delivery strategy, no subscriber-completion machinery.
-  Most of the eight properties below then have to be re-implemented by hand on
-  top of it, which is approximately what `TraceEmitter` already does.
+- **B4-atomic — 1 file.** An earlier revision charged this route 17 and was
+  importing B4-hub's cost into it. `makeAtomicUnbounded` is synchronous, and
+  so are the `Atomic`'s own `subscribe()` and `publish()` — verified by
+  running them. So `TraceEmitter` builds its own, owns the subscriptions
+  internally, and **keeps its existing synchronous `subscribe`/`emit`/detach
+  facade unchanged**. The 10 constructors are untouched _and so are the 16
+  subscribers_: they need lifecycle and assertion changes only if this route
+  separately chooses asynchronous delivery, which the `Atomic` does not
+  impose. The churn is the emitter implementation itself.
+
+  **Which makes the route nearly free and nearly pointless, and those are the
+  same fact.** What it buys is the storage layer — no delivery strategy, no
+  subscriber-completion machinery — so all seven adapter-owned properties
+  below stay hand-written. That is approximately what `TraceEmitter` already
+  is. B4-atomic swaps a hand-rolled subscriber array for an upstream one and
+  changes nothing else.
+
 - **B4-hub — 27 files, and that is a floor.** A real `PubSub` needs
   `PubSub.make` or `PubSub.unbounded`, both effectful, and `TraceEmitter.ts`
   cannot run them (not a ratchet boundary kind, and the below-boundary
@@ -502,8 +531,8 @@ tree, not as authoritative.
 **Both totals exclude the file being replaced, and should not.** 26 counts
 call sites — constructors and subscribers — but either route rewrites
 `src/agent/trace/TraceEmitter.ts` itself: the `subscribers` field, `subscribe`
-and `emit`. Counting it, the churn is **17 files for B4-atomic and 27 for
-B4-hub**, across **six production files rather than five**. An estimate that
+and `emit`. Counting it, the churn is **1 file for B4-atomic and at least 27
+for B4-hub**, across **six production files rather than five**. An estimate that
 prices a replacement while omitting the thing being replaced understates it by
 construction.
 
@@ -540,9 +569,10 @@ subscriber file for adapter-owned infrastructure inflates the case against
 B4, which is the direction this note has now erred in three separate
 places.
 
-That is the argument against B4, and it is an economic one: **17 files of churn
-for B4-atomic or **at least** 27 for B4-hub (injection propagates up factory
-chains this count never followed)**, mostly tests and each cheaper than first
+That is the argument against B4, and it is an economic one, and the two routes
+are no longer close: **1 file for B4-atomic — which buys almost nothing — or
+at least 27 for B4-hub (injection propagates up factory chains this count
+never followed)**, mostly tests and each cheaper than first
 charged, plus the eight behavioural properties below, against the listener
 machinery being replaced — the `subscribers` field (`:47`), `subscribe`
 (`:66-68`) and `emit` (`:70-94`), about 29 lines inside a 217-line class that
@@ -739,7 +769,8 @@ returns, the handover cap enforced at enqueue rather than in the handler, and
 ordering preserved against the separate status plane.
 Together with the subscription and lifecycle work above, that is the real size
 of B4 — and it is **route-dependent** in file count only: the constructor
-sites stay untouched for B4-atomic (17 files) and change for B4-hub (27).
+sites stay untouched for B4-atomic (1 file, and it buys almost nothing) and
+change for B4-hub (27 at least).
 
 **A previous revision said B4-hub "inherits" these eight properties. It does
 not, and that sentence was the most dangerous thing in this note** — an


### PR DESCRIPTION
## Summary

Six parallel lanes, each reviewed by two independent adversarial passes, produced a body of verified facts about `effect@4.0.0-rc.112`. Those facts were scattered across six issue threads, and **several open issues assert the opposite of what the pinned types say**. This note collects them in one citable place so the next pass does not re-derive them — and so the wrong claims stop propagating.

**The note has been through many adversarial review rounds; roughly seventy findings against it were accepted and two were rejected with evidence.** It records where its own conclusions weakened, including several it had backwards. That history is the point rather than an embarrassment: the same facts were being re-derived wrongly by successive passes, which is exactly what the note exists to stop.

*This description states the durable claims only. Round counts, commit counts and the current CI head are deliberately omitted — they changed every round and the description went stale chasing them. **The note itself is the record**; where the two disagree, the note wins. This description has itself been a source of retracted claims three times, which is why it now defers rather than restates.*

### The corrections that carry the note

- **`nodeChildProcessSpawner.ts` is already an `effect/unstable/process` implementation**, not a duplicate of one. There is no `ChildProcessSpawner` port in `src/platform/interfaces.ts`, and `effect` core has zero `node:child_process` references. #12078 was filed on the opposite premise.
- **`@effect/platform-node` carries a non-optional `redis` peer.** The zero-dependency profile belongs to `@effect/sql-sqlite-node`. On `cutover/native-runtime-llm-20260907` the package is in **`dependencies`**, `redis` is declared nowhere, and the lockfile still carries `redis@6.2.1` — because `pnpm-lock.yaml:4` sets `autoInstallPeers: true`. **There is no unmet-peer warning**; a Redis client enters the production install graph silently, which is worse than a warning.
- **The errno exposure is three predicates, and ENOSPC is exempt.** `PlatformError`'s constructor hoists `reason.cause` onto the wrapper as a top-level `.cause`, so `causeChain` reaches the errno in one hop and `isDiskFullError` works — but the wrapper gets no `.code`, so top-level reads still fail. Verified by running both. This fact later settled the `glob` question too, two sections away.
- **The `lstat` gap is the load-bearing one, and in one path it corrupts data.** `writeRoundOutput` (`XmlOutputManager.ts:47`) deletes a pre-staged symlink before writing "so the write never follows the link into the immutable snapshot"; the guard resolves through `stat().type`, so under link-following `stat` it returns false and the write goes **through** the link into that snapshot. Alongside it: `inspectRunStorageEntry` fails open on execution-directory containment, at least twelve production consumers branch on `readDirectory`'s type bits, and `glob`'s `FSOption` wants `lstat`.
- **The Effect→Promise bridge is a `run` site, and the ratchet governs where it may live.** Candidate B's systematic cost, found three times by accident: hub construction in `TraceEmitter.ts` (rejected outright — not a boundary kind, and the below-boundary register "is not an intake"), `glob`'s `FSOption.promises.lstat`, and the synchronous `subscribe` facade, since `PubSub.subscribe` returns `Effect<…, Scope>`. Anywhere B meets a synchronous or Promise-shaped third-party contract, the same cost applies.
- **`glob` costs candidate B two extra filesystem calls per entry *and* a run boundary.** `FSOption.readdir` demands `withFileTypes: true` and returns `Dirent[]`, while Effect's `readDirectory` returns names — so B manufactures each `Dirent` *and* still runs the symlink test. Candidate A's `lstat`-backed port pays neither. What fails outright is passing Effect's `FileSystem` *directly* as `FSOption`; an adapter works for both candidates. The three `globSync` callers keep separate wiring either way.
- **Storage errors are the loud half; unvalidated reads are the other half — and absence is neither.** `KVStore.read<T>` (`KVStore.ts:55-62`) is `JSON.parse(raw) as T`. **Missing is normal absence** (`withMissingFallback` → `undefined`), and for a new activity the memo row is *expected* absent. Unparseable throws. **Valid JSON of the wrong shape passes silently** and is consumed as runnable workflow state — that is the case the section exists to warn about.
- **`withCompensation` is rollback, not crash protection.** When a side effect succeeds and the process dies before memoization, **no finalizer runs at all**. The crash window needs idempotency or durable deduplication.
- **Everything outside an activity replays — and a deterministic body is not enough.** `resume` re-executes the body from the top and memoizes only activity *exits*. Worse, it runs whichever body is *installed now*, while the memo key carries no definition identity. After an update, a rename re-runs a completed effect and a **reorder binds a stored exit to a different invocation — succeeding silently with the wrong value**. Adoption needs a persisted definition identity checked on resume, rejecting an incompatible journal loudly rather than translating it. That check does not exist in the engine.

### Where this note's own claims weakened under review

- **B4 is not blocked, and it is not one candidate — and the two are not comparable.** **B4-atomic is 1 file.** `Atomic`'s `subscribe()`/`publish()` are synchronous (verified by running them), so `TraceEmitter` keeps its existing synchronous facade and neither the 10 constructors nor the 16 subscribers change. **B4-hub is at least 27**, because injection propagates up factory chains the count never followed — `createRunTrace` alone pulls in seven more files. An earlier revision priced B4-atomic at 17 by importing B4-hub's asynchronous-consumer cost into it.
- **B4-atomic being nearly free and nearly pointless is one fact.** It buys the storage layer — no delivery strategy, no subscriber-completion machinery — so every adapter-owned property stays hand-written. It swaps a hand-rolled subscriber array for an upstream one and changes nothing else.
- **A real `PubSub` supplies property 1 and nothing else.** **Properties 2–8, all seven, are adapter work under both routes.** Two earlier revisions got this wrong in sequence: the first said B4-hub "inherits" the properties (the most dangerous sentence in the note — an implementer would ship a hub missing guarantees whose absence loses or reorders durable events); the correction then said "two of eight, six adapter-owned" above a list of seven.
- **The `platform().fs` grep was run, then retracted twice.** Three of nine "production consumers" mention it *only in comments explaining why the file deliberately uses `node:fs/promises` instead* — documented non-consumers counted as consumers. And "a ceiling on run sites" was a category error: one leaf fans out to every independent host boundary above it (`workspaceFileOptions.ts` reaches three files across two host packages), so a leaf count cannot bound a fan-out. **Six off-boundary production leaves; the fan-out is still unmeasured.**
- **`runFork(publish)` is not backpressure.** It suspends the new fiber; the synchronous `emit` caller returns and can emit again, accumulating one suspended fiber per event. Honestly named: bounded-hub-with-unbounded-pending-publishers.
- **A trend claim in an earlier revision of this description has been retracted.** It said the cost of B4 "has only ever moved one way under scrutiny". Splitting by route, counting the emitter, and the run-boundary cost all moved it back up; then the B4-atomic correction moved that route sharply down. **Distrust any single number offered as "the cost of B4", this note's included.**
- **The attempt-counter claim was backwards and is retracted** — restarting at attempt 1 is deterministic replay, not collision, and the prescription would have broken resume. **Corrected on #12081.**
- **The `readLink` probe was wrong twice, in opposite ways**, and §2 of the note disproved the second. It is **correct but expensive**.
- **`interruptUnsafe` is a TeXRA architecture cost, not an interface limitation.**
- **Two findings were rejected with evidence**: that `causeChain` cannot reach the errno, and that rc.112 `Object.assign`s errno fields onto the wrapper. Both checked by running code.

**The four failure modes, named because they are more useful than any single finding.** (1) **A framing sentence outliving its body** — eleven-plus instances, three in this description; leads and closing summaries both drift, and they survive greps because they share no vocabulary with the change. (2) **Set-definition errors** — three in four rounds: enumerate correctly, then describe the set as something larger (call sites omitting the file being replaced; seam files omitting factory callers; leaf mentions omitting transitive boundaries). A re-count never catches these. (3) **Replies asserting what the note does not say** — three occurrences. (4) **Verified premises joined by an unverified step** — `grep -l` matches called "consumers" without opening a file; a hedge about *precision* does not repair a wrong *unit*. Claims independently reproduced are marked **[reproduced]**; every count is a **floor**. The glob paragraph alone has been wrong six times and says so.

## Issue acceptance gates

No gate is claimed as satisfied — this is a findings record, not an implementation. It supplies evidence to:

- **#12073** — **R-1 resolved** by running the corrected experiment on `claude/effect-ts-tracking-issues-usoj7h`. Result plus four addenda posted there.
- **#12074** — B4 stays rejected on cost rather than impossibility, but **read it as two candidates with two very different costs**, and read the retractions above before relying on either number.
- **#12078** — supplies the factual basis for closing it.
- **#12081** — the interrupt-retry cost, the storage requirements, the memo-key hazards, and two retractions.
- **#12025** — the umbrella these feed.

## Single source of truth

The note itself, for "what `effect@4.0.0-rc.112` actually provides". `node_modules/effect/dist/**` remains the underlying authority; `effect-solutions` is not installed, so AGENTS.md's fallback rule is what was followed.

## Duplication and abstraction budget

Removes duplication rather than adding it: the same API facts were being independently re-derived by successive passes, several of them *wrongly*. No abstraction added — one markdown file, no code.

## Net elements (R6)

- Files: 1 added, 0 modified, 0 deleted. All commits are prose.
- Exported symbols: 0 / 0. Classes / interfaces / enums: 0 / 0 / 0.
- No production code, no dependencies, no configuration.

## Consumer counts (R8)

n/a — no emit path, export, or subscription key is touched.

## Host impact

Extension: none. Desktop: none. CLI: none.

Documentation only, and outside the VitePress root — `.agents/docs/` is excluded by `docs/.vitepress/publicDocs.js`, so the texra.ai deploy is unaffected.

## Scheduled refactoring

- ~~**The R-1 experiment**~~ — **run.** One leaf converted to take `FileSystem` from context with its `platform().fs` deleted: 17 files, 384 lines of new layer, 3,913 extra `stat` syscalls and ~8× slower on a 3,096-file tree. Reverted rather than landed; full result on #12073.
- ~~Whether `Activity.CurrentAttempt` survives a restart~~ — **it does not, and that is by design.**
- ~~Whether the LLM branch carries an unmet `redis` peer~~ — **no warning at all**; it installs silently.
- ~~The `StreamLogStore` delta-emission question~~ — **closed.** `sessionFold.ts:1710` is an independent production consumer.
- **Open, and named as such:** the injection fan-out above candidate B's six off-boundary leaves, and whether R-1's ~8× per-entry-`stat` result transfers to `glob`'s workload. Neither has been measured; R-1's 17-files-for-one-leaf is the only datum on the first.

## Validation

- `npx prettier --check`, `check-guidance-refs.mjs` (58 files), `check-root-docs.mjs`, and `check-effect-migration-ratchet.mjs` — all clean before each push.
- **CI has been green on every head this PR has had**, with `validate`, `docs build`, `detect changes`, `guidance references` and `label` passing and heavy jobs correctly skipped for a docs-only change. Check the PR's current head for the live result rather than trusting a SHA quoted here.
- **Every file path and line number verified by hand and re-verified after each correction.** The ENOSPC, replay, errno-hoisting, `makeAtomicUnbounded` and `Atomic.subscribe`/`publish` claims were settled by running code, not by reading types.

No typecheck or test run: no code changed. Scratch probes were written to settle `effect` runtime behaviour and deliberately not committed — they pin upstream internals rather than any TeXRA behaviour.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRKNXQf68EFbEiMrsNboLo