### PR TITLE
docs: count constructor-only trace tests in migration estimate

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-effect-4-interface-findings.md
@@ -572,9 +572,10 @@ understates it by construction.
 The composition matters more than the total. **6 of the 27 are production** —
 `src/agent/trace/TraceEmitter.ts` itself, plus
 `packages/agent/src/effect/sessions.ts`, `ModelHandler.ts`,
-`SessionHandle.ts`, `channelTrace.ts`, `runTrace.ts` — and 11 are
-test-kernel, most passing a plain synchronous callback to `trace.subscribe`
-and reading events out of a local array on the next line. So the production
+`SessionHandle.ts`, `channelTrace.ts`, `runTrace.ts` — and 21 are
+test-kernel: 11 subscriber files and 10 additional constructor-only files.
+Most subscriber tests pass a plain synchronous callback to `trace.subscribe`
+and read events out of a local array on the next line. So the production
 blast radius is six files.
 
 **The synchronous `subscribe` facade is itself a third run-boundary site, and
@@ -591,7 +592,7 @@ and propagate that through every subscriber — **another injection chain the
 stated above, and the second time the note has held both halves of a fact in
 separate sections without joining them.
 
-**The eleven test files are cheaper than an earlier revision charged them.**
+**The eleven subscriber test files are cheaper than an earlier revision charged them.**
 That revision said each would need "a fiber, a scope and a drain". It would
 not: if `TraceEmitter.subscribe` stays a synchronous facade — possible only
 with the injected runtime just described — the adapter owns each


### PR DESCRIPTION
Correct the pinned trace-migration estimate: 27 files means six production files and 21 test files, comprising 11 subscribers and 10 additional constructor-only files. Qualify the later eleven-file discussion as subscriber tests.

Validation: formatting, guidance references, pinned inventory and diff checks pass. Production, configuration and dependencies are identical to the SQL merge validated by 8,863 passing tests, nine skips and green CI. No new tests or runtime changes.

Addresses the remaining count finding in #12126. The separate ENOSPC comment was resolved with the pinned constructor and actual predicate probe.
