### PR TITLE
chore: complete CLI admission review cleanup

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -6,7 +6,6 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  readdirSync,
   realpathSync,
   rmSync,
   statSync,

--- a/packages/cli/src/runtime/cliProcessRuntime.ts
+++ b/packages/cli/src/runtime/cliProcessRuntime.ts
@@ -7,10 +7,9 @@
  * opens the global state store on its own; and `clone`, which never builds a
  * platform at all yet reads and writes its remote's token through
  * `CliSecrets`; and the headless run commands, whose native validation runs
- * before platform initialization. Whichever arrives first builds the runtime
- * and the rest run on
- * it, so a normal run still ends with exactly the runtime the platform's
- * shutdown disposes.
+ * before platform initialization. Whichever arrives first builds the
+ * runtime and the rest run on it, so a normal run still ends with exactly
+ * the runtime the platform's shutdown disposes.
  *
  * Whether one is installed is asked of `@platform/processRuntime`, which owns
  * the reference, rather than tracked in a latch here: a boolean set beside the


### PR DESCRIPTION
Remove the unused `readdirSync` import left after the CLI validator stopped scanning `report.json`, and reflow the process-runtime initialization comment. This addresses the two minor review findings on #12097 without changing runtime behavior.

Validation: formatting, full typecheck, compilation, full lint, 108 affected tests, the full suite (8,857 passed and six skipped), both ratchets, and diff checks passed. No test files were added.

Follow-up to #12097 and #11867. Targets `cutover/persistence-substrate`.
