### PR TITLE
docs: identify the host bridge bootstrap source precisely

### DIFF
--- a/src/shared/hostBridge.ts
+++ b/src/shared/hostBridge.ts
@@ -1,10 +1,11 @@
 import { HOST_BRIDGE_API_KEY, type HostBridgeApi } from './hostBridgeTypes';
 
 /**
- * Every host (VS Code, Electron, the exported trace viewer) installs its
- * bridge at `globalThis[HOST_BRIDGE_API_KEY]` before this bundle loads — see
- * `BundledViewContentProvider.buildWebviewHtml` (VS Code), `installElectronHostBridge`
- * (desktop), and `installTraceHostBridge` (trace viewer).
+ * Every host installs its bridge at `globalThis[HOST_BRIDGE_API_KEY]` before
+ * this bundle loads. VS Code uses the module-level `buildWebviewHtml` in
+ * `packages/extension/src/common/webview/BundledViewContentProvider.ts`;
+ * desktop uses `installElectronHostBridge`, and the exported trace viewer
+ * uses `installTraceHostBridge`.
  */
 function resolveHostBridgeApi(): HostBridgeApi {
   const existing = (


### PR DESCRIPTION
Corrects the host-bridge comment to identify `buildWebviewHtml` as a module-level function and give its exact source file. This resolves [the remaining review finding on #12104](https://github.com/LionSR/TeXRA/pull/12104#discussion_r3955925784), whose merge preceded completion of review.

Only the comment changes. Format, full typecheck, compile:fast, lint, both ratchets, and the full test suite passed (8,858 tests passed, six skipped). No tests or configuration were changed.
