### PR TITLE
feat: store update-check state in SQLite

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
+++ b/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
@@ -328,7 +328,7 @@ latest-of-type lookup never has to disambiguate targets and no key column
 exists. A database `AggregateId` is the canonical encoding
 `aggregateId(kind, logicalId) = JSON.stringify([kind, logicalId])`, with kind
 `stream`, `execution`, `workflow-checkpoint`, `inquiry`, `session`,
-`desktop-projects`, or `global-inquiry`.
+`desktop-projects`, `global-inquiry`, or `update-check`.
 This encoding is injective even when logical ids coincide or contain
 punctuation. Raw logical ids never serve as database keys. The constructor
 accepts a kind and an unencoded logical id; encoded keys are a distinct type
@@ -342,6 +342,18 @@ complete reopening list. The desktop process owns the connection at
 `<Electron userData>/v1/global-storage/texra.db`; project sessions do not own
 this record, and it is excluded from session display transport. Each write
 borrows its aggregate claim for that transaction only.
+
+Update checks own private `aggregateId('update-check', host)` records, where
+`host` is `cli` or `desktop`. The latest `update.check.recorded` event stores
+the last successful check time and last notified version. CLI records use its
+configured global storage; desktop records use the Electron user-data profile
+database, independently of the shared desktop inquiry storage. Each read or
+write acquires its connection only for that operation, and each write borrows
+its aggregate claim within the transaction. No connection is held during a
+network request or notification. Notification and throttle updates remain
+separate commits, preserving the existing retry behavior. These records are
+excluded from session display transport; old JSON keys are neither read nor
+migrated.
 
 Every `aggregate_id`, `parent_id`, read or claim argument, per-aggregate fold
 map, and transport subscription key uses this qualified `AggregateId`.

--- a/packages/agent/src/effect/runtime.ts
+++ b/packages/agent/src/effect/runtime.ts
@@ -135,8 +135,10 @@ export function composeProcess(platform: AgentPlatform): ProcessHold {
     // pending read: the owner's map builds synchronously over it, so an
     // open registers its root before the opener's first await and only the
     // entry's build waits.
-    installProcessRuntime(platform.processes.selfIdentity(), () =>
-      platform.storage.getGlobalStoragePath(),
+    installProcessRuntime(
+      platform.processes.selfIdentity(),
+      () => platform.storage.getGlobalStoragePath(),
+      () => platform.storage.getGlobalStoragePath(),
     );
     if (!active) {
       initNodeAgentRuntime(platform.lifecycle, platform.globalState);

--- a/packages/cli/src/runtime/cliProcessRuntime.ts
+++ b/packages/cli/src/runtime/cliProcessRuntime.ts
@@ -37,8 +37,10 @@ export function installCliProcessRuntime(storageRoot?: string): Promise<void> {
   if (pending) return pending;
   const storage = createNodeStorageProvider({ storageRoot });
   pending = (async () => {
-    installProcessRuntime(await nodeProcesses.selfIdentity(), () =>
-      storage.getGlobalStoragePath(),
+    installProcessRuntime(
+      await nodeProcesses.selfIdentity(),
+      () => storage.getGlobalStoragePath(),
+      () => storage.getGlobalStoragePath(),
     );
   })().finally(() => {
     pending = null;

--- a/packages/cli/src/runtime/cliStateStores.ts
+++ b/packages/cli/src/runtime/cliStateStores.ts
@@ -2,7 +2,6 @@ import * as path from 'node:path';
 
 import { Effect } from 'effect';
 
-import type { StorageProvider } from '@platform/interfaces';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { openNodeWorkspaceStateStore } from '@platform/defaults/nodeStores';
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
@@ -11,18 +10,6 @@ interface CliStateStoresInit {
   readonly storageRoot?: string;
   readonly workspacePath: string | undefined;
 }
-
-/** Open the CLI's global `state.json` under the given storage provider. This
- *  is the single derivation of the global state path; pre-platform-init callers
- *  (e.g. the update checker) use it with a default provider instead of
- *  re-deriving the same path by hand. */
-export const openCliGlobalStateStore = Effect.fn(
-  'cliStateStores.openCliGlobalStateStore',
-)(function* (storage: StorageProvider) {
-  return yield* JsonStore.open(
-    path.join(storage.getGlobalStoragePath(), 'state.json'),
-  );
-});
 
 export const createCliStateStores = Effect.fn(
   'cliStateStores.createCliStateStores',
@@ -33,7 +20,7 @@ export const createCliStateStores = Effect.fn(
   });
   const [globalState, workspaceState] = yield* Effect.all(
     [
-      openCliGlobalStateStore(storage),
+      JsonStore.open(path.join(storage.getGlobalStoragePath(), 'state.json')),
       openNodeWorkspaceStateStore(storage.getStoragePath()),
     ],
     { concurrency: 'unbounded' },

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -6,8 +6,6 @@ import { z } from 'zod';
 import { Effect, Result } from 'effect';
 import { parseJsonWith } from '@common/parsing/safeParseJson';
 import { effectRuntime } from '@platform/processRuntime';
-import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
-import { GlobalStateKey } from '@shared/state/stateKeys';
 import { ensureError } from '@utils/errors/errorMessage';
 import { UPDATE_CHECK_SKIP_ENV } from '@utils/system/semverUpdateCheck';
 import { executeCommand } from '@utils/system/execUtils';
@@ -25,7 +23,6 @@ import {
   type CliContext,
 } from './cliContext';
 import { installCliProcessRuntime } from './cliProcessRuntime';
-import { openCliGlobalStateStore } from './cliStateStores';
 import { CliExitCode } from './exitCodes';
 import { askCliQuestion, writeTextStderr } from './logSinks';
 import { createCliStyle } from './style';
@@ -124,7 +121,7 @@ export function fetchLatestCliVersion(options?: {
   registry?: string;
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
-}): Promise<string | undefined> {
+}): Effect.Effect<string | undefined> {
   const registry = options?.registry ?? DEFAULT_REGISTRY;
   return fetchJsonStringField({
     url: `${registry}/${CLI_PACKAGE_NAME}/latest`,
@@ -282,13 +279,8 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
   const { command, args } = buildUpdateCommand(method);
   const updateCmd = [command, ...args].join(' ');
   const style = createCliStyle(context.stderrColorEnabled);
-  // Runs before `initInteractiveCliPlatform`, so `platform()` isn't up yet —
-  // open the same global `state.json` that `createCliStateStores` opens later
-  // via `openCliGlobalStateStore` (see `cliStateStores.ts`), on the process
-  // runtime this entry installs when it gets there first. Failures here
-  // (e.g. an unreadable or unwritable global-storage directory, or stdin
-  // closing mid-prompt) must stay as silent as a network failure: this whole
-  // check is best-effort and must never block `chat` / `orchestrate` startup.
+  // The process runtime captures the configured global storage root before
+  // the platform is installed. Check failures remain best-effort at this host.
   let latest: string | undefined;
   let confirmed = false;
   // `installCliProcessRuntime` is the pre-runtime edge: until it resolves
@@ -301,23 +293,25 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
   // below, which covers the part that actually runs on the runtime.
   await installCliProcessRuntime(context.storageRoot);
   const check = Effect.gen(function* () {
-    const globalState = yield* openCliGlobalStateStore(
-      createNodeStorageProvider(),
-    );
-    latest = yield* Effect.tryPromise({
-      try: () =>
-        runDailyUpdateCheck({
-          currentVersion: context.version,
-          state: globalState,
-          lastCheckedAtKey: GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
-          fetchLatest: async () => {
-            if (method === 'brew') {
-              return fetchLatestHomebrewFormulaVersion({ cwd: context.cwd });
-            }
-            const version = await fetchLatestCliVersion();
-            return { version, refreshed: version !== undefined };
-          },
-          notify: async (latestVersion) => {
+    latest = yield* runDailyUpdateCheck({
+      currentVersion: context.version,
+      host: 'cli',
+      fetchLatest:
+        method === 'brew'
+          ? Effect.tryPromise({
+              try: () =>
+                fetchLatestHomebrewFormulaVersion({ cwd: context.cwd }),
+              catch: ensureError,
+            })
+          : fetchLatestCliVersion().pipe(
+              Effect.map((version) => ({
+                version,
+                refreshed: version !== undefined,
+              })),
+            ),
+      notify: (latestVersion) =>
+        Effect.tryPromise({
+          try: async () => {
             writeTextStderr(
               `A new version of texra is available: ${context.version} → ${style.emphasis(style.success(latestVersion))}`,
             );
@@ -328,12 +322,9 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
             confirmed =
               normalized === '' || normalized === 'y' || normalized === 'yes';
           },
-          // A readable-but-unwritable global state file must not cancel an
-          // update the user already accepted; the next launch merely checks
-          // again early.
-          stampFailure: 'ignore',
+          catch: ensureError,
         }),
-      catch: (cause) => ensureError(cause),
+      stampFailure: 'ignore',
     });
   });
   // Best-effort by policy: any failure — typed, defect, or interruption —

--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -108,6 +108,6 @@ const runDesktopUpdateCheck = ({
             await notify({ version });
           },
           catch: ensureError,
-        }).pipe(Effect.uninterruptible),
+        }),
     });
   });

--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -1,5 +1,6 @@
-import type { StateStore } from '@platform/interfaces';
-import { GlobalStateKey } from '@shared/state/stateKeys';
+import { Effect } from 'effect';
+
+import { ensureError } from '@utils/errors/errorMessage';
 import { UPDATE_CHECK_SKIP_ENV } from '@utils/system/semverUpdateCheck';
 import { isEnvFlagEnabled } from '@utils/system/envFlags';
 import {
@@ -37,10 +38,8 @@ interface DesktopLatestRelease {
 }
 
 /** Fetch the latest release's version, or undefined on any failure. */
-async function fetchLatestDesktopRelease(): Promise<
-  DesktopLatestRelease | undefined
-> {
-  const tag = await fetchJsonStringField({
+const fetchLatestDesktopRelease = () =>
+  fetchJsonStringField({
     url: RELEASES_API_URL,
     field: 'tag_name',
     timeoutMs: FETCH_TIMEOUT_MS,
@@ -48,77 +47,67 @@ async function fetchLatestDesktopRelease(): Promise<
       accept: 'application/vnd.github+json',
       'user-agent': GITHUB_USER_AGENT,
     },
-  });
-  return tag ? { version: tag.replace(/^v/, '') } : undefined;
-}
+  }).pipe(
+    Effect.map((tag) => (tag ? { version: tag.replace(/^v/, '') } : undefined)),
+  );
 
 interface CheckForDesktopUpdateOptions {
   currentVersion: string;
-  globalState: StateStore;
   /** Skip entirely for unpackaged/dev runs, whose version is not meaningful. */
   isPackaged: boolean;
   notify: (release: DesktopLatestRelease) => Promise<void> | void;
-  now?: () => number;
-  fetchRelease?: typeof fetchLatestDesktopRelease;
+  fetchRelease?: Effect.Effect<DesktopLatestRelease | undefined, Error>;
   env?: NodeJS.ProcessEnv;
 }
 
-let desktopUpdateCheckInFlight: Promise<void> | undefined;
 let desktopUpdateCheckNotify:
   CheckForDesktopUpdateOptions['notify'] | undefined;
 
-/**
- * At most once per day (persisted in global state), check for a newer
- * desktop release and notify at most once per release version. The daily
- * throttle stamp is only persisted after a successful fetch and any required
- * notification, so a failed check retries on the next launch instead of being
- * suppressed for a full day. Concurrent callers share one process-level check.
- */
-export function checkForDesktopUpdate(
-  options: CheckForDesktopUpdateOptions,
-): Promise<void> {
-  // Window recreation may call again while the fetch is pending. Keep the
-  // newest callback so any eventual dialog is parented to the live window.
-  desktopUpdateCheckNotify = options.notify;
-  if (desktopUpdateCheckInFlight) return desktopUpdateCheckInFlight;
-
-  const check = runDesktopUpdateCheck({
-    ...options,
-    notify: (release) => desktopUpdateCheckNotify?.(release),
-  });
-  const tracked = check.finally(() => {
-    if (desktopUpdateCheckInFlight === tracked) {
-      desktopUpdateCheckInFlight = undefined;
-      desktopUpdateCheckNotify = undefined;
+/** One check owns the work; later windows supply the current dialog parent. */
+export const checkForDesktopUpdate = (options: CheckForDesktopUpdateOptions) =>
+  Effect.suspend(() => {
+    if (desktopUpdateCheckNotify !== undefined) {
+      desktopUpdateCheckNotify = options.notify;
+      return Effect.void;
     }
+    desktopUpdateCheckNotify = options.notify;
+    return runDesktopUpdateCheck({
+      ...options,
+      notify: (release) => desktopUpdateCheckNotify?.(release),
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          desktopUpdateCheckNotify = undefined;
+        }),
+      ),
+    );
   });
-  desktopUpdateCheckInFlight = tracked;
-  return tracked;
-}
 
-async function runDesktopUpdateCheck({
+const runDesktopUpdateCheck = ({
   currentVersion,
-  globalState,
   isPackaged,
   notify,
-  now = Date.now,
-  fetchRelease = fetchLatestDesktopRelease,
+  fetchRelease = fetchLatestDesktopRelease(),
   env = process.env,
-}: CheckForDesktopUpdateOptions): Promise<void> {
-  if (!isPackaged) return;
-  if (isEnvFlagEnabled(UPDATE_CHECK_SKIP_ENV, env)) return;
-
-  await runDailyUpdateCheck({
-    currentVersion,
-    state: globalState,
-    lastCheckedAtKey: GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
-    lastNotifiedVersionKey:
-      GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
-    fetchLatest: async () => {
-      const release = await fetchRelease();
-      return { version: release?.version, refreshed: release !== undefined };
-    },
-    notify: (version) => notify({ version }),
-    now,
+}: CheckForDesktopUpdateOptions) =>
+  Effect.gen(function* () {
+    if (!isPackaged || isEnvFlagEnabled(UPDATE_CHECK_SKIP_ENV, env)) return;
+    yield* runDailyUpdateCheck({
+      currentVersion,
+      host: 'desktop',
+      notifyOnce: true,
+      fetchLatest: fetchRelease.pipe(
+        Effect.map((release) => ({
+          version: release?.version,
+          refreshed: release !== undefined,
+        })),
+      ),
+      notify: (version) =>
+        Effect.tryPromise({
+          try: async () => {
+            await notify({ version });
+          },
+          catch: ensureError,
+        }).pipe(Effect.uninterruptible),
+    });
   });
-}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -462,28 +462,25 @@ function createWindow(options: {
   // no extra single-instance gate is needed here; `checkForDesktopUpdate`
   // itself dedupes concurrent calls and window reopens.
   effectRuntime().runFork(
-    hostPort(() =>
-      checkForDesktopUpdate({
-        currentVersion: app.getVersion(),
-        globalState: options.globalState,
-        isPackaged: app.isPackaged,
-        notify: async (release) => {
-          const { response } = await dialog.showMessageBox(window, {
-            type: 'info',
-            message: `TeXRA ${release.version} is available (you have ${app.getVersion()}).`,
-            buttons: ['Download', 'Later'],
-            defaultId: 0,
-            cancelId: 1,
-          });
-          if (response === 0) {
-            // Open the known-constant releases page rather than any
-            // network-provided URL, so an unauthenticated API response can
-            // never influence what shell.openExternal opens.
-            await shell.openExternal(DESKTOP_RELEASES_PAGE_URL);
-          }
-        },
-      }),
-    ).pipe(
+    checkForDesktopUpdate({
+      currentVersion: app.getVersion(),
+      isPackaged: app.isPackaged,
+      notify: async (release) => {
+        const { response } = await dialog.showMessageBox(window, {
+          type: 'info',
+          message: `TeXRA ${release.version} is available (you have ${app.getVersion()}).`,
+          buttons: ['Download', 'Later'],
+          defaultId: 0,
+          cancelId: 1,
+        });
+        if (response === 0) {
+          // Open the known-constant releases page rather than any
+          // network-provided URL, so an unauthenticated API response can
+          // never influence what shell.openExternal opens.
+          await shell.openExternal(DESKTOP_RELEASES_PAGE_URL);
+        }
+      },
+    }).pipe(
       Effect.catch((error) => Effect.sync(() => reportBackgroundError(error))),
     ),
   );

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -39,7 +39,10 @@ import {
   openNodeWorkspaceStateStore,
   openTexraConfigStores,
 } from '@platform/defaults/nodeStores';
-import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import {
+  WorkspaceStorageProvider,
+  resolveGlobalStoragePath,
+} from '@platform/defaults/workspaceStorage';
 import type { OwnerId } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { UsageLogService } from '@telemetry/UsageLogService';
@@ -116,7 +119,11 @@ export async function initializeElectronPlatform(
   // installing: an opener that uses the synchronous `open` would otherwise
   // face an asynchronous layer build.
   const processStart = await nodeProcesses.selfIdentity();
-  installProcessRuntime(processStart, () => storage.getGlobalStoragePath());
+  installProcessRuntime(
+    processStart,
+    () => storage.getGlobalStoragePath(),
+    () => resolveGlobalStoragePath(userDataPath),
+  );
   const { globalStateStore, workspaceStateStore, configStores, secretsStore } =
     await effectRuntime().runPromise(
       Effect.gen(function* () {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -157,8 +157,10 @@ async function initVscodePlatform(
   // `platform().processes`, read before installing: an opener that uses the
   // synchronous `open` would otherwise face an asynchronous layer build.
   const storage = createNodeStorageProvider({ workspacePath: workspaceRoot });
-  installProcessRuntime(await nodeProcesses.selfIdentity(), () =>
-    storage.getGlobalStoragePath(),
+  installProcessRuntime(
+    await nodeProcesses.selfIdentity(),
+    () => storage.getGlobalStoragePath(),
+    () => storage.getGlobalStoragePath(),
   );
   // VS Code restarts the extension host when the first workspace folder
   // changes, so the configuration stores stay pinned for this process.

--- a/src/controllers/session/Database.ts
+++ b/src/controllers/session/Database.ts
@@ -520,7 +520,8 @@ export const databaseLayer = (
           Effect.gen(function* () {
             if (
               draft.type === 'desktop.projects.changed' ||
-              draft.type === 'inquiry.recorded'
+              draft.type === 'inquiry.recorded' ||
+              draft.type === 'update.check.recorded'
             ) {
               // Profile-state writes own their aggregate only during this transaction.
               yield* sql.unsafe<Record<string, unknown>>(claim, [
@@ -704,7 +705,8 @@ export const databaseLayer = (
             }
             if (
               draft.type === 'desktop.projects.changed' ||
-              draft.type === 'inquiry.recorded'
+              draft.type === 'inquiry.recorded' ||
+              draft.type === 'update.check.recorded'
             ) {
               yield* sql.unsafe<Record<string, unknown>>(release, [
                 JSON.stringify([draft.aggregateId]),
@@ -759,6 +761,18 @@ export const databaseLayer = (
           throw new Error('Invalid global inquiry record');
         return event.record;
       };
+      const readUpdateCheck = (host: string) =>
+        Effect.gen(function* () {
+          const row = (yield* sql.unsafe<Record<string, unknown>>(
+            `SELECT ${EVENT_COLUMNS} FROM event e WHERE e.aggregate_id = ? ORDER BY e.seq DESC LIMIT 1`,
+            [qualifyAggregateId('update-check', host)],
+          ))[0];
+          if (row === undefined) return null;
+          const event = decodeEvent(row);
+          if (event.type !== 'update.check.recorded')
+            throw new Error('Invalid update check record');
+          return event.record;
+        });
       const readInquiryRecord = (id: string) =>
         Effect.gen(function* () {
           const row = (yield* sql.unsafe<Record<string, unknown>>(
@@ -804,6 +818,34 @@ export const databaseLayer = (
                 executionChildren,
                 [id],
               )).map(decodeEvent);
+            }),
+          ),
+        readUpdateCheck: (host) => query(readUpdateCheck(host)),
+        recordUpdateCheck: (host, change) =>
+          transact(
+            Effect.gen(function* () {
+              const current = yield* readUpdateCheck(host);
+              const record = {
+                lastCheckedAt:
+                  change.type === 'checked'
+                    ? change.at
+                    : (current?.lastCheckedAt ?? null),
+                lastNotifiedVersion:
+                  change.type === 'notified'
+                    ? change.version
+                    : (current?.lastNotifiedVersion ?? null),
+              };
+              const at = yield* Clock.currentTimeMillis;
+              yield* appendPrepared(
+                [
+                  prepareEventDraft({
+                    type: 'update.check.recorded',
+                    aggregateId: qualifyAggregateId('update-check', host),
+                    record,
+                  }),
+                ],
+                at,
+              );
             }),
           ),
         readInquiryRecord: (id) => query(readInquiryRecord(id)),

--- a/src/controllers/session/Database.ts
+++ b/src/controllers/session/Database.ts
@@ -761,12 +761,18 @@ export const databaseLayer = (
           throw new Error('Invalid global inquiry record');
         return event.record;
       };
+      const latestEventRow = (id: AggregateId) =>
+        sql
+          .unsafe<Record<string, unknown>>(
+            `SELECT ${EVENT_COLUMNS} FROM event e WHERE e.aggregate_id = ? ORDER BY e.seq DESC LIMIT 1`,
+            [id],
+          )
+          .pipe(Effect.map((rows) => rows[0]));
       const readUpdateCheck = (host: string) =>
         Effect.gen(function* () {
-          const row = (yield* sql.unsafe<Record<string, unknown>>(
-            `SELECT ${EVENT_COLUMNS} FROM event e WHERE e.aggregate_id = ? ORDER BY e.seq DESC LIMIT 1`,
-            [qualifyAggregateId('update-check', host)],
-          ))[0];
+          const row = yield* latestEventRow(
+            qualifyAggregateId('update-check', host),
+          );
           if (row === undefined) return null;
           const event = decodeEvent(row);
           if (event.type !== 'update.check.recorded')
@@ -775,10 +781,9 @@ export const databaseLayer = (
         });
       const readInquiryRecord = (id: string) =>
         Effect.gen(function* () {
-          const row = (yield* sql.unsafe<Record<string, unknown>>(
-            `SELECT ${EVENT_COLUMNS} FROM event e WHERE e.aggregate_id = ? ORDER BY e.seq DESC LIMIT 1`,
-            [qualifyAggregateId('global-inquiry', id)],
-          ))[0];
+          const row = yield* latestEventRow(
+            qualifyAggregateId('global-inquiry', id),
+          );
           return row === undefined ? null : inquiryRecordFromRow(row);
         });
       return {
@@ -887,10 +892,7 @@ export const databaseLayer = (
         readDesktopProjects: (id) =>
           query(
             Effect.gen(function* () {
-              const row = (yield* sql.unsafe<Record<string, unknown>>(
-                `SELECT ${EVENT_COLUMNS} FROM event e WHERE e.aggregate_id = ? ORDER BY e.seq DESC LIMIT 1`,
-                [id],
-              ))[0];
+              const row = yield* latestEventRow(id);
               return row === undefined ? undefined : decodeEvent(row);
             }),
           ),

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -78,6 +78,7 @@ import { Database } from '@shared/session/database';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 import { StreamSnapshotStore } from '@transcript/StreamSnapshotStore';
 import { inquiryRecordsLayer } from './inquiryRecords';
+import { updateCheckRecordsLayer } from './updateCheckRecords';
 import { databaseLayer } from './Database';
 import { collectPendingDeletions } from './deletionCleanup';
 import { sessionRequests } from './SessionRequests';
@@ -765,6 +766,7 @@ const closeSession = (root: string, signal?: AbortSignal) =>
 export function installProcessRuntime(
   processStart: string | undefined | Promise<string | undefined>,
   globalStorage: () => string,
+  updateCheckStorage: () => string,
 ): void {
   const identity =
     processStart instanceof Promise
@@ -779,9 +781,10 @@ export function installProcessRuntime(
           ),
         )
       : ProcessIdentity.layer(processOwnerId(processStart));
-  const services = inquiryRecordsLayer(globalStorage).pipe(
-    Layer.provideMerge(identity),
-  );
+  const services = Layer.merge(
+    inquiryRecordsLayer(globalStorage),
+    updateCheckRecordsLayer(updateCheckStorage),
+  ).pipe(Layer.provideMerge(identity));
   const release = (key: SessionKey): void => {
     runtime.runFork(Effect.flatMap(Sessions, (s) => s.invalidate(key)));
   };

--- a/src/controllers/session/updateCheckRecords.ts
+++ b/src/controllers/session/updateCheckRecords.ts
@@ -1,0 +1,51 @@
+/** Each update-record operation releases SQLite before fetching or notifying. */
+import { Effect, Layer } from 'effect';
+import { Database } from '@shared/session/database';
+import { ProcessIdentity } from '@shared/session/sessionEvents';
+import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
+import { ensureError } from '@utils/errors/errorMessage';
+import { databaseLayer } from './Database';
+import { WorkspaceRoots } from './WorkspaceRoots';
+
+export const updateCheckRecordsLayer = (storagePath: () => string) =>
+  Layer.effect(
+    UpdateCheckRecords,
+    Effect.gen(function* () {
+      const identity = yield* ProcessIdentity;
+      const withDatabase = <A, E>(operation: Effect.Effect<A, E, Database>) =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const storage = yield* Effect.try({
+              try: storagePath,
+              catch: ensureError,
+            });
+            return yield* operation.pipe(
+              Effect.provide(
+                databaseLayer('persistent').pipe(
+                  Layer.provide(Layer.succeed(WorkspaceRoots)({ storage })),
+                  Layer.provide(Layer.succeed(ProcessIdentity)(identity)),
+                ),
+              ),
+            );
+          }),
+        );
+      return {
+        read: (host) =>
+          withDatabase(
+            Effect.flatMap(Database, (db) => db.readUpdateCheck(host)),
+          ),
+        recordChecked: (host, at) =>
+          withDatabase(
+            Effect.flatMap(Database, (db) =>
+              db.recordUpdateCheck(host, { type: 'checked', at }),
+            ),
+          ),
+        recordNotified: (host, version) =>
+          withDatabase(
+            Effect.flatMap(Database, (db) =>
+              db.recordUpdateCheck(host, { type: 'notified', version }),
+            ),
+          ),
+      };
+    }),
+  );

--- a/src/platform/processRuntime.ts
+++ b/src/platform/processRuntime.ts
@@ -6,12 +6,13 @@
  * Promise-facing methods; inside, cancellation is fiber interruption.
  * Installed like the process roots: exactly once, by the entry.
  */
+import type { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 import type { InquiryRecords } from '@shared/session/inquiryRecords';
 import type { ManagedRuntime } from 'effect';
 import type { HttpClient } from 'effect/unstable/http';
 
 export type ProcessRuntime = ManagedRuntime.ManagedRuntime<
-  HttpClient.HttpClient | InquiryRecords,
+  HttpClient.HttpClient | InquiryRecords | UpdateCheckRecords,
   never
 >;
 

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -86,3 +86,5 @@ export * from './streamState';
 export * from './streamSnapshot';
 export * from './sessionEvent';
 export * from './traceEvent';
+
+export * from './updateCheck';

--- a/src/shared/schemas/sessionEvent.ts
+++ b/src/shared/schemas/sessionEvent.ts
@@ -21,6 +21,7 @@ import { z } from 'zod';
 import { parseJsonWith } from '@common/parsing/safeParseJson';
 
 import { TexraApprovalPolicySchema } from '@shared/approvalPolicy';
+import { UpdateCheckRecordSchema } from './updateCheck';
 import { AgentCategorySchema } from './agent';
 import { AgentConfigFieldsSchema } from './agentConfig';
 import { GoalStateSchema } from './goal';
@@ -104,6 +105,7 @@ const AggregateKeySchema = z.tuple([
     'session',
     'desktop-projects',
     'global-inquiry',
+    'update-check',
   ]),
   z.string().min(1),
 ]);
@@ -381,11 +383,17 @@ const GlobalInquiryDraftSchema = durable(
   { record: InquiryThreadRecordSchema },
   'global-inquiry',
 );
+const UpdateCheckDraftSchema = durable(
+  'update.check.recorded',
+  { record: UpdateCheckRecordSchema },
+  'update-check',
+);
 export const SessionEventDraftSchema = z.discriminatedUnion('type', [
   ...DisplaySessionEventDraftSchema.options,
   ...ExecutionEventDraftSchema.options,
   DesktopProjectsDraftSchema,
   GlobalInquiryDraftSchema,
+  UpdateCheckDraftSchema,
 ]);
 const DisplaySessionEventSchema = z.discriminatedUnion('type', [
   RunStartEventSchema.extend(envelope).refine(
@@ -419,6 +427,7 @@ export const SessionEventSchema = z.discriminatedUnion('type', [
   ...ExecutionEventDraftSchema.options.map((schema) => schema.extend(envelope)),
   DesktopProjectsDraftSchema.extend(envelope),
   GlobalInquiryDraftSchema.extend(envelope),
+  UpdateCheckDraftSchema.extend(envelope),
 ]);
 export type SessionEvent = z.infer<typeof SessionEventSchema>;
 

--- a/src/shared/schemas/updateCheck.ts
+++ b/src/shared/schemas/updateCheck.ts
@@ -1,0 +1,15 @@
+/** Persisted update notification state, isolated by host and configured storage root. */
+import { z } from 'zod';
+
+const UpdateCheckHostSchema = z.enum(['cli', 'desktop']);
+export type UpdateCheckHost = z.infer<typeof UpdateCheckHostSchema>;
+export const UpdateCheckRecordSchema = z.object({
+  lastCheckedAt: z.int().nonnegative().nullable(),
+  lastNotifiedVersion: z.string().min(1).nullable(),
+});
+export type UpdateCheckRecord = z.infer<typeof UpdateCheckRecordSchema>;
+const UpdateCheckChangeSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('checked'), at: z.int().nonnegative() }),
+  z.object({ type: z.literal('notified'), version: z.string().min(1) }),
+]);
+export type UpdateCheckChange = z.infer<typeof UpdateCheckChangeSchema>;

--- a/src/shared/session/database.ts
+++ b/src/shared/session/database.ts
@@ -17,6 +17,9 @@ import type {
   SessionEventDraft,
   InquiryThreadRecord,
   InquiryThreadId,
+  UpdateCheckHost,
+  UpdateCheckRecord,
+  UpdateCheckChange,
 } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -112,6 +115,13 @@ export class Database extends Context.Service<
     readonly readDesktopProjects: (
       id: AggregateId,
     ) => Effect.Effect<SessionEvent | undefined, DatabaseReadFailed>;
+    readonly readUpdateCheck: (
+      host: UpdateCheckHost,
+    ) => Effect.Effect<UpdateCheckRecord | null, DatabaseReadFailed>;
+    readonly recordUpdateCheck: (
+      host: UpdateCheckHost,
+      change: UpdateCheckChange,
+    ) => Effect.Effect<void, DatabaseWriteFailed>;
     /** Canonical global inquiry content, never a project display projection. */
     readonly readInquiryRecord: (
       id: InquiryThreadId,

--- a/src/shared/session/updateCheckRecords.ts
+++ b/src/shared/session/updateCheckRecords.ts
@@ -1,0 +1,20 @@
+/** Update-check persistence configured by the process's host. */
+import { Context, type Effect } from 'effect';
+import type { UpdateCheckHost, UpdateCheckRecord } from '@shared/schemas';
+
+export class UpdateCheckRecords extends Context.Service<
+  UpdateCheckRecords,
+  {
+    readonly read: (
+      host: UpdateCheckHost,
+    ) => Effect.Effect<UpdateCheckRecord | null, Error>;
+    readonly recordChecked: (
+      host: UpdateCheckHost,
+      at: number,
+    ) => Effect.Effect<void, Error>;
+    readonly recordNotified: (
+      host: UpdateCheckHost,
+      version: string,
+    ) => Effect.Effect<void, Error>;
+  }
+>()('@texra/UpdateCheckRecords') {}

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -138,13 +138,6 @@ export enum GlobalStateKey {
   // Tool settings
   DISABLED_TOOLS = 'texra.tools.disabled',
 
-  // Desktop-only lightweight update check (see desktopUpdateChecker.ts)
-  DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT = 'texra.desktop.updateCheck.lastCheckedAt',
-  DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION = 'texra.desktop.updateCheck.lastNotifiedVersion',
-
-  // CLI-only lightweight update check throttle (see packages/cli's updateChecker.ts)
-  CLI_UPDATE_CHECK_LAST_CHECKED_AT = 'texra.cli.updateCheck.lastCheckedAt',
-
   // Dismissable main-view hints. Written only by the banner's own close
   // button, read only to decide whether to show that banner again.
   LOGIN_BANNER_DISMISSED = 'texra.ui.loginBannerDismissed',

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
@@ -2,6 +2,7 @@
 import { it } from '@effect/vitest';
 import { Effect, Exit, Fiber } from 'effect';
 import { beforeEach, describe, expect, type Mock, vi } from 'vitest';
+import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 
 // Local imports
 import { testHttpClientLayer } from '@test/support/fetchTestUtils';
@@ -92,8 +93,9 @@ async function loadSupabaseAuth() {
   const storage = createFakePlatform().storage;
   initProcessRuntime(
     ManagedRuntime.make(
-      Layer.merge(
+      Layer.mergeAll(
         testHttpClientLayer,
+        Layer.mock(UpdateCheckRecords, {}),
         inquiryRecordsLayer(() => storage.getGlobalStoragePath()).pipe(
           Layer.provide(ProcessIdentity.layer(processOwnerId(undefined))),
         ),

--- a/src/test-kernel/cli/ClipboardText.vitest.ts
+++ b/src/test-kernel/cli/ClipboardText.vitest.ts
@@ -27,6 +27,7 @@ import { disposeProcessRuntime } from '@controllers/session/sessionLayer';
 import { initProcessRuntime } from '@platform/processRuntime';
 import { processOwnerId } from '@platform/defaults/nodeProcesses';
 import { ProcessIdentity } from '@shared/session/sessionEvents';
+import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { testHttpClientLayer } from '@test/support/fetchTestUtils';
 
@@ -97,8 +98,9 @@ describe('CLI clipboard text writer', () => {
       const storage = createFakePlatform().storage;
       initProcessRuntime(
         ManagedRuntime.make(
-          Layer.merge(
+          Layer.mergeAll(
             testHttpClientLayer,
+            Layer.mock(UpdateCheckRecords, {}),
             inquiryRecordsLayer(() => storage.getGlobalStoragePath()).pipe(
               Layer.provide(ProcessIdentity.layer(processOwnerId(undefined))),
             ),

--- a/src/test-kernel/cli/UpdateChecker.vitest.ts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.ts
@@ -1,3 +1,5 @@
+import { it as effectIt } from '@effect/vitest';
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -122,7 +124,7 @@ describe('buildUpdateCommand', () => {
 });
 
 describe('fetchLatestCliVersion', () => {
-  it.each([
+  effectIt.effect.each([
     {
       name: 'returns the version field from the latest dist-tag',
       fetchImpl: async () => jsonResponse({ version: '9.9.9' }),
@@ -145,11 +147,13 @@ describe('fetchLatestCliVersion', () => {
       fetchImpl: async () => jsonResponse({}),
       expected: undefined,
     },
-  ])('$name', async ({ fetchImpl, expected }) => {
-    await expect(
-      fetchLatestCliVersion({ fetchImpl: fetchImpl as typeof fetch }),
-    ).resolves.toBe(expected);
-  });
+  ])('$name', ({ fetchImpl, expected }) =>
+    Effect.gen(function* () {
+      expect(
+        yield* fetchLatestCliVersion({ fetchImpl: fetchImpl as typeof fetch }),
+      ).toBe(expected);
+    }),
+  );
 });
 
 describe('fetchLatestHomebrewFormulaVersion', () => {
@@ -256,18 +260,22 @@ describe('notifyCliUpdate', () => {
     });
   });
 
-  it('runs the check at most once per process', async () => {
-    await notifyCliUpdate(context);
-    await notifyCliUpdate(context);
+  effectIt.live('runs the check at most once per process', () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() => notifyCliUpdate(context));
+      yield* Effect.promise(() => notifyCliUpdate(context));
 
-    expect(mocks.readCliAmbientState).toHaveBeenCalledTimes(1);
-  });
+      expect(mocks.readCliAmbientState).toHaveBeenCalledTimes(1);
+    }),
+  );
 
-  it('starts a fresh check once the latch is cleared', async () => {
-    await notifyCliUpdate(context);
-    resetCliUpdateNotifyLatchForTests();
-    await notifyCliUpdate(context);
+  effectIt.live('starts a fresh check once the latch is cleared', () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() => notifyCliUpdate(context));
+      resetCliUpdateNotifyLatchForTests();
+      yield* Effect.promise(() => notifyCliUpdate(context));
 
-    expect(mocks.readCliAmbientState).toHaveBeenCalledTimes(2);
-  });
+      expect(mocks.readCliAmbientState).toHaveBeenCalledTimes(2);
+    }),
+  );
 });

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts
@@ -6,6 +6,7 @@ import { DefaultDesktopAgentSettingsController } from '@desktop/main/desktopAgen
 import { initProcessRuntime } from '@platform/processRuntime';
 import { processOwnerId } from '@platform/defaults/nodeProcesses';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 import { ProcessIdentity } from '@shared/session/sessionEvents';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { assertSupported, isUnsupported } from '@shared/utils/dispatcher';
@@ -46,8 +47,9 @@ beforeEach(() => {
   const storage = createFakePlatform().storage;
   initProcessRuntime(
     ManagedRuntime.make(
-      Layer.merge(
+      Layer.mergeAll(
         testHttpClientLayer,
+        Layer.mock(UpdateCheckRecords, {}),
         inquiryRecordsLayer(() => storage.getGlobalStoragePath()).pipe(
           Layer.provide(ProcessIdentity.layer(processOwnerId(undefined))),
         ),

--- a/src/test-kernel/desktop/DesktopUpdateChecker.vitest.ts
+++ b/src/test-kernel/desktop/DesktopUpdateChecker.vitest.ts
@@ -1,113 +1,117 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import { it } from '@effect/vitest';
+import { Deferred, Effect, Fiber, FileSystem, Layer } from 'effect';
+import { describe, expect, vi } from 'vitest';
+import { updateCheckRecordsLayer } from '@controllers/session/updateCheckRecords';
+import {
+  checkForDesktopUpdate,
+  DESKTOP_RELEASES_PAGE_URL,
+} from '@desktop/main/desktopUpdateChecker';
+import { processOwnerId } from '@platform/defaults/nodeProcesses';
+import { ProcessIdentity } from '@shared/session/sessionEvents';
+import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 
-import { GlobalStateKey } from '@shared/state/stateKeys';
-import { FakeStateStore } from '@test/support/FakePlatform';
-
-import { loadSourceModule } from './loadSourceModule.ts';
-
-type DesktopUpdateCheckerModule =
-  typeof import('@desktop/main/desktopUpdateChecker');
-type CheckForDesktopUpdateOptions = Parameters<
-  DesktopUpdateCheckerModule['checkForDesktopUpdate']
->[0];
-type DesktopLatestRelease = Parameters<
-  CheckForDesktopUpdateOptions['notify']
->[0];
+type Options = Parameters<typeof checkForDesktopUpdate>[0];
+const release = { version: '0.40.0' };
+const runCheck = (overrides: Partial<Options> = {}) =>
+  checkForDesktopUpdate({
+    currentVersion: '0.39.3',
+    isPackaged: true,
+    env: {},
+    notify: () => {},
+    fetchRelease: Effect.succeed(release),
+    ...overrides,
+  });
+const withRecords = <A, E>(program: Effect.Effect<A, E, UpdateCheckRecords>) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const storage = yield* fs.makeTempDirectoryScoped({
+        prefix: 'texra-desktop-update-',
+      });
+      return yield* program.pipe(
+        Effect.provide(
+          updateCheckRecordsLayer(() => storage).pipe(
+            Layer.provide(ProcessIdentity.layer(processOwnerId(undefined))),
+          ),
+        ),
+      );
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer));
 
 describe('desktop update checker', () => {
-  it('exposes a known-constant releases page URL (never opens API-provided URLs)', async () => {
-    const { DESKTOP_RELEASES_PAGE_URL } = await loadSourceModule(
-      '@desktop/main/desktopUpdateChecker',
-    );
-
+  it('exposes a known-constant releases page URL (never opens API-provided URLs)', () => {
     expect(DESKTOP_RELEASES_PAGE_URL).toBe(
       'https://github.com/texra-ai/texra-desktop-releases/releases',
     );
   });
-
-  describe('checkForDesktopUpdate', () => {
-    const release: DesktopLatestRelease = {
-      version: '0.40.0',
-    };
-    const CURRENT_VERSION = '0.39.3';
-    let checkForDesktopUpdate: DesktopUpdateCheckerModule['checkForDesktopUpdate'];
-    let globalState: FakeStateStore;
-
-    beforeEach(async () => {
-      ({ checkForDesktopUpdate } = await loadSourceModule(
-        '@desktop/main/desktopUpdateChecker',
-      ));
-      globalState = new FakeStateStore();
-    });
-
-    /** One check with the packaged, update-enabled defaults these cases share. */
-    function runCheck(
-      overrides: Partial<CheckForDesktopUpdateOptions> = {},
-    ): Promise<void> {
-      return checkForDesktopUpdate({
-        currentVersion: CURRENT_VERSION,
-        globalState,
-        isPackaged: true,
-        env: {},
-        notify: () => {},
-        fetchRelease: async () => release,
-        ...overrides,
-      });
-    }
-
-    it('skips entirely for unpackaged (dev) runs', async () => {
-      const notify = vi.fn();
-      const fetchRelease = vi.fn(async () => release);
-
-      await runCheck({ isPackaged: false, notify, fetchRelease });
-
-      expect(fetchRelease).not.toHaveBeenCalled();
-      expect(notify).not.toHaveBeenCalled();
-    });
-
-    it('skips entirely when TEXRA_NO_UPDATE_CHECK is set', async () => {
-      const fetchRelease = vi.fn(async () => release);
-
-      await runCheck({ env: { TEXRA_NO_UPDATE_CHECK: '1' }, fetchRelease });
-
-      expect(fetchRelease).not.toHaveBeenCalled();
-    });
-
-    // Wiring smoke case: the throttle/no-repeat semantics themselves are
-    // owned by SemverUpdateCheck.vitest.ts (runDailyUpdateCheck); this pins
-    // that desktop actually wires the once-per-release key through.
-    it('notifies once when a newer release is found, and persists the notified version', async () => {
-      const notify = vi.fn();
-
-      await runCheck({ notify });
-
-      expect(notify).toHaveBeenCalledExactlyOnceWith(release);
-      expect(
-        globalState.get(
-          GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
-        ),
-      ).toBe('0.40.0');
-    });
-
-    it('coalesces concurrent checks into one fetch and notification', async () => {
-      let resolveFetch: ((value: DesktopLatestRelease) => void) | undefined;
-      const pendingRelease = new Promise<DesktopLatestRelease>((resolve) => {
-        resolveFetch = resolve;
-      });
-      const fetchRelease = vi.fn(() => pendingRelease);
-      const firstNotify = vi.fn();
-      const secondNotify = vi.fn();
-
-      const first = runCheck({ notify: firstNotify, fetchRelease });
-      const second = runCheck({ notify: secondNotify, fetchRelease });
-      expect(fetchRelease).toHaveBeenCalledOnce();
-
-      resolveFetch?.(release);
-      await Promise.all([first, second]);
-
-      expect(fetchRelease).toHaveBeenCalledOnce();
-      expect(firstNotify).not.toHaveBeenCalled();
-      expect(secondNotify).toHaveBeenCalledOnce();
-    });
-  });
+  it.live('skips entirely for unpackaged (dev) runs', () =>
+    withRecords(
+      Effect.gen(function* () {
+        const notify = vi.fn();
+        const fetchRelease = vi.fn(() => release);
+        yield* runCheck({
+          isPackaged: false,
+          notify,
+          fetchRelease: Effect.sync(fetchRelease),
+        });
+        expect(fetchRelease).not.toHaveBeenCalled();
+        expect(notify).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+  it.live('skips entirely when TEXRA_NO_UPDATE_CHECK is set', () =>
+    withRecords(
+      Effect.gen(function* () {
+        const fetchRelease = vi.fn(() => release);
+        yield* runCheck({
+          env: { TEXRA_NO_UPDATE_CHECK: '1' },
+          fetchRelease: Effect.sync(fetchRelease),
+        });
+        expect(fetchRelease).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+  it.live(
+    'notifies once when a newer release is found, and persists the notified version',
+    () =>
+      withRecords(
+        Effect.gen(function* () {
+          const records = yield* UpdateCheckRecords;
+          const notify = vi.fn();
+          yield* runCheck({ notify });
+          expect(notify).toHaveBeenCalledExactlyOnceWith(release);
+          expect((yield* records.read('desktop'))?.lastNotifiedVersion).toBe(
+            '0.40.0',
+          );
+        }),
+      ),
+  );
+  it.live('coalesces concurrent checks into one fetch and notification', () =>
+    withRecords(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>();
+        const pending = yield* Deferred.make<typeof release>();
+        const fetched = vi.fn();
+        const fetchRelease = Effect.gen(function* () {
+          fetched();
+          yield* Deferred.succeed(started, undefined);
+          return yield* Deferred.await(pending);
+        });
+        const firstNotify = vi.fn();
+        const secondNotify = vi.fn();
+        const first = yield* Effect.forkChild(
+          runCheck({ notify: firstNotify, fetchRelease }),
+        );
+        yield* Deferred.await(started);
+        yield* runCheck({ notify: secondNotify, fetchRelease });
+        expect(fetched).toHaveBeenCalledOnce();
+        yield* Deferred.succeed(pending, release);
+        yield* Fiber.join(first);
+        expect(fetched).toHaveBeenCalledOnce();
+        expect(firstNotify).not.toHaveBeenCalled();
+        expect(secondNotify).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
 });

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -25,6 +25,7 @@ import { nodeHostEnvironment } from '@platform/defaults/nodeHostEnvironment';
 import { nodeProcesses } from '@platform/defaults/nodeProcesses';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 import { ProcessIdentity } from '@shared/session/sessionEvents';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { testHttpClientLayer } from '@test/support/fetchTestUtils';
@@ -106,8 +107,9 @@ describe('desktop agent directory bootstrap', () => {
       } catch {
         initProcessRuntime(
           ManagedRuntime.make(
-            Layer.merge(
+            Layer.mergeAll(
               testHttpClientLayer,
+              Layer.mock(UpdateCheckRecords, {}),
               inquiryRecordsLayer(() => storage.getGlobalStoragePath()).pipe(
                 Layer.provide(ProcessIdentity.layer(processOwnerId(undefined))),
               ),

--- a/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
+++ b/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
@@ -7,6 +7,7 @@ import { inquiryRecordsLayer } from '@controllers/session/inquiryRecords';
 import { initProcessRuntime } from '@platform/processRuntime';
 import { processOwnerId } from '@platform/defaults/nodeProcesses';
 import { AgentHandlers } from '@settingsView/handlers/agentHandlers';
+import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 import { ProcessIdentity } from '@shared/session/sessionEvents';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { testHttpClientLayer } from '@test/support/fetchTestUtils';
@@ -148,8 +149,9 @@ describe('AgentHandlers custom-agent file actions', () => {
     const storage = createFakePlatform().storage;
     initProcessRuntime(
       ManagedRuntime.make(
-        Layer.merge(
+        Layer.mergeAll(
           testHttpClientLayer,
+          Layer.mock(UpdateCheckRecords, {}),
           inquiryRecordsLayer(() => storage.getGlobalStoragePath()).pipe(
             Layer.provide(ProcessIdentity.layer(processOwnerId(undefined))),
           ),

--- a/src/test-kernel/support/sessionGraphTestSetup.ts
+++ b/src/test-kernel/support/sessionGraphTestSetup.ts
@@ -23,8 +23,10 @@ let installed = false;
 export function installTestSessionGraphs(): void {
   if (installed) return;
   installed = true;
-  installProcessRuntime('vitest', () =>
-    createFakePlatform().storage.getGlobalStoragePath(),
+  installProcessRuntime(
+    'vitest',
+    () => createFakePlatform().storage.getGlobalStoragePath(),
+    () => createFakePlatform().storage.getGlobalStoragePath(),
   );
 }
 

--- a/src/test-kernel/support/setupPlatform.ts
+++ b/src/test-kernel/support/setupPlatform.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach } from 'vitest';
 
 import type { Platform } from '@platform/platform';
 import type { WorkspaceRoots } from '@platform/workspaceRoots';
+import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 import { InquiryRecords } from '@shared/session/inquiryRecords';
 import {
   createFakePlatform,
@@ -82,8 +83,9 @@ export async function installFakeHost(host: FakeHost): Promise<void> {
   } catch {
     initProcessRuntime(
       ManagedRuntime.make(
-        Layer.merge(
+        Layer.mergeAll(
           testHttpClientLayer,
+          Layer.mock(UpdateCheckRecords, {}),
           // Suites using inquiries install the real service with their session
           // graph. Any inquiry call on this bare fake host is a test error.
           Layer.mock(InquiryRecords, {}),

--- a/src/test-kernel/utils/system/SemverUpdateCheck.vitest.ts
+++ b/src/test-kernel/utils/system/SemverUpdateCheck.vitest.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
 import { it as effectIt } from '@effect/vitest';
-import { Effect, FileSystem, Layer } from 'effect';
+import { Effect, Exit, Fiber, FileSystem, Layer } from 'effect';
 import { TestClock } from 'effect/testing';
 import { updateCheckRecordsLayer } from '@controllers/session/updateCheckRecords';
 import { processOwnerId } from '@platform/defaults/nodeProcesses';
@@ -176,6 +176,35 @@ describe('runDailyUpdateCheck', () => {
           expect((yield* records.read('desktop'))?.lastNotifiedVersion).toBe(
             '1.1.0',
           );
+        }),
+      ),
+  );
+
+  effectIt.live(
+    'records an announced release before honoring interruption',
+    () =>
+      withRecords(
+        Effect.gen(function* () {
+          const records = yield* UpdateCheckRecords;
+          const checking = yield* Effect.forkChild(
+            Effect.withFiber((fiber) =>
+              runDailyUpdateCheck(
+                checkOptions({
+                  notifyOnce: true,
+                  fetchLatest: Effect.succeed({
+                    version: '1.1.0',
+                    refreshed: true,
+                  }),
+                  notify: () => Effect.sync(() => fiber.interruptUnsafe()),
+                }),
+              ),
+            ),
+          );
+          expect(Exit.isFailure(yield* Fiber.await(checking))).toBe(true);
+          expect(yield* records.read('desktop')).toEqual({
+            lastNotifiedVersion: '1.1.0',
+            lastCheckedAt: null,
+          });
         }),
       ),
   );

--- a/src/test-kernel/utils/system/SemverUpdateCheck.vitest.ts
+++ b/src/test-kernel/utils/system/SemverUpdateCheck.vitest.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { FakeStateStore } from '@test/support/FakePlatform';
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import { it as effectIt } from '@effect/vitest';
+import { Effect, FileSystem, Layer } from 'effect';
+import { TestClock } from 'effect/testing';
+import { updateCheckRecordsLayer } from '@controllers/session/updateCheckRecords';
+import { processOwnerId } from '@platform/defaults/nodeProcesses';
+import { ProcessIdentity } from '@shared/session/sessionEvents';
+import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 import { isNewerSemverVersion } from '@utils/system/semverUpdateCheck';
 import {
   fetchJsonStringField,
@@ -32,177 +39,213 @@ describe('isNewerSemverVersion', () => {
 
 describe('runDailyUpdateCheck', () => {
   const nowMs = Date.UTC(2026, 0, 1);
-  const lastCheckedAtKey = 'update.lastCheckedAt';
-  const lastNotifiedVersionKey = 'update.lastNotifiedVersion';
-
   type CheckOptions = Parameters<typeof runDailyUpdateCheck>[0];
-
-  function checkOptions(
-    state: FakeStateStore,
+  const checkOptions = (
     overrides: Partial<CheckOptions> = {},
-  ): CheckOptions {
-    return {
-      currentVersion: '1.0.0',
-      state,
-      lastCheckedAtKey,
-      fetchLatest: async () => ({ version: '1.0.0', refreshed: true }),
-      notify: () => {},
-      now: () => nowMs,
-      ...overrides,
-    };
-  }
-
-  it('notifies before stamping a successful live check', async () => {
-    const state = new FakeStateStore();
-    let stampDuringNotify: number | undefined;
-
-    const latest = await runDailyUpdateCheck(
-      checkOptions(state, {
-        fetchLatest: async () => ({ version: '1.1.0', refreshed: true }),
-        notify: () => {
-          stampDuringNotify = state.get(lastCheckedAtKey);
-        },
+  ): CheckOptions => ({
+    currentVersion: '1.0.0',
+    host: 'desktop',
+    fetchLatest: Effect.succeed({ version: '1.0.0', refreshed: true }),
+    notify: () => Effect.void,
+    ...overrides,
+  });
+  const withRecords = <A, E>(
+    program: Effect.Effect<A, E, UpdateCheckRecords | TestClock.TestClock>,
+  ) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const storage = yield* fs.makeTempDirectoryScoped({
+          prefix: 'texra-update-check-',
+        });
+        yield* TestClock.setTime(nowMs);
+        return yield* program.pipe(
+          Effect.provide(
+            updateCheckRecordsLayer(() => storage).pipe(
+              Layer.provide(ProcessIdentity.layer(processOwnerId(undefined))),
+            ),
+          ),
+        );
       }),
+    ).pipe(
+      Effect.provide(NodeFileSystem.layer),
+      Effect.provide(TestClock.layer()),
     );
 
-    expect(latest).toBe('1.1.0');
-    expect(stampDuringNotify).toBeUndefined();
-    expect(state.get(lastCheckedAtKey)).toBe(nowMs);
-  });
-
-  it('does not repeat a release notification but still stamps a live refresh', async () => {
-    const state = new FakeStateStore({
-      [lastNotifiedVersionKey]: '1.1.0',
-    });
-    const notify = vi.fn();
-
-    await runDailyUpdateCheck(
-      checkOptions(state, {
-        lastNotifiedVersionKey,
-        fetchLatest: async () => ({ version: '1.1.0', refreshed: true }),
-        notify,
+  effectIt.live('notifies before stamping a successful live check', () =>
+    withRecords(
+      Effect.gen(function* () {
+        const records = yield* UpdateCheckRecords;
+        let stampDuringNotify: number | null | undefined;
+        const latest = yield* runDailyUpdateCheck(
+          checkOptions({
+            fetchLatest: Effect.succeed({ version: '1.1.0', refreshed: true }),
+            notify: () =>
+              Effect.gen(function* () {
+                stampDuringNotify = (yield* records.read('desktop'))
+                  ?.lastCheckedAt;
+              }),
+          }),
+        );
+        expect(latest).toBe('1.1.0');
+        expect(stampDuringNotify).toBeUndefined();
+        expect((yield* records.read('desktop'))?.lastCheckedAt).toBe(nowMs);
       }),
-    );
+    ),
+  );
 
-    expect(notify).not.toHaveBeenCalled();
-    expect(state.get(lastCheckedAtKey)).toBe(nowMs);
-  });
+  effectIt.live(
+    'does not repeat a release notification but still stamps a live refresh',
+    () =>
+      withRecords(
+        Effect.gen(function* () {
+          const records = yield* UpdateCheckRecords;
+          yield* records.recordNotified('desktop', '1.1.0');
+          const notify = vi.fn(() => Effect.void);
+          yield* runDailyUpdateCheck(
+            checkOptions({
+              notifyOnce: true,
+              fetchLatest: Effect.succeed({
+                version: '1.1.0',
+                refreshed: true,
+              }),
+              notify,
+            }),
+          );
+          expect(notify).not.toHaveBeenCalled();
+          expect((yield* records.read('desktop'))?.lastCheckedAt).toBe(nowMs);
+        }),
+      ),
+  );
 
-  it('throttles a repeat check within the same day', async () => {
-    const state = new FakeStateStore();
-    const fetchLatest = vi.fn(async () => ({
-      version: '1.0.0',
-      refreshed: true,
-    }));
-    let clockMs = nowMs;
-    const options = checkOptions(state, { fetchLatest, now: () => clockMs });
-
-    await runDailyUpdateCheck(options);
-    expect(fetchLatest).toHaveBeenCalledTimes(1);
-
-    // Ten minutes later: still inside the daily window, no fetch.
-    clockMs += 10 * 60 * 1000;
-    await runDailyUpdateCheck(options);
-    expect(fetchLatest).toHaveBeenCalledTimes(1);
-
-    // A full day later: the throttle window has elapsed.
-    clockMs += 24 * 60 * 60 * 1000;
-    await runDailyUpdateCheck(options);
-    expect(fetchLatest).toHaveBeenCalledTimes(2);
-  });
-
-  it('does not notify when the latest version is not newer', async () => {
-    const state = new FakeStateStore();
-    const notify = vi.fn();
-
-    await expect(
-      runDailyUpdateCheck(checkOptions(state, { notify })),
-    ).resolves.toBeUndefined();
-
-    expect(notify).not.toHaveBeenCalled();
-    // A live refresh still stamps the throttle even without a notification.
-    expect(state.get(lastCheckedAtKey)).toBe(nowMs);
-  });
-
-  it('retries a failed release notification before recording it as notified', async () => {
-    // A thrown notify must reject the check and leave no stamp or release key,
-    // so the next launch retries instead of silently skipping the announcement.
-    const state = new FakeStateStore();
-    const notify = vi.fn().mockImplementationOnce(() => {
-      throw new Error('dialog failed');
-    });
-    const options = checkOptions(state, {
-      lastNotifiedVersionKey,
-      fetchLatest: async () => ({ version: '1.1.0', refreshed: true }),
-      notify,
-    });
-
-    await expect(runDailyUpdateCheck(options)).rejects.toThrow('dialog failed');
-    expect(state.get(lastCheckedAtKey)).toBeUndefined();
-    expect(state.get(lastNotifiedVersionKey)).toBeUndefined();
-
-    await expect(runDailyUpdateCheck(options)).resolves.toBe('1.1.0');
-    expect(notify).toHaveBeenCalledTimes(2);
-    expect(state.get(lastNotifiedVersionKey)).toBe('1.1.0');
-  });
-
-  it('can offer stale source metadata without stamping the check', async () => {
-    const state = new FakeStateStore();
-    const notify = vi.fn();
-
-    await runDailyUpdateCheck(
-      checkOptions(state, {
-        fetchLatest: async () => ({ version: '1.1.0', refreshed: false }),
-        notify,
+  effectIt.live('throttles a repeat check within the same day', () =>
+    withRecords(
+      Effect.gen(function* () {
+        const fetchLatest = vi.fn(() => ({
+          version: '1.0.0',
+          refreshed: true,
+        }));
+        const options = checkOptions({ fetchLatest: Effect.sync(fetchLatest) });
+        yield* runDailyUpdateCheck(options);
+        expect(fetchLatest).toHaveBeenCalledTimes(1);
+        yield* TestClock.adjust('10 minutes');
+        yield* runDailyUpdateCheck(options);
+        expect(fetchLatest).toHaveBeenCalledTimes(1);
+        yield* TestClock.adjust('24 hours');
+        yield* runDailyUpdateCheck(options);
+        expect(fetchLatest).toHaveBeenCalledTimes(2);
       }),
-    );
+    ),
+  );
 
-    expect(notify).toHaveBeenCalledWith('1.1.0');
-    expect(state.get(lastCheckedAtKey)).toBeUndefined();
-  });
+  effectIt.live('does not notify when the latest version is not newer', () =>
+    withRecords(
+      Effect.gen(function* () {
+        const records = yield* UpdateCheckRecords;
+        const notify = vi.fn(() => Effect.void);
+        expect(
+          yield* runDailyUpdateCheck(checkOptions({ notify })),
+        ).toBeUndefined();
+        expect(notify).not.toHaveBeenCalled();
+        expect((yield* records.read('desktop'))?.lastCheckedAt).toBe(nowMs);
+      }),
+    ),
+  );
 
-  it('applies the host policy when the throttle stamp cannot be persisted', async () => {
-    const state = new FakeStateStore();
-    vi.spyOn(state, 'update').mockRejectedValue(new Error('read-only state'));
-    // With `ignore`, a failed stamp write must still hand back the newer
-    // version, so an update the user already accepted is not cancelled.
-    const options = checkOptions(state, {
-      fetchLatest: async () => ({ version: '1.1.0', refreshed: true }),
-    });
+  effectIt.live(
+    'retries a failed release notification before recording it as notified',
+    () =>
+      withRecords(
+        Effect.gen(function* () {
+          const records = yield* UpdateCheckRecords;
+          const failure = new Error('dialog failed');
+          const notify = vi
+            .fn<CheckOptions['notify']>(() => Effect.void)
+            .mockReturnValueOnce(Effect.fail(failure));
+          const options = checkOptions({
+            notifyOnce: true,
+            fetchLatest: Effect.succeed({ version: '1.1.0', refreshed: true }),
+            notify,
+          });
+          expect(yield* Effect.flip(runDailyUpdateCheck(options))).toBe(
+            failure,
+          );
+          expect(yield* records.read('desktop')).toBeNull();
+          expect(yield* runDailyUpdateCheck(options)).toBe('1.1.0');
+          expect(notify).toHaveBeenCalledTimes(2);
+          expect((yield* records.read('desktop'))?.lastNotifiedVersion).toBe(
+            '1.1.0',
+          );
+        }),
+      ),
+  );
 
-    await expect(
-      runDailyUpdateCheck({ ...options, stampFailure: 'ignore' }),
-    ).resolves.toBe('1.1.0');
-    await expect(runDailyUpdateCheck(options)).rejects.toThrow(
-      'read-only state',
-    );
-  });
+  effectIt.live(
+    'can offer stale source metadata without stamping the check',
+    () =>
+      withRecords(
+        Effect.gen(function* () {
+          const records = yield* UpdateCheckRecords;
+          const notify = vi.fn(() => Effect.void);
+          yield* runDailyUpdateCheck(
+            checkOptions({
+              fetchLatest: Effect.succeed({
+                version: '1.1.0',
+                refreshed: false,
+              }),
+              notify,
+            }),
+          );
+          expect(notify).toHaveBeenCalledWith('1.1.0');
+          expect(yield* records.read('desktop')).toBeNull();
+        }),
+      ),
+  );
 
-  it('ignores a synchronous throttle stamp failure when requested', async () => {
-    const state = new FakeStateStore();
-    vi.spyOn(state, 'update').mockImplementation(() => {
-      throw new Error('read-only state');
-    });
-
-    await expect(
-      runDailyUpdateCheck(checkOptions(state, { stampFailure: 'ignore' })),
-    ).resolves.toBeUndefined();
-  });
+  effectIt.live(
+    'applies the host policy when the throttle stamp cannot be persisted',
+    () =>
+      withRecords(
+        Effect.gen(function* () {
+          const records = yield* UpdateCheckRecords;
+          const failure = new Error('read-only state');
+          const layer = Layer.succeed(UpdateCheckRecords)({
+            ...records,
+            recordChecked: () => Effect.fail(failure),
+          });
+          const options = checkOptions({
+            fetchLatest: Effect.succeed({ version: '1.1.0', refreshed: true }),
+          });
+          expect(
+            yield* runDailyUpdateCheck({
+              ...options,
+              stampFailure: 'ignore',
+            }).pipe(Effect.provide(layer)),
+          ).toBe('1.1.0');
+          expect(
+            yield* Effect.flip(
+              runDailyUpdateCheck(options).pipe(Effect.provide(layer)),
+            ),
+          ).toBe(failure);
+        }),
+      ),
+  );
 });
 
 describe('fetchJsonStringField', () => {
-  it('rejects an empty string field', async () => {
-    const fetchImpl = vi.fn(async () =>
-      Response.json({ version: '' }),
-    ) as unknown as typeof fetch;
-
-    await expect(
-      fetchJsonStringField({
-        url: 'https://example.test/latest',
-        field: 'version',
-        timeoutMs: 1000,
-        fetchImpl,
-      }),
-    ).resolves.toBeUndefined();
-  });
+  effectIt.effect('rejects an empty string field', () =>
+    Effect.gen(function* () {
+      const fetchImpl = vi.fn(async () =>
+        Response.json({ version: '' }),
+      ) as unknown as typeof fetch;
+      expect(
+        yield* fetchJsonStringField({
+          url: 'https://example.test/latest',
+          field: 'version',
+          timeoutMs: 1000,
+          fetchImpl,
+        }),
+      ).toBeUndefined();
+    }),
+  );
 });

--- a/src/utils/system/updateCheck.ts
+++ b/src/utils/system/updateCheck.ts
@@ -55,8 +55,16 @@ export const runDailyUpdateCheck = ({
       latest !== undefined &&
       (!notifyOnce || previous?.lastNotifiedVersion !== latest)
     ) {
-      yield* notify(latest);
-      if (notifyOnce) yield* records.recordNotified(host, latest);
+      if (notifyOnce) {
+        yield* Effect.uninterruptible(
+          Effect.gen(function* () {
+            yield* notify(latest);
+            yield* records.recordNotified(host, latest);
+          }),
+        );
+      } else {
+        yield* notify(latest);
+      }
     }
     if (refreshed) {
       const stamp = records.recordChecked(host, nowMs);

--- a/src/utils/system/updateCheck.ts
+++ b/src/utils/system/updateCheck.ts
@@ -1,4 +1,7 @@
-import type { StateStore } from '@platform/interfaces';
+import { Clock, Effect } from 'effect';
+
+import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
+import { ensureError } from '@utils/errors/errorMessage';
 
 import {
   DAILY_UPDATE_CHECK_INTERVAL_MS,
@@ -15,73 +18,52 @@ export interface UpdateCheckFetchResult {
 
 interface DailyUpdateCheckOptions {
   currentVersion: string;
-  state: StateStore;
-  lastCheckedAtKey: string;
-  /** Persisted version used by hosts that notify only once per release. */
-  lastNotifiedVersionKey?: string;
-  fetchLatest: () => Promise<UpdateCheckFetchResult>;
-  notify: (latest: string) => PromiseLike<void> | void;
-  now?: () => number;
+  host: 'cli' | 'desktop';
+  /** Desktop announces each release only once. */
+  notifyOnce?: boolean;
+  fetchLatest: Effect.Effect<UpdateCheckFetchResult, Error>;
+  notify: (latest: string) => Effect.Effect<void, Error>;
   /** Whether failure to persist the throttle stamp rejects the check. */
   stampFailure?: 'throw' | 'ignore';
 }
 
-/**
- * Run one daily-throttled update check.
- *
- * The throttle stamp is written only after a live source consultation and any
- * required notification. Thus network failures, stale local metadata, and
- * failed notifications all retry on the next launch. Hosts may additionally
- * persist the last notified version when a release should be announced only
- * once, independently of the daily fetch cadence.
- */
-export async function runDailyUpdateCheck({
+/** Consult the source, notify, then persist the successful check in that order. */
+export const runDailyUpdateCheck = ({
   currentVersion,
-  state,
-  lastCheckedAtKey,
-  lastNotifiedVersionKey,
+  host,
+  notifyOnce = false,
   fetchLatest,
   notify,
-  now = Date.now,
   stampFailure = 'throw',
-}: DailyUpdateCheckOptions): Promise<string | undefined> {
-  const lastCheckedAt = state.get<number>(lastCheckedAtKey, 0);
-  const nowMs = now();
-  if (nowMs - lastCheckedAt < DAILY_UPDATE_CHECK_INTERVAL_MS) return undefined;
+}: DailyUpdateCheckOptions) =>
+  Effect.gen(function* () {
+    const records = yield* UpdateCheckRecords;
+    const previous = yield* records.read(host);
+    const nowMs = yield* Clock.currentTimeMillis;
+    if (
+      previous?.lastCheckedAt != null &&
+      nowMs - previous.lastCheckedAt < DAILY_UPDATE_CHECK_INTERVAL_MS
+    )
+      return undefined;
 
-  const { version, refreshed } = await fetchLatest();
-  if (version === undefined) return undefined;
-
-  const latest = isNewerSemverVersion(version, currentVersion)
-    ? version
-    : undefined;
-  const alreadyNotified =
-    latest !== undefined &&
-    lastNotifiedVersionKey !== undefined &&
-    state.get<string>(lastNotifiedVersionKey) === latest;
-
-  if (latest !== undefined && !alreadyNotified) {
-    await notify(latest);
-    if (lastNotifiedVersionKey !== undefined) {
-      await state.update(lastNotifiedVersionKey, latest);
+    const { version, refreshed } = yield* fetchLatest;
+    if (version === undefined) return undefined;
+    const latest = isNewerSemverVersion(version, currentVersion)
+      ? version
+      : undefined;
+    if (
+      latest !== undefined &&
+      (!notifyOnce || previous?.lastNotifiedVersion !== latest)
+    ) {
+      yield* notify(latest);
+      if (notifyOnce) yield* records.recordNotified(host, latest);
     }
-  }
-
-  if (refreshed) {
-    if (stampFailure === 'ignore') {
-      try {
-        await state.update(lastCheckedAtKey, nowMs);
-      } catch {
-        // CLI throttle persistence is best-effort; a read-only state store
-        // must not invalidate an update result that was already accepted.
-      }
-    } else {
-      await state.update(lastCheckedAtKey, nowMs);
+    if (refreshed) {
+      const stamp = records.recordChecked(host, nowMs);
+      yield* stampFailure === 'ignore' ? Effect.ignore(stamp) : stamp;
     }
-  }
-
-  return latest;
-}
+    return latest;
+  });
 
 interface FetchJsonStringFieldOptions {
   url: string;
@@ -96,27 +78,24 @@ interface FetchJsonStringFieldOptions {
  * non-success responses, malformed payloads, timeouts, and network failures
  * all yield `undefined`.
  */
-export async function fetchJsonStringField({
+export const fetchJsonStringField = ({
   url,
   field,
   timeoutMs,
   headers,
   fetchImpl = fetch,
-}: FetchJsonStringFieldOptions): Promise<string | undefined> {
-  try {
-    const response = await fetchImpl(url, {
-      signal: AbortSignal.timeout(timeoutMs),
-      headers,
-    });
-    if (!response.ok) return undefined;
-
-    const body: unknown = await response.json();
-    if (typeof body !== 'object' || body === null) return undefined;
-    const value = (body as Record<string, unknown>)[field];
-    return typeof value === 'string' && value !== '' ? value : undefined;
-  } catch {
-    // AbortError (timeout), TypeError (network), and SyntaxError (invalid JSON)
-    // all make this best-effort update source unavailable for the current run.
-    return undefined;
-  }
-}
+}: FetchJsonStringFieldOptions) =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const response = await fetchImpl(url, {
+        signal: AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]),
+        headers,
+      });
+      if (!response.ok) return undefined;
+      const body: unknown = await response.json();
+      if (typeof body !== 'object' || body === null) return undefined;
+      const value = (body as Record<string, unknown>)[field];
+      return typeof value === 'string' && value !== '' ? value : undefined;
+    },
+    catch: ensureError,
+  }).pipe(Effect.catch(() => Effect.succeed(undefined)));


### PR DESCRIPTION
Based on #12150; this comparison contains only update-check storage. It will move to `main` when the inquiry PR merges.

## Summary

Persist CLI and desktop update-check state in SQLite. Preserve the daily check interval, desktop notification suppression for an already announced release, and retry behavior after failed fetches or notifications. CLI checks now honor the configured storage root.

## Issue acceptance gates

Completes the update-check application-record slice of #11867 under the TeXRA 1.0 direction. Removes the three updater JSON keys and their access paths. Existing JSON files remain untouched; no migration is performed. Other application-state conversion remains outside this change.

## Single source of truth

`UpdateCheckRecords` owns host-configured access; `Database` serializes typed `update.check.recorded` snapshots. Each operation acquires and releases SQLite before returning. Network requests and dialogs hold no database connection. Notification and throttle writes remain separate, preserving their distinct failure behavior.

## Duplication and abstraction budget

Removes updater `StateStore` and key-string plumbing, the obsolete exported CLI JSON opener, and desktop shared-Promise orchestration. The new service captures the configured storage authority lazily. It adds no cache, generic key-value interface, or alternate SQL connection implementation.

## Net elements (R6)

30 files: 27 modified, 3 production files added, none deleted; +752/-530 lines (net +222). Export declaration lines: 10 added, 4 removed, including revised declarations. Classes/interfaces/enums: one service class added; none removed. No test files added. One retired synchronous StateStore case is removed; one regression protects durable notification recording during interruption.

## Consumer counts (R8)

The shared daily-check operation has two production callers: CLI and desktop. The retired CLI timestamp key had one host caller; both retired desktop keys had one host caller. Their record operations now use the configured service. The CLI JSON opener's updater caller is removed and its sole remaining settings call is inlined.

## Host impact

Extension: supplies a lazy configured getter; no update check is introduced.

Desktop: preserves Electron `userData` profile isolation, separate from shared inquiry storage. Concurrent window requests retain one reporting owner and the latest window callback. Fetch cancellation reaches the network; the notification and its durable recording complete together before interruption is honored.

CLI: uses its configured global root, preserves silent check failures and best-effort throttle writes after an accepted update.

SDK: service construction performs no storage access.

## Scheduled refactoring

None required for this slice; the supported storage behavior is stated below.

## Validation

Node 22.16: full format, typecheck, extension build, desktop build, lint, and full suite passed (9,275 tests; 9 skipped). After removing three unused exports identified by the final dead-code check: CLI typecheck, touched lint/format, 37 focused tests, and both Effect and dead-code ratchets passed. Earlier focused host/runtime validation passed 103 tests. No ratchet baseline was widened.

## Storage limitation

The read-only-storage review correctly identifies a SQLite limitation: on a readable but unwritable directory without usable WAL/SHM files, opening or reading the database can fail before the optional CLI check reaches the network. Explicit read-only opening alone does not solve that case. TeXRA 1.0 uses SQLite as the authoritative application store; it does not promise the former JSON file's read-only behavior. An unavailable database follows the existing skip-on-read-failure policy. Best-effort throttle writes still preserve an update already accepted after a successful read. No unreadable state is treated as empty, and no immutable mode, copied database, or alternate store is introduced. This is an explicit operating limitation, not a claimed code fix. See the [review clarification](https://github.com/LionSR/TeXRA/pull/12151#discussion_r3970640714); reproduction evidence is retained in `texra-artifacts/evidence/update-check-records-12151/`.

Review correction `dd78b1ad22` (rebased onto merged main `7bb0d04221`) consolidates the three identical latest-record queries and keeps notification plus durable notified-version recording within one interruption mask. The previous code fails the new regression; the correction passes. Five affected suites pass 66 tests, with three skipped; targeted types, lint, formatting and both ratchets pass.

