### PR TITLE
fix(edge): restore the usedRelay wire tolerance that broke the deno check

### DIFF
--- a/supabase/functions/log-usage/usageValidation.ts
+++ b/supabase/functions/log-usage/usageValidation.ts
@@ -31,6 +31,11 @@ const UsageLogEntryInputSchema = z.object({
   cachedInputTokens: optionalNonnegativeInt,
   reasoningTokens: optionalNonnegativeInt,
   usageRoute: optional(UsageRouteSchema),
+  /** LEGACY: relay wire tolerance. Released clients still post this field and
+   *  `index.ts` still writes the `used_relay` column from it. Retirement is
+   *  owned by #10921: after 2026-11, and only once the ops drain (#10920) has
+   *  completed. */
+  usedRelay: optionalBoolean,
   viaChatGptSubscription: z
     .boolean()
     .nullish()


### PR DESCRIPTION
## Summary

`main` is red. #12144 removed `usedRelay` from the log-usage entry schema, but `supabase/functions/log-usage/index.ts:151` still writes `used_relay: entry.usedRelay ?? false`, so `deno check` fails with two `TS2339`s and takes the whole `static checks` job down with it.

This restores the field with a comment naming its owner and its gate.

## Why restore rather than drop the write

The `log-usage` edge function is deployed infrastructure serving released 0.40 clients. It is not part of the 1.0 storage transition, so the direction's disapplication of the three-month compatibility window does not reach it. #10921 dates this exact member to after 2026-11 and gates it on #10920, the ops drain that is still open and still `priority:p0`.

If you would rather retire it now, the other half has to go in the same change: drop the `used_relay` write in `index.ts`, decide what the column does for entries that no longer carry the field, and close #10921 with a note that the gate was waived.

## Validation

Ran the same commands as the CI step, in `supabase/functions/log-usage`:

```
deno check index.ts *_test.ts   # ok
deno lint                        # Checked 5 files
deno test --allow-env            # ok | 15 passed | 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXEQSgSQ41krk3Vgcx9oY4