### PR TITLE
docs: align glob boundary counts in the summaries

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -244,7 +244,7 @@ does not control their inputs. The hole is closable for testing by handing
 **candidate A can serve the five async importers directly; candidate B can
 serve them only through an adapter** that costs **two** extra filesystem calls
 per entry — a `Dirent` probe plus the symlink test — **and a run boundary for
-four of the five consumers** (below). Only the three `globSync` callers are closed to both. This paragraph
+three of the five consumers** (below). Only the three `globSync` callers are closed to both. This paragraph
 has been wrong six times in six directions: two importers, then unclosable,
 then independent of R-1, then requiring synchronous methods, then B excluded on
 a correctness objection this note's own §2 disproves, then a lead still calling
@@ -386,7 +386,7 @@ earlier revisions of this very sentence**:
    `readLink`-plus-`stat` symlink test. A's `lstat`-backed port carries the
    type out of the directory read and pays neither.
 2. **A run boundary.** The `promises` callbacks must return real `Promise`s,
-   so four of the five consumers need adapter construction at an allowed
+   so three of the five consumers need adapter construction at an allowed
    boundary plus injection (above).
 3. The per-entry cost compounds with tree size, which is exactly the shape
    R-1 measured at ~8×.


### PR DESCRIPTION
Correct the two summary sentences that still counted four glob consumers without an execution boundary after #12127 established the correct count of three. The detailed analysis and both summaries now agree.

This completes the post-merge review corrections from #12127, which was merged externally before these two summary edits were published. No runtime code, migration policy or historical measurement baseline changes.

Validation: formatting, guidance references, full typecheck, extension compilation, lint and both ratchets passed. Two current full-test attempts were interrupted with SIGTERM (exit 143); neither is counted as a pass. A focused run of the affected suites reported 111 passed, 38 failed and 11 skipped, predominantly timeouts and subsequent incomplete mock setup. No timeout or test configuration was changed.

All production, test, dependency and configuration files are byte-identical to the preceding source tree that passed the complete suite (8,860 passed, nine skipped). This review round changes only two occurrences of “four” to “three” in the proposal. The final tree is `c205e7431114d2225f1c74e583392869bce75253`. Fresh remote checks and reviews remain required.
