### PR TITLE
fix(release): bump packages/llm with the rest of the workspace

### DIFF
--- a/scripts/bump-workspace-version.mjs
+++ b/scripts/bump-workspace-version.mjs
@@ -11,6 +11,7 @@ const MANIFEST_PATHS = [
   'packages/cli/package.json',
   'packages/desktop/package.json',
   'packages/extension/package.json',
+  'packages/llm/package.json',
 ];
 
 // Accept the canonical extension tag (`v0.38.9`), the CLI tag (`cli-v0.38.9`),

--- a/src/test-kernel/scripts/BumpWorkspaceVersion.vitest.ts
+++ b/src/test-kernel/scripts/BumpWorkspaceVersion.vitest.ts
@@ -16,6 +16,7 @@ const manifestPaths = [
   'packages/cli/package.json',
   'packages/desktop/package.json',
   'packages/extension/package.json',
+  'packages/llm/package.json',
 ];
 
 async function writeWorkspaceManifests(root: string, version: string) {


### PR DESCRIPTION
## Problem

`MANIFEST_PATHS` in `scripts/bump-workspace-version.mjs:8-14` lists every workspace manifest except `packages/llm/package.json`.

All six sit at 0.41.0 today, so nothing has drifted yet. The next release train would move five of them and leave the LLM package behind.

## Why it matters

The package being private and unpublished is presumably why it was missed. That does not make its version cosmetic. This list is what keeps the workspace coherent across a release train, and `packages/agent` is private too and is already listed.

`packages/llm` is the 1.0 provider path, so it wants a coherent version through the 1.0 line rather than a stale one.

## Scope

One line added, in the list's existing alphabetical order. No package source is touched. `node --check` passes.

Found while auditing release machinery for [#12168](https://github.com/LionSR/TeXRA/issues/12168).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QtWawFHNreKY2RkrRRHg4