### PR TITLE
docs: recognize the glob tool execution boundary

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -293,13 +293,16 @@ traversal actually calls. So:
   a second cost.** `FSOption.promises.lstat` must return a real `Promise`;
   Effect's `readLink`/`stat`/`readDirectory` return `Effect`s. Bridging them
   needs `runPromise` or an equivalent managed-runtime run **at each consumer**
-  — and four of the five async importers sit at non-boundary paths
-  (`src/agent/index/agentYamlScanner.ts`, `src/tools/glob.ts` — not a
-  `*Tool.ts` — `src/housekeeping/clean.ts`, `src/housekeeping/utils.ts`),
-  where the ratchet rejects a new `Effect.run*` exactly as it does for
-  `TraceEmitter.ts`. Only `packages/cli/src/runtime/workflowInputs.ts` is
-  already a boundary kind. So B needs the adapter built at an allowed boundary
-  and injected into four consumers, or a separate native seam for them — the
+  and three of the five async importers sit at non-boundary paths
+  (`src/agent/index/agentYamlScanner.ts`, `src/housekeeping/clean.ts`,
+  `src/housekeeping/utils.ts`), where the ratchet rejects a new `Effect.run*`
+  exactly as it does for `TraceEmitter.ts`. The CLI file
+  `packages/cli/src/runtime/workflowInputs.ts` is already a boundary kind.
+  `GlobTool.execute()` in `src/tools/glob.ts` also qualifies: the ratchet
+  recognizes the tool's `execute()` method regardless of its filename, so
+  an adapter callback constructed there can own the actual Promise boundary.
+  So B needs the adapter built at an allowed boundary and injected into three
+  consumers, or a separate native seam for them: the
   same structural cost this note found for the hub constructor, in a second
   place.
 


### PR DESCRIPTION
The Effect-interface findings overcounted the async glob consumers that lack an execution boundary. `GlobTool.execute()` already qualifies under the ratchet at the document’s stated `1cf1a84` baseline, regardless of the filename `glob.ts`.

This corrects the count from four to three, identifies the CLI and tool execution boundaries, and preserves the requirement that an adapter’s Promise callback be constructed at the actual boundary. Runtime code and migration policy are unchanged.

Addresses the substantive post-merge review finding on #12126: https://github.com/LionSR/TeXRA/pull/12126#discussion_r3959912085. The other historical citations retain their explicitly named baseline.

Validation passed: formatting, guidance references, full typecheck, extension compilation, lint, both ratchets and full npm test (8,860 passed; 9 skipped). The commit tree exactly matches the validated tree `ced60717b8979776d78082a7da43b6a9e9dffadb`. No runtime suite or package behavior changed.
