### PR TITLE
docs: preserve existing history in the intermediate release

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
+++ b/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
@@ -813,7 +813,8 @@ the owner has not yet ratified.
 ### 6.2 Stages
 
 Stages are lanes on one branch. The 2026-09-08 owner ruling in §8 permits
-#12108 to merge as an intermediate step; the remaining stages follow separately.
+independently safe changes to merge as an intermediate step; the remaining
+stages follow separately.
 
 | Stage | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Deletes in the same release                                                                                                                                                              | Companion step |
 | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
@@ -994,13 +995,22 @@ recorded there and in §10.
 
 ## 8. Process: one cutover, no dual system
 
-### Owner amendment, 2026-09-08: intermediate merge of #12108
+### Owner amendment, 2026-09-08: safe intermediate release
 
-The owner authorizes #12108 to merge into main as an intermediate change so
-other work can proceed. This supersedes the requirement that every stage
-land in the same merge or release. The completed metadata and cleanup work
-may land after synchronization, validation and review of the actual combined
-head. It is not completion of the event-table-only objective.
+The owner authorizes independently safe changes to merge into main as an
+intermediate release so other work can proceed. This supersedes the
+requirement that every stage land in the same merge or release. The smaller
+release is constructed from main and retains its existing metadata readers,
+writers and resume behavior while adding the independent cleanup and audio
+loading corrections. It requires synchronization, validation and review of
+the actual combined head. It is not completion of the event-table-only
+objective.
+
+#12108 remains held: its event-only metadata readers cannot replace current
+file-backed configuration before faithful conversion preserves history and
+resume access, including supported child-run events. The owner explicitly
+rejects temporary loss of that access. The metadata change remains a
+follow-up, not part of this intermediate release.
 
 Official Effect SQL adoption (#12102), the coordinated runtime and checkpoint
 replacement (#11869), and the remaining historical-data work (#11867) continue

--- a/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
+++ b/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
@@ -1002,12 +1002,12 @@ intermediate release so other work can proceed. This supersedes the
 requirement that every stage land in the same merge or release. The smaller
 release is constructed from main and retains its existing metadata readers,
 writers and resume behavior while adding the independent cleanup and audio
-loading corrections. It requires synchronization, validation and review of
+loading corrections in #12124. It requires synchronization, validation and review of
 the actual combined head. It is not completion of the event-table-only
 objective.
 
 #12108 remains held: its event-only metadata readers cannot replace current
-file-backed configuration before faithful conversion preserves history and
+file-backed execution metadata before faithful conversion preserves history and
 resume access, including supported child-run events. The owner explicitly
 rejects temporary loss of that access. The metadata change remains a
 follow-up, not part of this intermediate release.

--- a/.agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md
+++ b/.agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md
@@ -824,11 +824,13 @@ continuation and has no sub-agents yet). OpenCode does not use
 
 ## 3. Sequencing: the runtime is lane D of the cutover
 
-The 2026-09-08 owner amendment in the substrate proposal §8 permits #12108's
-completed metadata and cleanup changes to merge before this runtime work.
-Lane D continues as a follow-up. This changes release sequencing, not its
-joint replacement obligations or the outstanding D4 decision; checkpoint
-writers and their file-lease fences remain together until replaced.
+The 2026-09-08 owner amendment in the substrate proposal §8 permits a
+smaller, independently safe cleanup and audio-loading release before this
+runtime work. #12108's metadata replacement remains held until conversion
+preserves existing history and resume access. Lane D continues as a
+follow-up. This changes release sequencing, not its joint replacement
+obligations or the outstanding D4 decision; checkpoint writers and their
+file-lease fences remain together until replaced.
 
 The owner's rule is no intermediate projectors or adapters, only the target
 architecture. The first draft of this section had two intermediates: a

--- a/.agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md
+++ b/.agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md
@@ -825,7 +825,7 @@ continuation and has no sub-agents yet). OpenCode does not use
 ## 3. Sequencing: the runtime is lane D of the cutover
 
 The 2026-09-08 owner amendment in the substrate proposal §8 permits a
-smaller, independently safe cleanup and audio-loading release before this
+smaller, independently safe cleanup and audio-loading release (#12124) before this
 runtime work. #12108's metadata replacement remains held until conversion
 preserves existing history and resume access. Lane D continues as a
 follow-up. This changes release sequencing, not its joint replacement


### PR DESCRIPTION
The persistence proposals now distinguish the approved, smaller intermediate release from the metadata cutover. The smaller release is based on main, retains existing execution history and resume behavior, and adds cleanup and audio fixes in #12124. PR #12108 remains held until faithful conversion preserves existing history and supported resume behavior, including child executions.

This corrects the owner-ruling passages in substrate sections 6.2 and 8 and runtime section 3. D4, importer decisions, checkpoint and lease obligations, and the prohibition on parallel writers remain unchanged. No runtime behavior changes.

Validation: formatting, full typecheck, extension build, lint, both ratchets, guidance checks, and the full suite passed (8,860 tests; 9 skipped). The reconstructed commit has the exact validated tree `6f9f0522e69e99d3fb2dbc8c7414f0d783b97d70`, so changing its parent to the actual #12123 merge did not require duplicate source checks.

#12123 was merged externally before this correction was published, while its CI was still running. This followup contains only the two reviewed documentation corrections.
