### PR TITLE
refactor: finish transcript residency terminology

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -450,11 +450,11 @@ const assembleAgentLaunchContext = Effect.fn('assembleAgentLaunchContext')(
     });
     const modelCell = new ModelCell(modelHandler, config.model);
 
-    const transcriptWriter = yield* session.transcripts.acquireRunResidency(
+    const residency = yield* session.transcripts.acquireRunResidency(
       streamId,
       executionId,
     );
-    const rawRunTrace = createRunTrace(streamId, transcriptWriter);
+    const rawRunTrace = createRunTrace(streamId, residency);
     // The composed trace enters the store BEFORE session attachment, so a
     // failed attachment still disposes the raw trace through the store.
     const attachment: { detach?: () => void } = {};

--- a/src/test-kernel/agent/followUp/ClaudeAgentProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ClaudeAgentProgressEvents.vitest.ts
@@ -33,8 +33,7 @@ async function runWithLoggerStore<T>(
 }
 
 function collectToolLogs(store: StreamLog): unknown[] {
-  const log = store;
-  const entries = log?.getRange(0, log.head) ?? [];
+  const entries = store.getRange(0, store.head);
   return entries
     .filter((entry) => entry.messageType === MESSAGE_TYPES.TOOL_USE)
     .map((entry) => entry.data);

--- a/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
@@ -79,8 +79,7 @@ function threadOf(events: ThreadEvent[]): Thread {
 }
 
 function toolLogs(store: StreamLog): Record<string, unknown>[] {
-  const log = store;
-  const entries = log?.getRange(0, log.head) ?? [];
+  const entries = store.getRange(0, store.head);
   return entries
     .filter((entry) => entry.messageType === MESSAGE_TYPES.TOOL_USE)
     .map((entry) => entry.data as Record<string, unknown>);

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -487,7 +487,7 @@ describe('ModelInvocationNode retry', () => {
 
       await expect(node._exec(undefined)).resolves.toBe(ATTEMPT_SUCCESS);
 
-      const rows = transcript.getRange(0) ?? [];
+      const rows = transcript.getRange(0);
       const diagnostics = rows
         .map((row) => row.data)
         .filter(

--- a/src/test-kernel/agent/trace/AgentTrace.vitest.ts
+++ b/src/test-kernel/agent/trace/AgentTrace.vitest.ts
@@ -162,8 +162,7 @@ describe('logFileCategory', () => {
   });
 
   function capturedMessages(): any[] {
-    const log = store;
-    return log?.getRange(0, log.head) ?? [];
+    return store.getRange(0, store.head);
   }
 
   it('handles empty file array gracefully (no-op)', () => {

--- a/src/test-kernel/agent/trace/logUserMessage.vitest.ts
+++ b/src/test-kernel/agent/trace/logUserMessage.vitest.ts
@@ -25,8 +25,7 @@ describe('logUserMessage', () => {
   });
 
   function capturedEntries(): StreamLogEntry[] {
-    const log = store;
-    return log?.getRange(0, log.head) ?? [];
+    return store.getRange(0, store.head);
   }
 
   it('logs a plain userMessage row with no data when there are no attachments', () => {

--- a/src/test-kernel/logger/errorData.vitest.ts
+++ b/src/test-kernel/logger/errorData.vitest.ts
@@ -10,8 +10,7 @@ describe('AgentTrace error data', () => {
     const logger = createTestRunTrace('TestErrorLogger', store).trace;
     const err = new Error('test failure');
     logger.error(`Error occurred: ${err.message}`, { data: err });
-    const log = store;
-    const captured = log?.getRange(0, log.head).at(-1) as
+    const captured = store.getRange(0, store.head).at(-1) as
       { data: Error } | undefined;
     assert.ok(captured);
     assert.strictEqual(captured.data.message, 'test failure');

--- a/src/test-kernel/skills/RuntimeSkills.vitest.ts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.ts
@@ -238,7 +238,7 @@ describe('runtime skills', () => {
     ).not.toThrow();
     expect(
       store
-        ?.getRange(0)
+        .getRange(0)
         .find((entry) => entry.messageType === MESSAGE_TYPES.ACTIVE_SKILLS)
         ?.data,
     ).toStrictEqual({ skills: result.skills });


### PR DESCRIPTION
Finish the transcript residency cleanup from #12143: name the close-only launch handle `residency`, and read `StreamLog` directly in the converted tests. Remove obsolete aliases, optional access and an empty-array fallback. Behavior is unchanged.

## Net elements (R6)

Eight existing files; +9/-14 lines, five net lines removed. No files or exported declarations added or deleted.

## Consumer counts (R8)

One local launch-handle name and seven test files change. No public API, event or subscriber is removed; all three run-residency callers remain.

## Validation

Validated on latest main `dd0c053662` with its updated lockfile: formatting, full typecheck, extension build, lint and both ratchets pass. The full suite passes: 9,281 tests, nine skipped. No new tests.
