### PR TITLE
feat: keep CLI input history in bounded SQLite rows

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
+++ b/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
@@ -236,15 +236,16 @@ A persisted projection is a second copy with a lifecycle, a rebuild rule, and
 a way to drift. A column holding `outcome` or `resumable` is remembered status,
 which the owner's rule and the companion's D7 forbid. So:
 
-**Recommendation.** Two tables per workspace database, `event` and
-`event_sequence`, and nothing else persisted. Every surface, the launcher list
+**Recommendation, qualified by the 2026-09-09 C1 amendment below.** The
+event substrate uses `event` and `event_sequence`; bounded mutable records
+may use the current-state tables named in C1. Every execution surface, the launcher list
 and the resume picker included, is an in-memory fold or an indexed query over
 events. A derived row is added only after a measured query is too slow and an
 index has been tried first. Record the journal PRD as absorbed, the SQLite PRD
 as amended (§3.2 "entries as rows" becomes "events as rows, entries as a
 fold"; §8 Effect non-goal reversed per §7), and ship it as one cutover (§8).
 
-## 6. Target: two tables, folds everywhere
+## 6. Target: event folds and bounded current records
 
 ### 6.1 The contract (jointly owned with the view-state PRD)
 
@@ -259,6 +260,13 @@ records. The previous CLI history implementation discards entries beyond
 that behavior: insertion, adjacent-duplicate suppression, and removal of
 excess rows are atomic. Immutable events would instead retain discarded
 input. This is an implementation choice, not a new retention ruling.
+
+History uses the same local-filesystem admission below as other SQLite
+records, including when the global-storage directory is mounted separately
+from workspace storage. Directory symbolic links are resolved and accepted
+when their target is a verified local filesystem; the database, WAL, and SHM
+files themselves cannot be symbolic links. The earlier writable-JSONL behavior
+does not provide an alternative storage path.
 
 **C1. Persisted schema.** The event substrate uses the two tables below.
 The separate `input_history` current-state table stores bounded CLI history;

--- a/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
+++ b/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
@@ -252,8 +252,18 @@ This section is the only shared contract between the substrate program and
 `.agents/docs/implemented/architecture/2026-09-03-prd-one-fold-three-renderers.md`. The PRD references
 it; it does not restate it. Changes land here first.
 
-**C1. Persisted schema.** Two tables, nothing else app-owned on disk except the
-two permanent settings files (`state.json`, `config.json`).
+**Implementation amendment, 2026-09-09.** Under the accepted SQLite-authority
+direction, C1's event-only restriction is qualified for bounded mutable
+records. The previous CLI history implementation discards entries beyond
+1,000 and rewrites its file. The current `input_history` table preserves
+that behavior: insertion, adjacent-duplicate suppression, and removal of
+excess rows are atomic. Immutable events would instead retain discarded
+input. This is an implementation choice, not a new retention ruling.
+
+**C1. Persisted schema.** The event substrate uses the two tables below.
+The separate `input_history` current-state table stores bounded CLI history;
+it does not participate in event sequence or commit ordinals. The existing
+settings files (`state.json`, `config.json`) remain separately owned.
 
 ```
 event

--- a/.agents/docs/proposed/architecture/2026-09-09-texra-1-0-implementation-plan.md
+++ b/.agents/docs/proposed/architecture/2026-09-09-texra-1-0-implementation-plan.md
@@ -125,6 +125,14 @@ The current event store is a foundation; its two-table layout is not a reason
 to encode every setting or mutable record as an event. Add ordinary tables
 where they make the final model simpler while keeping related writes atomic.
 
+**Implementation amendment, 2026-09-09.** CLI input history uses bounded current rows: insertion, adjacent-duplicate
+suppression, and removal beyond 1,000 entries occur in one transaction.
+This preserves its existing replacement behavior without archiving discarded
+input. This implements the accepted SQLite-authority direction while
+preserving existing behavior; it is not a new retention ruling or acceptance
+of every recommendation in this plan. The substrate's C1 restriction is
+qualified accordingly for these current rows.
+
 Connect the provider package to scoped Effect tool-use and reflection loops.
 Commit a completed response before dispatching its tools, and commit the
 observed tool outcomes before continuing. Specify what happens if a process

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -16,7 +16,7 @@ import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { render } from 'ink';
-import { SubscriptionRef } from 'effect';
+import { Effect, SubscriptionRef } from 'effect';
 import { nanoid } from 'nanoid';
 import React from 'react';
 
@@ -368,8 +368,10 @@ const HARNESS_INPUT_HISTORY: InputHistory | undefined =
   HARNESS_INPUT_HISTORY_ENTRIES.length === 0
     ? undefined
     : {
-        async push(line) {
-          HARNESS_INPUT_HISTORY_ENTRIES.push(line);
+        push(line) {
+          return Effect.sync(() => {
+            HARNESS_INPUT_HISTORY_ENTRIES.push(line);
+          });
         },
         reverseFind: () => undefined,
         at: (index) => HARNESS_INPUT_HISTORY_ENTRIES[index],

--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -1,122 +1,103 @@
-// Per-user input history persisted as JSONL under the global storage path.
-//
-// File format: one `{"t": <ms>, "v": "<line>"}` record per line. We avoid a
-// single-JSON-blob format so partial writes never corrupt the history; the
-// session reader skips malformed lines silently.
+/** Global, bounded CLI input history. Older entries are replaced, not archived. */
+import { Clock, Effect, Layer, Result, Semaphore } from 'effect';
 
-import { z } from 'zod';
-
-import { Effect, Result } from 'effect';
-import { parseJsonWith } from '@common/parsing/safeParseJson';
-import { effectRuntime } from '@platform/processRuntime';
+import { databaseLayer } from '@controllers/session/Database';
+import { WorkspaceRoots } from '@controllers/session/WorkspaceRoots';
+import {
+  nodeProcesses,
+  processOwnerId,
+} from '@platform/defaults/nodeProcesses';
+import {
+  Database,
+  INPUT_HISTORY_LIMIT,
+  INPUT_HISTORY_LINE_LIMIT,
+  type InputHistoryRecord,
+} from '@shared/session/database';
+import { ProcessIdentity } from '@shared/session/sessionEvents';
 import { ensureError } from '@utils/errors/errorMessage';
-import { GlobalStorageFS } from '@utils/files/storageFS';
-
-const HISTORY_DIR = 'tui';
-const HISTORY_PATH = `${HISTORY_DIR}/input-history.jsonl`;
-const MAX_LINES = 1000;
-const MAX_LINE_CHARS = 4000;
-
-// No `.catch` on `t`: a record with a missing or corrupt timestamp fails
-// validation and is skipped by the reader below, per the malformed-line
-// policy — never rewritten into the file with a fabricated epoch-0 time.
-const HistoryRecordSchema = z.object({ t: z.number(), v: z.string() });
-type HistoryRecord = z.infer<typeof HistoryRecordSchema>;
 
 export interface InputHistory {
-  /** Append a new entry. Duplicates of the most-recent entry are skipped. */
-  push(line: string): Promise<void>;
-  /** Reverse-incremental search: returns the most recent entry containing
-   *  `needle`, or undefined. */
+  /** Persist a nonempty entry, suppressing an adjacent duplicate. */
+  push(line: string): Effect.Effect<void, Error>;
   reverseFind(
     needle: string,
     from?: number,
   ): { value: string; index: number } | undefined;
-  /** Entry at `index` (0 = oldest), for ↑/↓ history browsing. */
   at(index: number): string | undefined;
-  /** Number of stored entries. */
   length(): number;
 }
 
-/** Serialise the in-memory ring back to JSONL. Records keep their original
- *  timestamp so a compaction doesn't collapse the entire history to "now"
- *  in case anything ever reads the file externally. */
-function serializeRecords(records: readonly HistoryRecord[]): string {
-  return records.map((r) => JSON.stringify(r)).join('\n') + '\n';
-}
+/** Each I/O operation owns its database scope; browsing remains synchronous. */
+export const loadInputHistory = (
+  globalStorage: () => string,
+): Effect.Effect<InputHistory, Error> =>
+  Effect.gen(function* () {
+    const access = <A, E>(operation: Effect.Effect<A, E, Database>) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const ownerId = processOwnerId(
+            yield* Effect.tryPromise({
+              try: () => nodeProcesses.selfIdentity(),
+              catch: ensureError,
+            }),
+          );
 
-/** Read and parse the JSONL log, skipping malformed lines per the file-format
- *  policy in the header. */
-function readHistoryRecords(): Effect.Effect<HistoryRecord[], Error> {
-  return Effect.tryPromise({
-    try: () => GlobalStorageFS.read(HISTORY_PATH),
-    catch: (cause) => ensureError(cause),
-  }).pipe(
-    Effect.map((raw) => {
-      const records: HistoryRecord[] = [];
-      for (const line of raw.split('\n')) {
-        const rec = Result.getOrUndefined(
-          parseJsonWith(line, HistoryRecordSchema),
-        );
-        if (rec && rec.v.length > 0) records.push(rec);
-      }
-      return records;
-    }),
-  );
-}
-
-export async function loadInputHistory(): Promise<InputHistory> {
-  let records: HistoryRecord[] = [];
-  if (await GlobalStorageFS.exists(HISTORY_PATH)) {
-    // A read failure (EIO, permission, race-after-exists) must not block the
-    // TUI from mounting — the user can still type, just without history this
-    // session.
-    records = await effectRuntime().runPromise(
-      readHistoryRecords().pipe(Effect.catch(() => Effect.succeed([]))),
-    );
-  }
-  // Cap on load; older entries fall off when the ring is full.
-  if (records.length > MAX_LINES) records = records.slice(-MAX_LINES);
-
-  return {
-    async push(line: string) {
-      const trimmed = line.trim();
-      if (!trimmed) return;
-      const stored = trimmed.slice(0, MAX_LINE_CHARS);
-      if (records.at(-1)?.v === stored) return;
-      const record: HistoryRecord = { t: Date.now(), v: stored };
-      records.push(record);
-      await GlobalStorageFS.ensureDir(HISTORY_DIR);
-      if (records.length > MAX_LINES) {
-        const drop = records.length - MAX_LINES;
-        records.splice(0, drop);
-        await GlobalStorageFS.writeAtomic(
-          HISTORY_PATH,
-          serializeRecords(records),
-        );
-        return;
-      }
-      await GlobalStorageFS.appendFile(
-        HISTORY_PATH,
-        `${JSON.stringify(record)}\n`,
+          const storage = yield* Effect.try({
+            try: globalStorage,
+            catch: ensureError,
+          });
+          return yield* operation.pipe(
+            Effect.provide(
+              databaseLayer('persistent').pipe(
+                Layer.provide(Layer.succeed(WorkspaceRoots)({ storage })),
+                Layer.provide(ProcessIdentity.layer(ownerId)),
+              ),
+            ),
+          );
+        }),
       );
-    },
-    reverseFind(needle, from) {
-      if (!needle) return undefined;
-      const start = from === undefined ? records.length - 1 : from - 1;
-      for (let i = start; i >= 0; i--) {
-        const record = records[i];
-        if (record?.v.includes(needle)) {
-          return { value: record.v, index: i };
+    const read = Effect.flatMap(Database, (database) =>
+      database.readInputHistory(),
+    );
+    // History failure must not prevent typing. A subsequent push may retry storage.
+    let records: readonly InputHistoryRecord[] = Result.getOrElse(
+      yield* Effect.result(access(read)),
+      () => [],
+    );
+    const pushes = Semaphore.makeUnsafe(1);
+    return {
+      push: (line) =>
+        pushes.withPermit(
+          Effect.gen(function* () {
+            const value = line.trim().slice(0, INPUT_HISTORY_LINE_LIMIT);
+            if (value.length === 0 || records.at(-1)?.value === value) return;
+            const record = { at: yield* Clock.currentTimeMillis, value };
+            // Keep submitted text browsable even when storage fails.
+            records = [...records, record].slice(-INPUT_HISTORY_LIMIT);
+            yield* access(
+              Effect.gen(function* () {
+                const database = yield* Database;
+                yield* database.appendInputHistory(record);
+              }),
+            );
+          }),
+        ),
+      reverseFind(needle, from) {
+        if (!needle) return undefined;
+        const start = from === undefined ? records.length - 1 : from - 1;
+        for (let i = start; i >= 0; i--) {
+          const record = records[i];
+          if (record?.value.includes(needle)) {
+            return { value: record.value, index: i };
+          }
         }
-      }
-      return undefined;
-    },
-    at(index) {
-      return records[index]?.v;
-    },
-    length() {
-      return records.length;
-    },
-  };
-}
+        return undefined;
+      },
+      at(index) {
+        return records[index]?.value;
+      },
+      length() {
+        return records.length;
+      },
+    };
+  });

--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -70,10 +70,12 @@ export const loadInputHistory = (
         pushes.withPermit(
           Effect.gen(function* () {
             const value = line.trim().slice(0, INPUT_HISTORY_LINE_LIMIT);
-            if (value.length === 0 || records.at(-1)?.value === value) return;
+            if (value.length === 0) return;
             const record = { at: yield* Clock.currentTimeMillis, value };
             // Keep submitted text browsable even when storage fails.
-            records = [...records, record].slice(-INPUT_HISTORY_LIMIT);
+            if (records.at(-1)?.value !== value)
+              records = [...records, record].slice(-INPUT_HISTORY_LIMIT);
+            // Global adjacency belongs to SQLite, not this CLI's cached view.
             yield* access(
               Effect.gen(function* () {
                 const database = yield* Database;

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -13,6 +13,7 @@ import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
 import { isCtrlInput } from '@cli/tui/inputKeys';
 import { COLOR_BORDER, COLOR_HINT } from '@cli/tui/ui/colors';
 import { POINTER } from '@cli/tui/ui/glyphs';
+import { effectRuntime } from '@platform/processRuntime';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { textInputCappedRowCount } from '../input/textInputDisplay';
@@ -294,7 +295,8 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       // shared log sink so it isn't completely silent.
       const historyPersist =
         historyText.length > 0 && !shouldRedactSlashInput(historyText)
-          ? historyRef.current?.push(historyText)
+          ? historyRef.current &&
+            effectRuntime().runPromise(historyRef.current.push(historyText))
           : null;
       historyPersist?.catch((err: unknown) => {
         writeTextStderr(

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -300,7 +300,9 @@ export async function runChat(
     appendLocalAssistantTranscript(startupNotice);
   }
 
-  const inputHistory = await loadInputHistory();
+  const inputHistory = await effectRuntime().runPromise(
+    loadInputHistory(() => services.storage.getGlobalStoragePath()),
+  );
 
   // DA1 sentinel discovery runs *before* Ink mounts so it owns the raw-mode
   // toggle exclusively, interleaving with Ink's own raw-mode lifecycle (set

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -73,13 +73,13 @@ type CliPlatformInitOptions = Pick<
  * The platform services the CLI entry points read immediately after init.
  *
  * `initCliPlatform` already holds the whole `Platform` it just built (or the
- * one an earlier init installed), so it hands these three back instead of
+ * one an earlier init installed), so it hands these capabilities back instead of
  * leaving each caller to re-enter the ambient `platform()` singleton for a
  * value the composition root was holding all along.
  */
 export type CliPlatformServices = Pick<
   Platform,
-  'globalState' | 'secrets' | 'lifecycle'
+  'globalState' | 'secrets' | 'lifecycle' | 'storage'
 >;
 
 function logAt(
@@ -454,6 +454,7 @@ export async function initCliPlatform(
   });
 
   return {
+    storage: services.storage,
     globalState: services.globalState,
     secrets: services.secrets,
     lifecycle: services.lifecycle,

--- a/src/controllers/session/Database.ts
+++ b/src/controllers/session/Database.ts
@@ -61,6 +61,8 @@ import {
 import { ProcessIdentity } from '@shared/session/sessionEvents';
 import { redactTraceDraft } from '@shared/session/traceRedaction';
 import {
+  InputHistoryRecordSchema,
+  INPUT_HISTORY_LIMIT,
   AggregateStateSchema,
   DeletionModeSchema,
   type DeletionMode,
@@ -76,7 +78,7 @@ import { localDatabasePath } from './localDatabasePath';
 /** The database file of a session root, beside the stores it replaces. */
 const SESSION_DATABASE_FILE = 'texra.db';
 /**
- * The C1 schema. Two tables and nothing else app-owned on disk.
+ * Event history and bounded current application records.
  *
  * `commit` is a SQLite keyword, so the column is quoted at every site; the
  * stage 0 spike measured `CREATE TABLE t (commit INTEGER ...)` failing with a
@@ -97,6 +99,12 @@ const SESSION_DATABASE_FILE = 'texra.db';
  * from its seq.
  */
 const SCHEMA = `
+CREATE TABLE IF NOT EXISTS input_history (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  at INTEGER NOT NULL,
+  value TEXT NOT NULL
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS event_sequence (
   aggregate_id TEXT NOT NULL PRIMARY KEY,
   seq          INTEGER NOT NULL,
@@ -436,6 +444,11 @@ export const databaseLayer = (
         );
       const transact = <A>(body: Effect.Effect<A, unknown>) =>
         transaction('write', body, writeFailed);
+      const historyRows = Effect.gen(function* () {
+        return (yield* sql.unsafe<Record<string, unknown>>(
+          'SELECT at, value FROM input_history ORDER BY id',
+        )).map((row) => InputHistoryRecordSchema.parse(row));
+      });
       const createExecution = `INSERT INTO event_sequence
         (aggregate_id, seq, owner_id, parent_id) VALUES (?, 0, ?, ?)`;
       const claim = `UPDATE event_sequence SET owner_id = ?
@@ -840,6 +853,25 @@ export const databaseLayer = (
                 );
               }
               return result;
+            }),
+          ),
+        readInputHistory: () => query(historyRows),
+        appendInputHistory: ({ at, value }) =>
+          transact(
+            Effect.gen(function* () {
+              const latest = (yield* sql.unsafe<Record<string, unknown>>(
+                'SELECT value FROM input_history ORDER BY id DESC LIMIT 1',
+              ))[0];
+              if (latest?.value !== value) {
+                yield* sql.unsafe(
+                  'INSERT INTO input_history (at, value) VALUES (?, ?)',
+                  [at, value],
+                );
+                yield* sql.unsafe(
+                  'DELETE FROM input_history WHERE id NOT IN (SELECT id FROM input_history ORDER BY id DESC LIMIT ?)',
+                  [INPUT_HISTORY_LIMIT],
+                );
+              }
             }),
           ),
         readDesktopProjects: (id) =>

--- a/src/shared/session/database.ts
+++ b/src/shared/session/database.ts
@@ -20,6 +20,15 @@ import type {
 } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
+/** Current CLI history rows, ordered oldest first. */
+export const InputHistoryRecordSchema = z.object({
+  at: z.number(),
+  value: z.string(),
+});
+export type InputHistoryRecord = z.infer<typeof InputHistoryRecordSchema>;
+export const INPUT_HISTORY_LIMIT = 1000;
+export const INPUT_HISTORY_LINE_LIMIT = 4000;
+
 /** Only an explicit single-run deletion may replace an unprovable owner. */
 export const DeletionModeSchema = z.enum(['single', 'bulk', 'automatic']);
 export type DeletionMode = z.infer<typeof DeletionModeSchema>;
@@ -108,6 +117,14 @@ export class Database extends Context.Service<
     readonly readExecutionChildren: (
       id: AggregateId,
     ) => Effect.Effect<readonly SessionEvent[], DatabaseReadFailed>;
+    /** Bounded current CLI input rows, ordered oldest first. */
+    readonly readInputHistory: () => Effect.Effect<
+      readonly InputHistoryRecord[],
+      DatabaseReadFailed
+    >;
+    readonly appendInputHistory: (
+      record: InputHistoryRecord,
+    ) => Effect.Effect<void, DatabaseWriteFailed>;
     /** Latest desktop profile record, selected directly by its aggregate index. */
     readonly readDesktopProjects: (
       id: AggregateId,

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -2,6 +2,8 @@ import '@test/support/defaultSessionTestSetup';
 
 import { setTimeout as sleep } from 'node:timers/promises';
 
+import { Effect } from 'effect';
+
 import stripAnsi from 'strip-ansi';
 import {
   afterEach,
@@ -327,7 +329,7 @@ function currentFrame(stdout: InkRenderHandles['stdout']): string {
 
 function fakeHistory(entries: readonly string[]): InputHistory {
   return {
-    push: async () => undefined,
+    push: () => Effect.void,
     reverseFind: () => undefined,
     at: (index) => entries[index],
     length: () => entries.length,

--- a/src/test-kernel/cli/InputBar.vitest.ts
+++ b/src/test-kernel/cli/InputBar.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
@@ -97,7 +98,7 @@ describe('InputBar history arrow boundaries', () => {
   it('clamps at the oldest entry and restores the draft at the newest boundary', async () => {
     const { ink, React } = await loadInk();
     const history: InputHistory = {
-      push: async () => undefined,
+      push: () => Effect.void,
       reverseFind: () => undefined,
       at: (index) => ['first command', 'second command'][index],
       length: () => 2,

--- a/src/test-kernel/cli/InputHistory.vitest.ts
+++ b/src/test-kernel/cli/InputHistory.vitest.ts
@@ -50,6 +50,15 @@ describe('CLI TUI input history', () => {
         reloaded.at(0),
         reloaded.at(1),
       ]);
+      // Another CLI writes between two submissions identical in this cache.
+      yield* reloaded.push('gamma');
+      yield* history.push('beta');
+      const combined = yield* loadInputHistory(() => storage);
+      expect(
+        Array.from({ length: combined.length() }, (_, index) =>
+          combined.at(index),
+        ),
+      ).toEqual(['alpha', 'beta', 'gamma', 'beta']);
     }),
   );
 

--- a/src/test-kernel/cli/InputHistory.vitest.ts
+++ b/src/test-kernel/cli/InputHistory.vitest.ts
@@ -1,64 +1,70 @@
 // Persistent ↑/↓ + Ctrl-R input history for the chat TUI input bar.
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, beforeEach } from 'vitest';
+import { it } from '@effect/vitest';
+import { Effect } from 'effect';
 
 import { loadInputHistory } from '@cli/chat/tui/history/inputHistory';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createFakeHost, setupPlatform } from '@test/support/setupPlatform';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 const tempDirs = useTempDirs();
 
 describe('CLI TUI input history', () => {
-  // GlobalStorageFS resolves paths through the platform but writes with the
-  // real node fs, so the fake platform needs a real temp directory.
-  setupPlatform(async () =>
-    createFakeHost(
-      {
-        globalStoragePath: await makeTempDir('texra-input-history-', tempDirs),
-      },
-      { fs: nodeFilesystem },
-    ),
+  let storage: string;
+  beforeEach(async () => {
+    storage = await makeTempDir('texra-input-history-', tempDirs);
+  });
+
+  it.live('exposes indexed entries for ↑/↓ history browsing', () =>
+    Effect.gen(function* () {
+      const history = yield* loadInputHistory(() => storage);
+
+      expect(history.length()).toBe(0);
+      expect(history.at(0)).toBeUndefined();
+
+      yield* history.push('first message');
+      yield* history.push('second message');
+
+      expect(history.length()).toBe(2);
+      expect(history.at(0)).toBe('first message');
+      expect(history.at(1)).toBe('second message');
+      expect(history.at(2)).toBeUndefined();
+    }),
   );
 
-  it('exposes indexed entries for ↑/↓ history browsing', async () => {
-    const history = await loadInputHistory();
+  it.live('persists entries across loads and skips adjacent duplicates', () =>
+    Effect.gen(function* () {
+      const history = yield* loadInputHistory(() => storage);
+      yield* Effect.all(
+        [history.push('alpha'), history.push('alpha'), history.push('beta')],
+        { concurrency: 'unbounded' },
+      );
+      yield* history.push('   ');
 
-    expect(history.length()).toBe(0);
-    expect(history.at(0)).toBeUndefined();
+      const reloaded = yield* loadInputHistory(() => storage);
 
-    await history.push('first message');
-    await history.push('second message');
+      expect(reloaded.length()).toBe(2);
+      expect(reloaded.at(0)).toBe('alpha');
+      expect(reloaded.at(1)).toBe('beta');
+      expect([history.at(0), history.at(1)]).toEqual([
+        reloaded.at(0),
+        reloaded.at(1),
+      ]);
+    }),
+  );
 
-    expect(history.length()).toBe(2);
-    expect(history.at(0)).toBe('first message');
-    expect(history.at(1)).toBe('second message');
-    expect(history.at(2)).toBeUndefined();
-  });
+  it.live('reverse-finds the most recent matching entry first', () =>
+    Effect.gen(function* () {
+      const history = yield* loadInputHistory(() => storage);
+      yield* history.push('build the project');
+      yield* history.push('run the tests');
+      yield* history.push('build the docs');
 
-  it('persists entries across loads and skips adjacent duplicates', async () => {
-    const history = await loadInputHistory();
-    await history.push('alpha');
-    await history.push('alpha');
-    await history.push('beta');
+      const newest = history.reverseFind('build');
+      expect(newest).toEqual({ value: 'build the docs', index: 2 });
 
-    const reloaded = await loadInputHistory();
-
-    expect(reloaded.length()).toBe(2);
-    expect(reloaded.at(0)).toBe('alpha');
-    expect(reloaded.at(1)).toBe('beta');
-  });
-
-  it('reverse-finds the most recent matching entry first', async () => {
-    const history = await loadInputHistory();
-    await history.push('build the project');
-    await history.push('run the tests');
-    await history.push('build the docs');
-
-    const newest = history.reverseFind('build');
-    expect(newest).toEqual({ value: 'build the docs', index: 2 });
-
-    const older = history.reverseFind('build', newest?.index);
-    expect(older).toEqual({ value: 'build the project', index: 0 });
-  });
+      const older = history.reverseFind('build', newest?.index);
+      expect(older).toEqual({ value: 'build the project', index: 0 });
+    }),
+  );
 });

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
@@ -287,12 +287,14 @@ describe('runChat signal ownership wiring', () => {
     });
     mocks.chatToolUseAgentUsageError.mockReturnValue(undefined);
     mocks.selectCliRunnableModel.mockResolvedValue({ model: 'gpt-test' });
-    mocks.loadInputHistory.mockResolvedValue({
-      at: vi.fn(),
-      length: vi.fn(() => 0),
-      push: vi.fn(async () => undefined),
-      reverseFind: vi.fn(),
-    });
+    mocks.loadInputHistory.mockReturnValue(
+      Effect.succeed({
+        at: vi.fn(),
+        length: vi.fn(() => 0),
+        push: vi.fn(() => Effect.void),
+        reverseFind: vi.fn(),
+      }),
+    );
     mocks.discoverTerminalCapabilities.mockResolvedValue({
       kittyKeyboard: false,
       oscColorReports: false,


### PR DESCRIPTION
## Summary

Store CLI input history in bounded SQLite rows instead of a JSONL file. History remains global to the configured CLI storage root, with synchronous arrow-key browsing and reverse search. Blank input is ignored, SQLite suppresses globally consecutive duplicates, entries are limited to 4,000 characters, and the database retains the latest 1,000 entries.

Submitted text remains browsable if persistence fails, and a history failure does not prevent submission. Secret-bearing slash input is still excluded before persistence. Legacy history files are neither read nor changed.

History inherits the existing SQLite local-filesystem requirement. A separately mounted global-storage directory must therefore resolve to a verified local filesystem. Directory symlinks to supported local storage remain allowed; symlinked database, WAL, and SHM files are refused. This applies the existing C1 constraint to history, without a file fallback. A network-mounted whole CLI data root already fails persistent-session initialization before history is loaded.

## Issue acceptance gates

Advances the remaining application-state work in #11867 under the accepted fresh-state TeXRA 1.0 direction. Removes CLI history file reading, JSONL parsing, serialization, directory creation, append, and file compaction.

The dated C1 and implementation-plan amendment distinguishes event history from bounded mutable records. Current rows preserve the existing removal of older inputs; immutable events would retain discarded text. This preserves the existing retention behavior. Runtime continuation and UI draft work are outside this change.

## Single source of truth

`Database.ts` owns the `input_history` table and uses the existing official Effect SQL client and transaction implementation. Insertion, global adjacent-duplicate suppression, and removal beyond the bound are atomic. These rows do not allocate event sequence or commit ordinals.

`inputHistory.ts` normalizes submitted text once and owns the optimistic in-memory browsing ring. Each storage operation acquires and releases its own database scope using the configured storage provider. One native Effect semaphore serializes this history owner's push programs through persistence; it does not promise FIFO fairness. Local browsing suppresses its own consecutive duplicates, but every nonempty submission reaches SQLite so another CLI process cannot make a stale local cache suppress a valid global entry.

## Duplication and abstraction budget

Deletes the JSONL persistence implementation without adding a second SQL client, generic key-value adapter, migration, or historical mirror. The CLI composition root passes its existing storage port directly. The semaphore preserves submission order across concurrent push programs.

## Net elements (R6)

13 files changed, +257/-172 lines, net +85. No files added or deleted. Export-line accounting: 5 added, 1 removed, net +4; no class, interface, or enum declarations added or removed. The positive line count covers the shared current-row contract, native scoped operations, documentation amendment, and existing fixture adaptations; the retired file implementation is removed in the same change.

## Consumer counts (R8)

`loadInputHistory` retains one production caller in `runChatTui`. `InputHistory.push` retains one production caller in `InputBar`; its actual UI boundary now runs the native Effect. The TUI verification harness supplies the same revised interface. No event emitter is removed or renamed, and no production JSONL reader or writer remains.

## Host impact

Extension: shared database schema includes the current-row table; no extension history behavior changes.

Desktop: shared database schema includes the current-row table; no desktop history behavior changes.

CLI: history uses the configured global SQLite database, preserving browsing, limits, duplicate suppression, and secret-input exclusion.

## Scheduled refactoring

None required to complete this history replacement. The broader 1.0 work remains tracked in #11867.

## Validation

The original implementation passed the following full checks on Node 22.16.0 with the repository's 6 GB heap setting:

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run desktop:build`
- `npm run lint`
- `npm test`: 9,283 passed, 9 skipped; 763 test files passed, 1 skipped
- `npm run check:effect-migration-ratchet`
- `npm run check:dead-code-ratchet`: no new findings
- Guidance-reference and whitespace checks

Existing focused suites also passed. The existing history persistence case now submits concurrently and checks that browsing agrees with reopened history; no test files or test cases were added.

Evidence is archived under `texra-artifacts/evidence/texra-1.0-cli-input-history/`. The validated patch is based on `3add915ab79074c2c52e6135da7d108637a89e61`, with SHA-256 `1a1203636fecb4fd225ded7c43477026beabd611b381c236f6b694bb09e4d33c`.

The review correction in `e88327652e` aligns the proposal heading and recommendation with C1 and documents the inherited local-filesystem requirement. Production source is unchanged; prose formatting, guidance references and whitespace checks pass.


The branch is now based on merged inquiry PR #12150 at `7bb0d04221`. The sole rebase conflict was adjacent Database method insertions; inquiry and history operations are both preserved. On the combined tree, full typechecking, extension build, scoped lint, the Effect ratchet, and 37 focused tests passed (3 skipped).

The final cross-process correction in `e131692af6` removes the local cache as an authority for persisted duplicate suppression. The existing history test reproduced the missing final submission before the fix and passed afterward. Final focused validation: 14 tests passed; CLI and test-kernel types, scoped lint, and both ratchets passed. The earlier full-suite count is retained as prior implementation evidence, not represented as a new full run of this final correction. No test cases or files were added.

