### PR TITLE
fix(llm): compare JSON numbers, not JS identity

### DIFF
--- a/packages/llm/src/turn.ts
+++ b/packages/llm/src/turn.ts
@@ -262,9 +262,12 @@ const MessagePartSchema = z.strictObject({
  * refinement keeps the pair one value.
  */
 function sameJsonValue(left: unknown, right: unknown): boolean {
-  // `Object.is`, not `===`: JSON.parse keeps -0 while re-encoding the parsed
-  // value writes 0, so `===` would call a drifted pair one value.
-  if (Object.is(left, right)) return true;
+  // `===`, not `Object.is`: -0 and 0 are one JSON number. No encoder can write
+  // -0 back out, so a row that carries it always reads back as 0 in
+  // `arguments` while `argumentsText` still says -0. Demanding the distinction
+  // would make every such row unloadable and would reject the two producers
+  // below that have no provider bytes and must encode their own.
+  if (left === right) return true;
   if (
     typeof left !== 'object' ||
     typeof right !== 'object' ||


### PR DESCRIPTION
## Summary

Fast-follow on #12113, which merged at 13:26Z with head `eda962d` while its second review round was still open. One commit, one line of behavior.

#12113's round-1 fix took a reviewer suggestion and switched `sameJsonValue` to `Object.is`, so that a persisted `-0` would not read back as `0`. The round-2 review, which landed after the merge, showed the suggestion cannot hold, and it is now on this branch.

`JSON.stringify(-0)` is `"0"`. Two `local-call` producers own no provider bytes and must encode their own text: the Google background snapshot (`normalizeCompleted`, `googleInteractions.ts:526`) and the VS Code editor arm (`acquireVscodeLanguageModel.ts:547`). For a `-0` tool argument, each writes `argumentsText` that parses back to `0` while `arguments` still holds `-0`, so `validateLocalCallArguments` rejects the pair and the whole turn fails as `malformed-output`. Before #12113 there was no refinement and the same argument passed through, so this is a regression that #12113 introduced, not a pre-existing gap.

The problem is not confined to those two producers. No JSON encoder emits `-0`, so a durable row that carries one always re-reads as `0` in `arguments` while a retained `argumentsText` still says `-0`. Under `Object.is` such a row is unloadable. The refinement would reject rather than catch, which is the opposite of what it is for.

`-0` and `0` are one JSON number, and JSON-number equality is what a function called `sameJsonValue` is supposed to mean. This puts the check back to `===` and records the reasoning at the call site so it does not get swung a third time.

## Issue acceptance gates

No issue. Fast-follow correction to #12113, stacked on #11997's branch like its parent.

## Single source of truth

Unchanged. `packages/llm/src/turn.ts` remains the one place that decides `argumentsText` and `arguments` are one value.

## Duplication and abstraction budget

No new abstraction. One operator and a comment.

## Net elements (R6)

Files: 1 changed, 0 added, 0 deleted (+6 / -3, net +3 LoC, all comment). Exported symbols `+0 / -0`.

## Consumer counts (R8)

No emit path or export changed. n/a.

## Verification

Run in a worktree at this commit, all clean: `npm run typecheck`, `npx vitest run src/test-kernel/llm --reporter=dot` (402 passed), `npm run lint`, `npm run format`, `node scripts/check-dead-code-ratchet.mjs`, `node scripts/check-effect-migration-ratchet.mjs`.

No test is added. The refinement's behavior on `-0` is not a durable boundary worth pinning, and #12113's review history is the record of why the operator is what it is.

## Not landed

The three items #12113 left for the owner are untouched and still open: whether `finishEvidence` becomes required for the Google and Responses protocols, whether the six new `turn.ts` exports may stand without a consumer until the next PR in the stack, and whether a truncated Google interaction (`incomplete`, `budget_exceeded`) should become a result carrying its verbatim status instead of an error.
