### PR TITLE
refactor(storage): convert execution listing from p-map to Effect.forEach

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -94,7 +94,6 @@
     },
     "import:p-map": {
       "src/agent/modelHandlers/support/MediaAttachmentProcessor.ts": 1,
-      "src/agent/storage/executionListing.ts": 1,
       "src/latex/LatexMediaManager.ts": 1,
       "src/latex/extractFileDependencies.ts": 1
     },

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -223,7 +223,7 @@ async function runHistoryDelete(
     // stored execution, including `isUserVisibleExecution`-hidden
     // process-bookkeeping entries and agent-spawned child runs — don't add the
     // visibility filter here.
-    const count = (await listExecutions()).length;
+    const count = (await effectRuntime().runPromise(listExecutions())).length;
     writeTextStderr(
       `Refusing to delete ${formatResultCount(count, 'stored execution')}. Re-run with --yes to confirm.`,
     );

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -154,13 +154,15 @@ export async function maybeRunCliOnboarding(
       GlobalStateKey.ONBOARDING_FIRST_RUN_DONE,
     ) === undefined;
   const hasRunHistory = needsFirstRunBackfill
-    ? await listExecutions().then(
-        (entries) => entries.length > 0,
-        (error: unknown) => {
-          warnOnboardingFailure('Run-history check', error);
-          return false;
-        },
-      )
+    ? await effectRuntime()
+        .runPromise(listExecutions())
+        .then(
+          (entries) => entries.length > 0,
+          (error: unknown) => {
+            warnOnboardingFailure('Run-history check', error);
+            return false;
+          },
+        )
     : false;
   // LAST_KNOWN_VERSION is stamped by desktop/extension startup and is the
   // reliable prior-install signal shared across hosts.

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -142,9 +142,9 @@ async function loadUserDefaults(quiet: boolean): Promise<PartialDefaults> {
 
 async function loadHistoryDefaults(): Promise<PartialDefaults> {
   // An unreadable history listing means no history defaults.
-  const entries: ExecutionListingEntry[] = await listExecutions().catch(
-    () => [],
-  );
+  const entries: ExecutionListingEntry[] = await effectRuntime()
+    .runPromise(listExecutions())
+    .catch(() => []);
   const candidates = toNewestFirstByTimestamp(
     entries.filter(isUserVisibleExecution).filter(
       (entry) =>

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -153,15 +153,20 @@ export function parseCliHistoryId(raw: string): ExecutionId | undefined {
 }
 
 export async function listCliHistoryEntries(): Promise<CliHistoryEntry[]> {
-  const entries = await listExecutions();
   // A row's resumability comes from the checkpoint `stat` the listing already
   // did; only a failed workflow row still reads its persisted state. That read
   // is bounded here so a history full of failed workflow runs cannot open one
   // file handle burst per run. `Effect.forEach` preserves input order.
   return effectRuntime().runPromise(
-    Effect.forEach(entries.filter(isUserVisibleExecution), toCliHistoryEntry, {
-      concurrency: HISTORY_ENTRY_CONCURRENCY,
-    }),
+    listExecutions().pipe(
+      Effect.flatMap((entries) =>
+        Effect.forEach(
+          entries.filter(isUserVisibleExecution),
+          toCliHistoryEntry,
+          { concurrency: HISTORY_ENTRY_CONCURRENCY },
+        ),
+      ),
+    ),
   );
 }
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -585,7 +585,9 @@ async function activateExtension(context: vscode.ExtensionContext) {
         // Same non-blank provider-key/server-side-key check used by the
         // funnel and setup launch preflight.
         hasAnyUsableSetupCredential(),
-        listExecutions().then((entries) => entries.length > 0),
+        effectRuntime()
+          .runPromise(listExecutions())
+          .then((entries) => entries.length > 0),
       ]);
       await backfillFirstRunDone(context.globalState, {
         hasCredential,

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -5,7 +5,7 @@
  * and reading per-execution KV data (meta.json, config.json).
  */
 
-import pMap from 'p-map';
+import { Effect } from 'effect';
 
 import { type AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
@@ -27,7 +27,7 @@ import type {
 } from '@shared/schemas';
 import { filterNotNull, toNewestFirstByTimestamp } from '@utils/core';
 import { StorageFS } from '@utils/files/storageFS';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import { isDirectory } from '@utils/files/fsEntryType';
 
 import { getExecutionStore } from './ExecutionKVStore';
@@ -115,16 +115,22 @@ export function isUserVisibleExecution(
 }
 
 /**
- * Read a storage directory, returning an empty array if it doesn't exist.
- * Other I/O errors propagate.
+ * Read a storage directory, succeeding with an empty array if it doesn't
+ * exist. Other I/O errors stay on the error channel.
  */
-async function readDirOrEmpty(path: string): Promise<[string, number][]> {
-  try {
-    return await StorageFS.readDir(path);
-  } catch (error) {
-    if (isFileNotFoundError(error)) return [];
-    throw error;
-  }
+function readDirOrEmpty(
+  path: string,
+): Effect.Effect<[string, number][], Error> {
+  return Effect.tryPromise({
+    try: () => StorageFS.readDir(path),
+    catch: ensureError,
+  }).pipe(
+    Effect.catch((error) =>
+      isFileNotFoundError(error)
+        ? Effect.succeed<[string, number][]>([])
+        : Effect.fail(error),
+    ),
+  );
 }
 
 /**
@@ -143,33 +149,42 @@ function listExecutionDirs(entries: [string, number][]): ExecutionId[] {
 // ============================================================================
 
 /**
- * List all executions by scanning the executions/ directory.
- *
- * The storage root is shared by independent CLI, desktop, and extension
- * processes, so every call scans current disk state. A process-local cache
- * cannot observe another host's writes or metadata updates reliably.
+ * Read one execution's row. A row whose read fails warns and drops out of the
+ * listing rather than failing the whole scan.
  */
-export async function listExecutions(): Promise<ExecutionListingEntry[]> {
-  const entries = await readDirOrEmpty(RUNS_STORAGE_DIR);
-  const executionDirs = listExecutionDirs(entries);
-
-  // Read meta + config, and stat the checkpoint, with bounded concurrency.
-  // Large histories should not enqueue one storage read burst per execution
-  // all at once.
-  const results = await pMap(
-    executionDirs,
-    async (id): Promise<ExecutionListingEntry | null> => {
-      try {
-        const store = getExecutionStore(id);
-        // The checkpoint probe answers "no" and warns when the `stat` itself
-        // fails: a row whose meta and record are readable still belongs in
-        // history, and the open path re-reads the file anyway.
-        const [meta, record, checkpointPresent] = await Promise.all([
-          store.readMeta(),
-          store.readRunRecord(),
-          checkpointExists(id),
-        ]);
-
+function readListingRow(
+  id: ExecutionId,
+): Effect.Effect<ExecutionListingEntry | null> {
+  return Effect.try({
+    // Store construction resolves the run's storage path, so it belongs
+    // inside the per-row recovery below like every other read.
+    try: () => getExecutionStore(id),
+    catch: ensureError,
+  }).pipe(
+    Effect.flatMap((store) =>
+      // The checkpoint probe answers "no" and warns when the `stat` itself
+      // fails: a row whose meta and record are readable still belongs in
+      // history, and the open path re-reads the file anyway.
+      Effect.all(
+        [
+          Effect.tryPromise({
+            try: () => store.readMeta(),
+            catch: ensureError,
+          }),
+          Effect.tryPromise({
+            try: () => store.readRunRecord(),
+            catch: ensureError,
+          }),
+          Effect.tryPromise({
+            try: () => checkpointExists(id),
+            catch: ensureError,
+          }),
+        ],
+        { concurrency: 'unbounded' },
+      ),
+    ),
+    Effect.map(
+      ([meta, record, checkpointPresent]): ExecutionListingEntry | null => {
         if (!meta) return null;
 
         const base: ExecutionListingBase = {
@@ -193,17 +208,43 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
           return { ...base, kind: 'run', identity, record: agentRecord };
         }
         return { ...base, kind: 'run', identity, record };
-      } catch (error) {
+      },
+    ),
+    Effect.catch((error) =>
+      Effect.sync(() => {
         log.warn(`Skipping corrupt execution ${id}: ${toErrorMessage(error)}`);
         return null;
-      }
-    },
-    { concurrency: EXECUTION_STORAGE_CONCURRENCY },
+      }),
+    ),
   );
+}
 
-  return toNewestFirstByTimestamp(
-    results.filter(filterNotNull),
-    (item) => item.timestamp,
+/**
+ * List all executions by scanning the executions/ directory.
+ *
+ * The storage root is shared by independent CLI, desktop, and extension
+ * processes, so every call scans current disk state. A process-local cache
+ * cannot observe another host's writes or metadata updates reliably.
+ */
+export function listExecutions(): Effect.Effect<
+  ExecutionListingEntry[],
+  Error
+> {
+  // Read meta + config, and stat the checkpoint, with bounded concurrency.
+  // Large histories should not enqueue one storage read burst per execution
+  // all at once.
+  return readDirOrEmpty(RUNS_STORAGE_DIR).pipe(
+    Effect.flatMap((entries) =>
+      Effect.forEach(listExecutionDirs(entries), readListingRow, {
+        concurrency: EXECUTION_STORAGE_CONCURRENCY,
+      }),
+    ),
+    Effect.map((results) =>
+      toNewestFirstByTimestamp(
+        results.filter(filterNotNull),
+        (item) => item.timestamp,
+      ),
+    ),
   );
 }
 
@@ -213,18 +254,23 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
  */
 export function createLatexExecutionDiscovery(): LatexExecutionDiscoveryPort {
   return {
-    async listAgentRuns(): Promise<readonly LatexAgentRunEntry[]> {
-      const executions = await listExecutions();
-      return executions.filter(isAgentRunEntry).map((entry) => ({
-        id: entry.id,
-        timestamp: entry.timestamp,
-        agent: entry.record.agent,
-        model: entry.record.model,
-        inputFiles: entry.record.inputFiles,
-      }));
-    },
-    async readStreamId(executionId) {
-      return (await getExecutionStore(executionId).readMeta())?.streamId;
-    },
+    listAgentRuns: () =>
+      listExecutions().pipe(
+        Effect.map((executions) =>
+          executions.filter(isAgentRunEntry).map((entry) => ({
+            id: entry.id,
+            timestamp: entry.timestamp,
+            agent: entry.record.agent,
+            model: entry.record.model,
+            inputFiles: entry.record.inputFiles,
+          })),
+        ),
+      ),
+    readStreamId: (executionId) =>
+      Effect.tryPromise({
+        try: async () =>
+          (await getExecutionStore(executionId).readMeta())?.streamId,
+        catch: ensureError,
+      }),
   };
 }

--- a/src/latex/latexdiff/executionDiscovery.ts
+++ b/src/latex/latexdiff/executionDiscovery.ts
@@ -1,4 +1,5 @@
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import type { Effect } from 'effect';
 
 /**
  * The agent-run listing slice latexdiff discovery needs. Agent owns the
@@ -14,6 +15,8 @@ export interface LatexAgentRunEntry {
 }
 
 export interface LatexExecutionDiscoveryPort {
-  listAgentRuns(): Promise<readonly LatexAgentRunEntry[]>;
-  readStreamId(executionId: ExecutionId): Promise<StreamTabId | undefined>;
+  listAgentRuns(): Effect.Effect<readonly LatexAgentRunEntry[], Error>;
+  readStreamId(
+    executionId: ExecutionId,
+  ): Effect.Effect<StreamTabId | undefined, Error>;
 }

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -41,10 +41,7 @@ export const discoverLatestExecutionOutputs = Effect.fn(
   } | null,
   Error
 > {
-  const executions = yield* Effect.tryPromise({
-    try: () => discovery.listAgentRuns(),
-    catch: ensureError,
-  });
+  const executions = yield* discovery.listAgentRuns();
   // Normalize both sides so trivial path-format differences (duplicate
   // separators, `./`, mixed forward/backslash) don't silently miss a
   // matching execution.
@@ -68,10 +65,7 @@ export const discoverLatestExecutionOutputs = Effect.fn(
     // The stream stamped on execution metadata addresses its snapshot
     // directly; identity is never rebuilt from agent/model configuration.
     // Records without one go straight to the run-directory scan below.
-    const streamId = yield* Effect.tryPromise({
-      try: () => discovery.readStreamId(candidate.id),
-      catch: ensureError,
-    });
+    const streamId = yield* discovery.readStreamId(candidate.id);
     if (streamId !== undefined) {
       const { outputFilesByRound: rounds } = yield* snapshots.read(streamId);
       if (Object.keys(rounds).length > 0) {

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -57,12 +58,12 @@ describe('execution listing normalization', () => {
   });
 
   it('sees executions written by another host after an earlier listing', async () => {
-    expect(await listExecutions()).toEqual([]);
+    expect(await Effect.runPromise(listExecutions())).toEqual([]);
 
     const id = 'eee555' as ExecutionId;
     await writeExecution(id, '2026-07-15T11:00:00.000Z', config('assistant'));
 
-    expect(await listExecutions()).toEqual([
+    expect(await Effect.runPromise(listExecutions())).toEqual([
       expect.objectContaining({
         id,
         kind: 'run',
@@ -82,7 +83,7 @@ describe('execution listing normalization', () => {
       new Error('stat failed'),
     );
 
-    expect(await listExecutions()).toEqual([
+    expect(await Effect.runPromise(listExecutions())).toEqual([
       expect.objectContaining({ id, kind: 'run', checkpointPresent: false }),
     ]);
   });
@@ -90,7 +91,7 @@ describe('execution listing normalization', () => {
   it('sees metadata replaced by another host after an earlier listing', async () => {
     const id = 'fff666' as ExecutionId;
     await writeExecution(id, '2026-07-15T12:00:00.000Z', config('assistant'));
-    expect(await listExecutions()).toEqual([
+    expect(await Effect.runPromise(listExecutions())).toEqual([
       expect.not.objectContaining({ description: expect.any(String) }),
     ]);
 
@@ -100,7 +101,7 @@ describe('execution listing normalization', () => {
       outcome: 'completed',
     });
 
-    expect(await listExecutions()).toEqual([
+    expect(await Effect.runPromise(listExecutions())).toEqual([
       expect.objectContaining({
         id,
         description: 'Updated by another host',
@@ -114,7 +115,7 @@ describe('execution listing normalization', () => {
     const agentConfig = config('assistant');
     await writeExecution(id, '2026-07-15T10:00:00.000Z', agentConfig);
 
-    const entries = await listExecutions();
+    const entries = await Effect.runPromise(listExecutions());
 
     expect(entries).toEqual([
       {
@@ -149,7 +150,7 @@ describe('execution listing normalization', () => {
     );
     await writeExecution(incompleteId, '2026-07-15T07:00:00.000Z');
 
-    const entries = await listExecutions();
+    const entries = await Effect.runPromise(listExecutions());
 
     expect(entries.map(({ kind }) => kind)).toEqual([
       'run',
@@ -184,7 +185,7 @@ describe('execution listing normalization', () => {
     });
     await store.writeRunRecord({ name: 'bash', instruction: 'ls -la' });
 
-    const entries = await listExecutions();
+    const entries = await Effect.runPromise(listExecutions());
     const entry = entries.find((candidate) => candidate.id === id);
     expect(entry).toMatchObject({
       kind: 'run',
@@ -212,7 +213,7 @@ describe('execution listing normalization', () => {
       await store.writeRunRecord(config('assistant'));
     }
 
-    const entries = await listExecutions();
+    const entries = await Effect.runPromise(listExecutions());
 
     expect(entries.map(({ kind }) => kind)).toEqual([
       'incomplete',
@@ -250,7 +251,7 @@ describe('execution listing normalization', () => {
     // Persist the raw legacy bytes, bypassing the current input type.
     await store.writeRunRecord(legacyTeamRunConfig as unknown as AgentConfig);
 
-    const entries = await listExecutions();
+    const entries = await Effect.runPromise(listExecutions());
     const entry = entries.find((candidate) => candidate.id === id);
     expect(entry).toMatchObject({
       kind: 'run',
@@ -280,7 +281,7 @@ describe('execution listing normalization', () => {
       rootId,
     );
 
-    const entries = await listExecutions();
+    const entries = await Effect.runPromise(listExecutions());
 
     // The raw listing still carries the child so tool-facing callers can walk
     // the lineage; only the history-listing filter drops it.
@@ -318,7 +319,7 @@ describe('execution listing normalization', () => {
 
     // Unlike a history listing, latexdiff discovery keeps delegated children
     // and drops non-agent rows.
-    expect(await discovery.listAgentRuns()).toEqual([
+    expect(await Effect.runPromise(discovery.listAgentRuns())).toEqual([
       {
         id: rootId,
         timestamp: '2026-07-15T10:00:00.000Z',
@@ -334,9 +335,11 @@ describe('execution listing normalization', () => {
         inputFiles: ['child.tex'],
       },
     ]);
-    expect(await discovery.readStreamId(rootId)).toBe(
+    expect(await Effect.runPromise(discovery.readStreamId(rootId))).toBe(
       'assistant@deepseekT#ab1001',
     );
-    expect(await discovery.readStreamId(childId)).toBeUndefined();
+    expect(
+      await Effect.runPromise(discovery.readStreamId(childId)),
+    ).toBeUndefined();
   });
 });

--- a/src/test-kernel/cli/ChatDefaults.vitest.ts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.ts
@@ -1,10 +1,11 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
-import { listExecutions } from '@agent/storage';
+import { listExecutions, type ExecutionListingEntry } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
   __resetUserConfigWarningDedupeForTests,
@@ -45,7 +46,7 @@ function enoentError(): NodeJS.ErrnoException {
 
 vi.mock('@agent/storage', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agent/storage')>()),
-  listExecutions: vi.fn(async () => []),
+  listExecutions: vi.fn(),
 }));
 
 // Spied, not stubbed: the workspace tiers below still read real `.texra`
@@ -79,7 +80,7 @@ function historyEntry(
       agentCategory: AgentCategory.ToolUse,
       ...overrides,
     }),
-  } satisfies Awaited<ReturnType<typeof listExecutions>>[number];
+  } satisfies ExecutionListingEntry;
 }
 
 vi.mock('@utils/files/storageFS', () => ({
@@ -95,7 +96,7 @@ const mockedReadJson = vi.mocked(GlobalStorageFS.readJson);
 beforeEach(() => {
   mockedLoadWorkspaceCliConfig.mockClear();
   mockedListExecutions.mockReset();
-  mockedListExecutions.mockResolvedValue([]);
+  mockedListExecutions.mockReturnValue(Effect.succeed([]));
   mockedReadJson.mockReset();
   // A missing user config (the common case) mirrors a real ENOENT rejection.
   mockedReadJson.mockRejectedValue(enoentError());
@@ -179,7 +180,9 @@ describe('CLI chat defaults', () => {
   });
 
   it('inherits only the model from recent single-agent tool-use history', async () => {
-    mockedListExecutions.mockResolvedValueOnce([historyEntry('research')]);
+    mockedListExecutions.mockReturnValueOnce(
+      Effect.succeed([historyEntry('research')]),
+    );
 
     await expectChatDefaults(
       { cwd: NO_WORKSPACE },
@@ -194,9 +197,9 @@ describe('CLI chat defaults', () => {
   });
 
   it('ignores a history model that the CLI cannot run', async () => {
-    mockedListExecutions.mockResolvedValueOnce([
-      historyEntry('research', { model: 'Copilot GPT-4o' }),
-    ]);
+    mockedListExecutions.mockReturnValueOnce(
+      Effect.succeed([historyEntry('research', { model: 'Copilot GPT-4o' })]),
+    );
 
     await expectChatDefaults(
       { cwd: NO_WORKSPACE },
@@ -212,11 +215,13 @@ describe('CLI chat defaults', () => {
     // A `texra multi-agent run physicist` is stored as a tool-use execution
     // whose root is the team orchestrator. It must not affect plain
     // `texra chat` defaults — fall back to the built-ins instead.
-    mockedListExecutions.mockResolvedValueOnce([
-      historyEntry('leanOrchestrator', {
-        cli: { multiAgentPresetId: 'lean-project' },
-      }),
-    ]);
+    mockedListExecutions.mockReturnValueOnce(
+      Effect.succeed([
+        historyEntry('leanOrchestrator', {
+          cli: { multiAgentPresetId: 'lean-project' },
+        }),
+      ]),
+    );
 
     await expectChatDefaults(
       { cwd: NO_WORKSPACE },
@@ -234,10 +239,12 @@ describe('CLI chat defaults', () => {
   it.each(['bash', 'simplifier'])(
     'does not inherit %s as the default single-chat agent',
     async (agent) => {
-      mockedListExecutions.mockResolvedValueOnce([
-        historyEntry(agent, {}, '2026-05-21T08:02:00.000Z'),
-        historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),
-      ]);
+      mockedListExecutions.mockReturnValueOnce(
+        Effect.succeed([
+          historyEntry(agent, {}, '2026-05-21T08:02:00.000Z'),
+          historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),
+        ]),
+      );
 
       await expectChatDefaults(
         { cwd: NO_WORKSPACE },
@@ -251,16 +258,18 @@ describe('CLI chat defaults', () => {
   );
 
   it('skips a team run to reach an earlier single-agent model', async () => {
-    mockedListExecutions.mockResolvedValueOnce([
-      historyEntry(
-        'orchestrator',
-        {
-          cli: { multiAgentPresetId: 'physicist' },
-        },
-        '2026-05-21T08:02:00.000Z',
-      ),
-      historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),
-    ]);
+    mockedListExecutions.mockReturnValueOnce(
+      Effect.succeed([
+        historyEntry(
+          'orchestrator',
+          {
+            cli: { multiAgentPresetId: 'physicist' },
+          },
+          '2026-05-21T08:02:00.000Z',
+        ),
+        historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),
+      ]),
+    );
 
     await expectChatDefaults(
       { cwd: NO_WORKSPACE },
@@ -374,7 +383,9 @@ describe('CLI chat defaults', () => {
   });
 
   it('still loads history when only the agent is directly resolved', async () => {
-    mockedListExecutions.mockResolvedValueOnce([historyEntry('research')]);
+    mockedListExecutions.mockReturnValueOnce(
+      Effect.succeed([historyEntry('research')]),
+    );
 
     await expectChatDefaults(
       { cwd: NO_WORKSPACE, agentOverride: 'simplifier' },

--- a/src/test-kernel/cli/History.vitest.ts
+++ b/src/test-kernel/cli/History.vitest.ts
@@ -257,7 +257,7 @@ describe('CLI history runtime', () => {
   });
 
   it('formats history list rows with the stable tab-separated text shape', async () => {
-    mocks.listExecutions.mockResolvedValue([runListEntry('a1')]);
+    mocks.listExecutions.mockReturnValue(Effect.succeed([runListEntry('a1')]));
 
     const entries = await listCliHistoryEntries();
 
@@ -282,22 +282,24 @@ describe('CLI history runtime', () => {
     // Byte parity for the public stream (proposal gate G): terminal outcomes
     // emit as ExecutionStatus ('interrupted'/'error'/'completed');
     // 'resumable'/'unknown' pass through. Internal entries keep RunOutcome.
-    mocks.listExecutions.mockResolvedValue(
-      (
-        [
-          ['b1', 'cancelled'],
-          ['b2', 'failed'],
-          ['b3', 'completed'],
-          ['b4', undefined],
-        ] as const
-      ).map(([id, outcome]) => ({
-        kind: 'run',
-        identity: { kind: 'agent', agent: 'correct' },
-        id: id as ExecutionId,
-        timestamp: '2026-05-18T08:00:00.000Z',
-        record: config,
-        ...(outcome ? { outcome } : {}),
-      })),
+    mocks.listExecutions.mockReturnValue(
+      Effect.succeed(
+        (
+          [
+            ['b1', 'cancelled'],
+            ['b2', 'failed'],
+            ['b3', 'completed'],
+            ['b4', undefined],
+          ] as const
+        ).map(([id, outcome]) => ({
+          kind: 'run',
+          identity: { kind: 'agent', agent: 'correct' },
+          id: id as ExecutionId,
+          timestamp: '2026-05-18T08:00:00.000Z',
+          record: config,
+          ...(outcome ? { outcome } : {}),
+        })),
+      ),
     );
 
     const entries = await listCliHistoryEntries();
@@ -331,23 +333,25 @@ describe('CLI history runtime', () => {
 
   it('hides internal process-bookkeeping and configless entries from the history list', async () => {
     const processConfig = toolUseAgentConfig({ agent: 'bash' });
-    mocks.listExecutions.mockResolvedValue([
-      runListEntry('visible'),
-      {
-        kind: 'run',
-        identity: { kind: 'process', tool: 'bash' },
-        id: 'bash-process' as ExecutionId,
-        timestamp: '2026-05-18T08:01:00.000Z',
-        record: processConfig,
-        outcome: 'completed',
-      },
-      {
-        kind: 'incomplete',
-        id: 'configless' as ExecutionId,
-        timestamp: '2026-05-18T08:02:00.000Z',
-        outcome: 'completed',
-      },
-    ]);
+    mocks.listExecutions.mockReturnValue(
+      Effect.succeed([
+        runListEntry('visible'),
+        {
+          kind: 'run',
+          identity: { kind: 'process', tool: 'bash' },
+          id: 'bash-process' as ExecutionId,
+          timestamp: '2026-05-18T08:01:00.000Z',
+          record: processConfig,
+          outcome: 'completed',
+        },
+        {
+          kind: 'incomplete',
+          id: 'configless' as ExecutionId,
+          timestamp: '2026-05-18T08:02:00.000Z',
+          outcome: 'completed',
+        },
+      ]),
+    );
 
     const entries = await listCliHistoryEntries();
 
@@ -355,13 +359,15 @@ describe('CLI history runtime', () => {
   });
 
   it('hides agent-spawned child runs from the history list', async () => {
-    mocks.listExecutions.mockResolvedValue([
-      runListEntry('root'),
-      runListEntry('delegated-child', {
-        timestamp: '2026-05-18T08:01:00.000Z',
-        parentExecutionId: 'root' as ExecutionId,
-      }),
-    ]);
+    mocks.listExecutions.mockReturnValue(
+      Effect.succeed([
+        runListEntry('root'),
+        runListEntry('delegated-child', {
+          timestamp: '2026-05-18T08:01:00.000Z',
+          parentExecutionId: 'root' as ExecutionId,
+        }),
+      ]),
+    );
 
     const entries = await listCliHistoryEntries();
 
@@ -373,15 +379,17 @@ describe('CLI history runtime', () => {
       agent: 'engineer',
       cli: { multiAgentPresetId: ' software-engineer ' },
     });
-    mocks.listExecutions.mockResolvedValue([
-      runListEntry('team1', {
-        identity: { kind: 'agent', agent: 'engineer' },
-        timestamp: '2026-05-18T10:00:00.000Z',
-        record: teamConfig,
-        outcome: 'cancelled',
-        ...RESUMABLE_ROW_FACTS,
-      }),
-    ]);
+    mocks.listExecutions.mockReturnValue(
+      Effect.succeed([
+        runListEntry('team1', {
+          identity: { kind: 'agent', agent: 'engineer' },
+          timestamp: '2026-05-18T10:00:00.000Z',
+          record: teamConfig,
+          outcome: 'cancelled',
+          ...RESUMABLE_ROW_FACTS,
+        }),
+      ]),
+    );
 
     const entries = await listCliHistoryEntries();
 
@@ -394,16 +402,18 @@ describe('CLI history runtime', () => {
 
   it('uses the history description for no-input chat rows', async () => {
     const chatConfig = toolUseAgentConfig({ agent: 'assistant' });
-    mocks.listExecutions.mockResolvedValue([
-      runListEntry('chat1', {
-        identity: { kind: 'agent', agent: 'assistant' },
-        timestamp: '2026-05-18T11:00:00.000Z',
-        record: chatConfig,
-        outcome: 'cancelled',
-        description: 'Sketch a proof outline',
-        ...RESUMABLE_ROW_FACTS,
-      }),
-    ]);
+    mocks.listExecutions.mockReturnValue(
+      Effect.succeed([
+        runListEntry('chat1', {
+          identity: { kind: 'agent', agent: 'assistant' },
+          timestamp: '2026-05-18T11:00:00.000Z',
+          record: chatConfig,
+          outcome: 'cancelled',
+          description: 'Sketch a proof outline',
+          ...RESUMABLE_ROW_FACTS,
+        }),
+      ]),
+    );
 
     const entries = await listCliHistoryEntries();
 

--- a/src/test-kernel/cli/OnboardingGate.vitest.ts
+++ b/src/test-kernel/cli/OnboardingGate.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Integration tests for the maybeRunCliOnboarding gate's early-return branches.
@@ -43,7 +44,7 @@ describe('maybeRunCliOnboarding gate', () => {
 
   beforeEach(() => {
     mocks.hasUsableSetupCredential.mockReset().mockResolvedValue(false);
-    mocks.listExecutions.mockReset().mockResolvedValue([]);
+    mocks.listExecutions.mockReset().mockReturnValue(Effect.succeed([]));
     services = createFakePlatform();
     originalIsTty = process.stdout.isTTY;
     Object.defineProperty(process.stdout, 'isTTY', {
@@ -120,7 +121,9 @@ describe('maybeRunCliOnboarding gate', () => {
   });
 
   it('skips onboarding for credential-less users with prior run history', async () => {
-    mocks.listExecutions.mockResolvedValue([{ id: 'previous-run' }]);
+    mocks.listExecutions.mockReturnValue(
+      Effect.succeed([{ id: 'previous-run' }]),
+    );
 
     await expect(maybeRunCliOnboarding(services, INTERACTIVE)).resolves.toEqual(
       SKIPPED,

--- a/src/test-kernel/latex/OutputDiscovery.vitest.ts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.ts
@@ -45,10 +45,10 @@ function discoveryWith(entries: readonly LatexAgentRunEntry[]): {
   discovery: LatexExecutionDiscoveryPort;
   readStreamId: ReturnType<typeof vi.fn>;
 } {
-  const readStreamId = vi.fn(async () => undefined);
+  const readStreamId = vi.fn(() => Effect.succeed(undefined));
   return {
     discovery: {
-      listAgentRuns: async () => entries,
+      listAgentRuns: () => Effect.succeed(entries),
       readStreamId,
     },
     readStreamId,
@@ -111,7 +111,9 @@ describe('discoverLatestExecutionOutputs', () => {
       matchingExecution('exec-registered'),
     ]);
     // Registered under a stream the agent/model config would NOT derive.
-    readStreamId.mockResolvedValue('polish@earlierModel#exec-registered');
+    readStreamId.mockReturnValue(
+      Effect.succeed('polish@earlierModel#exec-registered'),
+    );
     const rounds = { 0: [] };
     mocks.read.mockReturnValue(Effect.succeed({ outputFilesByRound: rounds }));
 
@@ -195,10 +197,8 @@ describe('outputDiscovery logger seam', () => {
 
   it('propagates an unreadable execution index instead of choosing different outputs', async () => {
     const discovery: LatexExecutionDiscoveryPort = {
-      listAgentRuns: async () => {
-        throw new Error('execution index unreadable');
-      },
-      readStreamId: async () => undefined,
+      listAgentRuns: () => Effect.fail(new Error('execution index unreadable')),
+      readStreamId: () => Effect.succeed(undefined),
     };
     await expect(
       Effect.runPromise(

--- a/src/test-kernel/latex/RunLatexdiff.vitest.ts
+++ b/src/test-kernel/latex/RunLatexdiff.vitest.ts
@@ -43,8 +43,8 @@ function roundMap(): RoundIndexed<OutputFileInfo> {
 }
 
 const executionDiscovery: LatexExecutionDiscoveryPort = {
-  listAgentRuns: async () => [],
-  readStreamId: async () => undefined,
+  listAgentRuns: () => Effect.succeed([]),
+  readStreamId: () => Effect.succeed(undefined),
 };
 
 const snapshots = { read: vi.fn() };

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -5,6 +5,7 @@ import '@test/support/defaultSessionTestSetup';
 import { mkdir, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { flowKey } from '@agent/node/persistedFlow';
@@ -110,7 +111,7 @@ describe('ExecutionsTool', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.listExecutions.mockResolvedValue([]);
+    mocks.listExecutions.mockReturnValue(Effect.succeed([]));
     mocks.readMeta.mockResolvedValue(null);
     mocks.readChildren.mockResolvedValue([]);
     mocks.readReport.mockResolvedValue(null);

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -442,7 +442,12 @@ Delegated subagent and workflow results are delivered automatically as follow-up
 
   private readonly listExecutions = Effect.fn('ExecutionsTool.listExecutions')(
     function* (context: ExecutionToolContext, offset: number, limit: number) {
-      const entries = yield* executionsRead(context, () => listExecutions());
+      // The listing reads through the run's workspace storage root, which
+      // is AsyncLocalStorage-scoped: the fiber must start inside the bound
+      // frame or `StorageFS` resolves the process roots instead.
+      const entries = yield* executionsRead(context, () =>
+        effectRuntime().runPromise(listExecutions()),
+      );
 
       if (entries.length === 0) {
         return executed('No execution history found.');


### PR DESCRIPTION
## Summary

Converts `src/agent/storage/executionListing.ts` from `p-map` to `Effect.forEach`, taking `import:p-map` from 4 sites to 3. The concurrency bound is unchanged.

This is the only one of the four `p-map` sites worth converting today. The other three (`MediaAttachmentProcessor.ts`, `LatexMediaManager.ts`, `extractFileDependencies.ts`) sit in files that package D deletes, or whose only callers it deletes, so converting them is work that gets thrown away. `executionListing.ts` is named in the elimination ledger's "rewired, not deleted" list, so it survives the switch.

The conversion is net-negative in machinery rather than a relocation: `LatexExecutionDiscoveryPort` becomes Effect-typed, and two real `Effect.tryPromise` wrappers in `outputDiscovery.ts` are **deleted** rather than pushed one level out. A third wrapper, over `scanRunDirForOutputs`, correctly remains — that call is still Promise-shaped.

**One thing deliberately left alone.** `ExecutionsTool.listExecutions` keeps its `effectRuntime().runPromise(...)` inside `context.inRunScope(...)`, which reads as an Effect → Promise → Effect round trip. It is required, not gratuitous: the listing reads through the run's workspace storage root, which is `AsyncLocalStorage`-scoped (`StorageFS.getBasePath` returns `workspaceRoots().storage`), and Effect 4.0.0-rc.112 has no ALS awareness at all — a fiber resumed from outside the `als.run()` frame reads `undefined`. Verified empirically on this repo's pinned Effect:

```
same-frame  : {"before":"SCOPED","afterSleep":"SCOPED","afterPromise":"SCOPED"}
cross-frame : {"before":"SCOPED","afterWake":"undefined"}
```

Starting the fiber inside the bound frame is what keeps the read correct. The clean fix is making `workspaceRoots` a Context service, which belongs to package D — it is one of five ALS scopes (`workspaceRoots.ts:41`, `ToolFileInteractionContext.ts:49`, `TraceEmitter.ts:58`, `executionLease.ts:222`, `RunContext.ts:79`) that must all become Context services or FiberRefs in the same switch that makes their readers fibers. Filed as a follow-up below. The ratchet permits `Effect.run*` freely inside `src/tools/**/*Tool.ts`, so this is a correctness decision, not a ratchet workaround.

**One narrowing worth a reviewer's eye.** The per-row recovery now catches error-channel failures rather than every throw: a synchronous throw inside the `Effect.map` body would escape where the old `try/catch` swallowed it. The mapping body is total over already-validated data, and both reviewers rated this a note rather than a defect. Wrapping a total function in `Effect.try` to catch an unreachable throw would be the defensive band-aid this repo rules against, so it was not added. Flagging it explicitly rather than leaving it to be discovered.

## Issue acceptance gates

Advances #12072 (retire the superseded async dependencies). `import:p-map` 4 → 3; the row does not reach zero and is not deleted, because the remaining three sites are package-D work.

## Single source of truth

`listExecutions()` in `src/agent/storage/executionListing.ts` remains the one owner of execution-listing reads. `LatexExecutionDiscoveryPort` is now Effect-typed on both members, so the agent side owns the effect type and latexdiff no longer re-wraps it.

## Duplication and abstraction budget

Deletes two `Effect.tryPromise` wrappers outright. No new abstraction, no pass-through layer. The `p-map` import and its concurrency-limit call site are replaced by `Effect.forEach`'s own `concurrency` option, using the same existing constant.

## Net elements (R6)

17 files, +283/−199 = **+84 lines**, the majority in tests. Exported symbols: the `listExecutions` signature changes from `Promise` to `Effect` — no export added or removed. No classes, interfaces or enums added. Ratchet: `import:p-map` 4 files / 4 sites → 3 / 3; `catch:effect-importer` unchanged at 8 files / 13 sites.

## Consumer counts (R8)

`listExecutions()` has 6 production consumers, all converted: `packages/extension/src/extension.ts`, `packages/cli/src/commands/history.ts`, `packages/cli/src/onboarding/runOnboarding.tsx`, `packages/cli/src/runtime/chatDefaults.ts`, `packages/cli/src/runtime/history.ts`, `src/tools/ExecutionsTool.ts`. `LatexExecutionDiscoveryPort` has one implementor and one consumer (`outputDiscovery.ts`).

The bare host callers deliberately do **not** gain an `import ... from 'effect'`; they call `effectRuntime().runPromise(...)` from `@platform/processRuntime`. Adding a runtime `effect` import to them would drag their existing catch clauses into `catch:effect-importer`, a closed allowlist that `--update` cannot extend.

## Host impact

Extension: `extension.ts` listing call converted; behaviour unchanged.

Desktop: none.

CLI: four call sites converted (`history`, `chatDefaults`, `runtime/history`, `runOnboarding`); behaviour unchanged.

## Scheduled refactoring

The five `AsyncLocalStorage` scopes need to become Context services or FiberRefs in the same change that makes their readers fibers, or a suspended fiber silently reads the wrong workspace root, loses its tool-call context, or drops its trace stage. This is package-D scope and is not currently named in any of the migration documents. Worth filing against #11868 before D starts.

## Validation

- `node scripts/check-effect-migration-ratchet.mjs` — OK, no count grew, no baseline headroom. Baseline regenerated with `--update`; the only key removed is `executionListing.ts` from `import:p-map`.
- `node scripts/check-browser-safe-utils.mjs` — OK, 65 total / 5 reachable, unchanged.
- Two independent adversarial reviews, one on behaviour preservation and one running the checks rather than reasoning about them; both returned "ship" with the two notes disclosed above.
- Not run here: full `typecheck`/`test`/`knip` in a lane worktree without its own `node_modules`. CI covers them.

**Merge note:** this PR, #12130 and #12131 all edit `config/ratchets/effect-migration-baseline.json`. Whichever lands first, the others need a rebase plus `--update`; the conflict is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RQMAka6wK7ds8X9hPFNwZ
