### PR TITLE
docs: define TeXRA 1.0 direction and retirement plan

### DIFF
--- a/.agents/docs/proposed/architecture/2026-08-26-effect-4-runtime-migration.md
+++ b/.agents/docs/proposed/architecture/2026-08-26-effect-4-runtime-migration.md
@@ -6,6 +6,12 @@ status: proposed
 
 # PRD: Effect 4 as the TeXRA backend runtime
 
+**Amendment (2026-09-09):** The accepted [TeXRA 1.0 direction](../../../../AGENTS.md#texra-10-direction)
+sets the release target to 1.0 and confirms Effect-native implementation.
+The legacy JSON store will not be migrated; older conditional compatibility
+requirements below do not apply to the 1.0 storage transition. Use **project**
+for the application's working unit, reserving **paper** for scholarly documents.
+
 **Status:** Owner ruling of 2026-09-06: the agent runtime is written in pure
 Effect to Effect's best practice, and PocketFlow is not retained. That ruling
 amends R4, 8.4, Phase 2, and alternative 13.C below, in the form

--- a/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
+++ b/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
@@ -2,6 +2,16 @@
 
 Status: proposed
 
+**Amendment (2026-09-09):** The accepted [TeXRA 1.0 direction](../../../../AGENTS.md#texra-10-direction)
+supersedes this proposal's legacy-state import and migration requirements.
+The new release starts with fresh SQLite application state; no legacy JSON
+store migration is required or planned. Existing user data must remain
+untouched. This amendment does not waive the storage correctness requirements.
+The same direction requires retiring the custom native cleanup addon and its
+build machinery. Reconsider generated-file ownership and deletion as part of
+the final 1.0 design; do not extend that addon merely to retain this proposal's
+earlier filesystem arrangement.
+
 > **Status:** survey + decision proposal, revised the same day after reading
 > OpenCode's V2 session core. Grounded on `main` at `1fbcaa0108`. Companion to
 > `.agents/docs/archived/architecture/2026-09-03-startup-repair-is-the-wrong-shape.md`, which owns the lifecycle

--- a/.agents/docs/proposed/architecture/2026-09-06-persistence-cutover-integration.md
+++ b/.agents/docs/proposed/architecture/2026-09-06-persistence-cutover-integration.md
@@ -2,6 +2,13 @@
 
 Status: proposed
 
+**Amendment (2026-09-09):** The accepted [TeXRA 1.0 direction](../../../../AGENTS.md#texra-10-direction)
+supersedes the legacy-state import and preservation-as-current-state gates
+recorded below. TeXRA 1.0 starts with fresh SQLite application state and does
+not require JSON migration. Existing user data must remain untouched. The
+remaining entries describe this audit's historical checkpoint, not a current
+assessment of implementation progress.
+
 This is a reviewable integration checkpoint for #11972, not the completed
 persistence cutover or a release candidate. Production still opens file-backed
 transcripts and composes `SessionEventLog.memoryLayer`; the SQLite foundation

--- a/.agents/docs/proposed/architecture/2026-09-09-texra-1-0-implementation-plan.md
+++ b/.agents/docs/proposed/architecture/2026-09-09-texra-1-0-implementation-plan.md
@@ -1,0 +1,257 @@
+# TeXRA 1.0: direct implementation and retirement plan
+
+Status: proposed — implementation sequence under the accepted 1.0 policy.
+
+This assessment examines `main` at `9ae9ab875b` on 2026-09-09. The
+[repository policy](../../../../AGENTS.md#texra-10-direction) establishes the
+release direction: projects, fresh SQLite application state, Effect-native
+execution, no legacy JSON migration, and no temporary replacement systems.
+The policy is accepted; the specific design choices below are recommendations.
+
+## 1. Release separation
+
+`release/0.40` has been created locally and on GitHub at `v0.40.10`
+(`d64cfc5006418a2d1e997eaf4aa1b9bf6b522e91`). It preserves the released
+architecture and storage format for existing users. `main` is the 1.0 line.
+
+Backport fixes by their effect on released behavior, not by their commit
+title. Several recent fixes repair defects introduced by unreleased redesigns.
+Those are not maintenance-release changes. When a useful fix is mixed into a
+large PR, extract the necessary change and its regression test, record the
+original commit, and validate against the release branch's dependencies.
+Do not merge the 1.0 development line into the maintenance branch.
+
+The first prepared backport batch contains:
+
+| Change                                                      | Source                                           | Release-specific treatment                                          |
+| ----------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------- |
+| Keep document replacement rules out of helper output        | `84737d090e`, from #11997                        | Adapt the desktop caller and test session setup to 0.40 APIs.       |
+| Fit VS Code model output allowance to the available context | `373b05b814`, #12008, and follow-up `71b8565114` | Include the follow-up so unsupported tools do not affect the count. |
+| Isolate cached credentials by their secret store            | `6709198ddf`, from #11997                        | Extract only `apiProviders.ts` and its existing regression suite.   |
+
+Further candidates require separate, focused backports: canonical-path checks
+for workflow inputs and partial Google attachment failures from #11943;
+preserving the CLI conversation when resume is refused; and removing arXiv
+staging directories after failures. The first two extend earlier release
+fixes rather than duplicating them. The arXiv fix should use the release's
+existing control flow, without importing the later Effect rewrite.
+
+## 2. What the implementation actually contains
+
+The SQLite session store and shared session view are substantial completed
+work. They should be retained. However, they do not yet replace the execution
+engine or execution persistence.
+
+- [`executeAgent.ts`](../../../../src/agent/runtime/executeAgent.ts) still
+  calls `runToolUseFlow` and `runReflectionFlow` from an asynchronous body
+  enclosed by Effect.
+- [`runToolUseFlow.ts`](../../../../src/agent/implementations/flows/tooluse/runToolUseFlow.ts)
+  obtains an execution KV store and constructs a persisted flow. Reflection
+  uses `RoundPersistedFlow`.
+- [`persistedFlow.ts`](../../../../src/agent/node/persistedFlow.ts) stores a
+  graph cursor through `ExecutionKVStore`. Reimplementing that KV interface
+  with SQLite would retain the old engine and checkpoint representation.
+- [`AgentLaunchContext.ts`](../../../../src/agent/runtime/AgentLaunchContext.ts)
+  still constructs models through the old `ModelFactory` and handler classes.
+  [`packages/llm/src/turn.ts`](../../../../packages/llm/src/turn.ts) defines the
+  new Effect/Stream model contract, but the provider package is not yet used
+  by the production agent execution path at this revision.
+- [`sessionLayer.ts`](../../../../src/controllers/session/sessionLayer.ts),
+  [`SessionView.ts`](../../../../src/controllers/session/SessionView.ts), and
+  the shared session fold already provide useful scoped services and a common
+  view for the hosts. Replacing the execution engine does not require another
+  UI rewrite.
+
+## 3. Retirement boundary
+
+These are removal targets, not an invitation to improve their internal design.
+
+| Current mechanism                                               | Final treatment                                                                                                                                          |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KVStore` and `ExecutionKVStore`                                | Delete with their execution-state consumers. Introduce typed Effect database operations directly; do not implement the old interface over SQL.           |
+| `PersistedFlow`, graph-cursor checkpoints, `RoundPersistedFlow` | Replace with the final Effect loops and durable model/tool/workflow state, then delete the old interpreter and its dedicated tests.                      |
+| File-based `executionLease`                                     | Replace ownership admission and write checks with database transactions; delete lease files, polling, legacy readers, and compatibility writes together. |
+| Application-state uses of `JsonStore`                           | Move host state and mutable application records to SQLite. Do not migrate their old contents.                                                            |
+| Legacy workspace-directory rename and sidecar registry          | Remove when selecting fresh 1.0 state locations and project identity.                                                                                    |
+| JSON-state file locks, caches, directory indexes, atomic writes | Delete when their state owner is replaced, rather than converting these mechanisms to Effect first.                                                      |
+| `scripts/native-cleanup`                                        | Remove with the final generated-file ownership change, including the loader, binaries, build jobs, packaging hooks, and addon-only tests.                |
+| Old model-handler hierarchy                                     | Retire after both agent execution and helper calls use the new provider contract.                                                                        |
+
+Some similarly named facilities have independent consumers:
+
+- `fileLocks` also coordinates copying bundled agent directories. Prefer
+  reading immutable packaged defaults and separate user-managed agent files
+  if that satisfies the product requirements; this removes the shared copy,
+  synchronization marker, and lock together.
+- `writeAtomic` also writes Markdown memory files, CLI input history, and
+  inquiry records. History and inquiry metadata are application state;
+  deliberately editable memory files require a separate file-format decision.
+  Atomic replacement is not inherently obsolete, nor is it appropriate for
+  every research file: replacing a symlink changes its meaning.
+- `JsonStore` also serves explicit configuration and credentials. Preserve a
+  deliberate configuration format where useful. Preserve credential protection
+  and host secret providers; the storage change must not silently replace
+  encrypted credentials with ordinary plaintext database rows.
+- `leaseOwnerLiveness.ts` is already used by `Database.ts`. Deleting file
+  leases does not remove the need to determine whether another process still
+  owns an execution.
+
+## 4. Recommended implementation order
+
+### A. Establish fresh state and project identity
+
+Choose one application-state namespace for 1.0, with global state and
+project-scoped databases, consistently resolved by all three hosts. Start with
+the existing per-root database design; avoid adding an unrelated persistence
+framework. Keep the database location distinct from the research folder.
+
+This must precede removal of compatibility readers. The current
+[`nodeStorage.ts`](../../../../src/platform/defaults/nodeStorage.ts) still
+defaults to `~/.texra`, and
+[`workspaceStorage.ts`](../../../../src/platform/defaults/workspaceStorage.ts)
+automatically renames a legacy workspace directory from `getStoragePath()`.
+A fresh reader alone would not prevent old user data from being touched.
+
+Complete this change with removal of that rename, old-state discovery, and
+legacy-only schemas and tests. Verify that opening 1.0 leaves a representative
+0.40 state directory unchanged and creates only current-format state.
+
+### B. Replace execution persistence and execution together
+
+Define the durable facts needed to start, stop, resume, and inspect a run:
+configuration, completed model turns, tool outcomes, workflow progress,
+parent/child relationships, and ownership. Use explicit schemas and queries.
+The current event store is a foundation; its two-table layout is not a reason
+to encode every setting or mutable record as an event. Add ordinary tables
+where they make the final model simpler while keeping related writes atomic.
+
+Connect the provider package to scoped Effect tool-use and reflection loops.
+Commit a completed response before dispatching its tools, and commit the
+observed tool outcomes before continuing. Specify what happens if a process
+dies during an external operation: a database transaction cannot make an
+arbitrary external side effect exactly-once.
+
+Replace each complete execution path through its callers, then delete its old
+flow, checkpoint, KV, and file-lease dependencies. A completed path must have
+one implementation and one persistent authority. Staging work for review is
+reasonable; shipping a second engine, dual writes, or a temporary SQL-KV
+adapter is not.
+
+Verify fresh launch, interruption, approval waiting, resume after process
+exit, competing owners, child results, and provider continuation. Extend the
+existing behavioral suites where they protect these contracts; remove tests
+whose only subject is the retired engine or format.
+
+Write the new runtime tests as Effect programs with `@effect/vitest` and
+scoped test layers. Use the Effect test clock to advance retries and deadlines
+deterministically; exercise failure, interruption, and resource release through
+the same Effect scopes used in production. Use `it.live` for tests requiring
+real I/O or real time. Avoid rebuilding the old Promise orchestration in test
+helpers or replacing every internal service with a mock. Pure transformations
+and schemas can retain ordinary Vitest tests. Tests of released 0.40 fixes
+continue to use that branch's existing runtime and test conventions.
+
+### C. Finish application records and generated-file ownership
+
+Move remaining host state, input history, inquiry metadata, and mutable
+registries into the final database model. Keep configuration, credentials,
+research files, and exports explicit in the ownership model.
+
+Run directories currently contain generated TeX/PDF outputs, original
+snapshots, and workspace links as well as obsolete state. Therefore moving
+JSON records into SQLite does not make those directories disposable.
+
+Prefer an ownership model where deleting a conversation deletes its database
+records, while exported research outputs remain ordinary project files.
+Application-owned payloads that require atomic deletion can reside in SQLite
+where practical. External tools still need scratch files; define their
+lifetime and permissible location explicitly.
+
+The existing native addon holds directory handles and confines deletion under
+concurrent directory replacement. A path check followed by recursive removal
+does not establish the same property. Resolve the final file ownership and
+deletion contract before choosing its implementation; do not build another
+temporary cleanup framework. If SQL-owned files remain external, interruption
+between database changes and filesystem operations needs a durable retry
+policy. SQLite transactions cover database contents, not independent file
+deletion ([SQLite transaction guarantees](https://www.sqlite.org/transactional.html)).
+
+Remove the addon and its entire build/package dependency in this complete
+change. Keep unrelated native dependencies, such as terminal support, when
+they still serve the product.
+
+### D. Rename the working unit coherently
+
+This can proceed independently once project identity is settled. Rename the
+desktop registry, messages, state keys, shared display record, renderer
+workbench, and interface text together. The main locations are
+`desktopPapers.ts`, `desktopPaperMessages.ts`, `hostSnapshot.ts`,
+`hostSnapshotSource.ts`, `paperWorkbench.ts`, and `taskShell.ts`.
+
+Adopt the new internal names directly, without aliases or a desktop-state
+migration. Retain **paper** for scholarly documents and literature operations.
+Preserve the existing per-folder session and resource ownership behavior.
+
+## 5. Work to stop scheduling
+
+Use supported upstream facilities before implementing infrastructure. Evaluate
+Effect's database, concurrency, process, filesystem, and resource-management
+facilities against the final product requirements and the version actually
+used by the hosts. Prefer direct adoption over a custom equivalent or an
+adapter preserving the old API. Keep a custom implementation only for a
+demonstrated requirement the supported facilities cannot meet. Upgrading the
+supported stack and deleting redundant code is preferable to extending an
+obsolete internal contract.
+
+Do not fund another round of Effect conversions inside the retiring JSON
+store, file lease implementation, persisted graph, or old model handlers
+merely to reduce a count of Promise calls. Convert durable consumers to their
+final services. A wrapper count is not evidence that execution has changed.
+
+Do not develop JSON import manifests, history converters, old-format readers,
+or a temporary generated-file cleanup implementation. Existing defects on the
+released line can be fixed there without expanding those systems on `main`.
+
+Earlier proposals remain useful as historical evidence, but their migration
+checklists and adapter suggestions are not current work orders. This plan
+supersedes those items for 1.0. Before implementing a subsystem, replace its
+obsolete acceptance criteria with the current contract rather than adding yet
+another conflicting amendment. Architecture checks must protect ownership and
+correctness, not force preservation of a retired class or filename.
+
+## 6. Release readiness
+
+The current release workflow excludes prereleases from publishing jobs and
+uses ordinary `npm publish` for stable CLI releases. Define and verify an
+explicit 1.0 preview distribution before asking existing users to test it;
+creating a version tag alone does not establish a preview channel.
+
+The 1.0 release should require: fresh-state isolation, functioning execution
+through the final provider/runtime path on each host, tested interruption and
+reopening behavior, coherent project terminology, removal of the old state
+and native-cleanup machinery, and clear instructions that old application
+state is not imported. Removing legacy migration does not remove the need to
+identify the current database format and reject unsupported state clearly.
+
+## 7. Open PR disposition at the decision point
+
+The seven pre-existing open PRs inspected on 2026-09-09 all target `main`.
+Creating the maintenance branch did not move, close, or merge them. The
+recommendations below concern their fit with 1.0; they are not substitutes for
+code review or completed validation. Large diffs were inspected selectively.
+
+| PR                                                                                 | Recommended disposition                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#12108: execution metadata in SQLite](https://github.com/LionSR/TeXRA/pull/12108) | Keep as a draft and revise against the final storage contract. Its description already drops JSON import and requires fresh-state isolation. It adopts the official Effect SQLite client and removes metadata accessors, but retains file checkpoints, delegation state, file leases, and native cleanup. Preserve useful SQL work; do not describe this intermediate state as completed 1.0 persistence or expand the remaining doomed machinery. |
+| [#12106: Effect filesystem reads](https://github.com/LionSR/TeXRA/pull/12106)      | Keep and reconcile with current main. It uses the official filesystem layer and scoped reads for retained memory files; it is not a JSON migration system.                                                                                                                                                                                                                                                                                         |
+| [#12005: bounded conversation readers](https://github.com/LionSR/TeXRA/pull/12005) | Keep. Bounded SQL reads, controlled frame delivery, and scoped transcript interests serve the final session design. Review the proposed memory and frame limits as product behavior.                                                                                                                                                                                                                                                               |
+| [#12068: runtime measurements](https://github.com/LionSR/TeXRA/pull/12068)         | Keep useful measurement evidence; revise the framing. Record the measured commit and workload, rename the working unit to project, and remove an obsolete planning gate if it would delay replacement.                                                                                                                                                                                                                                             |
+| [#12109: filesystem experiment](https://github.com/LionSR/TeXRA/pull/12109)        | Revise. The custom filesystem experiment was reverted; the final PR contains a report, benchmark, and comment correction. Keep useful evidence, but remove stale dependency claims and conclusions that use retiring run/lease files to justify new infrastructure.                                                                                                                                                                                |
+| [#12067: Astra pricing](https://github.com/LionSR/TeXRA/pull/12067)                | Prioritize a focused maintenance backport. The released handler lacks long-context tier selection, while its pricing calculator already supports it. The reasoning clamp is already fixed in 0.40.10; the PR title should describe the pricing change alone. Carry the same pricing behavior into the final provider implementation.                                                                                                               |
+| [#12134: desktop log severity](https://github.com/LionSR/TeXRA/pull/12134)         | Keep the defect fix, review the proposed representation. The current diff reconstructs severity by parsing formatted log text. Prefer carrying structured severity to the host's logging output and formatting at the destination, using supported logging facilities rather than introducing another text protocol.                                                                                                                               |
+
+[Maintenance PR #12140](https://github.com/LionSR/TeXRA/pull/12140) separately
+targets `release/0.40` with the three fixes in section 1. Local full type checks,
+lint, extension build, and tests passed: 821 suites and 10,023 tests passed,
+with one suite and six tests skipped. Package publication is a separate step;
+the PR does not bump the version or publish a release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,84 @@
 
 This document sets the common conventions for contributions. Follow these norms when working anywhere in this repository.
 
+## TeXRA 1.0 direction
+
+Accepted 2026-09-09. TeXRA 1.0 is the next release generation, developed on
+`main` in this repository. It introduces breaking changes to the application
+and its stored state. This is a development target, not a claim that 1.0 has
+shipped or that the transition is complete.
+
+The [implementation and retirement plan](.agents/docs/proposed/architecture/2026-09-09-texra-1-0-implementation-plan.md)
+records the audited removal targets and proposed order. `release/0.40` starts
+at `v0.40.10` and carries focused fixes for existing users under the released
+storage and execution contracts; the 1.0 breaking changes apply to `main`.
+
+- **Project terminology.** Use **project** for the user's working unit in
+  product text, documentation, and new or revised application interfaces. A
+  project may contain papers, code, data, and other research materials. Use
+  **paper** when referring to an actual scholarly document, not as a synonym
+  for a project. Existing application identifiers using `paper` should be
+  renamed coherently when their surrounding interfaces are revised.
+- **Breaking storage format.** SQLite is the authoritative store for
+  persistent application state. TeXRA 1.0 does not import or migrate the
+  legacy JSON store, histories, or execution checkpoints. Do not develop
+  JSON-to-SQLite migration, legacy readers, dual writes, or compatibility
+  adapters for this transition. Remove obsolete compatibility code and its
+  dedicated tests when replacing the corresponding storage path. This
+  decision supersedes earlier proposals requiring preservation or import of
+  legacy application state, and the general three-month compatibility window
+  below does not apply to this transition. It does not authorize deleting
+  existing user data: initialize new state separately and leave old state
+  untouched. Research files remain ordinary files; JSON may still be used
+  for deliberate configuration, interchange, and export formats.
+- **Effect-native implementation.** Express asynchronous application logic
+  directly through Effect services, layers, scoped resources, typed errors,
+  and structured concurrency. Keep execution of Effect programs at the
+  established host, tool, and SDK boundaries. Use the supported idioms of the
+  pinned Effect version; do not preserve Promise-based orchestration or add
+  pass-through adapters merely to retain an old internal interface. Pure
+  computation should remain simple TypeScript where Effect adds no value.
+- **Effect-native tests.** Test Effect programs with `@effect/vitest`,
+  `it.effect`, and scoped test layers. Use the Effect test clock for retries,
+  delays, and deadlines, and test interruption and resource release through
+  Effect's own lifecycle. Use `it.live` when the test intentionally exercises
+  real external I/O or real time. Do not rebuild a Promise-based test harness
+  around the retired implementation or mock every internal service call.
+  Pure functions and schemas may use ordinary Vitest. Retire obsolete tests
+  with their implementation and keep behavioral coverage at the final
+  application's durable boundaries.
+- **Modern, direct design.** Prefer the current supported APIs and one
+  coherent implementation. Historical internal formats and interfaces are
+  not constraints on the 1.0 design. This does not remove requirements for
+  correctness, interruption handling, transactional storage, or the external
+  protocols that TeXRA continues to support.
+- **Use the supported stack before writing infrastructure.** Prefer the
+  maintained facilities provided by Effect, SQLite, Node, and the host APIs
+  for concurrency, resource lifetime, retries, streams, database access, and
+  filesystem operations. Check their actual supported APIs before adding a
+  custom implementation. Custom infrastructure requires a concrete product
+  requirement that those facilities cannot meet; preserving an old internal
+  interface is not such a requirement. Remove redundant implementations and
+  pass-through layers when adopting the supported facility. Do not preserve
+  technical debt merely because removing it breaks an internal API, schema,
+  or test tied to the old design.
+- **Build the intended 1.0 design directly.** Do not spend implementation
+  effort on temporary migration tools, transitional adapters, compatibility
+  mirrors, or cleanup systems whose purpose disappears with the old design.
+  Divide work into complete changes that remain useful in 1.0, rather than
+  intermediate systems scheduled for replacement. Revise an obsolete
+  requirement before building machinery to satisfy it.
+- **Retire the custom native cleanup addon.** The 1.0 storage work must
+  eliminate `scripts/native-cleanup` and its native loader, binary artifacts,
+  CI jobs, packaging requirements, and addon-specific tests together with
+  the application dependency on it. Do not expand this machinery as an
+  intermediate step. First settle how the final design owns and deletes
+  generated files; preserve research files and prevent deletion outside
+  application-owned storage. The addon currently serves SQLite-backed
+  session deletion, so dropping legacy JSON migration alone does not remove
+  that dependency. Effect-native means using Effect's execution model, not
+  adding custom compiled extensions.
+
 ## Changelog Guidelines
 
 When updating CHANGELOG.md:
@@ -692,7 +770,7 @@ These rules were earned from a 2026-07 whole-repo simplification campaign, not d
 
 - **No bare module-level mutable singletons in tested code.** State that tests need to isolate belongs behind an injectable, resettable handle, not a bare module-level variable. The only test flake hit during the 2026-07 campaign was a module-level session singleton colliding across suites.
 
-- **Serialize async work with `p-queue`, not hand-rolled promise chains.** When operations must run one at a time (per-file write ordering, approval prompts, follow-up dispatch), use the root-dependency `p-queue`: `new PQueue({ concurrency: 1 })`, or a `Map` of queues for per-key ordering, as `src/agent/runtime/executionLanes.ts` and the CLI's `chatSessionController.followUpQueue` already do. Inside an Effect program use `withPerKeyLane` (`src/utils/core/perKeyQueue.ts`) instead: it is the same FIFO per-key lane, released on success, failure, and interruption alike. Don't hand-roll the `chain = chain.then(...)` idiom — every copy re-solves error isolation (a swallowed rejection poisons or silently skips later work) and map-entry cleanup by hand, and the 2026-07-18 coupling audit found each existing copy did so differently (the 2026-07-25 sweep migrated all of them, including `writeChains` in `src/platform/defaults/jsonStore.ts` — since moved onto `withPerKeyLane` — and `todoPersistChain` in `ToolUseCycleNode.ts`, onto this pattern).
+- **Serialize asynchronous work through Effect.** Use Effect concurrency primitives or the existing Effect-based per-key ordering helper when operations must run one at a time. Resource ownership must be released on success, failure, and interruption. Do not introduce `p-queue` orchestration or hand-written Promise chains; follow the TeXRA 1.0 direction above.
 
 ### Test fixtures and fakes
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Lean 4. It takes on open problems in long autonomous runs, with a team of
 specialist agents. Apache 2.0, and you bring your own model keys or
 subscriptions.
 
+Development on `main` targets **TeXRA 1.0**, with a redesigned interface
+organized around **projects** and a breaking change to stored application
+state. Version 1.0 will start with fresh state; it will not migrate previous
+JSON-based settings, session histories, or execution checkpoints. Existing
+research files are outside this storage change. The implementation follows
+the [1.0 development direction](AGENTS.md#texra-10-direction), using SQLite
+for application state and Effect for asynchronous execution. This describes
+work in progress, not the currently published release.
+
 ## Install
 
 ```sh

--- a/scripts/native-cleanup/README.md
+++ b/scripts/native-cleanup/README.md
@@ -1,5 +1,14 @@
 # Confined generated-file cleanup
 
+**TeXRA 1.0 direction (2026-09-09):** This addon is to be retired as part of
+the final storage design, together with its runtime dependency, native
+artifacts, CI jobs, and packaging requirements. Do not expand it or build a
+temporary replacement. The [repository policy](../../AGENTS.md#texra-10-direction)
+requires resolving generated-file ownership and deletion directly in the
+1.0 design. The description below documents the current implementation; the
+addon remains in use until that complete change is made. It is not a legacy
+JSON migration tool.
+
 This private N-API 8 addon removes tombstone-recorded execution directories without following links outside the admitted storage directory. Database access is separate from this addon; it contains no SQLite engine, connection, extension or VFS.
 
 The native operation acquires a storage-directory handle synchronously before returning its Promise, opens the generated directory and execution IDs relative to that handle, and awaits cleanup before releasing its existing deletion claim. POSIX uses directory-relative system calls; Windows uses relative native handle opens with reparse-point refusal. Link leaves are removed without traversing their targets. The operation owns this one handle through worker completion, then releases it; JavaScript never owns a separate handle. Missing directories succeed; other failures retain the tombstone for retry.


### PR DESCRIPTION
## Summary

Establish TeXRA 1.0 on `main`, with projects, fresh SQLite application state, Effect-native execution and tests, and no legacy JSON migration. Keep focused fixes for existing users on `release/0.40`.

The [implementation and retirement plan](https://github.com/LionSR/TeXRA/blob/docs/texra-1.0-direction-20260909/.agents/docs/proposed/architecture/2026-09-09-texra-1-0-implementation-plan.md) distinguishes accepted policy from proposed implementation order, identifies obsolete storage and execution machinery, and explains the remaining configuration, credential, ownership, and generated-file requirements. Earlier proposals are explicitly superseded where they conflict. The plan also records recommendations for the seven pre-existing open PRs without changing their status.

## Issue acceptance gates

Document the agreed release separation, direct implementation approach, and retirement targets. This PR changes documentation only; the 1.0 transition remains unimplemented. The first maintenance fixes are proposed separately in #12140.

## Single source of truth

`AGENTS.md` owns the accepted 1.0 policy. The linked plan records the audited findings and proposed sequence.

## Duplication and abstraction budget

No runtime abstraction. Existing proposals point to the accepted policy instead of remaining competing work orders.

## Net elements (R6)

Not applicable: documentation policy and plan, with no code refactor.

## Consumer counts (R8)

Not applicable: no exports or event paths change.

## Host impact

Extension, desktop, and CLI: no behavior change in this PR. The policy applies to their 1.0 development; 0.40 retains its released contracts.

## Scheduled refactoring

See the implementation plan for fresh-state isolation, final execution/database services, generated-file ownership and addon retirement, and coherent project terminology. Prefer supported upstream facilities over custom infrastructure or temporary adapters.

## Validation

- Passed: `npm run format`, explicit formatting of the changed architecture documents, `npm run lint`, `npm run check:guidance-refs`, local links in the implementation plan, and `git diff --check`.
- `npm run typecheck`: workspace and test-kernel checks passed; the agent build then failed because this checkout lacks the twelve `scripts/native-cleanup/prebuilds/*.node` assets. Later typecheck stages did not run.
- `npm run compile:fast`: failed resolving those same missing native cleanup assets.
- `npm test`: 762 suites passed, 2 failed, 1 skipped; 9,295 tests passed, 10 failed, 9 skipped. Eight packaging cases could not copy `darwin-x64.node`; two session-deletion cases could not complete cleanup without `darwin-arm64.node`.

Dependencies were installed from the frozen lockfile in an independent worktree. No runtime files or tests changed, and no native artifacts were built for this documentation change.
