### PR TITLE
refactor(cli): dedupe formatElapsed into the shared formatCompactDuration

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -25,7 +25,7 @@ import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
 import type { SessionView, StreamView } from '@shared/session/sessionView';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
-import { pluralize } from '@utils/text/stringUtils';
+import { formatCompactDuration, pluralize } from '@utils/text/stringUtils';
 
 import {
   safeTerminalText,
@@ -302,7 +302,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
       parts.push(`${plannedRounds} rounds`);
     }
     const runStartedAt = root.runStartedAt ?? this.attachedAt;
-    const elapsed = formatElapsed(now - runStartedAt);
+    const elapsed = formatCompactDuration(now - runStartedAt);
     const children = this.liveChildren();
     const nameOnlySubagents = formatActiveChildren(children, 0);
     if (nameOnlySubagents) {
@@ -396,14 +396,6 @@ function normalizeTerminalColumns(
 
 function isMultiRound(rounds: number | undefined): rounds is number {
   return rounds != null && rounds > 1;
-}
-
-function formatElapsed(ms: number): string {
-  const seconds = Math.max(0, Math.floor(ms / 1000));
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  if (minutes === 0) return `${remainingSeconds}s`;
-  return `${minutes}m ${remainingSeconds.toString().padStart(2, '0')}s`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.ts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.ts
@@ -473,15 +473,15 @@ describe('CLI run progress renderer', () => {
     expect(output.text.endsWith('\r\x1b[2K')).toBe(true);
   });
 
-  it('keeps long elapsed times in minute-second form', async () => {
+  it('formats long elapsed times with compact duration units', async () => {
     let now = 0;
     const output = outputBuffer();
     const renderer = ansiRenderer(output, { nowMs: () => now });
 
-    now = 3_600_000;
+    now = 3_723_000;
     await handleRunConfig(renderer);
 
-    expect(output.text).toContain('\r\x1b[2Kpolish paper.tex · 60m 00s');
+    expect(output.text).toContain('\r\x1b[2Kpolish paper.tex · 1h 2m');
   });
 
   it('ticks the ANSI status line while a root workflow is quiet', async () => {


### PR DESCRIPTION
## Summary

Scheduled a code-consolidation sweep (per the `find-simplification` skill) across `src/utils/`, `src/common/`, `src/agent/`, `packages/*/src/common/`, the three webview trees, and per-host wiring, using two independent parallel research agents. This is an unusually well-consolidated codebase (~1100 prior tech-debt-tournament cycles), and both agents independently converged on the same single genuine, verified candidate — everything else they checked (debounce, event fan-out, path resolution, retry/queue machinery, `Object.hasOwn`, `structuredClone`, dedup helpers, etc.) was already correctly consolidated.

`packages/cli/src/runtime/runProgressRenderer.ts` hand-rolled its own `formatElapsed(ms)` minutes/seconds formatter for the live `texra run` progress line, duplicating `formatCompactDuration` (`src/utils/text/stringUtils.ts`, backed by `pretty-ms`) — the convention already used for the exact same "elapsed since start" display at ~13 other call sites, including elsewhere in this same CLI package: `statusBarDisplay.ts`, `WorkflowPopup.tsx`, `WorkflowRunDetails.tsx`, and `childControls.ts`.

## Issue acceptance gates

No tracked issue — filed directly as a scheduled consolidation sweep finding, verified end-to-end (no pre-existing tech-debt issue covered this; searched before implementing).

## Single source of truth

`formatCompactDuration` (`src/utils/text/stringUtils.ts`) is now the sole "elapsed since start" formatter across the CLI package; `runProgressRenderer.ts` no longer carries its own divergent copy.

## Duplication and abstraction budget

Removed the duplicate `formatElapsed` helper (7 lines) in favor of the existing shared helper. No new abstraction added.

## Net elements (R6)

- Files: 2 changed, 0 added/removed
- Exported symbols: none added/removed (`formatElapsed` was private/unexported)
- Classes/interfaces/enums: none
- Net LoC: -8 (`+5 -13` per `git diff --stat origin/main...HEAD`)

## Consumer counts (R8)

n/a — no emit path or export was deleted/re-routed; `formatElapsed` had exactly one call site (verified via repo-wide grep), now replaced with `formatCompactDuration`.

## Host impact

Extension: none

Desktop: none

CLI: The `texra run` live progress line's elapsed-time suffix now matches the CLI's own status-bar convention: no zero-padding (`3m 5s` instead of `3m 05s`), and rolls into hours past 60 minutes (`1h 2m` instead of `62m 03s`), consistent with how the same package already renders elapsed time everywhere else.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/cli/RunProgressRenderer.vitest.ts` — 40/40 pass (updated the one assertion pinning the old zero-padded, non-hour-rolling format)
- `npx vitest run src/test-kernel/cli` — 133 files, 2174/2175 pass (1 pre-existing skip), full CLI test-kernel suite green
- `npm run typecheck:workspace` — clean
- `npm run typecheck:test-kernel` — clean
- `npm run typecheck:cli` — clean
- `npx eslint packages/cli/src/runtime/runProgressRenderer.ts src/test-kernel/cli/RunProgressRenderer.vitest.ts` — clean
- `npx prettier --check` on both changed files — clean
- `npm run check:dead-code-ratchet` — no new findings
- `npm run typecheck:agent` was not run: it fails in this sandbox on an unrelated, pre-existing issue (missing native prebuild binaries for `nativeGeneratedCleanup.mts`), unaffected by this change and reproducible on a clean checkout of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMb8ohVC6fzimpRmhrzsrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMb8ohVC6fzimpRmhrzsrj)_