### PR TITLE
docs: align runtime plan with ledger proposal

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md
+++ b/.agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md
@@ -973,8 +973,10 @@ compresses when the phase ceremony goes. `output/` (3,482) and
    as in §3; record the R4 and 13.C reversal in the migration PRD; add the
    six row types to the one-fold PRD §6 durable set; state the retention
    rule.
-1. Foundation: `RunLedger` service over `SessionEvents`, the six
-   `AgentEvent` arms with Zod schemas, `foldRunState` in `src/shared`, the
+1. Foundation: `RunLedger` service over `SessionEvents`, the Zod row
+   vocabulary and `SessionEventDraftSchema` placement specified by the
+   [PR 1 foundation proposal](./2026-09-08-pr1-run-ledger-foundation.md#28-the-arms-in-sessioneventts),
+   `foldRunState` in `src/shared`, the
    in-memory ledger layer, one ledger test and one fold test. Nothing
    deleted yet; nothing in production calls it yet.
 2. Both families on the ledger, one PR: `ModelInvoker`, `Tools`,

--- a/.agents/docs/proposed/architecture/2026-09-08-pr1-run-ledger-foundation.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-pr1-run-ledger-foundation.md
@@ -1585,7 +1585,12 @@ also the only one that lets `flow.snapshot` freeze.
 
 Every path:line below was opened on 2026-09-08 before it was written down.
 
-Repo (`main` at the worktree's base): `ReflectionFlowStateSchema` at
+Repo line references use the `main` snapshot
+[`77b8866c467cf939e5a84d94cd7682da262393b4`](https://github.com/LionSR/TeXRA/tree/77b8866c467cf939e5a84d94cd7682da262393b4).
+Cutover changes can move these line numbers; the named symbols identify the
+corresponding current code.
+
+`ReflectionFlowStateSchema` at
 `ReflectionFlowState.ts:39-65`, with `workspaceSnapshot` :43, `context` :44,
 `outputLocation` :45, `runStateSnapshot` :47, `roundOutputs` :49,
 `continueRounds`/`endTurn` :51-52, `lastError` :55,


### PR DESCRIPTION
The runtime PR plan still called the foundation rows `AgentEvent` arms even though the new foundation proposal places them in `SessionEventDraftSchema`. Replace that stale description with a link to the proposed row vocabulary and placement. Pin the foundation's line-reference baseline to immutable main revision `77b8866c467cf939e5a84d94cd7682da262393b4`; the cited Database.ts offsets are correct there, while cutover has moved them.

These are documentation corrections to the two review comments on #12118, which merged before the corrections landed. No payload decision, runtime behavior, data format or test source changes.

Validation: format, full typecheck, compile:fast, lint, both ratchets, guidance references and root-document checks pass. Full npm test passes 8,860 tests with nine skips. Reconstructing this correction against the actual #12118 merge preserves exactly the validated tree `040554d1ef85006337cab8cd762e6a1873973838`; no redundant full test was run for changed commit parents alone.

R6: two existing documentation files, ten insertions and three deletions; no new file, production export, class, interface or enum. R8: no runtime consumer changes.

Refs #12118, #11867.
