### PR TITLE
fix: initialize headless CLI commands before running Effect

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -110,17 +110,6 @@ function assertSuccess(result, label) {
   );
 }
 
-function readNamedFiles(root, name) {
-  if (!existsSync(root)) return [];
-  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
-    const entryPath = path.join(root, entry.name);
-    if (entry.isDirectory()) return readNamedFiles(entryPath, name);
-    return entry.isFile() && entry.name === name
-      ? [readFileSync(entryPath, 'utf8')]
-      : [];
-  });
-}
-
 function assertUsageError(result, label, expectedText) {
   assert(
     result.status === 2,
@@ -1012,15 +1001,40 @@ prompts:
       workflowCompletedIndex >= 0 && parentResultIndex > workflowCompletedIndex,
       'workflow-script run should wait for and return the terminal child report to the headless parent',
     );
-    const reports = readNamedFiles(home, 'report.json').join('\n');
+    const childId = records[workflowCompletedIndex].payload.streamId.slice(
+      'workflow-script#'.length,
+    );
+    const history = run(
+      process.execPath,
+      [
+        binaryPath,
+        'history',
+        'show',
+        childId,
+        '--cwd',
+        cwd,
+        '--output-format',
+        'json',
+      ],
+      { cwd: repoRoot, env: isolatedCliHomeEnv(home) },
+    );
+    assertSuccess(history, 'texra history show workflow-script child');
+    const { report } = parseJson(
+      history.stdout,
+      'workflow-script child history',
+    );
     assert(
-      reports.includes('<workflow-script-result'),
+      typeof report === 'string',
+      'workflow-script child history should contain its saved report',
+    );
+    assert(
+      report.includes('<workflow-script-result'),
       'workflow-script run should persist its terminal child report',
     );
     assert(
-      reports.includes('(±23,±22)') &&
-        reports.includes('det(I+A)=4') &&
-        reports.includes('1/4'),
+      report.includes('(±23,±22)') &&
+        report.includes('det(I+A)=4') &&
+        report.includes('1/4'),
       'workflow-script run should contain all structured mathematical results',
     );
   } finally {

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -18,6 +18,7 @@ import {
   resolveCliLaunchAgent,
 } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
+import { installCliProcessRuntime } from '../runtime/cliProcessRuntime';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
@@ -151,12 +152,13 @@ export const agentsRunCommand = defineCliCommand({
         'File whose contents are passed before --instruction when both are set',
     },
   },
-  run: (context, ctx) =>
-    effectRuntime().runPromise(
-      runToolUseAgent(context, {
-        agent: ctx.args.name,
-        ...collectCommonAgentRunFlags(ctx.rawArgs, ctx.args.instruction),
-        model: optString(ctx.args.model),
-      }),
-    ),
+  run: async (context, ctx) => {
+    const init = {
+      agent: ctx.args.name,
+      ...collectCommonAgentRunFlags(ctx.rawArgs, ctx.args.instruction),
+      model: optString(ctx.args.model),
+    };
+    await installCliProcessRuntime();
+    return effectRuntime().runPromise(runToolUseAgent(context, init));
+  },
 });

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -16,6 +16,7 @@ import {
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform, initLocalCliPlatform } from '../runtime/initPlatform';
+import { installCliProcessRuntime } from '../runtime/cliProcessRuntime';
 import { writeTextStderr } from '../runtime/logSinks';
 import {
   cliMultiAgentPresetListRecord,
@@ -330,15 +331,16 @@ const multiAgentRunCommand = withUsageSections(
           'File whose contents are passed before --instruction when both are set',
       },
     },
-    run: (context, ctx) =>
-      effectRuntime().runPromise(
-        runMultiAgentPreset(context, {
-          preset: ctx.args.preset,
-          ...collectCommonAgentRunFlags(ctx.rawArgs, ctx.args.instruction),
-          agent: optString(ctx.args.agent),
-          model: optString(ctx.args.model),
-        }),
-      ),
+    run: async (context, ctx) => {
+      const init = {
+        preset: ctx.args.preset,
+        ...collectCommonAgentRunFlags(ctx.rawArgs, ctx.args.instruction),
+        agent: optString(ctx.args.agent),
+        model: optString(ctx.args.model),
+      };
+      await installCliProcessRuntime();
+      return effectRuntime().runPromise(runMultiAgentPreset(context, init));
+    },
   }),
   [
     {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -38,6 +38,7 @@ import {
   WORKFLOW_AGENT_NAME_DESCRIPTION,
 } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
+import { installCliProcessRuntime } from '../runtime/cliProcessRuntime';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { emitCliResult } from './_helpers/output';
@@ -409,14 +410,15 @@ export const runWorkflowCommand = defineCliCommand({
         'File whose contents are passed before --instruction when both are set',
     },
   },
-  run: (context, ctx) =>
-    effectRuntime().runPromise(
-      runWorkflowAgent(context, {
-        agent: ctx.args.agent,
-        ...collectCommonAgentRunFlags(ctx.rawArgs, ctx.args.instruction),
-        output: optionalStringFlagValue(ctx.rawArgs, 'output'),
-        outputDir: optionalStringFlagValue(ctx.rawArgs, 'output-dir'),
-        model: optString(ctx.args.model),
-      }),
-    ),
+  run: async (context, ctx) => {
+    const init = {
+      agent: ctx.args.agent,
+      ...collectCommonAgentRunFlags(ctx.rawArgs, ctx.args.instruction),
+      output: optionalStringFlagValue(ctx.rawArgs, 'output'),
+      outputDir: optionalStringFlagValue(ctx.rawArgs, 'output-dir'),
+      model: optString(ctx.args.model),
+    };
+    await installCliProcessRuntime();
+    return effectRuntime().runPromise(runWorkflowAgent(context, init));
+  },
 });

--- a/packages/cli/src/runtime/cliProcessRuntime.ts
+++ b/packages/cli/src/runtime/cliProcessRuntime.ts
@@ -1,12 +1,14 @@
 /**
  * The CLI's install of the process Effect runtime (PRD 7.7).
  *
- * Three CLI entries need one, and any of them may be first: `initCliPlatform`,
+ * Several CLI entries need one, and any of them may be first: `initCliPlatform`,
  * which opens the state and config stores as Effect programs before it wires
  * the platform; `notifyCliUpdate`, which runs before any platform exists and
  * opens the global state store on its own; and `clone`, which never builds a
  * platform at all yet reads and writes its remote's token through
- * `CliSecrets`. Whichever arrives first builds the runtime and the rest run on
+ * `CliSecrets`; and the headless run commands, whose native validation runs
+ * before platform initialization. Whichever arrives first builds the runtime
+ * and the rest run on
  * it, so a normal run still ends with exactly the runtime the platform's
  * shutdown disposes.
  *


### PR DESCRIPTION
Fresh `texra run`, `texra agents run`, and `texra multi-agent run` processes tried to use the Effect runtime before installing it. Valid runs failed during startup, and malformed flags could report an initialization error with exit 1 instead of the expected usage error with exit 2.

Each command now parses its flags, installs the existing CLI process runtime, and then runs its native Effect program. File and instruction validation still precede platform initialization; the platform reuses the same runtime and retains its shutdown ownership.

The existing runtime validator now reads the completed workflow-script child report through a fresh `history show` process. This deletes its recursive search for the retired `report.json` store and verifies the current persisted read path.

Validation: format, full typecheck, extension build, full lint, both ratchets, 58 affected tests, and the full suite with 8,857 passing and six skipped. The complete CLI runtime validator also passes. No test files were added.

Part of #11867. Targets `cutover/persistence-substrate`.
