### PR TITLE
consolidate: reuse formatBytes and isTransientHttpStatus instead of ad-hoc reimplementations

### DIFF
--- a/packages/cli/src/runtime/supabaseAuthDeviceCode.ts
+++ b/packages/cli/src/runtime/supabaseAuthDeviceCode.ts
@@ -20,6 +20,7 @@ import {
 import { parseOAuthJson, postOAuth } from '@auth/oauth/oauthRequest';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import { isObject } from '@utils/core';
+import { isTransientHttpStatus } from '@utils/core/httpStatus';
 
 const DEVICE_AUTH_REQUEST_TIMEOUT_MS = 30000;
 
@@ -194,7 +195,7 @@ const pollOnce = Effect.fn('supabaseAuthDeviceCode.pollOnce')(function* (
         message: 'Sign-in was denied in the browser.',
       });
     default:
-      if (response.status === 429 || response.status >= 500) {
+      if (isTransientHttpStatus(response.status)) {
         return yield* transient(
           new DeviceSignInError({
             reason: 'poll',

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -13,7 +13,7 @@ import {
 } from '@tools/pathResolution';
 import { recordToolFileRead } from '@tools/fileInteractions';
 import { parseEml, type EmlImageAttachment } from '@tools/emlParser';
-import { splitContentLines } from '@utils/text/stringUtils';
+import { formatBytes, splitContentLines } from '@utils/text/stringUtils';
 import { hasExtension, getExtensionLowercase } from '@utils/core/pathCore';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import {
@@ -155,7 +155,7 @@ export class ReadFileTool extends defineTool({
       const stats = await WorkspaceFS.stat(filePath);
       if (stats.size > MAX_EML_BYTES) {
         throw new ToolError(
-          `EML file exceeds maximum size of ${MAX_EML_BYTES / (1024 * 1024)} MiB.`,
+          `EML file exceeds maximum size of ${formatBytes(MAX_EML_BYTES)}.`,
         );
       }
       const raw = await WorkspaceFS.read(filePath);

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -12,6 +12,7 @@ import { isNonEmptyString } from '@utils/core';
 import { getMimeType, isImageMimeType } from '@utils/files/mimeUtils';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toPosixPath } from '@utils/core/pathCore';
+import { formatBytes } from '@utils/text/stringUtils';
 
 export interface BuildFileAttachmentOptions {
   /** Path to a workspace file (relative or absolute) */
@@ -117,9 +118,8 @@ export async function buildFileAttachment({
   );
 
   if (stats.size > ATTACHMENT_MAX_BYTES) {
-    const limitMb = (ATTACHMENT_MAX_BYTES / (1024 * 1024)).toFixed(1);
     throw new ToolError(
-      `Attachment ${display} exceeds maximum size of ${limitMb} MiB.`,
+      `Attachment ${display} exceeds maximum size of ${formatBytes(ATTACHMENT_MAX_BYTES)}.`,
     );
   }
 

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -19,7 +19,7 @@ import { formatBytes } from '@utils/text/stringUtils';
 
 const WEB_FETCH_TIMEOUT_MS = 30_000; // 30 s
 const WEB_FETCH_RETRIES = 2;
-const MAX_CONTENT_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_CONTENT_BYTES = 10 * 1024 * 1024; // 10 MiB
 
 const WebFetchInputSchema = z.strictObject({
   url: z

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -15,6 +15,7 @@ import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { createHtmlToMarkdown } from '@utils/text/htmlToMarkdown';
+import { formatBytes } from '@utils/text/stringUtils';
 
 const WEB_FETCH_TIMEOUT_MS = 30_000; // 30 s
 const WEB_FETCH_RETRIES = 2;
@@ -63,7 +64,7 @@ const fetchPage = Effect.fn('WebFetchTool.fetchPage')((url: string) =>
         // Permanent: not retried.
         return yield* Effect.fail(
           new Error(
-            `Response too large (${lengthHeader} bytes); maximum is ${MAX_CONTENT_BYTES / (1024 * 1024)} MB.`,
+            `Response too large (${lengthHeader} bytes); maximum is ${formatBytes(MAX_CONTENT_BYTES)}.`,
           ),
         );
       }
@@ -90,7 +91,7 @@ const fetchPage = Effect.fn('WebFetchTool.fetchPage')((url: string) =>
           if (total > MAX_CONTENT_BYTES) {
             return Effect.fail(
               new Error(
-                `Response too large (exceeds ${MAX_CONTENT_BYTES / (1024 * 1024)} MB maximum).`,
+                `Response too large (exceeds ${formatBytes(MAX_CONTENT_BYTES)} maximum).`,
               ),
             );
           }


### PR DESCRIPTION
## Summary

Small, low-risk consolidation from a codebase-wide sweep for duplicated logic and hand-rolled reimplementations of native/existing-dependency functionality (four parallel Explore surveys covering the webview trees, provider model handlers/tools, hand-rolled async serialization, and native-builtin reimplementations). Most of the codebase turned out to already be well-consolidated on these axes — see below for what was found but *not* changed here.

- `src/tools/ReadTool.ts`, `src/tools/attachments.ts`, and `src/tools/web/WebFetchTool.ts` each hand-computed a byte-limit label by dividing a constant by `1024 * 1024` (three call sites, two different unit labels for the same binary math). Switched all three to the existing `formatBytes()` helper (`src/utils/text/stringUtils.ts:350`, backed by the already-installed `pretty-bytes`). This also fixes a minor mislabeling in `WebFetchTool.ts`, which said "MB" for a value that was always binary MiB.
- `packages/cli/src/runtime/supabaseAuthDeviceCode.ts:197` re-implemented the transient-HTTP-status check (`status === 429 || status >= 500`) inline. Switched to the centralized `isTransientHttpStatus()` (`src/utils/core/httpStatus.ts`), already shared by `src/tools/timeouts.ts` and `src/latex/arxivProcessor.ts` for exactly this policy. Behavior note: this also makes 408 (Request Timeout) transient here, matching the other two call sites' policy — previously it was treated as a hard failure only in this one spot.

## Issue acceptance gates

No tracking issue for this specific PR (a routine consolidation sweep). Two follow-up findings from the same survey were filed as separate issues rather than folded in here, since they need dev-server visual verification (UI) or dedicated test review (retry-classification logic) that don't belong in a small, low-risk PR:
- #12089 — two duplicated `<wa-details>` toggle-handler shapes across `progressView`/`settingsView` webview components
- #12090 — `providerErrorFormat.ts`'s hand-rolled transport-error code list vs. the installed `is-network-error` dependency

## Single source of truth

`formatBytes()` (`src/utils/text/stringUtils.ts`) is now the single place that turns a byte count into a human-readable size across these three tools. `isTransientHttpStatus()` (`src/utils/core/httpStatus.ts`) is now the single place that decides whether an HTTP status is worth retrying, across the CLI auth poller and the two prior call sites.

## Duplication and abstraction budget

Removed three duplicated `/ (1024 * 1024)` byte-math expressions and one duplicated transient-status boolean expression. No new abstractions added — both helpers already existed and were already used elsewhere in the codebase; this PR only routes three additional call sites through them.

## Net elements (R6)

- Files: 4 changed, 0 added, 0 deleted
- Exported symbols (`^[+-]export` in diff): 0
- Classes/interfaces/enums: 0
- Net LoC: +9/-7 (+2 net) — the two-line `formatBytes` import additions outweigh the one-liner call-site simplifications; no behavior-preserving refactor here nets negative LoC since the "duplication" was inline expressions, not whole functions.

## Consumer counts (R8)

n/a — no export deleted or re-routed; this PR only changes internal call sites to use existing shared exports.

## Host impact

Extension: none (all four touched files are host-agnostic tool/CLI-runtime code).

Desktop: none.

CLI: `packages/cli/src/runtime/supabaseAuthDeviceCode.ts` now also retries on HTTP 408 during device-code sign-in polling (previously only 429/5xx), matching the shared transient-status policy used elsewhere.

## Scheduled refactoring

None beyond the two filed issues (#12089, #12090) noted above.

## Validation

- `npm run typecheck` — clean across all packages (workspace, test-kernel, agent, cli, trace-viewer, desktop)
- `npx eslint` on the four touched files — clean
- `npx prettier --check` on the four touched files — clean
- `npx vitest run` on the directly relevant suites (`DeviceCodeAuth.vitest.ts`, `Attachments.vitest.ts`, `ReadToolRange.vitest.ts`) — 23/23 passing
- No dedicated `WebFetchTool` unit test exists; covered by typecheck + lint only for that file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Po81RPB8cTeJS6CeAa3mQb


---
_Generated by [Claude Code](https://claude.ai/code/session_01Po81RPB8cTeJS6CeAa3mQb)_