### PR TITLE
fix: resolve workflow defaults from current agent definitions

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -22,7 +22,6 @@
       "src/agent/implementations/flows/reflection/output/compiledPdfArtifacts.ts": 2,
       "src/agent/index/agentRegistry.ts": 2,
       "src/agent/index/platformAgentDirectories.ts": 3,
-      "src/agent/index/remoteAgentMeta.ts": 2,
       "src/agent/modelHandlers/ModelHandler.ts": 1,
       "src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts": 1,
       "src/agent/runtime/AgentRunLifecycle.ts": 1,

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -34,7 +34,7 @@ import {
   inlineAgentDefinition,
   inlineAgentEntries,
 } from './inlineAgents';
-import { loadRemoteAgents, persistRemoteAgentMeta } from './remoteAgentMeta';
+import { loadRemoteAgents } from './remoteAgentMeta';
 import type { AgentEntry, ResolvedAgent } from './agentEntry';
 
 const log = createLog('agentRegistry');
@@ -276,14 +276,7 @@ export function getAgent(
   return undefined;
 }
 
-/**
- * Update a remote agent's metadata in the cache after its YAML is loaded.
- *
- * `description` is display-only and not persisted. `tools` and
- * `defaultOutputFiles` are persisted so orchestrator agents can see them across
- * reloads; passing an empty/undefined value clears stale entries. Fields absent
- * from `meta` are left untouched.
- */
+/** Refresh the live catalog entry from a remote agent's validated YAML. */
 export function updateAgentMeta(
   identifier: string,
   meta: {
@@ -294,24 +287,13 @@ export function updateAgentMeta(
 ): void {
   const entry = getAgent(identifier);
   if (!entry) return;
-
-  if (meta.description) {
-    entry.description = meta.description;
-  }
-
-  const persisted: { tools?: string[]; defaultOutputFiles?: string[] } = {};
-  if ('tools' in meta) {
-    entry.tools = persisted.tools = meta.tools?.length ? meta.tools : undefined;
-  }
-  if ('defaultOutputFiles' in meta) {
-    const value = meta.defaultOutputFiles?.length
+  if (meta.description) entry.description = meta.description;
+  if ('tools' in meta)
+    entry.tools = meta.tools?.length ? meta.tools : undefined;
+  if ('defaultOutputFiles' in meta)
+    entry.defaultOutputFiles = meta.defaultOutputFiles?.length
       ? meta.defaultOutputFiles
       : undefined;
-    entry.defaultOutputFiles = persisted.defaultOutputFiles = value;
-  }
-  if ('tools' in meta || 'defaultOutputFiles' in meta) {
-    persistRemoteAgentMeta(entry.name, persisted);
-  }
 }
 
 /**

--- a/src/agent/index/remoteAgentMeta.ts
+++ b/src/agent/index/remoteAgentMeta.ts
@@ -1,47 +1,13 @@
-/** Remote agent metadata persistence and loading for the agent registry. */
+/** Current remote catalog metadata for the agent registry. */
 
 import { Effect } from 'effect';
 import { RemoteAgentListError } from '@agent/remote/errorData';
 import { createLog } from '@logger/logUtils';
-import { platform } from '@platform/platform';
 import { AgentCategory } from '@shared/schemas';
-import { GlobalStateKey } from '@shared/state/stateKeys';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { AgentEntry } from './agentEntry';
 
 const log = createLog('agentRegistry');
-
-/**
- * Cached metadata for a remote agent, persisted in globalState.
- * Populated lazily when a remote agent's YAML is first loaded.
- */
-interface RemoteAgentMetaCache {
-  [agentName: string]: {
-    tools?: string[];
-    defaultOutputFiles?: string[];
-  };
-}
-
-/** Persist remote agent metadata to globalState for cross-session availability. */
-export function persistRemoteAgentMeta(
-  agentName: string,
-  meta: { tools?: string[]; defaultOutputFiles?: string[] },
-): void {
-  const stored = getPersistedRemoteAgentMeta();
-  stored[agentName] = { ...stored[agentName], ...meta };
-  void platform().globalState.update(
-    GlobalStateKey.REMOTE_AGENT_META_CACHE,
-    stored,
-  );
-}
-
-/** Load persisted remote agent metadata from globalState. */
-function getPersistedRemoteAgentMeta(): RemoteAgentMetaCache {
-  return platform().globalState.get<RemoteAgentMetaCache>(
-    GlobalStateKey.REMOTE_AGENT_META_CACHE,
-    {},
-  );
-}
 
 export function loadRemoteAgents(): Effect.Effect<AgentEntry[]> {
   return Effect.gen(function* () {
@@ -51,10 +17,8 @@ export function loadRemoteAgents(): Effect.Effect<AgentEntry[]> {
         new RemoteAgentListError({ message: toErrorMessage(cause), cause }),
     });
     const remotes = yield* listRemoteAgents();
-    const metaCache = getPersistedRemoteAgentMeta();
 
     return remotes.map((remote) => {
-      const cached = metaCache[remote.name];
       return {
         name: remote.name,
         source: 'remote' as const,
@@ -64,8 +28,7 @@ export function loadRemoteAgents(): Effect.Effect<AgentEntry[]> {
             ? AgentCategory.ToolUse
             : AgentCategory.Workflow,
         description: remote.description ?? undefined,
-        tools: remote.tools?.length ? remote.tools : cached?.tools,
-        defaultOutputFiles: cached?.defaultOutputFiles,
+        tools: remote.tools ?? undefined,
       };
     });
   }).pipe(

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -103,7 +103,6 @@ export enum GlobalStateKey {
 
   // Agent settings (migrated from VS Code config)
   CUSTOM_AGENT_DIR = 'texra.customAgentDir',
-  REMOTE_AGENT_META_CACHE = 'texra.remoteAgentMetaCache',
 
   // Endpoint settings
   ENDPOINT_OPENAI = 'texra.endpoint.openai',

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -813,19 +813,6 @@ describe('createWorkflowScriptAgentRunner', () => {
     expect(reported(report, 'childStreamId')).toEqual([]);
   });
 
-  it('aborts the run when a file-editing agent gets no input files', async () => {
-    const runner = defaultRunner();
-
-    // Run-fatal (WorkflowRunAbortError), not a per-call failure: a plain
-    // error would resolve to null inside parallel() and be silently filtered.
-    await expect(runner(invocation({}))).rejects.toMatchObject({
-      name: 'WorkflowRunAbortError',
-      message: expect.stringMatching(
-        /pass options\.inputFiles with files that still exist/,
-      ),
-    });
-  });
-
   it('rejects a tool-use default agent used as a workflow agent', async () => {
     const runner = createWorkflowScriptAgentRunner(
       parentContext(),
@@ -840,17 +827,6 @@ describe('createWorkflowScriptAgentRunner', () => {
         /is a toolUse agent but was launched as workflow/,
       ),
     });
-  });
-
-  it('allows empty input files when the agent declares default outputs', async () => {
-    const runner = createWorkflowScriptAgentRunner(
-      parentContext(),
-      { ...defaultAgent, defaultOutputFiles: ['generated.tex'] },
-      'tool-call-7',
-      run,
-    );
-
-    await expect(runner(invocation({}))).resolves.toBe(result);
   });
 
   it('uses one stable child id per workflow call identity', async () => {

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -3,6 +3,7 @@ import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
 import { Effect } from 'effect';
+import { it as effectIt } from '@effect/vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -42,6 +43,7 @@ function executeStableSubagentInBand(
 const mocks = vi.hoisted(() => ({
   configureDelegatedChildApprovals: vi.fn(),
   executeAgent: vi.fn(),
+  prepareAgentDefinition: vi.fn(),
   resumeToolUseTurn: vi.fn(),
   getExecutionStore: vi.fn(),
   getVisibleAgents: vi.fn(),
@@ -56,8 +58,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@agent/runtime/AgentLaunchContext', () => ({
-  prepareAgentDefinition: ({ config }: { config: unknown }) =>
-    Effect.succeed({ config }),
+  prepareAgentDefinition: mocks.prepareAgentDefinition,
 }));
 
 // Delegation resolves targets through the scope resolver; with no active run
@@ -413,6 +414,10 @@ describe('headless delegation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.prepareAgentDefinition.mockImplementation(
+      ({ config }: { config: unknown }) =>
+        Effect.succeed({ config, setting: { defaultOutputFiles: [] } }),
+    );
     mocks.registerExecution.mockReturnValue(Effect.void);
     mocks.releaseOwnedExecutionLease.mockResolvedValue(undefined);
     restoreAgentEngine = provideAgentEngine({
@@ -467,6 +472,58 @@ describe('headless delegation', () => {
       files: [],
     });
   });
+
+  effectIt.effect(
+    'validates workflow inputs against its once-loaded definition before registration',
+    () =>
+      Effect.gen(function* () {
+        const setting = {
+          defaultOutputFiles: [] as string[],
+          tools: ['read_file'],
+        };
+        mocks.prepareAgentDefinition.mockImplementation(
+          ({ config }: { config: unknown }) =>
+            Effect.succeed({ config, setting }),
+        );
+        const options = delegationOptions({
+          configPayload: {
+            agent: 'review',
+            agentSource: 'remote',
+            agentCategory: AgentCategory.Workflow,
+            model: 'deepseekT',
+          },
+        });
+        const { parentExecutionId, signal, ...prepared } = options;
+        const run = () =>
+          executeStableSubagentInBandEffect({
+            executionId: IN_BAND_LOGICAL_EXECUTION_ID,
+            parentExecutionId,
+            session: prepared.session,
+            signal,
+            prepare: () => Effect.succeed(prepared),
+          });
+        expect(yield* Effect.flip(run())).toMatchObject({
+          name: 'WorkflowRunAbortError',
+          message: expect.stringContaining('pass options.inputFiles'),
+        });
+        expect(mocks.registerExecution).not.toHaveBeenCalled();
+        setting.defaultOutputFiles = ['generated.tex'];
+        mocks.prepareAgentDefinition.mockClear();
+        mocks.executeAgent.mockResolvedValue({
+          category: 'workflow',
+          outcome: 'completed',
+          outputs: [],
+          files: [],
+        });
+        yield* run();
+        expect(mocks.prepareAgentDefinition).toHaveBeenCalledOnce();
+        expect(mocks.executeAgent).toHaveBeenCalledWith(
+          expect.objectContaining({ setting }),
+          expect.any(String),
+          expect.any(Object),
+        );
+      }),
+  );
 
   afterEach(async () => {
     const session = defaultSession();

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -21,7 +21,11 @@ import {
   getExecutionRecords,
   type ResultMeta,
 } from '@agent/storage';
-import { prepareAgentDefinition } from '@agent/runtime/AgentLaunchContext';
+import { WorkflowRunAbortError } from '@agent/workflowScript';
+import {
+  prepareAgentDefinition,
+  type PreparedAgentDefinition,
+} from '@agent/runtime/AgentLaunchContext';
 import {
   AgentConfigSchema,
   type AgentConfigPayload,
@@ -32,6 +36,7 @@ import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { createLog } from '@logger/logUtils';
 import {
   RUN_OUTCOME,
+  AgentCategory,
   USER_FOLLOW_UP_SUPPORT,
   type ExecutionId,
   type StreamTabId,
@@ -131,6 +136,20 @@ const stableExecutions = new Map<
   }
 >();
 
+/** Resolve the definition once before either in-band launch path registers it. */
+const prepareInBandDefinition = Effect.fn('prepareInBandDefinition')(function* (
+  options: InBandSubagentDeliveryOptions,
+) {
+  options.signal?.throwIfAborted();
+  return yield* prepareAgentDefinition({
+    config: AgentConfigSchema.parse(options.configPayload),
+    session: options.session,
+    enforceCategory: true,
+    signal: options.signal,
+    suppressErrorNotification: true,
+  });
+});
+
 /**
  * Execute one child through the one shared driver and read its typed result
  * back from the durable record. The child runs under the same detached
@@ -150,19 +169,11 @@ const stableExecutions = new Map<
 const executeInBand = Effect.fn('executeInBand')(
   function* (
     options: InBandSubagentDeliveryOptions,
+    definition: PreparedAgentDefinition,
     mode: PersistenceMode,
     executionId: ExecutionId,
     stableAttempt?: StableSubagentAttempt,
   ): Effect.fn.Return<InBandSubagentDeliveryResult, Error> {
-    options.signal?.throwIfAborted();
-
-    const definition = yield* prepareAgentDefinition({
-      config: AgentConfigSchema.parse(options.configPayload),
-      session: options.session,
-      enforceCategory: true,
-      signal: options.signal,
-      suppressErrorNotification: true,
-    });
     const { config } = definition;
     const startedAt = Date.now();
     const workingDirectory = config.workingDirectory ?? undefined;
@@ -430,12 +441,30 @@ export const executeStableSubagentInBand = Effect.fn(
             // Publish the physical attempt id before resolving mutable launch state.
             options.onActiveExecutionId?.(executionId);
             const prepared = yield* options.prepare();
+            const launch = {
+              ...prepared,
+              parentExecutionId: options.parentExecutionId,
+              signal: options.signal,
+            };
+            const definition = yield* prepareInBandDefinition(launch);
+            // Validate the current definition, not metadata left by an earlier
+            // catalog load. Recovery returned above without loading it again.
+            if (
+              definition.config.agentCategory === AgentCategory.Workflow &&
+              definition.config.inputFiles.length === 0 &&
+              definition.setting.defaultOutputFiles.length === 0
+            ) {
+              return yield* Effect.fail(
+                new WorkflowRunAbortError(
+                  `Workflow agent '${launch.agentName}' edits files: pass options.inputFiles ` +
+                    `with files that still exist (its result carries output files and ` +
+                    `diffs, not response text).`,
+                ),
+              );
+            }
             const completed = yield* executeInBand(
-              {
-                ...prepared,
-                parentExecutionId: options.parentExecutionId,
-                signal: options.signal,
-              },
+              launch,
+              definition,
               'required-result',
               executionId,
               attempt,
@@ -459,8 +488,10 @@ export const executeSubagentForDeliveryInBand = Effect.fn(
 )(function* (
   options: InBandSubagentDeliveryOptions,
 ): Effect.fn.Return<InBandSubagentDeliveryResult, Error> {
+  const definition = yield* prepareInBandDefinition(options);
   return yield* executeInBand(
     options,
+    definition,
     'best-effort-delivery',
     generateExecutionId(),
   );

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -169,22 +169,6 @@ const resolveWorkflowCallConfig = Effect.fn('resolveWorkflowCallConfig')(
       if (oversizedBibRejection) {
         throw new WorkflowRunAbortError(oversizedBibRejection.error);
       }
-      // Run-storage references can disappear during recovery. Validate
-      // the resolved inputs, not merely the paths supplied by the script,
-      // so a stale reference cannot launch a useless empty-envelope run.
-      // Run-fatal, not a per-call failure: a plain error would resolve
-      // this agent() to null inside parallel(), silently
-      // filtering away the very misuse this guard exists to surface.
-      if (
-        inputFiles.length === 0 &&
-        (agent.defaultOutputFiles ?? []).length === 0
-      ) {
-        throw new WorkflowRunAbortError(
-          `Workflow agent '${agent.name}' edits files: pass options.inputFiles ` +
-            `with files that still exist (its result carries output files and ` +
-            `diffs, not response text).`,
-        );
-      }
       agentName = agent.name;
       configPayload = {
         ...sharedConfigFields,


### PR DESCRIPTION
## Summary

A remote workflow with no input files could be refused before its definition was loaded, because the preflight check depended on default outputs remembered from an earlier launch. Validate against the current agent definition after loading it once, then pass that same prepared definition into execution. Workflows that have neither input files nor default outputs still fail before registration.

Delete the persisted remote-agent metadata cache. Catalog tools come from the published remote metadata; loading validated YAML continues to refresh the live catalog's description, tools and default outputs. Earlier state files are left untouched.

## Issue acceptance gates

Addresses the derived metadata-cache deletion recorded in #12071 and advances #11867. Removes the global-state key, cache schema, reader, writer and cached listing fallback. Current definition loading supplies launch defaults directly. Execution checkpoints and resume behavior are unchanged.

## Single source of truth

The validated prepared agent definition supplies launch configuration and output defaults. Both existing in-band launch entries prepare once and pass the definition to their shared execution function. Stable workflow validation follows that preparation and precedes registration.

## Duplication and abstraction budget

Removes a persistent copy of metadata already present in validated YAML. One private preparation function serves the two real in-band entry points. The existing live catalog refresh remains available to CLI detail/output consumers.

## Net elements (R6)

Eight files changed, +114/-123 lines, net -9. The Effect migration baseline decreases by the two removed platform accesses; no allowance is added. No files added or deleted. One exported persistence function and one private cache interface are removed; no exported declaration or class is added. One existing regression case replaces tests attached to the earlier preflight location. No new test files.

## Consumer counts (R8)

The deleted persistence writer had one caller, updateAgentMeta; the deleted persisted-cache reader served that writer and remote listing. The shared definition-preparation function has two callers: stable workflow execution and in-band delivery. Both reuse the prepared definition at execution.

## Host impact

Extension and desktop: remote workflows with declared default outputs can start without a prior cached launch. Loaded YAML still refreshes the live catalog.

CLI: current catalog fields used for details and output naming are retained. No configuration or credential storage is changed.

## Scheduled refactoring

None required for this cache deletion. The broader persistence programme remains tracked in #11867.

## Validation

Validated on Node 22.16: formatting, full typecheck, extension bundle, desktop build, full lint, both ratchets and diff checks passed. The full test suite passed with 9,276 tests and 9 skips; six focused suites passed with 116 tests. Independent review found no blockers. No new test files were added.
