### PR TITLE
chore(build): remove the retired native addon's asset routing

### DIFF
--- a/packages/agent/scripts/bundle.mjs
+++ b/packages/agent/scripts/bundle.mjs
@@ -62,10 +62,8 @@ await build({
       },
     },
   ],
-  assetNames: '[name]',
   loader: {
     '.wasm': 'binary',
-    '.node': 'file',
   },
   sourcemap: false,
   splitting: true,

--- a/packages/cli/scripts/build-harness.mjs
+++ b/packages/cli/scripts/build-harness.mjs
@@ -28,7 +28,7 @@ try {
     external: ['fsevents', 'clipboardy'],
     jsx: 'automatic',
     // Keep the harness build graph faithful to the production CLI bundle.
-    loader: { '.tsx': 'tsx', '.ts': 'ts', '.wasm': 'binary', '.node': 'file' },
+    loader: { '.tsx': 'tsx', '.ts': 'ts', '.wasm': 'binary' },
     alias: { 'react-devtools-core': reactDevtoolsStub },
     outfile,
     banner: {

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -15,7 +15,6 @@ asar: true
 asarUnpack:
   # node-pty loads a native .node binary at runtime, which cannot be read from
   # inside an asar archive.
-  - '**/dist/main/*.node'
   - '**/node_modules/node-pty/**'
 npmRebuild: false
 directories:
@@ -60,7 +59,7 @@ mac:
   # @electron/universal refuses to merge Mach-O files that are byte-identical
   # across arches unless they are declared here; declaring them keeps every
   # prebuild in the merged app so each arch still resolves its own.
-  x64ArchFiles: '**/app.asar.unpacked/{node_modules/node-pty/prebuilds/**,dist/main/*.node}'
+  x64ArchFiles: '**/app.asar.unpacked/node_modules/node-pty/prebuilds/**'
   target:
     - target: dmg
       arch:

--- a/packages/desktop/esbuild.main.options.mjs
+++ b/packages/desktop/esbuild.main.options.mjs
@@ -29,8 +29,7 @@ export const mainBuildOptions = {
   // a bundle chunk. Keep it external so the require resolves to the real
   // installed package (electron-builder ships it via node_modules).
   external: ['electron', 'fsevents', 'node-pty'],
-  assetNames: '[name]',
-  loader: { '.wasm': 'binary', '.node': 'file' },
+  loader: { '.wasm': 'binary' },
   tsconfig: 'tsconfig.main.json',
   target: 'node22',
   banner: { js: esmCjsGlobalsBanner },

--- a/packages/extension/esbuild.config.mjs
+++ b/packages/extension/esbuild.config.mjs
@@ -52,8 +52,7 @@ const extensionConfig = {
     'bufferutil', // Optional native module
     'utf-8-validate', // Optional native module
   ],
-  assetNames: '[name]',
-  loader: { '.tex': 'text', '.wasm': 'binary', '.node': 'file' },
+  loader: { '.tex': 'text', '.wasm': 'binary' },
   plugins: [progressPlugin],
   logLevel: 'warning',
   // Polyfill import.meta.url for ESM-only dependencies (e.g. @openai/codex-sdk)

--- a/scripts/desktop-package-smoke-environment.mjs
+++ b/scripts/desktop-package-smoke-environment.mjs
@@ -98,8 +98,6 @@ export async function loadDatabaseFixture(userDataPath) {
     bundle: true,
     platform: 'node',
     format: 'esm',
-    loader: { '.node': 'file' },
-    assetNames: '[name]',
     target: 'node22.16',
     tsconfig: join(root, 'tsconfig.json'),
     banner: {

--- a/src/types/ambient.d.ts
+++ b/src/types/ambient.d.ts
@@ -154,9 +154,3 @@ declare module 'which' {
   const which: Which;
   export default which;
 }
-
-/** Native assets are packaged beside the executable JavaScript. */
-declare module '*.node' {
-  const location: string;
-  export default location;
-}


### PR DESCRIPTION
## Problem

#12163 deleted the native generated-file cleanup addon. The build configuration that routed its compiled artifact stayed behind. Nothing emits or imports a `.node` file any more:

```
$ grep -rn "from '.*\.node'" --include="*.ts" --include="*.tsx" src packages/*/src
(no matches)
```

So the ambient module declaration, four esbuild `file` loaders with their `assetNames` companions, and two electron-builder globs are inert.

## Provenance

Every site removed here was introduced by `ee2c41e4d0`, the commit that added the addon:

```
$ git log --oneline -1 -S"assetNames: '[name]'" -- packages/extension/esbuild.config.mjs
ee2c41e4d0 fix: confine cleanup and defer audio loading
```

This restores the pre-addon configuration rather than inventing a new one.

## node-pty is untouched

The terminal addon stays. It is listed in `external: ['electron', 'fsevents', 'node-pty']` for the desktop main bundle, so it never passed through a loader. It keeps its own coverage in both electron-builder fields:

- `asarUnpack` retains `'**/node_modules/node-pty/**'`; only `'**/dist/main/*.node'` goes.
- `x64ArchFiles` drops the brace alternative and returns to `'**/app.asar.unpacked/node_modules/node-pty/prebuilds/**'`.

Both were confirmed after the edit by parsing the YAML.

## Net elements (R6)

| | |
| --- | --- |
| Files changed | 7 |
| Exported symbols | 0 added, 0 removed |
| Declarations removed | 1 ambient module |
| Net LoC | -13 |

## Consumer counts (R8)

| Removed | Consumers found |
| --- | --- |
| `declare module '*.node'` | 0 importers in `src`, `packages/*/src` |
| `'.node': 'file'` loaders | 0 files reach the loader; the only bundled `.node` was the addon |
| `'**/dist/main/*.node'` | addon output only; node-pty ships from `node_modules` |

## Verification

`node --check` passes on all five edited `.mjs` files. The electron-builder YAML parses and both node-pty globs are present. No new tests, no ratchet: a future `.node` import fails loudly in tsc and esbuild, which is the wanted behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QtWawFHNreKY2RkrRRHg4