### PR TITLE
docs: drop the retired native-cleanup path from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,14 +69,14 @@ storage and execution contracts; the 1.0 breaking changes apply to `main`.
   Divide work into complete changes that remain useful in 1.0, rather than
   intermediate systems scheduled for replacement. Revise an obsolete
   requirement before building machinery to satisfy it.
-- **The native cleanup addon is retired.** `scripts/native-cleanup`, its
-  loader, prebuilt binaries, CI matrix, packaging assertions, and
-  addon-specific tests are gone. Generated-file deletion now resolves and
+- **The native cleanup addon is retired.** Its script directory, loader,
+  prebuilt binaries, CI matrix, packaging assertions, and addon-specific
+  tests are gone. Generated-file deletion now resolves and
   checks in `src/controllers/session/deletionCleanup.ts`: the storage root and
   its runs directory are resolved with `realpath`, a runs directory that does
   not resolve to itself is refused rather than followed, and every target must
   fall inside it. That is weaker than the addon's handle-confined deletion,
-  which also survived a root replaced *during* the removal; #12139 owns the
+  which also survived a root replaced _during_ the removal; #12139 owns the
   final file ownership and deletion contract. Do not reintroduce a compiled extension for
   this. Effect-native means using Effect's execution model, not adding custom
   compiled extensions.


### PR DESCRIPTION
## Problem

`scripts/native-cleanup` was deleted in #12163. `AGENTS.md:72` still named the directory while describing it as gone, so `check-guidance-refs` fails on a clean `main`:

```
Guidance references point at paths that do not exist:
  AGENTS.md:72  scripts/native-cleanup
1 stale reference(s).
```

The guidance-refs job is required by `validate-status`, so this gate is red for **every** PR targeting `main` until it lands. That includes all TeXRA 1.0 work.

## Change

Name the addon's script directory instead of citing its removed path. Unchanged: the retirement claim, the pointer to `src/controllers/session/deletionCleanup.ts`, the `#12139` ownership note, and the guardrail against reintroducing a compiled extension.

No `<!-- guidance-refs-ignore -->` marker was added. That would preserve a stale path rather than remove it.

Line 79 also carries a pre-existing prettier fixup (`*during*` to `_during_`) that is unrelated to this change and was already drifted on `main`.

## Verification

`node scripts/check-guidance-refs.mjs` exits 0, checking 58 files. Docs-only, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzVsFKuUTdeDHy4PyxbnaH