### PR TITLE
fix: load OpenAI only when transcribing audio

### DIFF
--- a/src/tools/media/audio.ts
+++ b/src/tools/media/audio.ts
@@ -3,7 +3,6 @@ import * as path from 'node:path';
 import { execa, type Subprocess } from 'execa';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
-import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
 import { createLog } from '@logger/logUtils';
 import { delay } from '@utils/core';
@@ -180,6 +179,8 @@ export async function stopRecordingAndTranscribe(): Promise<{
       return { success: false, text: '', error: 'Recording file is empty' };
     }
 
+    const { ModelHandlerOpenAI } =
+      await import('@agent/modelHandlers/openai/modelHandlerOpenAI');
     const handler = new ModelHandlerOpenAI(MODEL_CONFIGS['gpt4o']);
     const client = await handler.getClient();
     const result = await client.audio.transcriptions.create({


### PR DESCRIPTION
Desktop startup imports recording cleanup from the audio module, whose static model-handler import also loads the OpenAI SDK. This causes desktop package verification to reject 175 eagerly included provider modules.

The transcription operation now imports the handler immediately before use. Recording cleanup loads without the provider SDK, and the packaged startup graph contains zero eager OpenAI modules.

Validation: format, full typecheck, compile:fast, lint, both ratchets, the existing package suite (9 passed), and full npm test (8,857 passed, 6 skipped). A fresh universal macOS package builds and passes both artifact and package verification, including the startup import rule.

Closes #12096.
