### PR TITLE
fix(latex): anchor the latexdiff-vc output name to the file extension

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -41,6 +41,7 @@ import {
   formatResultCount,
 } from '@utils/text/stringUtils';
 import { getTimeFormatter } from '../formatters/timestampUtils';
+import { dispatchGroupToggle } from '../utils';
 
 /** The card's key in `Surface.groups` for its stream. */
 const DISPATCH_GROUP_KEY = 'dispatch';
@@ -348,14 +349,11 @@ export class BackgroundTasksPanel extends LitElement {
   }
 
   private handleToggle(event: Event): void {
-    if (event.target !== event.currentTarget || !this.stream) return;
-    this.dispatchEvent(
-      SessionUiEvents.surface({
-        kind: 'group',
-        streamId: this.stream.id,
-        key: DISPATCH_GROUP_KEY,
-        expanded: event.type === 'wa-show',
-      }),
+    dispatchGroupToggle(
+      this,
+      event,
+      this.stream?.id ?? null,
+      DISPATCH_GROUP_KEY,
     );
   }
 

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -53,6 +53,7 @@ import { logStyles } from '../styles/logStyles';
 // Local imports - formatters
 import { formatLogEntry } from '../formatters';
 import { getTimeFormatter } from '../formatters/timestampUtils';
+import { dispatchGroupToggle } from '../utils';
 
 // Local imports - sibling helpers
 // Side-effect import: registers <terminal-output>, which the terminal-stream
@@ -386,26 +387,18 @@ export class TaskGroupList extends LitElement {
   }
 
   /**
-   * Handle a group's open/close — wired to both wa-show and wa-hide. Those
-   * events BUBBLE (unlike the native <details> `toggle`), so nested child
-   * groups would otherwise re-trigger their ancestors — guard on
-   * target === currentTarget. Open state comes from the event type; groupId
-   * from the element ID (no per-row closures). Lit binds the host as `this`.
-   * The surface owns the answer: the toggle is dispatched, and the group
-   * body follows the `expanded` map the host hands back.
+   * Handle a group's open/close — wired to both wa-show and wa-hide. The
+   * groupId comes from the element ID, so there are no per-row closures; Lit
+   * binds the host as `this`. `dispatchGroupToggle` owns the bubble guard and
+   * the direction the event type carries.
    */
   private handleGroupToggle(event: Event): void {
-    if (event.target !== event.currentTarget) return;
     const details = event.currentTarget as HTMLElement;
-    const groupId = details.id.slice(GROUP_DOM_IDS.DETAILS_PREFIX.length);
-    if (this.streamId === null) return;
-    this.dispatchEvent(
-      SessionUiEvents.surface({
-        kind: 'group',
-        streamId: this.streamId,
-        key: groupId,
-        expanded: event.type === 'wa-show',
-      }),
+    dispatchGroupToggle(
+      this,
+      event,
+      this.streamId,
+      details.id.slice(GROUP_DOM_IDS.DETAILS_PREFIX.length),
     );
   }
 

--- a/packages/extension/src/progressView/frontend/utils.ts
+++ b/packages/extension/src/progressView/frontend/utils.ts
@@ -1,5 +1,8 @@
 // Shared utility functions for the progress view frontend.
 
+import type { StreamTabId } from '@shared/schemas';
+import { SessionUiEvents } from '@shared/session/uiEvents';
+
 /**
  * Find the first matching element in a composed event path.
  */
@@ -14,4 +17,30 @@ export function getComposedPathElement<T extends Element>(
     }
   }
   return null;
+}
+
+/**
+ * Dispatch a `<wa-details>` group's open/close as a surface action. Wired to
+ * both `wa-show` and `wa-hide`, which BUBBLE (unlike the native `<details>`
+ * `toggle`), so a nested group's toggle would otherwise re-trigger every
+ * ancestor — hence the `target === currentTarget` guard. Direction comes from
+ * the event type rather than local state, so no per-row closures are needed,
+ * and the surface owns the answer: the group body follows the `expanded` map
+ * the host hands back.
+ */
+export function dispatchGroupToggle(
+  host: EventTarget,
+  event: Event,
+  streamId: StreamTabId | null,
+  key: string,
+): void {
+  if (event.target !== event.currentTarget || streamId === null) return;
+  host.dispatchEvent(
+    SessionUiEvents.surface({
+      kind: 'group',
+      streamId,
+      key,
+      expanded: event.type === 'wa-show',
+    }),
+  );
 }

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -174,8 +174,16 @@ export class LaTeXdiffService {
         cwd,
       });
 
-      // latexdiff-vc writes output alongside the input, relative to cwd
-      const diffFilePath = filePath.replace('.tex', `-diff${commitHash}.tex`);
+      // latexdiff-vc writes output alongside the input, relative to cwd,
+      // inserting `-diff<hash>` before the extension. Anchor the insertion to
+      // the parsed extension: a plain `.tex` string replacement would land on
+      // the first literal `.tex` anywhere in the path, so a directory such as
+      // `my.texnotes/` would send us looking for a file that was never written.
+      const parsedFilePath = path.parse(filePath);
+      const diffFilePath = path.join(
+        parsedFilePath.dir,
+        `${parsedFilePath.name}-diff${commitHash}${parsedFilePath.ext}`,
+      );
       const outputPath = path.join(cwd, diffFilePath);
       await this.fileProcessor.processDiffFile(
         pathToLocation(outputPath),


### PR DESCRIPTION
runDiffVc built the generated diff's path with
`filePath.replace('.tex', ...)`, which rewrites the FIRST literal `.tex`
anywhere in the git-root-relative path. A directory whose name contains
that substring (`my.texnotes/paper.tex`) therefore produced a path
latexdiff-vc never wrote, and processDiffFile then failed to find the
diff even though the command succeeded.

Build the name from `path.parse` instead, inserting `-diff<hash>` before
the parsed extension — the same shape `VERSION_CONTROL_DIFF_PATTERN` in
diffFileNameManager reads back.

Closes #12099

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AHDU3T2FkobhpQdD2JRcPW