### PR TITLE
refactor(session): drive surface prune from a declared per-stream-map list

### DIFF
--- a/src/shared/session/surface.ts
+++ b/src/shared/session/surface.ts
@@ -241,11 +241,16 @@ type StreamKeyedMapField = {
 }[keyof Surface];
 
 /**
- * The surface fields keyed by `StreamTabId`, in one place so `pruneSurface`
- * can never fall out of sync with the record: a field added here is pruned,
- * a field left off keeps a deleted stream's entry forever. `inquiryDrafts`
- * is deliberately absent — it is keyed by `${InquiryThreadId}#${turn}`, not
- * by stream, so no stream leaving the view can retire one.
+ * The single list `pruneSurface` reads: the per-stream maps it retains over.
+ * `StreamKeyedMapField` refuses any entry that is not a stream-keyed map, so a
+ * typo or a non-map field fails here at the list. It does not enforce the
+ * reverse — the type system cannot, since `StreamTabId` is `string` and so a
+ * stream-keyed map is indistinguishable from any other string-keyed one — so a
+ * new per-stream field added to `Surface` but left off this list still keeps a
+ * deleted stream's entry forever, and adding such a field means adding it here.
+ * `inquiryDrafts` is that indistinguishable case made deliberate: it is a
+ * string-keyed map too, but keyed by `${InquiryThreadId}#${turn}`, not by
+ * stream, so no stream leaving the view can retire one and it stays off.
  */
 const PER_STREAM_MAPS = [
   'drafts',

--- a/src/shared/session/surface.ts
+++ b/src/shared/session/surface.ts
@@ -229,6 +229,22 @@ function retain<V>(
 }
 
 /**
+ * The surface fields keyed by `StreamTabId`, in one place so `pruneSurface`
+ * can never fall out of sync with the record: a field added here is pruned,
+ * a field left off keeps a deleted stream's entry forever. `inquiryDrafts`
+ * is deliberately absent — it is keyed by `${InquiryThreadId}#${turn}`, not
+ * by stream, so no stream leaving the view can retire one.
+ */
+const PER_STREAM_MAPS = [
+  'drafts',
+  'expanded',
+  'groups',
+  'phase',
+  'scroll',
+  'rejected',
+] as const satisfies readonly (keyof Surface)[];
+
+/**
  * Every per-stream map drops its entry when that stream leaves the view
  * (PRD 9): an id is never reused, so the entry can never become valid
  * again, and without the prune the maps and the persisted form grow without
@@ -236,23 +252,19 @@ function retain<V>(
  * when nothing left.
  */
 export function pruneSurface(surface: Surface, view: SessionView): Surface {
-  const drafts = retain(surface.drafts, view);
-  const expanded = retain(surface.expanded, view);
-  const groups = retain(surface.groups, view);
-  const phase = retain(surface.phase, view);
-  const scroll = retain(surface.scroll, view);
-  const rejected = retain(surface.rejected, view);
-  if (
-    drafts === surface.drafts &&
-    expanded === surface.expanded &&
-    groups === surface.groups &&
-    phase === surface.phase &&
-    scroll === surface.scroll &&
-    rejected === surface.rejected
-  ) {
-    return surface;
+  // `retain` only ever drops entries, never changes a value, so each pruned
+  // map keeps its field's element type; the maps are read through the common
+  // read-only supertype and the once-narrowed patch is cast back at the end.
+  const patch: Partial<
+    Record<(typeof PER_STREAM_MAPS)[number], ReadonlyMap<StreamTabId, unknown>>
+  > = {};
+  for (const key of PER_STREAM_MAPS) {
+    const current: ReadonlyMap<StreamTabId, unknown> = surface[key];
+    const next = retain(current, view);
+    if (next !== current) patch[key] = next;
   }
-  return { ...surface, drafts, expanded, groups, phase, scroll, rejected };
+  if (Object.keys(patch).length === 0) return surface;
+  return { ...surface, ...patch } as Surface;
 }
 
 /**

--- a/src/shared/session/surface.ts
+++ b/src/shared/session/surface.ts
@@ -229,6 +229,18 @@ function retain<V>(
 }
 
 /**
+ * The `Surface` fields that are stream-keyed maps — the only fields
+ * `pruneSurface` may retain over. Restricting the list below to these keys
+ * means a non-map field (`search`, `drawerOpen`) is refused at the list
+ * itself, not several lines later at the read.
+ */
+type StreamKeyedMapField = {
+  [K in keyof Surface]: Surface[K] extends ReadonlyMap<StreamTabId, unknown>
+    ? K
+    : never;
+}[keyof Surface];
+
+/**
  * The surface fields keyed by `StreamTabId`, in one place so `pruneSurface`
  * can never fall out of sync with the record: a field added here is pruned,
  * a field left off keeps a deleted stream's entry forever. `inquiryDrafts`
@@ -242,7 +254,7 @@ const PER_STREAM_MAPS = [
   'phase',
   'scroll',
   'rejected',
-] as const satisfies readonly (keyof Surface)[];
+] as const satisfies readonly StreamKeyedMapField[];
 
 /**
  * Every per-stream map drops its entry when that stream leaves the view


### PR DESCRIPTION
## Summary

`pruneSurface` in `src/shared/session/surface.ts` drops each per-stream map's entry when its stream leaves the view. It did this by restating the set of per-stream maps **three times** — one `retain` call, one term in the equality comparison, and one field in the final spread, per map. Nothing linked the three lists at compile time, so a per-stream map added to the `Surface` record but forgotten in `pruneSurface` would silently keep a deleted stream's state (draft text, expansion, scroll…) forever — the exact leak the file's own comment warns about.

This declares the set once as a `PER_STREAM_MAPS` list and iterates it. Adding a per-stream field is now a single edit, and the loop is behavior-preserving: the same six maps are pruned, and the same `Surface` reference is returned when nothing changed.

This is the first, lowest-risk item from a broader refactoring audit of the repo; the larger candidates (host-request dispatcher dedup, `LaTeXTab` settings-field family, model-handler provider symmetry) are left as separate follow-ups.

## Issue acceptance gates

No tracked issue — surfaced by a codebase refactoring audit. Gate: remove the three-way restatement in `pruneSurface` without changing its behavior.

## Single source of truth

`PER_STREAM_MAPS` (module-private in `src/shared/session/surface.ts`) now owns the set of `StreamTabId`-keyed surface fields that prune when a stream leaves the view. `pruneSurface` derives its work from that one list instead of re-enumerating it. `inquiryDrafts` is deliberately excluded, documented at the list, because it is keyed by `${InquiryThreadId}#${turn}`, not by stream.

## Duplication and abstraction budget

Removed: the per-map triple restatement (6 `retain` calls → a loop, a 6-term equality check → reference-compare inside the loop, a 6-field spread → a `Partial` patch). No new abstraction or pass-through layer — `PER_STREAM_MAPS` is a plain `as const satisfies` list, and `retain` is unchanged.

## Net elements (R6)

- Files: 1 changed (`+28 / −16`, net **+12 LoC** — the SSOT list carries a doc comment; the removed code was untyped restatement).
- Exported symbols: **0 change** (`^[+-]export` over the diff is empty; `pruneSurface` signature unchanged, `PER_STREAM_MAPS` is module-private).
- Classes / interfaces / enums: 0 added, 0 removed.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed. `pruneSurface`'s signature is unchanged; its one caller (`packages/extension/src/progressView/frontend/sessionSurfaces.ts`) is untouched.

## Host impact

Extension: behavior unchanged — `pruneSurface`'s only caller lives in the progressView frontend; same maps pruned, same reference identity preserved.

Desktop: no change — consumes the shared surface module; behavior-preserving.

CLI: no change — behavior-preserving.

## Scheduled refactoring

None required for this change. Follow-up audit candidates (host-request dispatcher dedup across extension/desktop, declarative `LaTeXTab` settings fields, model-handler stream-failure/media/background symmetry) are tracked separately and out of scope here.

## Validation

- `tsc --noEmit --checkers 8` (workspace typecheck): clean.
- `eslint src/shared/session/surface.ts`: clean.
- `vitest run src/test-kernel/progressView/SessionSurfaces.vitest.ts`: 9/9 pass (includes the prune-on-authoritative-absence case).
- `vitest run src/test-kernel/shared/session src/test-kernel/progressView`: 194/194 pass.
- `node scripts/check-effect-migration-ratchet.mjs`: OK (no count grew).
- `node scripts/check-dead-code-ratchet.mjs`: OK (no new findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HkZxbfHuwD3dtPFATGWt6

---
_Generated by [Claude Code](https://claude.ai/code/session_018HkZxbfHuwD3dtPFATGWt6)_