### PR TITLE
feat(ratchet): count consumers of the flow engine and model handlers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,13 +44,15 @@ Things the tree won't tell you:
   included), `shared-schemas-deep-import`, `host-agent-mock`,
   `architecture-edges`, and `effect-migration` (per-file allowlists of
   shrink-only counts: `platform()`, `setServices()`, `new AbortController(`,
-  superseded package imports, `Effect.run*` boundary calls, and raw catches in
-  `effect`-importing files; the same script fails on any `@adapter-until`
-  marker, since the owner ruled there are no temporary adapters, and admits a
-  new `Effect.run*` file only under `packages/{extension,desktop,cli,agent}/src/`
-  or `src/tools/**/*Tool.ts`, R1's three boundary kinds). The invariant to hold
-  is "never widen a baseline"; the
-  open work is the Tier-1 public manifest and shrinking the frozen lists, not
+  superseded package imports, `Effect.run*` boundary calls, raw catches in
+  `effect`-importing files, and imports reaching into `src/agent/node/` or
+  `src/agent/modelHandlers/` from outside them; the same script fails on any
+  `@adapter-until` marker, since the owner ruled there are no temporary
+  adapters, and admits a new `Effect.run*` file only under
+  `packages/{extension,desktop,cli,agent}/src/` or `src/tools/**/*Tool.ts`,
+  R1's three boundary kinds). The invariant to hold is "never widen a
+  baseline"; the open work is the Tier-1 public manifest and shrinking the
+  frozen lists, not
   another lint rule. npm publication is deliberately held until a named external
   consumer exists. Kernel architecture tests under
   `src/test-kernel/architecture/` (including

--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -1,5 +1,5 @@
 {
-  "semantics": "Per-file counts of the mechanisms the Effect 4 migration retires (.agents/docs/proposed/architecture/2026-08-26-effect-4-runtime-migration.md, execution rule 3), owned by scripts/check-effect-migration-ratchet.mjs. Scope: *.ts, *.tsx and *.mts under src/ and packages/*/src/, excluding src/test-kernel/, *.vitest.ts, and any dist/ or node_modules/ directory (packages/*/scripts and packages/*/tests are outside the scanned roots). Files are parsed with the TypeScript compiler API, so comments and string literals never count. Rows: 'platform()' counts calls of the platform export of @platform/platform (src/platform/platform.ts) under whatever local name the file binds it to: `import { platform as p }` then p(), and `import * as P` then P.platform(), included; tryPlatform and unrelated bindings such as node:os platform excluded; 'setServices()' counts calls whose callee is setServices or ends in .setServices; 'new AbortController()' counts new-expressions on the identifier AbortController; 'import:<pkg>' counts import/export-from/import-equals/require()/import() specifiers exactly equal to the package name (type-only imports included, because they still pin the dependency); 'Effect.run*' counts calls named runPromise, runPromiseExit, runSync, runFork, or runCallback, and counts them ONLY below R1's boundary kinds (packages/extension/src/**, packages/desktop/src/**, packages/cli/src/**, packages/agent/src/**, or src/tools/**/*Tool.ts, the last recognised by the class that extends the imported defineTool). A run at one of those kinds is the destination, not debt, and is absent from this row, so converting a subsystem cannot raise it. Every file here belongs to the lane named for it in the closed 'debtLanes' register: --update refuses a below-boundary file the register does not already name, never adds a file to a row, and writes the lower of the committed count and the tree's); 'catch:effect-importer' counts, only in files with a runtime import specifier equal to effect or starting with effect/ or @effect/ (type-only imports and all-type specifier lists do not qualify), catch clauses plus .catch( calls, excluding the Effect.catch combinator. Every row is a per-file allowlist of shrink-only counts: a count that rose, or a file absent from its row, fails. A count that shrank or a file that disappeared is stale headroom and also fails (unlike the dead-code ratchet, which only reports resolved findings), because a stale count is room a later PR could regrow into unnoticed; regenerate with `node scripts/check-effect-migration-ratchet.mjs --update` in the same PR. 'debtLanes' maps each below-boundary 'Effect.run*' file to the lane that removes it; an entry whose file leaves the row is stale and --update drops it. The PR that zeroes a row deletes the row. The same script fails on the presence of any `@adapter-until` marker in scope (owner ruling 2026-09-06: no temporary adapters), a hard check with no baseline.",
+  "semantics": "Per-file counts of the mechanisms the Effect 4 migration retires (.agents/docs/proposed/architecture/2026-08-26-effect-4-runtime-migration.md, execution rule 3), owned by scripts/check-effect-migration-ratchet.mjs. Scope: *.ts, *.tsx and *.mts under src/ and packages/*/src/, excluding src/test-kernel/, *.vitest.ts, and any dist/ or node_modules/ directory (packages/*/scripts and packages/*/tests are outside the scanned roots). Files are parsed with the TypeScript compiler API, so comments and string literals never count. Rows: 'platform()' counts calls of the platform export of @platform/platform (src/platform/platform.ts) under whatever local name the file binds it to: `import { platform as p }` then p(), and `import * as P` then P.platform(), included; tryPlatform and unrelated bindings such as node:os platform excluded; 'setServices()' counts calls whose callee is setServices or ends in .setServices; 'new AbortController()' counts new-expressions on the identifier AbortController; 'import:<pkg>' counts import/export-from/import-equals/require()/import() specifiers exactly equal to the package name (type-only imports included, because they still pin the dependency); 'Effect.run*' counts calls named runPromise, runPromiseExit, runSync, runFork, or runCallback, and counts them ONLY below R1's boundary kinds (packages/extension/src/**, packages/desktop/src/**, packages/cli/src/**, packages/agent/src/**, or src/tools/**/*Tool.ts, the last recognised by the class that extends the imported defineTool). A run at one of those kinds is the destination, not debt, and is absent from this row, so converting a subsystem cannot raise it. Every file here belongs to the lane named for it in the closed 'debtLanes' register: --update refuses a below-boundary file the register does not already name, never adds a file to a row, and writes the lower of the committed count and the tree's); 'catch:effect-importer' counts, only in files with a runtime import specifier equal to effect or starting with effect/ or @effect/ (type-only imports and all-type specifier lists do not qualify), catch clauses plus .catch( calls, excluding the Effect.catch combinator; 'dep:@agent/node' counts, in each file OUTSIDE src/agent/node/, the module specifiers that reach into that directory — the @agent/node alias itself or any deeper path under it, plus relative specifiers that resolve inside it (type-only included, as for the package rows) — so the row measures the PocketFlow engine's consumers, not its class hierarchy, and a file inside the directory importing its own sibling is not a consumer and does not count; 'dep:@agent/modelHandlers' counts the same reaches into src/agent/modelHandlers/, the model handler hierarchy the ModelInvoker service replaces. Every row is a per-file allowlist of shrink-only counts: a count that rose, or a file absent from its row, fails. A count that shrank or a file that disappeared is stale headroom and also fails (unlike the dead-code ratchet, which only reports resolved findings), because a stale count is room a later PR could regrow into unnoticed; regenerate with `node scripts/check-effect-migration-ratchet.mjs --update` in the same PR. 'debtLanes' maps each below-boundary 'Effect.run*' file to the lane that removes it; an entry whose file leaves the row is stale and --update drops it. The PR that zeroes a row deletes the row. The same script fails on the presence of any `@adapter-until` marker in scope (owner ruling 2026-09-06: no temporary adapters), a hard check with no baseline.",
   "rows": {
     "platform()": {
       "packages/cli/src/chat/tui/state/subscribeApprovals.ts": 2,
@@ -139,6 +139,44 @@
       "src/agent/runtime/bundledPrompts.ts": 1,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/utils/files/relativeFS.ts": 2
+    },
+    "dep:@agent/node": {
+      "src/agent/core/flows/ModelInvocationNode.ts": 1,
+      "src/agent/implementations/flows/reflection/ResponseCycleFlow.ts": 1,
+      "src/agent/implementations/flows/reflection/RoundPersistedFlow.ts": 2,
+      "src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts": 1,
+      "src/agent/implementations/flows/reflection/nodes/OutputNode.ts": 1,
+      "src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts": 1,
+      "src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts": 1,
+      "src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts": 1,
+      "src/agent/implementations/flows/reflection/runReflectionFlow.ts": 1,
+      "src/agent/implementations/flows/tooluse/ToolUseRoundFlow.ts": 1,
+      "src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts": 1,
+      "src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts": 1,
+      "src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts": 1,
+      "src/agent/implementations/flows/tooluse/runToolUseFlow.ts": 2,
+      "src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts": 1,
+      "src/agent/implementations/flows/tooluse/toolUseRound/ToolUseProcessNode.ts": 1,
+      "src/agent/implementations/flows/tooluse/toolUseRound/ToolUseRoundPrepNode.ts": 1,
+      "src/agent/runtime/AgentLaunchContext.ts": 1,
+      "src/agent/runtime/SessionResumeRetrieval.ts": 1,
+      "src/agent/runtime/persistedCompileRejection.ts": 1,
+      "src/agent/runtime/resumeRun.ts": 1,
+      "src/agent/storage/executionLifecycle.ts": 1,
+      "src/agent/storage/resumability.ts": 1,
+      "src/tools/executions/executionKvFiles.ts": 1,
+      "src/tools/executions/executionLiveness.ts": 1
+    },
+    "dep:@agent/modelHandlers": {
+      "src/agent/export/normalizeConversation.ts": 2,
+      "src/agent/implementations/flows/tooluse/toolUseRound/ToolUseProcessNode.ts": 1,
+      "src/agent/runtime/ModelFactory.ts": 18,
+      "src/agent/runtime/helperModel.ts": 2,
+      "src/agent/types/IModelHandler.ts": 1,
+      "src/tools/bash.ts": 1,
+      "src/tools/media/audio.ts": 1,
+      "src/tools/structuredOutput.ts": 1,
+      "src/transcript/completedRunArchive.ts": 1
     }
   },
   "debtLanes": {

--- a/scripts/check-effect-migration-ratchet.mjs
+++ b/scripts/check-effect-migration-ratchet.mjs
@@ -135,7 +135,37 @@ const ROW_SET_SERVICES = 'setServices()';
 const ROW_ABORT_CONTROLLER = 'new AbortController()';
 const ROW_RUN_BOUNDARY = 'Effect.run*';
 const ROW_CATCH = 'catch:effect-importer';
+const ROW_NODE_ENGINE = 'dep:@agent/node';
+const ROW_MODEL_HANDLERS = 'dep:@agent/modelHandlers';
 const importRow = (pkg) => `import:${pkg}`;
+
+/**
+ * Directory rows: a subsystem the migration replaces wholesale, measured by
+ * the files that import INTO it. Counting consumers rather than class
+ * declarations is what makes such a row track the work the migration actually
+ * has to do. A heritage row over `src/agent/node/` (classes extending the
+ * engine's bases) finds 17 files, two of which are the engine's own
+ * `index.ts` and `persistedFlow.ts` — the files the elimination ledger
+ * deletes outright, so they measure the thing being removed rather than
+ * anything that has to be rewired — and none of which are the
+ * flow-checkpoint callers the ledger rewires or deletes one by one:
+ * `runReflectionFlow`, `ToolUseRoundFlow`, `AgentLaunchContext`,
+ * `SessionResumeRetrieval`, `persistedCompileRejection`, `resumeRun`,
+ * `executionLifecycle`, `resumability`, `executionKvFiles` and
+ * `executionLiveness`. Over `src/agent/modelHandlers/` the difference is
+ * total: every class extending the handler superclass lives inside the
+ * directory, so a heritage row would report zero consumers of a
+ * 21,000-line subsystem while `ModelFactory.ts` alone reaches into it 18
+ * times.
+ */
+const DIRECTORY_ROWS = [
+  { id: ROW_NODE_ENGINE, alias: '@agent/node', root: 'src/agent/node' },
+  {
+    id: ROW_MODEL_HANDLERS,
+    alias: '@agent/modelHandlers',
+    root: 'src/agent/modelHandlers',
+  },
+];
 
 /**
  * Baseline rows in output order. Every row is a per-file allowlist of
@@ -168,6 +198,14 @@ const ROWS = [
     id: ROW_CATCH,
     rule: `${PRD} R7 and execution rule 2 (one pass per file): a file that imports 'effect' converts its catch sites in the same pass — typed recovery, scope finalizers, or Exit folds; a raw catch remains only inside a named foreign-runtime adapter`,
   },
+  {
+    id: ROW_NODE_ENGINE,
+    rule: `${PRD} R4 (amended 2026-09-06): there is no PocketFlow, no node, no graph, no action string and no flow record — each flow family becomes one plain Effect loop over the run ledger, so every file still importing src/agent/node/ is a consumer of an engine that is being deleted, not extended (elimination ledger: .agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md §4)`,
+  },
+  {
+    id: ROW_MODEL_HANDLERS,
+    rule: `${PRD} R2 and .agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md §2 (Ownership): provider protocol behaviour moves to packages/llm behind the ModelInvoker service, with "no forwarding facade over IModelHandler or the old superclass" — so every file still importing src/agent/modelHandlers/ is a call site that has to move to the service`,
+  },
 ];
 
 const SEMANTICS =
@@ -177,7 +215,9 @@ const SEMANTICS =
   "Rows: 'platform()' counts calls of the platform export of @platform/platform (src/platform/platform.ts) under whatever local name the file binds it to: `import { platform as p }` then p(), and `import * as P` then P.platform(), included; tryPlatform and unrelated bindings such as node:os platform excluded; 'setServices()' counts calls whose callee is setServices or ends in .setServices; 'new AbortController()' counts new-expressions on the identifier AbortController; " +
   "'import:<pkg>' counts import/export-from/import-equals/require()/import() specifiers exactly equal to the package name (type-only imports included, because they still pin the dependency); " +
   "'Effect.run*' counts calls named runPromise, runPromiseExit, runSync, runFork, or runCallback, and counts them ONLY below R1's boundary kinds (packages/extension/src/**, packages/desktop/src/**, packages/cli/src/**, packages/agent/src/**, or src/tools/**/*Tool.ts, the last recognised by the class that extends the imported defineTool). A run at one of those kinds is the destination, not debt, and is absent from this row, so converting a subsystem cannot raise it. Every file here belongs to the lane named for it in the closed 'debtLanes' register: --update refuses a below-boundary file the register does not already name, never adds a file to a row, and writes the lower of the committed count and the tree's); " +
-  "'catch:effect-importer' counts, only in files with a runtime import specifier equal to effect or starting with effect/ or @effect/ (type-only imports and all-type specifier lists do not qualify), catch clauses plus .catch( calls, excluding the Effect.catch combinator. " +
+  "'catch:effect-importer' counts, only in files with a runtime import specifier equal to effect or starting with effect/ or @effect/ (type-only imports and all-type specifier lists do not qualify), catch clauses plus .catch( calls, excluding the Effect.catch combinator; " +
+  "'dep:@agent/node' counts, in each file OUTSIDE src/agent/node/, the module specifiers that reach into that directory — the @agent/node alias itself or any deeper path under it, plus relative specifiers that resolve inside it (type-only included, as for the package rows) — so the row measures the PocketFlow engine's consumers, not its class hierarchy, and a file inside the directory importing its own sibling is not a consumer and does not count; " +
+  "'dep:@agent/modelHandlers' counts the same reaches into src/agent/modelHandlers/, the model handler hierarchy the ModelInvoker service replaces. " +
   'Every row is a per-file allowlist of shrink-only counts: a count that rose, or a file absent from its row, fails. A count that shrank or a file that disappeared is stale headroom and also fails (unlike the dead-code ratchet, which only reports resolved findings), because a stale count is room a later PR could regrow into unnoticed; regenerate with `node scripts/check-effect-migration-ratchet.mjs --update` in the same PR. ' +
   "'debtLanes' maps each below-boundary 'Effect.run*' file to the lane that removes it; an entry whose file leaves the row is stale and --update drops it. " +
   'The PR that zeroes a row deletes the row. The same script fails on the presence of any `@adapter-until` marker in scope (owner ruling 2026-09-06: no temporary adapters), a hard check with no baseline.';
@@ -385,6 +425,28 @@ function isPlatformModule(specifier, fileName) {
 }
 
 /**
+ * Whether a specifier reaches into `root` from a file outside it: the path
+ * alias (`@agent/node`, or any deeper path under it) or a relative specifier
+ * that resolves inside the directory, resolved the same way
+ * {@link isPlatformModule} resolves one.
+ *
+ * The `fileName` guard is the row's definition, not a nicety: these rows
+ * count CONSUMERS of a subsystem, and a file inside the subsystem importing
+ * its own sibling is not one. Counting those would put the directory's own
+ * files in the row, where they could only leave by being deleted — which
+ * makes the row unshrinkable by the rewiring work it is supposed to measure.
+ */
+function reachesDirectory(specifier, fileName, alias, root) {
+  if (fileName === root || fileName.startsWith(`${root}/`)) return false;
+  if (specifier === alias || specifier.startsWith(`${alias}/`)) return true;
+  if (!specifier.startsWith('.')) return false;
+  const resolved = posix
+    .normalize(posix.join(posix.dirname(fileName), specifier))
+    .replace(/\.(tsx?|js)$/, '');
+  return resolved === root || resolved.startsWith(`${root}/`);
+}
+
+/**
  * Local names a file binds the platform locator to: `locals` are bindings of
  * the `platform` export itself (aliased or not); `namespaces` are namespace
  * imports whose `.platform` member is the locator. Import declarations are
@@ -499,6 +561,11 @@ function surveySource(text, fileName) {
     const specifier = moduleSpecifier(node);
     if (specifier != null) {
       if (SUPERSEDED_PACKAGES.includes(specifier)) bump(importRow(specifier));
+      for (const row of DIRECTORY_ROWS) {
+        if (reachesDirectory(specifier, fileName, row.alias, row.root)) {
+          bump(row.id);
+        }
+      }
       if (importsEffect(specifier) && !isTypeOnly(node)) effectImporter = true;
     }
     if (ts.isCallExpression(node)) {
@@ -717,6 +784,31 @@ function selfTestSurvey() {
     {
       text: 'const c = new AbortController();\nflow.setServices(services);\nsetServices(services);\n',
       expected: { [ROW_ABORT_CONTROLLER]: 1, [ROW_SET_SERVICES]: 2 },
+    },
+    {
+      // A consumer of both directories: the alias, a deeper path under it,
+      // the equivalent relative import, and an `export ... from`. The three
+      // near-misses pin the edges a later edit could silently widen: a
+      // similarly-named sibling directory under the same alias prefix
+      // (@agent/nodeUtils, @agent/modelHandlersRegistry) and a relative
+      // import that merely starts with the directory's name.
+      text: "import { BaseNode } from '@agent/node';\nimport { PersistedFlow } from '@agent/node/persistedFlow';\nimport type { Action } from '../node';\nimport { pick } from '@agent/nodeUtils';\nimport { helper } from './nodeHelpers';\nimport { registry } from '@agent/modelHandlersRegistry';\nexport { build } from '@agent/modelHandlers/registry';\n",
+      fileName: 'src/agent/runtime/probe.ts',
+      expected: { [ROW_NODE_ENGINE]: 3, [ROW_MODEL_HANDLERS]: 1 },
+    },
+    {
+      // Inside the directory: neither the sibling relative import nor the
+      // alias counts, because the row measures consumers. Without this the
+      // engine's own files would sit in their own row and could leave it
+      // only by deletion.
+      text: "import { BaseNode } from './index';\nimport { Flow } from '@agent/node';\n",
+      fileName: 'src/agent/node/persistedFlow.ts',
+      expected: {},
+    },
+    {
+      text: "import { attach } from '../utils/toolAttachmentUtils';\nimport { base } from '@agent/modelHandlers/ModelHandler';\n",
+      fileName: 'src/agent/modelHandlers/openai/modelHandlerOpenAI.ts',
+      expected: {},
     },
   ];
   for (const { text, fileName = 'case.ts', expected } of cases) {
@@ -984,6 +1076,24 @@ function selfTestBoundaryAndMarkers() {
     console.error('staleDebtLanes self-test failed:', JSON.stringify(stale));
     process.exit(1);
   }
+
+  // A row the committed baseline does not carry has no ceiling yet, so
+  // `--update`'s pre-write diff must not report its entries as growth: they
+  // are about to be seeded, and saying "the check stays red" about them is
+  // false. Row-agnostic on purpose, so retiring a row does not touch it.
+  const emptyShape = Object.fromEntries(ROWS.map((row) => [row.id, {}]));
+  const oneEntry = {
+    ...emptyShape,
+    [ROWS[0].id]: { 'src/agent/runtime/probe.ts': 3 },
+  };
+  if (
+    diffRows(oneEntry, emptyShape, new Set([ROWS[0].id])).failures.length !==
+      0 ||
+    diffRows(oneEntry, emptyShape).failures.length !== 1
+  ) {
+    console.error('diffRows unseeded-row self-test failed');
+    process.exit(1);
+  }
 }
 
 const BASELINE_MISSING = `Baseline missing: ${baselinePath}. Restore it from git; it cannot be regenerated from scratch, because the lane names in its debtLanes map are written by hand and --update cannot recover them.`;
@@ -1101,11 +1211,22 @@ function writeBaseline(rows, debtLanes) {
   );
 }
 
-/** Compare a survey against the baseline: { failures, stale }. */
-function diffRows(current, baseline) {
+/**
+ * Compare a survey against the baseline: { failures, stale }.
+ *
+ * `unseeded` names rows the comparison has no committed opinion about, which
+ * only `--update` has: a row the script has just gained reads as `{}` there,
+ * so every real entry in it would be reported as a count that "grew" and as a
+ * check that "stays red", moments before `--update` seeds the row from the
+ * tree and the check goes green. Skipping those rows keeps the pre-write
+ * report about actual growth. The post-write comparison passes nothing,
+ * because `readBaseline` guarantees a row for every entry in ROWS.
+ */
+function diffRows(current, baseline, unseeded = new Set()) {
   const failures = [];
   const stale = [];
   for (const row of ROWS) {
+    if (unseeded.has(row.id)) continue;
     const now = current[row.id];
     const was = baseline[row.id];
     for (const [file, count] of Object.entries(now)) {
@@ -1163,7 +1284,11 @@ function main() {
     // blocks the write -- refusing outright meant a tree with one new site
     // could not record any of its genuine shrinkage, which is how a
     // legitimate reduction ended up needing a hand edit.
-    const { failures: grew } = diffRows(rows, committed.rows);
+    const { failures: grew } = diffRows(
+      rows,
+      committed.rows,
+      committed.unseeded,
+    );
     if (grew.length > 0) {
       console.error(
         `\n${grew.length} count(s) grew; the baseline keeps the committed ceiling for each and the check stays red until they are gone.`,


### PR DESCRIPTION
## Summary

The migration ratchet measures 12 rows and 196 sites, and none of them covers the two largest pieces of the architecture: the PocketFlow graph engine and the model handler hierarchy. A reader watching the burn-down sees a program roughly 42% complete while ~28,000 lines of the thing being replaced are untouched and invisible to the instrument.

This adds two rows that count **consumers** of those subsystems, so the numbers fall as the authority switch progresses rather than only when the implementation is finally deleted.

- `dep:@agent/node` — **27 sites across 25 files**
- `dep:@agent/modelHandlers` — **28 sites across 9 files**

Both are module-specifier rows, not AST-heritage rows counting class declarations. The specifier shape was chosen on evidence: it catches 25 files where the heritage shape catches 17, and the extra files are precisely the flow-checkpoint coupling the delivery plan names as a deletion target (`runReflectionFlow`, `AgentLaunchContext`, `SessionResumeRetrieval`, `persistedCompileRejection`, `resumeRun`, `executionLifecycle`, `resumability`, `executionKvFiles`, `executionLiveness`) — eight of which are in the elimination ledger's own "rewired, not deleted" list. The heritage shape also never counts `src/agent/node/index.ts` itself, which the ledger deletes outright.

A file inside the measured directory importing its own sibling does **not** count; the row measures consumers, and self-reference would make it unshrinkable. That is pinned by a self-test case, along with a same-directory relative import and a similarly-named-but-different module.

Also fixes a real diagnostic bug found while seeding: `diffRows` ran against `committed.rows`, where a brand-new unseeded row is `{}`, so the first `--update` printed a full "N count(s) grew … the check stays red" block before writing the seeded row. Unseeded rows are now skipped in that pre-write diff.

**On the obvious objection** — neither row can shrink until package D lands, so is this a frozen row that reports nothing? It is not noise, for two reasons. The ratchet fails on a shrink without regeneration, so a frozen row costs nothing to carry. And these rows are not actually frozen: they count consumers, so every consumer that moves to the native package or the Effect loops drops the number, giving the switch per-file progress instead of one all-or-nothing deletion at the end.

## Issue acceptance gates

Addresses the measurement gap recorded in #12074 (catalogue of Effect 4 features that replace hand-rolled mechanisms), which exists because these subsystems appear as debt nowhere else. It does not close #12074.

## Single source of truth

`scripts/check-effect-migration-ratchet.mjs` remains the only instrument that measures migration debt. One shared `reachesDirectory` helper, modelled on the existing `isPlatformModule`, serves both new rows; no second mechanism is introduced.

## Duplication and abstraction budget

One helper shared by two rows, rather than two near-identical matchers. No new file, no new export, no new dependency.

## Net elements (R6)

3 files, +177/−12 = **+165 lines**, of which the baseline JSON is the majority. Exported symbols: 0 added, 0 removed. Ratchet: 12 rows / 196 sites → **14 rows / 251 sites**. Any percentage-complete figure drops, correctly — the denominator was previously blind to the trunk.

## Consumer counts (R8)

n/a — no emit path or export is deleted or re-routed. The two new rows are themselves consumer counts: 25 files reach `@agent/node`, 9 reach `@agent/modelHandlers`.

## Host impact

Extension: none. Desktop: none. CLI: none. Tooling only.

## Scheduled refactoring

Both rows are retired by package D. `dep:@agent/node` reaches zero when PocketFlow is deleted; `dep:@agent/modelHandlers` reaches zero when the handler hierarchy is replaced by `@texra-ai/llm` (#12070, PR #11997).

## Validation

- `node scripts/check-effect-migration-ratchet.mjs` — OK, no count grew, no baseline headroom. Both rows seeded via `--update`; the script's own self-test passes, including the three new negative cases.
- `node scripts/check-browser-safe-utils.mjs` — OK, unchanged.
- The `diffRows` bug was reproduced before it was fixed.
- `CLAUDE.md`'s ratchet sentence was updated only where it became factually wrong.

**Merge note:** this PR, #12130 and the `executionListing` p-map PR all edit `config/ratchets/effect-migration-baseline.json`. Whichever lands first, the others need a rebase plus `--update`; the conflict is mechanical. This branch still carries `import:delay` at 1 because it is based on `origin/main`; #12130 deletes that row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RQMAka6wK7ds8X9hPFNwZ
