### PR TITLE
refactor(memory): adopt native Effect filesystem reads

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@awesome.me/webawesome": "^3.12.0",
     "@cantoo/pdf-lib": "^2.9.1",
     "@date-fns/tz": "^1.5.0",
+    "@effect/platform-node": "4.0.0-rc.112",
     "@fortawesome/free-solid-svg-icons": "^7.3.1",
     "@google/genai": "^2.21.0",
     "@jamesgopsill/crossref-client": "^1.1.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -52,6 +52,7 @@
     "@anthropic-ai/sdk": "^0.123.0",
     "@cantoo/pdf-lib": "^2.9.1",
     "@date-fns/tz": "^1.5.0",
+    "@effect/platform-node": "4.0.0-rc.112",
     "@google/genai": "^2.21.0",
     "@jamesgopsill/crossref-client": "^1.1.0",
     "@jitl/quickjs-wasmfile-release-sync": "0.32.0",

--- a/packages/cli/src/runtime/memory.ts
+++ b/packages/cli/src/runtime/memory.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect';
+import { Effect, type FileSystem } from 'effect';
 
 import { effectRuntime } from '@platform/processRuntime';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
@@ -107,7 +107,7 @@ export const loadCliMemoryDetail = Effect.fn('cli.loadCliMemoryDetail')(
  * prints that message.
  */
 export function runCliMemory<A>(
-  program: Effect.Effect<A, MemoryEntryUnreadable>,
+  program: Effect.Effect<A, MemoryEntryUnreadable, FileSystem.FileSystem>,
 ): Promise<A> {
   return effectRuntime().runPromise(
     Effect.catch(program, (error) => Effect.die(error.cause)),

--- a/packages/cli/src/runtime/memory.ts
+++ b/packages/cli/src/runtime/memory.ts
@@ -1,4 +1,4 @@
-import { Effect, type FileSystem } from 'effect';
+import { Cause, Effect, type FileSystem, Result } from 'effect';
 
 import { effectRuntime } from '@platform/processRuntime';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
@@ -110,7 +110,19 @@ export function runCliMemory<A>(
   program: Effect.Effect<A, MemoryEntryUnreadable, FileSystem.FileSystem>,
 ): Promise<A> {
   return effectRuntime().runPromise(
-    Effect.catch(program, (error) => Effect.die(error.cause)),
+    Effect.catchCause(program, (cause) => {
+      const unwrapped = Cause.map(cause, (error) => error.cause);
+      // runPromise otherwise keeps only the first error of a compound cause.
+      if (unwrapped.reasons.length > 1 && !Cause.hasInterruptsOnly(unwrapped)) {
+        return Effect.die(
+          new Error(Cause.pretty(unwrapped), { cause: unwrapped }),
+        );
+      }
+      const error = Cause.findError(unwrapped);
+      return Result.isFailure(error)
+        ? Effect.failCause(error.failure)
+        : Effect.die(error.success);
+    }),
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@date-fns/tz':
         specifier: ^1.5.0
         version: 1.5.0
+      '@effect/platform-node':
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1(@opentelemetry/api@1.9.1))
       '@fortawesome/free-solid-svg-icons':
         specifier: ^7.3.1
         version: 7.3.1
@@ -1477,6 +1480,19 @@ packages:
     resolution: {integrity: sha512-CfiSoaVQO8pZgaMZGw5VvMvRGybsJ2LaSDoLYaqiVGvo/YYPYVR2GzUKY0h1NtIweq/+SQ5XLrvtzPIttWQ0GQ==}
     hasBin: true
 
+  '@effect/platform-node-shared@4.0.0-rc.112':
+    resolution: {integrity: sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
+
+  '@effect/platform-node@4.0.0-rc.112':
+    resolution: {integrity: sha512-/BMAcdNGQQskLmI0Zoa95KfTZkr9HV9N4NSxaSrusG6GeW6Ulp9KvZ+Rlaiw8lnOt43CXjFLdfll5/k5rxL4hQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
+      redis: '>=5.0.0 <7.0.0'
+
   '@effect/vitest@4.0.0-rc.112':
     resolution: {integrity: sha512-mEKh/FI64mt8JK1/v9mpOrJYdnp+UFZdRUBMEdZMiKz7klg6NPqVgg/oeAGH6wOOQc2iAPcfc2H9BbAv1KyzMQ==}
     peerDependencies:
@@ -2500,6 +2516,42 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
+  '@redis/bloom@6.2.1':
+    resolution: {integrity: sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/client@6.2.1':
+    resolution: {integrity: sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@6.2.1':
+    resolution: {integrity: sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/search@6.2.1':
+    resolution: {integrity: sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/time-series@6.2.1':
+    resolution: {integrity: sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
   '@rolldown/binding-android-arm-eabi@1.2.5':
     resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2911,6 +2963,9 @@ packages:
 
   '@types/write-file-atomic@4.0.3':
     resolution: {integrity: sha512-qdo+vZRchyJIHNeuI1nrpsLw+hnkgqP/8mlaN6Wle/NKhydHmUN9l4p3ZE8yP90AJNJW4uB8HQhedb4f1vNayQ==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.69.0':
     resolution: {integrity: sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==}
@@ -3702,6 +3757,10 @@ packages:
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   cockatiel@3.2.1:
     resolution: {integrity: sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==}
@@ -5200,6 +5259,11 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
+  mime@4.1.0:
+    resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -5813,6 +5877,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  redis@6.2.1:
+    resolution: {integrity: sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==}
+    engines: {node: '>= 20.0.0'}
 
   regjsparser@0.13.2:
     resolution: {integrity: sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==}
@@ -7283,6 +7351,26 @@ snapshots:
 
   '@effect/language-service@0.87.2': {}
 
+  '@effect/platform-node-shared@4.0.0-rc.112(effect@4.0.0-rc.112)':
+    dependencies:
+      '@types/ws': 8.18.1
+      effect: 4.0.0-rc.112
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@effect/platform-node-shared': 4.0.0-rc.112(effect@4.0.0-rc.112)
+      effect: 4.0.0-rc.112
+      mime: 4.1.0
+      redis: 6.2.1(@opentelemetry/api@1.9.1)
+      undici: 8.10.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@effect/vitest@4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.2(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))':
     dependencies:
       effect: 4.0.0-rc.112
@@ -8213,6 +8301,28 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
+  '@redis/bloom@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+
+  '@redis/client@6.2.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@redis/json@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+
+  '@redis/search@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+
+  '@redis/time-series@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+
   '@rolldown/binding-android-arm-eabi@1.2.5':
     optional: true
 
@@ -8623,6 +8733,10 @@ snapshots:
   '@types/vscode@1.125.0': {}
 
   '@types/write-file-atomic@4.0.3':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.17
 
@@ -9455,6 +9569,8 @@ snapshots:
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
+
+  cluster-key-slot@1.1.2: {}
 
   cockatiel@3.2.1: {}
 
@@ -11081,6 +11197,8 @@ snapshots:
 
   mime@2.6.0: {}
 
+  mime@4.1.0: {}
+
   mimic-fn@2.1.0: {}
 
   mimic-response@1.0.1: {}
@@ -11702,6 +11820,17 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
     optional: true
+
+  redis@6.2.1(@opentelemetry/api@1.9.1):
+    dependencies:
+      '@redis/bloom': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+      '@redis/json': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   regjsparser@0.13.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,6 +406,9 @@ importers:
       '@date-fns/tz':
         specifier: ^1.5.0
         version: 1.5.0
+      '@effect/platform-node':
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1(@opentelemetry/api@1.9.1))
       '@google/genai':
         specifier: ^2.21.0
         version: 2.21.0(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -19,6 +19,7 @@
  * supply durable transcript history; the remaining bridge is removed with
  * the transcript file writer.
  */
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
 import {
   Context,
   Deferred,
@@ -724,7 +725,11 @@ export function installProcessRuntime(
   const runtime = ManagedRuntime.make(
     Sessions.layer(release, identity).pipe(
       Layer.provideMerge(
-        Layer.mergeAll(effectDiagnosticsLayer, FetchHttpClient.layer),
+        Layer.mergeAll(
+          effectDiagnosticsLayer,
+          FetchHttpClient.layer,
+          NodeFileSystem.layer,
+        ),
       ),
     ),
   );

--- a/src/controllers/settingsView/SettingsViewHost.ts
+++ b/src/controllers/settingsView/SettingsViewHost.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Exit } from 'effect';
+import { Cause, Effect, Exit, Result } from 'effect';
 
 import { hostPort } from '@common/hostPort';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
@@ -43,12 +43,24 @@ interface SettingsViewHostOptions {
  * raised. The memory path has no recovery above
  * this point — the previous `await` chain let the same error reach the host's
  * own error handling — so the host edge's `runPromise` rejects with that
- * instance rather than with a tagged wrapper nobody reads.
+ * instance rather than with a tagged wrapper nobody reads. Compound failures
+ * are reported together, with their complete Cause retained on the error.
  */
 function raiseCause<A, E extends { readonly cause: unknown }, R>(
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, never, R> {
-  return Effect.catch(effect, (error) => Effect.die(error.cause));
+  return Effect.catchCause(effect, (cause) => {
+    const unwrapped = Cause.map(cause, (error) => error.cause);
+    if (unwrapped.reasons.length > 1 && !Cause.hasInterruptsOnly(unwrapped)) {
+      return Effect.die(
+        new Error(Cause.pretty(unwrapped), { cause: unwrapped }),
+      );
+    }
+    const error = Cause.findError(unwrapped);
+    return Result.isFailure(error)
+      ? Effect.failCause(error.failure)
+      : Effect.die(error.success);
+  });
 }
 
 interface SettingsViewHostMutationOptions {
@@ -97,10 +109,10 @@ export class SettingsViewHost {
       } = {},
     ) {
       const posted = yield* Effect.exit(
-        this.memoryController.getMemoryPreviewMessage(data.storagePath).pipe(
-          // Unwrap only the memory failure; hostPort preserves the response
-          // error itself, including an error that has its own cause field.
-          Effect.catch((error) => Effect.fail(error.cause)),
+        // Unwrap only memory failures; response errors keep their own cause.
+        raiseCause(
+          this.memoryController.getMemoryPreviewMessage(data.storagePath),
+        ).pipe(
           Effect.flatMap((message) =>
             hostPort(() => this.post(message, options.respond)),
           ),

--- a/src/platform/processRuntime.ts
+++ b/src/platform/processRuntime.ts
@@ -6,11 +6,11 @@
  * Promise-facing methods; inside, cancellation is fiber interruption.
  * Installed like the process roots: exactly once, by the entry.
  */
-import type { ManagedRuntime } from 'effect';
+import type { FileSystem, ManagedRuntime } from 'effect';
 import type { HttpClient } from 'effect/unstable/http';
 
 export type ProcessRuntime = ManagedRuntime.ManagedRuntime<
-  HttpClient.HttpClient,
+  HttpClient.HttpClient | FileSystem.FileSystem,
   never
 >;
 

--- a/src/test-kernel/cli/CliMemory.vitest.ts
+++ b/src/test-kernel/cli/CliMemory.vitest.ts
@@ -1,7 +1,7 @@
 // Third-party imports
 import { it } from '@effect/vitest';
-import { Cause, Effect, Exit } from 'effect';
-import { describe, expect, vi } from 'vitest';
+import { Cause, Effect, Exit, FileSystem } from 'effect';
+import { expect, it as plainIt, vi } from 'vitest';
 
 // Local imports
 import {
@@ -29,8 +29,8 @@ const item: MemoryViewItem = {
 const failureOf = (exit: Exit.Exit<unknown, unknown>): unknown =>
   Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined;
 
-describe('CLI memory formatting', () => {
-  it('formats memory rows with stable user-facing fields', () => {
+it.layer(FileSystem.layerNoop({}))('CLI memory formatting', (it) => {
+  plainIt('formats memory rows with stable user-facing fields', () => {
     const description = cliMemoryItemDescription(item);
 
     expect(description).toContain('pinned');
@@ -38,21 +38,24 @@ describe('CLI memory formatting', () => {
     expect(description).toContain('by researcher');
   });
 
-  it('does not treat the Unix epoch as an unknown modification date', () => {
-    const description = cliMemoryItemDescription({
-      ...item,
-      mtime: '1970-01-01T00:00:00.000Z',
-    });
+  plainIt(
+    'does not treat the Unix epoch as an unknown modification date',
+    () => {
+      const description = cliMemoryItemDescription({
+        ...item,
+        mtime: '1970-01-01T00:00:00.000Z',
+      });
 
-    expect(description).toContain('modified:');
-    expect(description).not.toContain('modified: unknown');
-  });
+      expect(description).toContain('modified:');
+      expect(description).not.toContain('modified: unknown');
+    },
+  );
 
-  it('formats an empty memory listing explicitly', () => {
+  plainIt('formats an empty memory listing explicitly', () => {
     expect(formatCliMemoryList([])).toBe('No memory files found.');
   });
 
-  it('limits long memory listings and reports hidden rows', () => {
+  plainIt('limits long memory listings and reports hidden rows', () => {
     const list = formatCliMemoryList(
       Array.from({ length: CLI_MEMORY_LIST_LIMIT + 1 }, (_unused, index) => ({
         ...item,

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
@@ -79,11 +79,15 @@ async function loadSupabaseAuth() {
   // `vi.resetModules()` gives the module graph a fresh `@platform/processRuntime`
   // whose runtime the shared fake-host install never reached; the module's own
   // `initializeCliSupabaseAuth` installs the auth run edge from it.
-  const [{ initProcessRuntime }, { ManagedRuntime }] = await Promise.all([
-    import('@platform/processRuntime'),
-    import('effect'),
-  ]);
-  initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
+  const [{ initProcessRuntime }, { Layer, ManagedRuntime }, NodeFileSystem] =
+    await Promise.all([
+      import('@platform/processRuntime'),
+      import('effect'),
+      import('@effect/platform-node/NodeFileSystem'),
+    ]);
+  initProcessRuntime(
+    ManagedRuntime.make(Layer.merge(testHttpClientLayer, NodeFileSystem.layer)),
+  );
   return import('@cli/runtime/supabaseAuth');
 }
 

--- a/src/test-kernel/cli/ClipboardText.vitest.ts
+++ b/src/test-kernel/cli/ClipboardText.vitest.ts
@@ -1,4 +1,5 @@
-import { ManagedRuntime } from 'effect';
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import { Layer, ManagedRuntime } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const writeMock = vi.hoisted(() => vi.fn());
@@ -90,7 +91,11 @@ describe('CLI clipboard text writer', () => {
       expect(execFileMock).toHaveBeenCalled();
     } finally {
       await disposeProcessRuntime();
-      initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
+      initProcessRuntime(
+        ManagedRuntime.make(
+          Layer.merge(testHttpClientLayer, NodeFileSystem.layer),
+        ),
+      );
     }
   });
 

--- a/src/test-kernel/controllers/SettingsMemoryController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsMemoryController.vitest.ts
@@ -1,8 +1,8 @@
 /* eslint-disable import/order -- Vitest mocks must be declared before importing the module under test. */
 import { strict as assert } from 'node:assert';
 import { it } from '@effect/vitest';
-import { Effect } from 'effect';
-import { afterEach, describe, it as plainIt, vi } from 'vitest';
+import { Effect, FileSystem } from 'effect';
+import { afterEach, it as plainIt, vi } from 'vitest';
 
 import { createFakeUIHosts } from '../support/FakeHosts';
 
@@ -61,7 +61,7 @@ function createController(options?: {
   };
 }
 
-describe('SettingsMemoryController', () => {
+it.layer(FileSystem.layerNoop({}))('SettingsMemoryController', (it) => {
   afterEach(() => {
     vi.clearAllMocks();
   });

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts
@@ -1,4 +1,5 @@
-import { Effect, ManagedRuntime } from 'effect';
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import { Effect, Layer, ManagedRuntime } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DefaultDesktopAgentSettingsController } from '@desktop/main/desktopAgentSettingsController';
@@ -39,7 +40,9 @@ interface ControllerFixtureOptions {
 }
 
 beforeEach(() => {
-  initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
+  initProcessRuntime(
+    ManagedRuntime.make(Layer.merge(testHttpClientLayer, NodeFileSystem.layer)),
+  );
 });
 
 function createControllerFixture(options: ControllerFixtureOptions = {}) {

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -4,8 +4,9 @@ import { dirname, join } from 'node:path';
 import { setImmediate as nextTurn } from 'node:timers/promises';
 
 // Third-party imports
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
 import { it } from '@effect/vitest';
-import { Cause, Effect, Exit, Fiber, ManagedRuntime } from 'effect';
+import { Cause, Effect, Exit, Fiber, Layer, ManagedRuntime } from 'effect';
 import { afterEach, describe, expect, vi } from 'vitest';
 
 // Local imports
@@ -100,7 +101,11 @@ describe('desktop agent directory bootstrap', () => {
       try {
         effectRuntime();
       } catch {
-        initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
+        initProcessRuntime(
+          ManagedRuntime.make(
+            Layer.merge(testHttpClientLayer, NodeFileSystem.layer),
+          ),
+        );
       }
       const storage = new WorkspaceStorageProvider(userDataPath, workspacePath);
       const [globalStateStore, workspaceStateStore] = yield* Effect.all([

--- a/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
+++ b/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 
-import { Effect, ManagedRuntime } from 'effect';
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import { Effect, Layer, ManagedRuntime } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { initProcessRuntime } from '@platform/processRuntime';
@@ -141,7 +142,11 @@ const APPLY_AGENT_MODE_PRESET = {
 describe('AgentHandlers custom-agent file actions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
+    initProcessRuntime(
+      ManagedRuntime.make(
+        Layer.merge(testHttpClientLayer, NodeFileSystem.layer),
+      ),
+    );
   });
 
   it('logs notification failures after applying a team preset', async () => {

--- a/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
+++ b/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
@@ -1,11 +1,10 @@
 // Node imports
 import { Buffer } from 'node:buffer';
 import * as path from 'node:path';
-import { Readable } from 'node:stream';
 
 // Third-party imports
 import { it } from '@effect/vitest';
-import { Effect, Stream } from 'effect';
+import { Effect, FileSystem, Stream } from 'effect';
 import { afterEach, describe, expect, vi } from 'vitest';
 
 // Local imports
@@ -42,12 +41,10 @@ function memoryFiles(): [string, number][] {
   );
 }
 
-function readStreamFromText(
-  text: string,
-): ReturnType<typeof StorageFS.createReadStream> {
-  return Readable.from([Buffer.from(text)]) as unknown as ReturnType<
-    typeof StorageFS.createReadStream
-  >;
+const memoryFS = FileSystem.makeNoop({});
+
+function readStreamFromText(text: string) {
+  return Stream.make(Buffer.from(text));
 }
 
 function testFileStat(content: string): FileStat {
@@ -98,7 +95,7 @@ describe('memory filesystem listing', () => {
           return testFileStat(TEST_FRONTMATTER);
         });
 
-        vi.spyOn(StorageFS, 'createReadStream').mockImplementation(() =>
+        vi.spyOn(memoryFS, 'stream').mockImplementation(() =>
           readStreamFromText(TEST_FRONTMATTER),
         );
 
@@ -111,7 +108,7 @@ describe('memory filesystem listing', () => {
         expect(maxActiveMetadataReads).toBeLessThanOrEqual(
           MEMORY_LISTING_CONCURRENCY,
         );
-      }),
+      }).pipe(Effect.provideService(FileSystem.FileSystem, memoryFS)),
   );
 
   it.effect(
@@ -135,12 +132,12 @@ describe('memory filesystem listing', () => {
           return testFileStat(PINNED_FRONTMATTER);
         });
         const readStream = vi
-          .spyOn(StorageFS, 'createReadStream')
+          .spyOn(memoryFS, 'stream')
           .mockImplementation(() => readStreamFromText(PINNED_FRONTMATTER));
 
         expect(yield* countPinnedMemories(1)).toBe(1);
         expect(readStream.mock.calls.length).toBeLessThan(files.length);
-      }),
+      }).pipe(Effect.provideService(FileSystem.FileSystem, memoryFS)),
   );
 
   it.effect('fails the walk with the filesystem error itself', () =>
@@ -160,6 +157,6 @@ describe('memory filesystem listing', () => {
       expect(failure._tag).toBe('MemoryEntryUnreadable');
       expect(failure.cause).toBe(cause);
       expect(failure.cause).toMatchObject({ code: 'ENOENT' });
-    }),
+    }).pipe(Effect.provideService(FileSystem.FileSystem, memoryFS)),
   );
 });

--- a/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
+++ b/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 
 // Third-party imports
 import { it } from '@effect/vitest';
-import { Effect, FileSystem, Stream } from 'effect';
+import { Effect, Exit, FileSystem, PlatformError, Stream } from 'effect';
 import { afterEach, describe, expect, vi } from 'vitest';
 
 // Local imports
@@ -12,6 +12,7 @@ import { FileType, type FileStat } from '@platform/interfaces';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import {
   countPinnedMemories,
+  MemoryEntryUnreadable,
   walkMemoryDirectory,
 } from '@tools/memory/memoryFileSystem';
 import { delay } from '@utils/core';
@@ -158,5 +159,51 @@ describe('memory filesystem listing', () => {
       expect(failure.cause).toBe(cause);
       expect(failure.cause).toMatchObject({ code: 'ENOENT' });
     }).pipe(Effect.provideService(FileSystem.FileSystem, memoryFS)),
+  );
+
+  it.effect(
+    'retains a close failure when the attribution read also fails',
+    () =>
+      Effect.gen(function* () {
+        const readFailure = new Error('memory read failed');
+        const closeFailure = PlatformError.systemError({
+          _tag: 'Unknown',
+          module: 'FileSystem',
+          method: 'close',
+          cause: new Error('memory close failed'),
+        });
+        vi.spyOn(StorageFS, 'readDir').mockResolvedValue([
+          ['note.md', FileType.File],
+        ]);
+        vi.spyOn(StorageFS, 'stat').mockResolvedValue(
+          testFileStat(TEST_FRONTMATTER),
+        );
+        vi.spyOn(memoryFS, 'stream').mockReturnValue(
+          Stream.fail(
+            PlatformError.systemError({
+              _tag: 'Unknown',
+              module: 'FileSystem',
+              method: 'readAlloc',
+              cause: readFailure,
+            }),
+          ).pipe(Stream.ensuring(Effect.die(closeFailure))),
+        );
+
+        const result = yield* Effect.exit(
+          Stream.runDrain(walkMemoryDirectory(MEMORY_STORAGE_DIR)),
+        );
+        expect(Exit.isFailure(result)).toBe(true);
+        if (Exit.isSuccess(result)) return;
+        expect(result.cause.reasons).toMatchObject([
+          {
+            _tag: 'Fail',
+            error: new MemoryEntryUnreadable({
+              storagePath: path.join(MEMORY_STORAGE_DIR, 'note.md'),
+              cause: readFailure,
+            }),
+          },
+          { _tag: 'Die', defect: closeFailure },
+        ]);
+      }).pipe(Effect.provideService(FileSystem.FileSystem, memoryFS)),
   );
 });

--- a/src/test-kernel/support/setupPlatform.ts
+++ b/src/test-kernel/support/setupPlatform.ts
@@ -58,8 +58,9 @@ export async function installFakeHost(host: FakeHost): Promise<void> {
     { initProcessWorkspaceRoots },
     { effectRuntime, initProcessRuntime },
     { installAuthProgramEdge },
-    { ManagedRuntime },
+    { Layer, ManagedRuntime },
     { testHttpClientLayer },
+    NodeFileSystem,
   ] = await Promise.all([
     import('@platform/platform'),
     import('@platform/workspaceRoots'),
@@ -67,6 +68,7 @@ export async function installFakeHost(host: FakeHost): Promise<void> {
     import('@auth/authProgram'),
     import('effect'),
     import('@test/support/fetchTestUtils'),
+    import('@effect/platform-node/NodeFileSystem'),
   ]);
   initPlatform(host.platform);
   initProcessWorkspaceRoots(host.roots);
@@ -79,7 +81,11 @@ export async function installFakeHost(host: FakeHost): Promise<void> {
   try {
     effectRuntime();
   } catch {
-    initProcessRuntime(ManagedRuntime.make(testHttpClientLayer));
+    initProcessRuntime(
+      ManagedRuntime.make(
+        Layer.merge(testHttpClientLayer, NodeFileSystem.layer),
+      ),
+    );
   }
   // The auth run edge, unconditionally: a suite that reset modules gets a
   // fresh `@auth/authProgram` instance, and this install must land on it.

--- a/src/test-kernel/tools/MemoryTool.vitest.ts
+++ b/src/test-kernel/tools/MemoryTool.vitest.ts
@@ -1,13 +1,15 @@
 // Node imports
 import { Buffer } from 'node:buffer';
 import * as path from 'node:path';
-import { Readable } from 'node:stream';
 
 // Third-party imports
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FileSystem, Stream } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { FileType, type FileStat } from '@platform/interfaces';
+import { effectRuntime } from '@platform/processRuntime';
+import { workspaceRoots } from '@platform/workspaceRoots';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { MEMORY_DISPLAY_ROOT } from '@tools/memory/constants';
 import { MemoryTool } from '@tools/memory/MemoryTool';
@@ -49,12 +51,8 @@ function fileStat(size: number): FileStat {
   };
 }
 
-function streamOf(
-  content: string,
-): ReturnType<typeof StorageFS.createReadStream> {
-  return Readable.from([Buffer.from(content)]) as unknown as ReturnType<
-    typeof StorageFS.createReadStream
-  >;
+function streamOf(content: string) {
+  return Stream.make(Buffer.from(content));
 }
 
 function viewMemory(path?: string) {
@@ -62,6 +60,10 @@ function viewMemory(path?: string) {
 }
 
 describe('MemoryTool view with an omitted path', () => {
+  let memoryFS: FileSystem.FileSystem;
+  beforeEach(() => {
+    memoryFS = effectRuntime().runSync(FileSystem.FileSystem);
+  });
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -91,7 +93,7 @@ describe('MemoryTool view with an omitted path', () => {
       target === MEMORY_STORAGE_DIR ? [['notes.md', FileType.File]] : [],
     );
     vi.spyOn(StorageFS, 'read').mockResolvedValue(TEST_FRONTMATTER);
-    vi.spyOn(StorageFS, 'createReadStream').mockImplementation(() =>
+    vi.spyOn(memoryFS, 'stream').mockImplementation(() =>
       streamOf(TEST_FRONTMATTER),
     );
 
@@ -175,8 +177,12 @@ describe('MemoryTool view with an omitted path', () => {
       }
       return dirStat();
     });
-    vi.spyOn(StorageFS, 'createReadStream').mockImplementation((target) =>
-      streamOf(target === pinnedPath ? PINNED_FRONTMATTER : TEST_FRONTMATTER),
+    vi.spyOn(memoryFS, 'stream').mockImplementation((target) =>
+      streamOf(
+        path.relative(workspaceRoots().storage, target) === pinnedPath
+          ? PINNED_FRONTMATTER
+          : TEST_FRONTMATTER,
+      ),
     );
 
     const result = await viewMemory(MEMORY_DISPLAY_ROOT);

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 // Third-party imports
-import { Effect, Stream } from 'effect';
+import { Cause, Effect, Stream } from 'effect';
 import { z } from 'zod';
 
 // Local imports
@@ -200,16 +200,38 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
    * The two filesystem failures are re-raised as their own causes so a
    * caller still sees the error the filesystem raised, exactly as the
    * previous `await` chain did; a `ToolError` stays a typed failure and
-   * `runPromise` rejects with that instance.
+   * `runPromise` rejects with that instance. A compound failure retains all
+   * reasons in one error before the public tool result formats its message.
    */
   protected execute(input: MemoryToolInput): Promise<ToolResult> {
     return effectRuntime().runPromise(
-      this.run(input).pipe(
-        Effect.catchTags({
-          MemoryEntryUnreadable: (error) => Effect.die(error.cause),
-          MemoryFileUnwritable: (error) => Effect.die(error.cause),
-        }),
-      ),
+      Effect.catchCause(this.run(input), (cause) => {
+        const unwrapped = Cause.map(cause, (error) =>
+          '_tag' in error &&
+          (error._tag === 'MemoryEntryUnreadable' ||
+            error._tag === 'MemoryFileUnwritable')
+            ? error.cause
+            : error,
+        );
+        if (
+          unwrapped.reasons.length > 1 &&
+          !Cause.hasInterruptsOnly(unwrapped)
+        ) {
+          return Effect.die(
+            new Error(Cause.pretty(unwrapped), { cause: unwrapped }),
+          );
+        }
+        const reason = cause.reasons[0];
+        if (
+          reason?._tag === 'Fail' &&
+          '_tag' in reason.error &&
+          (reason.error._tag === 'MemoryEntryUnreadable' ||
+            reason.error._tag === 'MemoryFileUnwritable')
+        ) {
+          return Effect.die(reason.error.cause);
+        }
+        return Effect.failCause(cause);
+      }),
     );
   }
 

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -185,11 +185,15 @@ const readMemoryMeta = Effect.fn('memoryFileSystem.readMemoryMeta')(
         Effect.try({
           try: () => parseFrontmatter(text).meta,
           catch: (cause) => new MemoryMetaUnreadable({ storagePath, cause }),
-        }),
+        }).pipe(Effect.catch(skipAttribution)),
       ),
-      Effect.catchTags({
-        MemoryMetaUnreadable: skipAttribution,
-        MemoryEntryUnreadable: skipAttribution,
+      Effect.catchCause((cause) => {
+        const reason = cause.reasons[0];
+        // An unreadable head may omit attribution, but a failed close must
+        // remain visible even when the read failed as well.
+        return cause.reasons.length === 1 && reason?._tag === 'Fail'
+          ? skipAttribution(reason.error)
+          : Effect.failCause(cause);
       }),
     ),
 );

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -12,9 +12,10 @@
 import { Buffer } from 'node:buffer';
 import * as path from 'node:path';
 
-import { Data, Effect, Semaphore, Stream } from 'effect';
+import { Cause, Data, Effect, FileSystem, Semaphore, Stream } from 'effect';
 
 import { debug } from '@logger/logUtils';
+import { workspaceRoots } from '@platform/workspaceRoots';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type { MemoryPreview, MemoryViewItem } from '@shared/schemas';
 import {
@@ -41,6 +42,13 @@ import {
 const FRONTMATTER_SCAN_BYTES = 16 * 1024;
 const PREVIEW_SCAN_BYTES = 64 * 1024;
 const MEMORY_LISTING_CONCURRENCY = 8;
+
+/** Resolve relative memory paths against the calling session's storage root. */
+function absoluteMemoryPath(storagePath: string): string {
+  return path.isAbsolute(storagePath)
+    ? storagePath
+    : path.join(workspaceRoots().storage, storagePath);
+}
 
 /** Options controlling how far and how much {@link walkMemoryDirectory} descends. */
 export interface MemoryWalkOptions {
@@ -136,22 +144,33 @@ const readStoragePrefix = Effect.fn('memoryFileSystem.readStoragePrefix')(
     if (fileStats.size === 0) {
       return { text: '', truncated: false };
     }
-    const end = Math.min(maxBytes, fileStats.size) - 1;
-    const chunks = yield* Stream.unwrap(
-      Effect.try({
-        try: () =>
-          Stream.fromAsyncIterable(
-            StorageFS.createReadStream(storagePath, { start: 0, end }),
-            (cause) => new MemoryEntryUnreadable({ storagePath, cause }),
+    const fs = yield* FileSystem.FileSystem;
+    const chunks = yield* fs
+      .stream(absoluteMemoryPath(storagePath), {
+        bytesToRead: Math.min(maxBytes, fileStats.size),
+      })
+      .pipe(
+        // Finish an admitted read before the stream's scope closes its fd.
+        // Cancellation remains available between filesystem pulls.
+        (stream) =>
+          Stream.transformPull(stream, (pull) =>
+            Effect.succeed(Effect.uninterruptible(pull)),
           ),
-        catch: (cause) => new MemoryEntryUnreadable({ storagePath, cause }),
-      }),
-    ).pipe(Stream.runCollect);
-    const text = Buffer.concat(
-      chunks.map((chunk) =>
-        Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
-      ),
-    ).toString('utf-8');
+        Stream.runCollect,
+        Effect.catchCause((cause) =>
+          Effect.failCause(
+            Cause.map(
+              cause,
+              (error) =>
+                new MemoryEntryUnreadable({
+                  storagePath,
+                  cause: error.reason.cause ?? error,
+                }),
+            ),
+          ),
+        ),
+      );
+    const text = Buffer.concat(chunks).toString('utf-8');
     return {
       text: normalizeLineEndings(text),
       truncated: fileStats.size > maxBytes,
@@ -240,7 +259,11 @@ function walkLevel(
   depth: number,
   options: MemoryWalkOptions,
   permits: Semaphore.Semaphore,
-): Stream.Stream<MemoryWalkEntry, MemoryEntryUnreadable> {
+): Stream.Stream<
+  MemoryWalkEntry,
+  MemoryEntryUnreadable,
+  FileSystem.FileSystem
+> {
   return Stream.fromEffect(
     Effect.tryPromise({
       try: () => StorageFS.readDir(storagePath),
@@ -298,7 +321,11 @@ export function walkMemoryDirectory(
   storagePath: string,
   relativeRoot = '',
   options: MemoryWalkOptions = {},
-): Stream.Stream<MemoryWalkEntry, MemoryEntryUnreadable> {
+): Stream.Stream<
+  MemoryWalkEntry,
+  MemoryEntryUnreadable,
+  FileSystem.FileSystem
+> {
   return Stream.unwrap(
     Effect.map(Semaphore.make(MEMORY_LISTING_CONCURRENCY), (permits) =>
       walkLevel(storagePath, relativeRoot, 0, options, permits),
@@ -379,10 +406,22 @@ type SetMemoryPinnedResult =
  */
 export const setMemoryPinned = Effect.fn('memoryFileSystem.setMemoryPinned')(
   function* (storagePath: string, pinned: boolean) {
-    const raw = yield* Effect.tryPromise({
-      try: () => StorageFS.read(storagePath),
-      catch: (cause) => new MemoryEntryUnreadable({ storagePath, cause }),
-    });
+    const fs = yield* FileSystem.FileSystem;
+    const bytes = yield* fs.readFile(absoluteMemoryPath(storagePath)).pipe(
+      Effect.catchCause((cause) =>
+        Effect.failCause(
+          Cause.map(
+            cause,
+            (error) =>
+              new MemoryEntryUnreadable({
+                storagePath,
+                cause: error.reason.cause ?? error,
+              }),
+          ),
+        ),
+      ),
+    );
+    const raw = normalizeLineEndings(Buffer.from(bytes).toString('utf-8'));
     const { meta, content } = parseFrontmatter(raw);
 
     const alreadyInState = pinned ? !!meta?.pinned : !meta?.pinned;


### PR DESCRIPTION
## Summary

Uses the official `@effect/platform-node@4.0.0-rc.112` filesystem service for bounded memory previews and full reads used by pinning. The shared process runtime supplies the service; readers do not construct private runtimes or Node layers.

The bounded reader retains byte limits and final Buffer decoding, including BOM and incomplete UTF-8 behavior. An admitted filesystem pull finishes before its descriptor closes; cancellation remains possible between pulls. Atomic writes, symlink-safe directory listing, existence checks and stat behavior remain unchanged.

Concurrent read and close failures are retained through metadata recovery and the CLI, settings and memory-tool reporting boundaries. Ordinary errors preserve their identity. Compound failures produce one reporting error containing the complete mapped Cause; the public tool result preserves readable reasons, not a structured Cause field.

## Acceptance gates

Keep this PR draft pending integration acceptance. The seven filesystem-service fixture updates and the compound-error correction have independent source acceptance. The combined full suite passes. The SDK now declares the exact official Node dependency, and full type checking, including SDK artifact validation, passes. No artifact check or baseline has been weakened.

## Single source of truth

`installProcessRuntime` provides the official FileSystem service. Session-relative paths still use the existing workspace-roots context. Five manual test runtimes provide the same service; two suites whose memory programs are mocked provide an explicit noop test service rather than casting away their requirements.

## Duplication and abstraction budget

Removes the prefix reader's Node-readable-to-AsyncIterable bridge and chunk normalization, and the Promise bridge for the full pinning read. StorageFS remains for operations with host-specific semantics. No replacement adapter, service, runtime or compatibility path is introduced.

## Net elements (R6)

Against the recorded base, 19 existing files change (+412/-103; net +309, including 132 lockfile additions). No new production file, class, interface, enum or exported symbol. One private path resolver serves two read paths. This dependency-and-consumer migration is not a net-line reduction.

## Consumer counts (R8)

The private path resolver has two consumers: bounded prefix reads and full pinning reads. The prefix reader serves frontmatter and preview reads. No event or exported symbol is removed.

## Host impact and coordination

Extension, desktop and CLI receive FileSystem through the shared process runtime. No LLM implementation changes. The manifest/runtime prerequisites and the narrow existing Electron test-runtime update were explicitly authorized despite overlapping ownership; no other worktree was modified. Base: `4d538c5e40253224f37a83f16c69d4ddad28c038`.

## Validation

- Combined full Vitest: 760 files passed, 1 skipped; 8,880 tests passed, 6 skipped, in 619.44 seconds on Node 22 with two workers.
- Seven updated fixture suites: all 65 existing cases pass; all 15 reported fixture type errors are resolved.
- One regression added to the existing memory-filesystem suite for the reproduced concurrent read/close failure.
- Independent filesystem diagnostics verify bounded reads, EOF/early-stop closure, interruption ordering, UTF-8 decoding and concurrent failures. Independent reviewers accepted the exact fixture and production-correction sources.
- Combined workspace, test-kernel, CLI, trace-viewer and desktop type checks: passed. Extension build, full lint, formatting, Effect migration/dead-code ratchets, browser-safety and guidance-reference checks: passed.
- Full typecheck, including SDK artifact validation: passed after adding the SDK dependency declaration. Frozen installation, full formatting, extension build and full lint also passed again. The dependency follow-up changes only the SDK manifest and lockfile importer; resolved packages and executable sources are unchanged from the 8,880-test hold.
- Published follow-up commits: `c8fe35e1f3` (compound failures) and `e2cabe393a` (seven fixtures); normal commit hooks and push completed without bypasses.
- The SDK dependency follow-up `9e838b4948` has independent exact-diff acceptance and passed normal commit/push hooks. [CI on that head](https://github.com/LionSR/TeXRA/actions/runs/34228316145) passed: full static checks, both kernel-test groups, package build, macOS smoke tests and guidance checks.

## Scheduled refactoring

Obtain complete integration acceptance before leaving draft. Further MemoryTool read migration and native process/terminal adapters remain outside this PR.
