### PR TITLE
refactor: flatten single-caller indirection and tighten export surface

### DIFF
--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -14,18 +14,8 @@ import {
 const FIGURE_EXTENSIONS = ['.pdf', '.png', '.jpg', '.jpeg'];
 
 /**
- * Normalize a path to ensure it has a trailing slash.
- */
-function ensureTrailingSlash(p: string): string {
-  const trimmed = p.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
-}
-
-/**
  * Parse graphicspath commands supporting both single and multiple path formats.
+ * Each entry is trimmed and given a trailing slash; blank entries are skipped.
  * @param content LaTeX file content
  * @returns Array of paths found in graphicspath commands
  */
@@ -36,10 +26,11 @@ function parseGraphicspath(content: string): string[] {
   const extractedPaths: string[] = [];
   for (const outerMatch of content.matchAll(graphicspathPattern)) {
     for (const pathMatch of outerMatch[1].matchAll(pathPattern)) {
-      const normalized = ensureTrailingSlash(pathMatch[1]);
-      if (normalized) {
-        extractedPaths.push(normalized);
+      const trimmed = pathMatch[1].trim();
+      if (!trimmed) {
+        continue;
       }
+      extractedPaths.push(trimmed.endsWith('/') ? trimmed : `${trimmed}/`);
     }
   }
 

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -1,9 +1,7 @@
 /**
- * Shared LaTeX content parsing utilities.
- *
- * Common patterns used by both extractBibliography.ts and
- * extractFileDependencies.ts for comment stripping and
- * bibliography directive matching.
+ * Shared LaTeX content parsing utilities: comment stripping, citation and
+ * bibliography directive matching, and the path resolution the LaTeX
+ * dependency extractors share.
  */
 
 import * as path from 'node:path';

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -152,7 +152,7 @@ export class LaTeXdiffService {
   ): Promise<LaTeXdiffResult> {
     try {
       const inputFile = inputLocation.absolutePath;
-      if (!(await this.validateDocumentStructure(inputLocation))) {
+      if (!hasDocumentEnvironment(await AbsoluteFS.read(inputFile))) {
         const message =
           'File missing document environment (must contain \\begin{document} and \\end{document})';
         this.log.error(message);
@@ -246,12 +246,6 @@ export class LaTeXdiffService {
     } catch (err) {
       return this.logDiffError('Error in runDiffBetweenRounds', err);
     }
-  }
-
-  private async validateDocumentStructure(
-    file: FileLocation,
-  ): Promise<boolean> {
-    return hasDocumentEnvironment(await AbsoluteFS.read(file.absolutePath));
   }
 
   private async bothFilesExist(

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -249,7 +249,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       ),
     };
     return effectRuntime().runPromise(
-      this.run(context, input, context.session).pipe(
+      this.run(context, input).pipe(
         Effect.catchTag('ExecutionsReadFailed', (error) =>
           Effect.die(error.cause),
         ),
@@ -261,7 +261,6 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     this: ExecutionsTool,
     context: ExecutionToolContext,
     input: ExecutionsToolInput,
-    session: SessionHandle,
   ) {
     const segments = getPathSegments(input.path);
     const [namespace, id, resource, ...rest] = segments;
@@ -337,7 +336,6 @@ Delegated subagent and workflow results are delivered automatically as follow-up
           executionId,
           input.offset,
           input.limit,
-          session,
         );
       }
       case 'todos':
@@ -849,12 +847,11 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     executionId: ExecutionId,
     offset: number,
     limit: number,
-    session: SessionHandle,
   ) {
     const store = context.inRunScope(() => getExecutionStore(executionId));
     const conversationResult = yield* readCompletedRunConversation(
       executionId,
-      session,
+      context.session,
     ).pipe(Effect.mapError((cause) => new ExecutionsReadFailed({ cause })));
     const { conversation, source, streamId } = conversationResult;
     const streamDiagnostics = [`Stream: ${streamId ?? 'none'}`];

--- a/src/tools/executions/conversationFormat.ts
+++ b/src/tools/executions/conversationFormat.ts
@@ -14,7 +14,7 @@ const CONVERSATION_FORMAT_OPTIONS: ConversationFormatOptions = {
   toolBlockLimit: 100,
 };
 
-export interface ConversationPageFormatOptions {
+interface ConversationPageFormatOptions {
   /** Zero-based index of the first message in this page. */
   readonly offset?: number;
   /** Total messages in the unsliced archive. */

--- a/src/tools/executions/processOutput.ts
+++ b/src/tools/executions/processOutput.ts
@@ -32,7 +32,7 @@ const OUTPUT_STDERR_PREFIX = 'err: ';
  */
 const OUTPUT_LINE_BREAK = /\r\n|\r|\n/;
 
-export interface ProcessOutputProjection {
+interface ProcessOutputProjection {
   readonly lines: readonly string[];
   readonly chars: number;
 }


### PR DESCRIPTION
## Summary

A behavior-preserving cleanup in `src/latex` and `src/tools`, from a whole-repo tech-debt audit. The audit's headline finding is that this codebase is in good shape — 2 `TODO/FIXME` markers repo-wide, zero empty `catch {}`, and shared logic already factored into `@controllers/` and `modelHandlers/support/`. Most of the large "duplication" candidates did not survive verification (see *Duplication and abstraction budget*), so what remains is small and surgical rather than a big sweep.

Four changes, all pure pass-through removal or export tightening:

**`src/latex`**
- Inline `ensureTrailingSlash` into `parseGraphicspath`. The helper returned `''` for a blank entry only so its single caller could re-derive "was it blank" via `if (normalized)`; a `continue` guard states it once. Equivalence is total — the non-empty branch always returns a truthy string, so `if (normalized)` ⟺ `if (trimmed)`.
- Inline `LaTeXdiffService.validateDocumentStructure`. It wrapped `hasDocumentEnvironment(await AbsoluteFS.read(...))` for one caller that already held the absolute path, while the sibling `runDiff` path already calls `hasDocumentEnvironment` directly. Removing it makes the two validation sites read alike.
- Correct a stale `latexParsingUtils` module header: it named two consumers when the module now has five, and did not mention the path-resolution helpers it carries.

**`src/tools`**
- Drop the redundant `session` parameter from `ExecutionsTool.run` and `showConversation`. Both received an object already reachable as `context.session` — provably the same reference, since both originate from the one `currentSession()` call in `execute` — and `run` used it solely to forward it onward.
- Make `ProcessOutputProjection` and `ConversationPageFormatOptions` file-local; neither had a consumer outside its defining file.

## Issue acceptance gates

No issue — this came from a scheduled tech-debt audit. No acceptance gates apply.

## Single source of truth

No ownership moved. `context.session` (built once in `ExecutionsTool.execute` from `currentSession()`) is now the single route to the session handle within the tool, instead of that same handle also travelling as a parameter down two call levels. `hasDocumentEnvironment` is now the single, directly-called document-structure check on both `LaTeXdiffService` paths.

## Duplication and abstraction budget

**No new abstraction is introduced.** Every change is a deletion.

Duplication *deliberately not* removed, with the accounting that rejected each:

- `listWorkspaceFiles` / `readWorkspaceFile` share an 8-line store + `Effect.all` prelude (2 real sites). A module-level helper plus the doc comment this file's style requires is ~17–18 lines added against 16 removed → **net +4**. Rejected.
- `showReport` / `showResultMeta` share a store + `turnAttributionNote` + empty-guard skeleton, but differ in the first read, so a shared helper must be higher-order (callback-parameterized) → **net ≈ +9** for two call sites. Rejected.
- The `\begin{env}…\end{env}` / `\includegraphics` regexes across `TikzPictureManager`, `diffFileProcessor` (×2) and `extractFigure` looked like one pattern copied four times. Read in full they are four different shapes: literal vs. 6-way alternation env name, optional vs. required brace argument, capture-the-body vs. capture-the-argument vs. capture-nothing, and two of them do no balanced matching at all (no `\end`, no backreference). A builder covering that variance would be larger than the five regexes it replaced. Rejected as a false abstraction.
- Three `switch (liveness.kind)` ladders word the same union differently per surface, by documented intent. Rejected.

Also rejected: inlining `listingDisplay` (its exhaustive `switch` over a discriminated union would become a ternary, losing compile-time exhaustiveness on a future entry kind).

## Net elements (R6)

| Construct | Δ |
| --- | --- |
| Files | 6 changed, 0 added, 0 deleted |
| Exported symbols (`^[+-]export` over the diff) | **−2** (`ProcessOutputProjection`, `ConversationPageFormatOptions` → file-local) |
| Functions / methods | **−2** (`ensureTrailingSlash`, `LaTeXdiffService.validateDocumentStructure`) |
| Parameters | **−2** (`run(session)`, `showConversation(session)`) |
| Classes / interfaces / enums | 0 added, 0 deleted (the two interfaces remain; only their `export` is gone) |
| Net LoC | **−20** (+13 / −33) |

Six elements removed, zero added.

## Consumer counts (R8)

No emit path or subscribe surface is touched — no `bus.emit`, `SessionHandle.publish`, or `AgentEvent`/`SessionEvent` change.

For the two de-exported types, grepped repo-wide excluding `node_modules`/`dist`: **0 consumers outside the defining file** each (both appear exactly twice, both times in their own file). Neither is in `config/ratchets/knip-baseline.json`, so the baseline is untouched and the public surface shrinks. The two deleted functions were file-local and private respectively, with 1 call site each and no mock path targeting them by string.

## Host impact

Extension: None — no host file changed; no behavior, output text, or command surface affected.

Desktop: None — same. Desktop suites were run because `LaTeXdiffService` is reachable from the desktop bridge, and pass.

CLI: None — `packages/cli/src/runtime/history.ts` is the only non-test consumer under `src/tools/executions/` and it imports `listRunGeneratedFiles`/`RunGeneratedFile`, neither of which is touched.

## Scheduled refactoring

None required for this PR. Three leads were found and deliberately left out of scope because they are not behavior-preserving:

- `LatexMediaManager.collectDependencies` re-reads, re-realpaths and re-strips comments on a file `extractLatexFileDependencies` just read — a genuine redundant round trip per `.tex`, but fixing it changes I/O counts and merges two `try` blocks with distinct debug messages.
- `latexdiff.ts` `runDiffVc` builds its output path with `filePath.replace('.tex', …)`, which replaces the first literal `.tex` anywhere in the path — a directory named `my.texnotes/` yields a wrong output path. A latent defect; fixing it changes behavior.
- `src/tools/executionFormatters.ts` exports 14 symbols with exactly one production consumer (`ExecutionsTool.ts`) — effectively one module in two files. Merging is net-zero LoC and would yield a ~1,550-line file, so it is not worth doing on its own.

## Validation

All run on the final combined tree:

- `npm run typecheck` — **exit 0** (workspace, test-kernel, agent, cli, trace-viewer, desktop). Run explicitly because builds do not type check.
- `npx vitest run src/test-kernel/tools src/test-kernel/latex` — **114 files / 901 tests passing**.
- `npx eslint` on all six changed files — **exit 0**, no warnings.
- `npx prettier --check` on all six changed files — clean.
- `npm run check:dead-code-ratchet` — **278 baselined, no new findings** (baseline unchanged).

No new tests were added, per the testing-budget rule for behavior-preserving refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cJgP2Usbtui534YBidUGC

---
_Generated by [Claude Code](https://claude.ai/code/session_015cJgP2Usbtui534YBidUGC)_