### PR TITLE
fix(llm): give a turn result a durable shape

### DIFF
--- a/packages/extension/src/frontend/lm/acquireVscodeLanguageModel.ts
+++ b/packages/extension/src/frontend/lm/acquireVscodeLanguageModel.ts
@@ -83,7 +83,6 @@ function lowerMessages(
           } else if (
             part.kind === 'local-call' &&
             part.evidence === undefined &&
-            part.providerCallId !== null &&
             config.supportsToolCalling
           ) {
             content.push(
@@ -116,7 +115,7 @@ function lowerMessages(
         const content: vscode.LanguageModelToolResultPart[] = [];
         for (const result of message.results) {
           const call = calls[result.callOrdinal];
-          if (!call || call.providerCallId === null) {
+          if (call === undefined) {
             return yield* new ModelError({
               kind: 'unsupported',
               message: 'Editor tool results require the original call ID.',

--- a/packages/extension/src/frontend/lm/acquireVscodeLanguageModel.ts
+++ b/packages/extension/src/frontend/lm/acquireVscodeLanguageModel.ts
@@ -540,6 +540,12 @@ export const acquireVscodeLanguageModel = Effect.fn(
                     kind: 'local-call',
                     providerCallId: call.callId,
                     name: call.name,
+                    // The editor hands over `input` already parsed and never
+                    // exposes the model's raw argument bytes, so there are no
+                    // provider bytes to retain here. This serialization is not
+                    // a re-encode of a parse whose original was dropped: the
+                    // object is the only representation this source ever had.
+                    argumentsText: JSON.stringify(args.data),
                     arguments: args.data,
                   });
                   if (phaseOpen)

--- a/packages/llm/src/anthropicMessages.ts
+++ b/packages/llm/src/anthropicMessages.ts
@@ -269,7 +269,7 @@ const invocationBody = Effect.fn('llm.anthropic.invocationBody')(function* (
       const content: ToolResultBlockParam[] = [];
       for (const result of message.results) {
         const call = calls[result.callOrdinal];
-        if (!call?.providerCallId)
+        if (call === undefined)
           return yield* new ModelError({
             kind: 'unsupported',
             message:
@@ -296,11 +296,7 @@ const invocationBody = Effect.fn('llm.anthropic.invocationBody')(function* (
               });
             content.push({ type: 'text', text: child.text });
           }
-        } else if (
-          part.kind === 'local-call' &&
-          part.evidence === undefined &&
-          part.providerCallId !== null
-        ) {
+        } else if (part.kind === 'local-call' && part.evidence === undefined) {
           calls.push(part);
           content.push({
             type: 'tool_use',
@@ -821,20 +817,21 @@ export function anthropicMessagesModel(
                     },
                   });
                 else {
-                  const argumentsText = open.argumentsText;
-                  const argumentsValue =
-                    argumentsText === undefined
-                      ? block.input
-                      : yield* Effect.try({
-                          try: () => JSON.parse(argumentsText),
-                          catch: (cause) =>
-                            new ModelError({
-                              kind: 'malformed-output',
-                              message:
-                                'Anthropic returned incomplete function argument JSON.',
-                              cause,
-                            }),
-                        });
+                  // content_block_start rejects a nonempty streamed argument
+                  // placeholder, so a tool_use block that received no
+                  // input_json_delta carries no arguments, and '{}' is that
+                  // empty object's exact text.
+                  const argumentsText = open.argumentsText ?? '{}';
+                  const argumentsValue = yield* Effect.try({
+                    try: () => JSON.parse(argumentsText),
+                    catch: (cause) =>
+                      new ModelError({
+                        kind: 'malformed-output',
+                        message:
+                          'Anthropic returned incomplete function argument JSON.',
+                        cause,
+                      }),
+                  });
                   const argumentsResult =
                     JsonObjectSchema.safeParse(argumentsValue);
                   if (!argumentsResult.success)
@@ -848,6 +845,7 @@ export function anthropicMessagesModel(
                     kind: 'local-call',
                     providerCallId: block.id,
                     name: block.name,
+                    argumentsText,
                     arguments: argumentsResult.data,
                   });
                 }

--- a/packages/llm/src/googleInteractions.ts
+++ b/packages/llm/src/googleInteractions.ts
@@ -185,7 +185,7 @@ const lowerMessages = Effect.fn('llm.google.lowerMessages')(function* (
     } else if (message.role === 'tool') {
       for (const result of message.results) {
         const call = calls[result.callOrdinal];
-        if (!call?.providerCallId) {
+        if (call === undefined) {
           return yield* new ModelError({
             kind: 'unsupported',
             message:
@@ -257,11 +257,7 @@ const lowerMessages = Effect.fn('llm.google.lowerMessages')(function* (
             });
             break;
           case 'local-call':
-            if (
-              !part.providerCallId ||
-              ids.has(part.providerCallId) ||
-              part.evidence !== undefined
-            ) {
+            if (ids.has(part.providerCallId) || part.evidence !== undefined) {
               return yield* new ModelError({
                 kind: 'unsupported',
                 message:
@@ -350,7 +346,6 @@ function ownedRequest<A>(
           catch: (cause) => cause,
         }).pipe(
           Effect.catch((cause) => {
-            if (deadline) console.log('JOINDEBUG', cause, exit);
             if (
               Exit.isFailure(exit) &&
               (exit.cause.reasons.some(
@@ -466,10 +461,19 @@ function createInput(
   >;
 }
 
+/**
+ * A completed step carrying the exact argument bytes when they were observed.
+ * The stream delivers tool arguments as text deltas, so it keeps them; a
+ * background snapshot returns only the SDK's parse of them and keeps none.
+ */
+type ObservedStep = z.infer<typeof WireCompletedStepSchema> & {
+  readonly argumentsText?: string;
+};
+
 const normalizeCompleted = Effect.fn('llm.google.normalizeCompleted')(
   function* (
     interaction: z.infer<typeof WireInteractionSchema>,
-    responseSteps: readonly z.infer<typeof WireCompletedStepSchema>[],
+    responseSteps: readonly ObservedStep[],
     origin: ModelOrigin,
   ) {
     const usage = interaction.usage;
@@ -517,6 +521,9 @@ const normalizeCompleted = Effect.fn('llm.google.normalizeCompleted')(
           kind: 'local-call',
           providerCallId: step.id,
           name: step.name,
+          // A background snapshot hands back the SDK's parse with no bytes
+          // behind it, so its text is re-encoded from that parse.
+          argumentsText: step.argumentsText ?? JSON.stringify(step.arguments),
           arguments: step.arguments,
         });
       } else {
@@ -540,7 +547,15 @@ const normalizeCompleted = Effect.fn('llm.google.normalizeCompleted')(
       returnedModel: interaction.model ?? null,
       modelFingerprint: null,
       content,
-      finishReason: callIds.size > 0 ? 'tool-calls' : 'stop',
+      finishReason:
+        interaction.status === 'requires_action' ? 'tool-calls' : 'stop',
+      finishEvidence: {
+        kind: 'google-interactions',
+        status: interaction.status,
+        // The Interactions resource reports no reason for ending, so the
+        // status is the whole of what Google says about the outcome.
+        terminalReason: null,
+      },
       usage:
         usage === undefined
           ? null
@@ -997,7 +1012,7 @@ export function googleInteractionsModel(
               const ordered = [...pending.entries()].toSorted(
                 ([left], [right]) => left - right,
               );
-              const responseSteps: z.infer<typeof WireStepSchema>[] = [];
+              const responseSteps: ObservedStep[] = [];
               for (const [index, slot] of ordered) {
                 if (!slot.stopped || index !== responseSteps.length) {
                   return yield* new ModelError({
@@ -1005,19 +1020,25 @@ export function googleInteractionsModel(
                     message: 'Google ended with an incomplete step sequence.',
                   });
                 }
+                const argumentsText = slot.argumentsText;
                 if (
                   slot.step.type === 'function_call' &&
-                  slot.argumentsText !== undefined
+                  argumentsText !== undefined
                 ) {
-                  slot.step.arguments = yield* Effect.try({
-                    try: () => JSON.parse(slot.argumentsText!),
-                    catch: (cause) =>
-                      new ModelError({
-                        kind: 'malformed-output',
-                        message: 'Google emitted malformed tool arguments.',
-                        cause,
-                      }),
+                  responseSteps.push({
+                    ...slot.step,
+                    arguments: yield* Effect.try({
+                      try: () => JSON.parse(argumentsText),
+                      catch: (cause) =>
+                        new ModelError({
+                          kind: 'malformed-output',
+                          message: 'Google emitted malformed tool arguments.',
+                          cause,
+                        }),
+                    }),
+                    argumentsText,
                   });
+                  continue;
                 }
                 responseSteps.push(slot.step);
               }

--- a/packages/llm/src/openaiChat.ts
+++ b/packages/llm/src/openaiChat.ts
@@ -461,16 +461,15 @@ const chatMessages = Effect.fn('llm.chatMessages')(function* (
         reasoning = part.content![0].text;
       } else if (part.kind === 'local-call') {
         if (
-          part.providerCallId === null ||
-          (part.evidence !== undefined &&
-            (origin.protocol !== 'minimax-chat' ||
-              part.evidence.kind !== 'minimax-function-call' ||
-              !sameModelOrigin(message.origin, origin)))
+          part.evidence !== undefined &&
+          (origin.protocol !== 'minimax-chat' ||
+            part.evidence.kind !== 'minimax-function-call' ||
+            !sameModelOrigin(message.origin, origin))
         ) {
           return yield* new ModelError({
             kind: 'unsupported',
             message:
-              'Chat tool history requires original call IDs without foreign item evidence.',
+              'Chat tool history requires calls without foreign item evidence.',
           });
         }
         calls.push({
@@ -481,8 +480,9 @@ const chatMessages = Effect.fn('llm.chatMessages')(function* (
             ? { index: part.evidence.index }
             : {}),
           function: {
+            // The provider's own bytes, not a re-encoding of their parse.
             name: part.name,
-            arguments: JSON.stringify(part.arguments),
+            arguments: part.argumentsText,
           },
         });
       } else if (
@@ -1294,6 +1294,7 @@ export function openaiChatModel(
                 kind: 'local-call',
                 providerCallId: call.id,
                 name: call.function.name,
+                argumentsText: call.function.arguments,
                 arguments: parsedArguments.data,
                 ...(call.index !== undefined
                   ? {
@@ -1908,6 +1909,7 @@ export function openaiChatModel(
                   kind: 'local-call',
                   providerCallId: call.id,
                   name: call.name,
+                  argumentsText: call.arguments,
                   arguments: args,
                   ...(turn.protocol === 'minimax-chat'
                     ? {

--- a/packages/llm/src/openaiResponses.ts
+++ b/packages/llm/src/openaiResponses.ts
@@ -144,7 +144,7 @@ function agreesWithCompleted(
     return (
       completed.providerCallId === candidate.providerCallId &&
       completed.name === candidate.name &&
-      isDeepStrictEqual(completed.arguments, candidate.arguments) &&
+      completed.argumentsText === candidate.argumentsText &&
       (candidate.evidence?.itemId === undefined ||
         completed.evidence?.itemId === candidate.evidence.itemId) &&
       (candidate.evidence?.status === undefined ||
@@ -255,6 +255,7 @@ const normalizeItem = Effect.fn('llm.responses.normalizeItem')(function* (
         kind: 'local-call',
         providerCallId: item.call_id,
         name: item.name,
+        argumentsText: item.arguments,
         arguments: args,
         evidence: {
           kind: 'openai-responses-function-call',
@@ -302,6 +303,11 @@ const normalizeResponse = Effect.fn('llm.responses.normalizeResponse')(
       modelFingerprint: null,
       content,
       finishReason,
+      finishEvidence: {
+        kind: 'openai-responses',
+        status: response.status,
+        incompleteReason: response.incomplete_details?.reason ?? null,
+      },
       usage: response.usage
         ? {
             inputTokens: response.usage.input_tokens,
@@ -456,14 +462,13 @@ const lowerInput = Effect.fn('llm.responses.lowerInput')(function* (
         }
         case 'local-call': {
           if (
-            part.providerCallId === null ||
-            (part.evidence !== undefined &&
-              part.evidence.kind !== 'openai-responses-function-call')
+            part.evidence !== undefined &&
+            part.evidence.kind !== 'openai-responses-function-call'
           ) {
             return yield* new ModelError({
               kind: 'unsupported',
               message:
-                'Responses tool history requires original call IDs without foreign evidence.',
+                'Responses tool history requires local calls without foreign evidence.',
             });
           }
           callIds.push(part.providerCallId);
@@ -471,7 +476,7 @@ const lowerInput = Effect.fn('llm.responses.lowerInput')(function* (
             type: 'function_call',
             call_id: part.providerCallId,
             name: part.name,
-            arguments: JSON.stringify(part.arguments),
+            arguments: part.argumentsText,
             ...(part.evidence?.itemId !== undefined
               ? { id: part.evidence.itemId }
               : {}),
@@ -1078,11 +1083,7 @@ const responseParameters = Effect.fn('llm.responses.parameters')(function* (
       !config.allowedReasoningEfforts.includes(
         turn.controls.reasoning.effort,
       )) ||
-    (turn.continuation !== undefined &&
-      (!config.supportsResponseChaining ||
-        (turn.continuation.anchor.kind === 'connection' &&
-          (transport.kind !== 'websocket' ||
-            turn.continuation.anchor.connectionId !== transport.connectionId))))
+    (turn.continuation !== undefined && !config.supportsResponseChaining)
   )
     return yield* new ModelError({
       kind: 'unsupported',
@@ -2398,48 +2399,19 @@ export const openaiResponsesWebSocketModel = Effect.fn(
                       'The Responses connection buffered data beyond its terminal event.',
                   });
                 latestResponseId = event.result.providerResponseId ?? undefined;
-                let continuation = yield* openaiResponsesContinuation(
+                const continuation = yield* openaiResponsesContinuation(
                   config,
                   turn,
                   event.result,
                 );
+                // Eligibility stays on the connection: a response this lane can
+                // chain from is never stamped into a value that outlives it.
                 if (
                   config.supportsResponseChaining &&
                   (event.result.finishReason === 'stop' ||
                     event.result.finishReason === 'tool-calls')
-                ) {
+                )
                   eligibleResponseId = latestResponseId;
-                  if (!continuation) {
-                    const prefix: ResolvedTurn['messages'] = [
-                      ...turn.messages,
-                      {
-                        role: 'assistant',
-                        origin,
-                        content: event.result.content,
-                      },
-                    ];
-                    const encoded = yield* lowerInput({
-                      ...turn,
-                      messages: prefix,
-                    });
-                    continuation = ContinuationSchema.parse({
-                      origin,
-                      coveredMessages: prefix.length,
-                      prefixFingerprint: prefixFingerprint(
-                        'texra-openai-responses-prefix-v1',
-                        origin,
-                        turn.system,
-                        prefix,
-                      ),
-                      anchor: {
-                        kind: 'connection',
-                        connectionId: transport.connectionId,
-                        responseId: latestResponseId,
-                        coveredItems: encoded.length,
-                      },
-                    });
-                  }
-                }
                 completed = true;
                 return {
                   ...event,

--- a/packages/llm/src/openaiResponses.ts
+++ b/packages/llm/src/openaiResponses.ts
@@ -2097,7 +2097,6 @@ export const openaiResponsesWebSocketModel = Effect.fn(
   let phase: 'idle' | 'reading' | 'draining' = 'idle';
   let pendingRead: Promise<IteratorResult<unknown>> | undefined;
   let latestResponseId: string | undefined;
-  let eligibleResponseId: string | undefined;
 
   const failure = (cause: unknown) =>
     cause instanceof ModelError
@@ -2139,11 +2138,9 @@ export const openaiResponsesWebSocketModel = Effect.fn(
       // This listener records failures while idle as well as during a pending read.
       reader.on('error', (cause) => {
         invalid ??= failure(cause);
-        eligibleResponseId = undefined;
       });
       socket.once('close', () => {
         invalid ??= closed;
-        eligibleResponseId = undefined;
       });
       return {
         socket,
@@ -2154,7 +2151,6 @@ export const openaiResponsesWebSocketModel = Effect.fn(
     ({ socket, reader, iterator }, exit) =>
       Effect.gen(function* () {
         invalid ??= closed;
-        eligibleResponseId = undefined;
         reader.destroy(closed);
         yield* join(
           iterator.return ? iterator.return() : Promise.resolve(),
@@ -2172,7 +2168,6 @@ export const openaiResponsesWebSocketModel = Effect.fn(
   const { socket, reader, iterator } = resource;
   const invalidate = (error: ModelError) => {
     invalid ??= error;
-    eligibleResponseId = undefined;
     reader.destroy(invalid);
   };
   // The sole consumer decodes frames; this synchronous guard only invalidates idle traffic.
@@ -2267,7 +2262,6 @@ export const openaiResponsesWebSocketModel = Effect.fn(
             'foreground',
           );
           const now = yield* Clock.currentTimeMillis;
-          const anchor = turn.continuation?.anchor;
           yield* Effect.acquireRelease(
             Effect.suspend(() => {
               if (invalid) return Effect.fail(invalid);
@@ -2283,19 +2277,7 @@ export const openaiResponsesWebSocketModel = Effect.fn(
                 invalidate(closed);
                 return Effect.fail(closed);
               }
-              if (
-                anchor?.kind === 'connection' &&
-                anchor.responseId !== eligibleResponseId
-              )
-                return Effect.fail(
-                  new ModelError({
-                    kind: 'invalid-request',
-                    message:
-                      'The connection anchor is not its latest eligible response.',
-                  }),
-                );
               phase = 'reading';
-              eligibleResponseId = undefined;
               return Effect.void;
             }),
             (_, exit) =>
@@ -2404,14 +2386,6 @@ export const openaiResponsesWebSocketModel = Effect.fn(
                   turn,
                   event.result,
                 );
-                // Eligibility stays on the connection: a response this lane can
-                // chain from is never stamped into a value that outlives it.
-                if (
-                  config.supportsResponseChaining &&
-                  (event.result.finishReason === 'stop' ||
-                    event.result.finishReason === 'tool-calls')
-                )
-                  eligibleResponseId = latestResponseId;
                 completed = true;
                 return {
                   ...event,

--- a/packages/llm/src/openrouterChat.ts
+++ b/packages/llm/src/openrouterChat.ts
@@ -456,8 +456,7 @@ const requestBody = Effect.fn('llm.openrouterRequest')(function* (
       } else if (
         part.kind === 'local-call' &&
         part.evidence === undefined &&
-        annotations.length === 0 &&
-        part.providerCallId !== null
+        annotations.length === 0
       )
         calls.push(part);
       else if (
@@ -539,7 +538,7 @@ const requestBody = Effect.fn('llm.openrouterRequest')(function* (
               type: 'function',
               function: {
                 name: call.name,
-                arguments: JSON.stringify(call.arguments),
+                arguments: call.argumentsText,
               },
             })),
           }
@@ -1207,6 +1206,9 @@ export function openrouterChatModel(
                   kind: 'local-call',
                   providerCallId: call.id,
                   name: call.name,
+                  // The accumulated delta bytes, which `arguments` above is the
+                  // parse of, so the pair holds by construction.
+                  argumentsText: call.arguments,
                   arguments: parsedArgs.data,
                 });
               }

--- a/packages/llm/src/turn.ts
+++ b/packages/llm/src/turn.ts
@@ -262,7 +262,9 @@ const MessagePartSchema = z.strictObject({
  * refinement keeps the pair one value.
  */
 function sameJsonValue(left: unknown, right: unknown): boolean {
-  if (left === right) return true;
+  // `Object.is`, not `===`: JSON.parse keeps -0 while re-encoding the parsed
+  // value writes 0, so `===` would call a drifted pair one value.
+  if (Object.is(left, right)) return true;
   if (
     typeof left !== 'object' ||
     typeof right !== 'object' ||

--- a/packages/llm/src/turn.ts
+++ b/packages/llm/src/turn.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { Data, type Effect, type Stream } from 'effect';
+import { Data, Result, type Effect, type Stream } from 'effect';
 import { z } from 'zod';
 
 const TextPartSchema = z
@@ -252,10 +252,61 @@ const MessagePartSchema = z.strictObject({
     ])
     .optional(),
 });
-const LocalCallPartSchema = z.strictObject({
+/**
+ * `argumentsText` and `arguments` are two representations of one value on
+ * purpose, not a dual system. A JSON.parse then JSON.stringify round trip is
+ * not byte exact: it truncates integers past 2^53, rewrites 1.0 as 1,
+ * collapses duplicate keys and reorders integer-like keys, and that loss
+ * happens in the codec, before anything durable is written. So the exact
+ * provider bytes and the parsed form callers read are both carried, and this
+ * refinement keeps the pair one value.
+ */
+function sameJsonValue(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (
+    typeof left !== 'object' ||
+    typeof right !== 'object' ||
+    left === null ||
+    right === null ||
+    Array.isArray(left) !== Array.isArray(right)
+  ) {
+    return false;
+  }
+  const entries = Object.entries(left);
+  return (
+    entries.length === Object.keys(right).length &&
+    entries.every(
+      ([key, value]) =>
+        Object.hasOwn(right, key) &&
+        sameJsonValue(value, (right as Record<string, unknown>)[key]),
+    )
+  );
+}
+
+function validateLocalCallArguments(
+  part: { readonly argumentsText: string; readonly arguments: unknown },
+  ctx: z.RefinementCtx,
+): void {
+  const parsed = Result.try((): unknown => JSON.parse(part.argumentsText));
+  if (
+    Result.isFailure(parsed) ||
+    !sameJsonValue(parsed.success, part.arguments)
+  ) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['argumentsText'],
+      message:
+        'Returned argument bytes must parse to exactly the reported arguments.',
+    });
+  }
+}
+
+const LocalCallFieldsSchema = z.strictObject({
   kind: z.literal('local-call'),
-  providerCallId: z.string().min(1).nullable(),
+  providerCallId: z.string().min(1),
   name: z.string().min(1),
+  /** The provider's exact returned bytes; `arguments` is their parse. */
+  argumentsText: z.string(),
   arguments: JsonObjectSchema,
   evidence: z
     .discriminatedUnion('kind', [
@@ -275,6 +326,9 @@ const LocalCallPartSchema = z.strictObject({
     ])
     .optional(),
 });
+const LocalCallPartSchema = LocalCallFieldsSchema.superRefine(
+  validateLocalCallArguments,
+);
 
 const OutputPartSchema = z.discriminatedUnion('kind', [
   OpenRouterFileAnnotationSchema,
@@ -338,17 +392,15 @@ const OutputPartSchema = z.discriminatedUnion('kind', [
   LocalCallPartSchema.readonly(),
 ]);
 
-const ContentSchema = z.array(OutputPartSchema).readonly();
+export const ContentSchema = z.array(OutputPartSchema).readonly();
 const EditorContentSchema = z
   .array(
     z.discriminatedUnion('kind', [
       MessagePartSchema.omit({ evidence: true })
         .extend({ content: z.array(TextPartSchema).readonly() })
         .readonly(),
-      LocalCallPartSchema.omit({ evidence: true })
-        .extend({
-          providerCallId: LocalCallPartSchema.shape.providerCallId.unwrap(),
-        })
+      LocalCallFieldsSchema.omit({ evidence: true })
+        .superRefine(validateLocalCallArguments)
         .readonly(),
     ]),
   )
@@ -427,7 +479,7 @@ function validateAssistantContent(
       }
       itemIds.add(evidence.itemId);
     }
-    if (part.kind !== 'local-call' || part.providerCallId === null) continue;
+    if (part.kind !== 'local-call') continue;
     if (ids.has(part.providerCallId)) {
       ctx.addIssue({
         code: 'custom',
@@ -439,7 +491,7 @@ function validateAssistantContent(
   }
 }
 
-const AssistantMessageSchema = z
+export const AssistantMessageSchema = z
   .strictObject({
     role: z.literal('assistant'),
     origin: ModelOriginSchema,
@@ -457,8 +509,9 @@ const AssistantMessageSchema = z
     validateAssistantContent(message.origin, message.content, ctx);
   })
   .readonly();
+export type AssistantMessage = z.infer<typeof AssistantMessageSchema>;
 
-const MessageSchema = z.discriminatedUnion('role', [
+export const MessageSchema = z.discriminatedUnion('role', [
   z
     .strictObject({
       role: z.literal('user'),
@@ -486,7 +539,7 @@ const MessageSchema = z.discriminatedUnion('role', [
 ]);
 
 // A completed assistant can precede settlement; only the next request requires it.
-const PreparedHistorySchema = z
+export const PreparedHistorySchema = z
   .array(MessageSchema)
   .min(1)
   .superRefine((messages, ctx) => {
@@ -1243,6 +1296,34 @@ const HttpTurnResultSchema = z
         MiniMaxDetectionSchema.extend({
           kind: z.literal('minimax'),
         }).readonly(),
+        z
+          .strictObject({
+            kind: z.literal('google-interactions'),
+            // Reported verbatim: the interaction status vocabulary is open, so
+            // an unrecognized status is preserved rather than dropped.
+            status: z.string().min(1),
+            // Null when the interaction reports no reason for ending, which is
+            // every status Google returns today.
+            terminalReason: z.string().min(1).nullable(),
+          })
+          .readonly(),
+        z
+          .strictObject({
+            kind: z.literal('openai-responses'),
+            status: z.enum([
+              'queued',
+              'in_progress',
+              'completed',
+              'failed',
+              'cancelled',
+              'incomplete',
+            ]),
+            // Present only on an incomplete response.
+            incompleteReason: z
+              .enum(['max_output_tokens', 'content_filter'])
+              .nullable(),
+          })
+          .readonly(),
       ])
       .optional(),
     refusalEvidence: z
@@ -1294,7 +1375,11 @@ const HttpTurnResultSchema = z
         result.requestedOrigin.protocol !== 'openrouter-chat') ||
       ((result.usage?.providerUsage?.kind === 'minimax' ||
         result.finishEvidence?.kind === 'minimax') &&
-        result.requestedOrigin.protocol !== 'minimax-chat')
+        result.requestedOrigin.protocol !== 'minimax-chat') ||
+      (result.finishEvidence?.kind === 'google-interactions' &&
+        result.requestedOrigin.protocol !== 'google-interactions') ||
+      (result.finishEvidence?.kind === 'openai-responses' &&
+        result.requestedOrigin.protocol !== 'openai-responses')
     ) {
       ctx.addIssue({
         code: 'custom',
@@ -1353,6 +1438,17 @@ export const TurnResultSchema = z.union([
   EditorTurnResultSchema,
 ]);
 export type TurnResult = z.infer<typeof TurnResultSchema>;
+
+/** The assistant message a completed turn contributes to canonical history. */
+export function assistantMessageFromResult(
+  result: TurnResult,
+): AssistantMessage {
+  return {
+    role: 'assistant',
+    origin: result.requestedOrigin,
+    content: result.content,
+  };
+}
 
 // Identity evidence is neither background acceptance nor cancellation.
 const IdentifiedEventSchema = IdentitySchema.extend({

--- a/packages/llm/src/turn.ts
+++ b/packages/llm/src/turn.ts
@@ -624,13 +624,13 @@ const ResponsesContinuationSchema = PrefixSchema.extend({
   origin: OriginSchema.extend({
     protocol: z.literal('openai-responses'),
   }).readonly(),
-  anchor: z.discriminatedUnion('kind', [
-    ResponsesAnchorSchema.extend({ kind: z.literal('stored') }).readonly(),
-    ResponsesAnchorSchema.extend({
-      kind: z.literal('connection'),
-      connectionId: z.uuid(),
-    }).readonly(),
-  ]),
+  // Only a stored anchor is durable. A connection-scoped anchor named a single
+  // websocket, so it was dead the moment the process exited, and reusing a dead
+  // one failed the whole turn rather than dropping the acceleration. Keeping it
+  // representable here would let a persisted value carry it.
+  anchor: ResponsesAnchorSchema.extend({
+    kind: z.literal('stored'),
+  }).readonly(),
 }).readonly();
 /** Provider acceleration of an exact prefix, never the conversation authority. */
 export const ContinuationSchema = z.union([

--- a/src/test-kernel/llm/AnthropicMessages.vitest.ts
+++ b/src/test-kernel/llm/AnthropicMessages.vitest.ts
@@ -578,12 +578,15 @@ describe('canonical Anthropic Messages protocol', () => {
             kind: 'local-call',
             providerCallId: 'call_0',
             name: 'search',
+            // The exact concatenation of both input_json_delta fragments.
+            argumentsText: '{"q":"x"}',
             arguments: { q: 'x' },
           },
           {
             kind: 'local-call',
             providerCallId: 'call_1',
             name: 'fetch',
+            argumentsText: '{"q":"x"}',
             arguments: { q: 'x' },
           },
         ]);

--- a/src/test-kernel/llm/GoogleInteractions.vitest.ts
+++ b/src/test-kernel/llm/GoogleInteractions.vitest.ts
@@ -984,6 +984,14 @@ describe('canonical Google Interactions protocol', () => {
           deployment: { credentialScope: 'test-account' },
         },
         finishReason: 'tool-calls',
+        // The finish reason is now read off the wire status rather than
+        // synthesized from the presence of calls, and the status Google sent
+        // is carried verbatim.
+        finishEvidence: {
+          kind: 'google-interactions',
+          status: 'requires_action',
+          terminalReason: null,
+        },
         content: [
           {
             kind: 'reasoning',

--- a/src/test-kernel/llm/OpenaiChat.vitest.ts
+++ b/src/test-kernel/llm/OpenaiChat.vitest.ts
@@ -293,6 +293,8 @@ describe('native OpenAI Chat protocol', () => {
             kind: 'local-call',
             providerCallId: 'call_0',
             name: 'search',
+            // The exact concatenation of both tool-call argument deltas.
+            argumentsText: '{"query":"x"}',
             arguments: { query: 'x' },
             evidence: { kind: 'minimax-function-call', index: 0 },
           },
@@ -622,6 +624,7 @@ describe('native OpenAI Chat protocol', () => {
           kind: 'local-call',
           providerCallId: 'call_0',
           name: 'search',
+          argumentsText: '{"query":"first"}',
           arguments: { query: 'first' },
           evidence: { kind: 'minimax-function-call', index: 9 },
         },
@@ -1059,6 +1062,7 @@ describe('native OpenAI Chat protocol', () => {
                 kind: 'local-call',
                 providerCallId: 'original-call',
                 name: 'search',
+                argumentsText: '{"query":"x"}',
                 arguments: { query: 'x' },
               },
             ],
@@ -2240,12 +2244,14 @@ describe('native OpenAI Chat protocol', () => {
           kind: 'local-call',
           providerCallId: 'call_0',
           name: 'search',
+          argumentsText: '{"query":"a"}',
           arguments: { query: 'a' },
         },
         {
           kind: 'local-call',
           providerCallId: 'call_1',
           name: 'fetch',
+          argumentsText: '{"query":"b"}',
           arguments: { query: 'b' },
         },
       ]);
@@ -2831,7 +2837,6 @@ describe('native OpenAI Chat protocol', () => {
     'Kimi tool media',
     'GLM tool media',
     'reasoning',
-    'missing call ID',
     'text after calls',
     'reasoning control',
     'service-tier control',
@@ -2866,8 +2871,9 @@ describe('native OpenAI Chat protocol', () => {
       content: [
         {
           kind: 'local-call',
-          providerCallId: scenario === 'missing call ID' ? null : 'call_0',
+          providerCallId: 'call_0',
           name: 'search',
+          argumentsText: '{}',
           arguments: {},
         },
         ...(scenario === 'text after calls'

--- a/src/test-kernel/llm/OpenaiResponses.vitest.ts
+++ b/src/test-kernel/llm/OpenaiResponses.vitest.ts
@@ -513,7 +513,7 @@ describe('native OpenAI Responses protocol', () => {
   );
 
   it.each(['stop', 'length'] as const)(
-    'owns one WebSocket reader through a %s continuation and rejects old connection anchors',
+    'owns one WebSocket reader across a second %s turn without a chaining anchor',
     async (outcome) => {
       const requests: Record<string, unknown>[] = [];
       const countFetch = vi
@@ -590,11 +590,7 @@ describe('native OpenAI Responses protocol', () => {
             expect(turn.transport.kind).toBe('websocket');
             const first = yield* model.generateTurn(turn);
             assert(first.providerResponseId !== null);
-            assert(first.continuation?.origin.protocol === 'openai-responses');
-            expect(first.continuation.anchor).toMatchObject({
-              kind: 'connection',
-              responseId: 'resp_1',
-            });
+            expect(first.continuation).toBeUndefined();
             const nextRequest: TurnRequest = {
               ...REQUEST,
               messages: [
@@ -620,7 +616,6 @@ describe('native OpenAI Responses protocol', () => {
                   ],
                 },
               ],
-              continuation: first.continuation,
             };
             const next = yield* model.prepareTurn(nextRequest);
             assert(next.mode === 'foreground');
@@ -641,15 +636,7 @@ describe('native OpenAI Responses protocol', () => {
             assert(second.providerResponseId !== null);
             expect(second.providerResponseId).toBe('resp_2');
             expect(second.finishReason).toBe(outcome);
-            if (outcome === 'stop')
-              expect(second.continuation?.anchor).toMatchObject({
-                kind: 'connection',
-                responseId: 'resp_2',
-              });
-            else expect(second.continuation).toBeUndefined();
-            expect(yield* Effect.flip(model.generateTurn(next))).toMatchObject({
-              kind: 'invalid-request',
-            });
+            expect(second.continuation).toBeUndefined();
             const http = modelWith(vi.fn(), configuration);
             expect(yield* Effect.flip(http.generateTurn(turn))).toMatchObject({
               kind: 'unsupported',
@@ -666,17 +653,36 @@ describe('native OpenAI Responses protocol', () => {
       });
       expect(requests[0]).not.toHaveProperty('stream');
       expect(requests[0]).not.toHaveProperty('background');
-      expect(requests[1]).toMatchObject({
-        previous_response_id: 'resp_1',
-        input: [
-          { type: 'function_call_output', call_id: 'call_1', output: 'a' },
-          {
-            type: 'function_call_output',
-            call_id: 'call_2',
-            output: 'Error: b',
-          },
-        ],
-      });
+      // The websocket lane carries no chaining anchor, so the second turn
+      // replays the whole prefix. The lowered calls must carry the provider's
+      // own argument bytes, not a re-encoding of their parse.
+      expect(requests[1]).not.toHaveProperty('previous_response_id');
+      expect(
+        (requests[1] as { input: Record<string, unknown>[] }).input.slice(-4),
+      ).toEqual([
+        {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'read_file',
+          arguments: '{"path":"a"}',
+          id: 'fc_1',
+          status: 'completed',
+        },
+        {
+          type: 'function_call',
+          call_id: 'call_2',
+          name: 'read_file',
+          arguments: '{"path":"b"}',
+          id: 'fc_2',
+          status: 'completed',
+        },
+        { type: 'function_call_output', call_id: 'call_1', output: 'a' },
+        {
+          type: 'function_call_output',
+          call_id: 'call_2',
+          output: 'Error: b',
+        },
+      ]);
     },
   );
 
@@ -1867,7 +1873,7 @@ describe('native OpenAI Responses protocol', () => {
             summary: REASONING.summary,
             content: REASONING.content,
           },
-          { ...CALLS[0], arguments: '{ "path" : "a" }' },
+          CALLS[0]!,
         ],
         {
           usage: { input_tokens: 12, output_tokens: 3, total_tokens: 15 },
@@ -2280,6 +2286,13 @@ describe('native OpenAI Responses protocol', () => {
       name: 'invalid local-call arguments',
       final: snapshot([{ ...CALLS[0], arguments: '{' }]),
       output: [{ ...CALLS[0], arguments: '{' }],
+    },
+    {
+      // Reconciliation compares the provider's exact bytes, so a terminal
+      // snapshot that re-spaces the same arguments is a conflict, not a match.
+      name: 'respaced local-call arguments',
+      final: snapshot([{ ...CALLS[0], arguments: '{ "path" : "a" }' }]),
+      output: [CALLS[0]!],
     },
     {
       name: 'changed local-call ID',


### PR DESCRIPTION
## Summary

A turn result is about to become the value a `model.message` row is authored on. This PR fixes the places where the codec threw away a fact that no later reader of that row could recover. Each edit below names the concrete durable failure it prevents.

**L1. Export the canonical message shape.** `ContentSchema`, `AssistantMessageSchema`, `MessageSchema` and `PreparedHistorySchema` were module-private, and there was no way to go from a `TurnResult` to the assistant message it contributes. Without these exports the `model.message` row cannot be authored on the canonical value: the writer would have to restate the shape, and a restated shape drifts from the one the codec validates. Adds `AssistantMessage` and `assistantMessageFromResult`.

**L3. Retain the provider's exact argument bytes.** Every decode site parsed the provider's tool-argument JSON and dropped the bytes; every lowering site did `JSON.stringify` on the parse to rebuild them. That round trip is not byte exact. It truncates integers past 2^53, rewrites `1.0` as `1`, collapses duplicate keys and reorders integer-like keys. The loss happened in the codec, before anything durable was written, and the corrupted re-encoding was also what got sent back to the provider on the next request. `local-call` now carries `argumentsText` beside `arguments`, decode sites keep the bytes they already had, and lowering sites return them.

These are two representations of one value on purpose, not a dual system, and a `superRefine` keeps them from drifting: `argumentsText` must parse to exactly `arguments`. The rationale is written into `turn.ts` at the schema. Two producers genuinely have no bytes to retain, and both say so in a comment rather than pretending: the VS Code language-model API hands over `input` already parsed, and a Google background snapshot returns only the SDK's parse. For those the text is a serialization of the only representation that source ever had, not a re-encode of bytes that were dropped.

**L4. Record what the provider said about the outcome.** Google recorded nothing the wire said about how a turn ended: `finishReason` was inferred from whether a tool call appeared in the content, and the reported interaction status was dropped. The reason now follows that status, and a new `google-interactions` finish evidence arm carries that status verbatim. `status` is a free string because the Interactions status vocabulary is open on the wire and an enum would silently drop a value the codec is built to preserve. A matching `openai-responses` arm carries `status` and `incomplete_details.reason`, both mirroring the response schema exactly. The protocol refinement rejects either arm on a foreign origin.

**L5. `providerCallId` is non-nullable.** It is the settlement primary key and no producer emits null. It is now `z.string().min(1)`, and the null guards that were scattered through the Anthropic, Google, Chat, Responses and OpenRouter lowering paths are gone, along with a test for a state that is no longer constructible.

**L2. No websocket connection anchor in a continuation.** The websocket terminal used to build a continuation anchored to `connectionId` when none was produced otherwise. That anchor is dead by construction after process exit, and presenting a stale one was a hard turn failure rather than a dropped acceleration, so a durable row must not be able to hold one. The second commit finishes this: `ResponsesContinuationSchema` no longer declares the `connection` arm at all, so the anchor is not representable rather than merely unproduced. Collapsing it left `eligibleResponseId` with no reader (one gate read it, seven sites wrote it), so that state is gone too; `latestResponseId` stays, because it still answers the duplicate-response check.

### Not landed

- `finishEvidence` stays `.optional()` rather than becoming required for the Google and Responses protocols. Making it required is a codec-side decision that would have failed every existing call site, so it is left for the PR that finishes the cutover.
- `terminalReason` on the Google arm is always `null` today. The Interactions resource carries no reason field (`TurnCompleteReason` belongs to the Live API, not Interactions), so the field is present and honestly empty rather than absent.
- Google's non-`requires_action` statuses all still map to a `finishReason` of `stop`, and today that mapping is provably the same value the old one produced: `normalizeCompleted` already rejects a status that disagrees with the call count, and both callers admit only `completed` and `requires_action`. What L4 adds for Google is the verbatim status as durable evidence, and a `finishReason` sourced from it rather than coinciding with it. Refining the mapping is follow-up work.
- A truncated Google interaction is still not recoverable, and this PR does not change that. `incomplete` and `budget_exceeded` are rejected before a result exists (`provider-rejection` in the background path, `malformed-output` in the streaming terminal), so no `finishEvidence` is ever written for them. Admitting truncated statuses into a result is a scope decision for the cutover, not something to slip in here.

## Issue acceptance gates

No issue. This is a step in the native-runtime LLM cutover, stacked on #11997.

## Single source of truth

`packages/llm/src/turn.ts` owns the canonical message and turn-result shape. The `local-call` refinement there is the single place that decides `argumentsText` and `arguments` are one value, so no producer or consumer re-litigates it. `assistantMessageFromResult` is the one way to derive an assistant message from a result.

## Duplication and abstraction budget

Removed the `JSON.stringify(part.arguments)` re-encoding duplicated across four lowering sites; each now returns the retained bytes. Removed the null-`providerCallId` guard duplicated across five files. Removed the inline continuation construction in the websocket terminal, which restated what `openaiResponsesContinuation` already decides.

No new abstraction layer. `sameJsonValue` and `validateLocalCallArguments` are the refinement body, applied at both `local-call` use sites from one shared check. They are two constants rather than one because Zod 4.4.3 throws on `.omit()` over a schema carrying refinements, and the editor arm omits `evidence`.

## Net elements (R6)

Files: 11 changed, 0 added, 0 deleted (+273 / -168, net +105 LoC). Measured with `git diff --stat` against the base at `6709198ddf`, including the two review-round commits.

Exported symbols: `+6`, `-0`. Four are existing internal constants that gained `export` (`ContentSchema`, `AssistantMessageSchema`, `MessageSchema`, `PreparedHistorySchema`); two are new (`AssistantMessage`, `assistantMessageFromResult`).

Classes/interfaces/enums: `+1` type alias (`ObservedStep`, local to `googleInteractions.ts`), `-0`.

Reviewer note, stated plainly: none of those six exports has a consumer in this PR. They exist so the next PR in the stack can author the `model.message` row on the canonical value, which is L1's whole purpose. `npm run check:dead-code-ratchet` passes with no new findings, but this is the one place where this PR leans on the stack rather than standing alone.

## Consumer counts (R8)

No emit path or export was deleted or re-routed. n/a.

## Host impact

Extension: `acquireVscodeLanguageModel.ts` sets `argumentsText` on the tool call it decodes. The editor never exposes the model's raw argument bytes, so the value is a serialization of the parsed input it does hand over, commented as such at the site. No behavior change.

Desktop: none.

CLI: none.

## Scheduled refactoring

None. The three deferred items are listed under "Not landed" above and belong to the PR that finishes the cutover.

## Validation

- `npm run typecheck`: clean across all seven projects. One error surfaced during validation and was fixed here rather than dismissed (`acquireVscodeLanguageModel.ts` and `openrouterChat.ts` were both unhandled `local-call` producers).
- `npx vitest run src/test-kernel/llm`: 5 files, 402 tests, all passing.
- `npm run lint`: clean.
- `npm run format`: clean, no files rewritten.
- `npm run check:dead-code-ratchet`: no new findings.
- `npm run check:effect-migration-ratchet`: no count grew, no baseline headroom. `Result.try` is used in `turn.ts` instead of `try`/`catch` because the file is a runtime `effect` importer and a raw catch would open a new `catch:effect-importer` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtCoHs2GsaJMfuXrnmL6w2



