### PR TITLE
refactor(errors): share SDK error candidate lookup across status detectors

### DIFF
--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -128,21 +128,29 @@ type SdkErrorLike = {
   data?: unknown;
 };
 
+/** Direct-or-enveloped SDK error candidates: the thrown error itself, then
+ *  its nested `.response` and `.error` carriers (some SDKs preserve the full
+ *  envelope, others unwrap it before it reaches us). Mirrors
+ *  {@link errorBodyCandidates} for the analogous raw-body case. Shared by
+ *  `detectStatusCode`/`detectStatusText`, which both check the same fields
+ *  across the same three shapes. */
+function sdkErrorCandidates(err: unknown): Record<string, unknown>[] {
+  if (!isObject(err)) return [];
+  const candidate = err as SdkErrorLike;
+  return [candidate, candidate.response, candidate.error].filter(isObject);
+}
+
 /** Canonical HTTP status extractor for thrown SDK/provider errors. The only
  *  place that knows the candidate field shapes (`status`, `statusCode`,
  *  `code`, `response.status`, `error.status`). */
 export function detectStatusCode(err: unknown): number | undefined {
-  if (!isObject(err)) {
-    return undefined;
-  }
-
-  const candidate = err as SdkErrorLike;
+  const [direct, ...nested] = sdkErrorCandidates(err);
+  if (!direct) return undefined;
   return (
-    pickStatus(candidate.status) ??
-    pickStatus(candidate.statusCode) ??
-    pickStatus(candidate.code) ??
-    pickStatus(candidate.response?.status) ??
-    pickStatus(candidate.error?.status)
+    pickStatus(direct.status) ??
+    pickStatus(direct.statusCode) ??
+    pickStatus(direct.code) ??
+    nested.map((c) => pickStatus(c.status)).find((v) => v !== undefined)
   );
 }
 
@@ -150,14 +158,11 @@ export function detectStatusText(
   err: unknown,
   statusCode?: number,
 ): string | undefined {
-  if (isObject(err)) {
-    const candidate = err as SdkErrorLike;
-    const explicit =
-      candidate.statusText ??
-      candidate.response?.statusText ??
-      candidate.error?.statusText;
-    if (isString(explicit) && explicit) return explicit;
-  }
+  const candidates = sdkErrorCandidates(err);
+  const explicit = candidates
+    .map((c) => pickStringField(c, 'statusText'))
+    .find((v) => v !== undefined);
+  if (explicit) return explicit;
   return statusCode ? safeGetReasonPhrase(statusCode) : undefined;
 }
 


### PR DESCRIPTION
## Summary

A scheduled data-structure design audit (deeply nested maps, structures needing repeated type assertions/null checks, duplicated transforms) flagged `detectStatusCode` and `detectStatusText` in `src/common/errors/sdkError/errorInspection.ts` as hand-chaining the same direct-error/`.response`/`.error` envelope lookup independently. This PR extracts that lookup into a shared `sdkErrorCandidates()` helper, mirroring the existing `errorBodyCandidates()` pattern already used for raw error bodies in the same file, so both detectors scan one candidate list instead of re-deriving the "check direct, then response, then error" unwrap per field.

Behavior is unchanged: `detectStatusCode` still checks `status`/`statusCode`/`code` on the direct error and only `.status` on the nested `response`/`error` carriers, in the same priority order; `detectStatusText` still checks `.statusText` across all three in the same order, now via the already-exported `pickStringField` helper instead of a raw `??` chain.

### Findings considered but not changed

The audit surfaced several other "complex data structure" candidates. After reading each one in context, I scoped this PR down to the one change above, and left the rest alone for reasons worth recording:

- **`WorkflowExecutionCallSchema`'s `z.never()`-sentinel variants** (`src/shared/schemas/workflowExecutionSnapshot.ts`) and **`WorkflowCallProgressSchema`'s parallel status enum** — both are load-bearing, widely-consumed wire schemas; reshaping them is a real migration, not a mechanical refactor, and belongs in its own reviewed change. Note also that the `projectWorkflowCallStatus` mapping in `workflowScriptRun.ts` the audit called "silently goes stale" is in fact already exhaustively checked by TypeScript (no `default` branch; a new status left unhandled fails to compile) — not a live bug.
- **`ToolUseLogSchema`'s duplicated `summary`/`error`/`isError`/`userInstruction` at top level and nested in `output`** — real duplication on the wire, but `src/shared/toolUse.ts` is already the single documented reconciliation point ("This module is the single entry point... so hosts don't drift"), so the practical risk is lower than it first appears; fixing it at the source means touching every tool producer, out of scope here.
- **`RoundIndexed<T>` as a numeric-keyed `Record`** (`src/shared/schemas/roundIndexed.ts`) — the file's own header comment states this Record *is* the JSON wire/disk format with no separate encode step; converting in-memory state to a `Map` would introduce an encode/decode boundary the design deliberately avoids, across 19 consumer files. Not a genuine simplification once the rationale is read.
- **`StateSettingEntry`'s optional fields** and **`HostInteractions`' 11 optional methods** — both are real design observations, but reshaping either is a wide, multi-consumer change (150+ settings rows; every host's interaction adapter) that deserves its own scoped PR and reviewer buy-in, not a bundled drive-by fix.

## Issue acceptance gates

No linked issue — this PR implements one finding from an ad hoc scheduled codebase audit. Acceptance gate: `detectStatusCode`/`detectStatusText` behavior is unchanged and the duplicated envelope-unwrap logic between them is removed.

## Single source of truth

`sdkErrorCandidates()` in `errorInspection.ts` is now the one place that knows an SDK error may arrive as itself, or enveloped under `.response`/`.error`.

## Duplication and abstraction budget

Removed: the repeated `candidate.response?.X ?? candidate.error?.X` unwrap, previously written out separately in both `detectStatusCode` and `detectStatusText`. No new exported abstraction — `sdkErrorCandidates` is a private helper, same visibility tier as the existing `errorBodyCandidates` it mirrors.

## Net elements (R6)

1 file changed, 23 insertions(+)/18 deletions(-), net +5 LoC. No exported symbols added or removed (`git diff` has zero `^[+-]export` lines) — `sdkErrorCandidates` is module-private.

## Consumer counts (R8)

n/a — `detectStatusCode`/`detectStatusText` signatures and public behavior are unchanged; no emit path or export was deleted or re-routed.

## Host impact

Extension: none (shared, host-agnostic error-inspection code; behavior-preserving).
Desktop: none (same).
CLI: none (same).

## Scheduled refactoring

None. The four larger findings above are recorded in this PR's description for anyone who wants to scope follow-up work; no tracking issue filed.

## Validation

- `npm run typecheck:workspace` — passes.
- `npx eslint src/common/errors/sdkError/errorInspection.ts` — clean.
- `npx vitest run src/test-kernel/common/SdkErrorUtils.vitest.ts src/test-kernel/common/ChatGptSubscriptionDetection.vitest.ts src/test-kernel/common/KimiCodeSubscriptionDetection.vitest.ts src/test-kernel/common/XaiSubscriptionDetection.vitest.ts src/test-kernel/common/GlmCodingPlanDetection.vitest.ts` — 89/89 passed.
- `npx vitest run src/test-kernel/agent/modelHandlers` — 766/766 passed (4 pre-existing skips).
- `npm run check:dead-code-ratchet` — no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5QNAyWSECQgotFTvAGnCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5QNAyWSECQgotFTvAGnCU)_