### PR TITLE
test: repair the two red kernel fixtures

### DIFF
--- a/src/test-kernel/llm/GoogleInteractions.vitest.ts
+++ b/src/test-kernel/llm/GoogleInteractions.vitest.ts
@@ -253,6 +253,15 @@ function exchange(result: TurnResult): TurnRequest {
   };
 }
 
+// The Google SDK clones every request before handing it to `fetch`, and Node
+// links a cloned Request's abort signal to its parent only weakly: once that
+// dependent controller is collected the clone never sees the abort, so the
+// signal reaching `fetch` is not a sound place to observe cancellation. The
+// pre-clone signal the SDK derived from ours stays linked, so record it here
+// and let the abort fixtures watch that one.
+const preCloneSignal = new WeakMap<Request, AbortSignal>();
+const cloneRequest = Request.prototype.clone;
+
 describe('canonical Google Interactions protocol', () => {
   const fetchModel = vi.fn<typeof fetch>();
 
@@ -261,8 +270,14 @@ describe('canonical Google Interactions protocol', () => {
       .mockReset()
       .mockImplementation(async () => response(signedEvents()));
     vi.stubGlobal('fetch', fetchModel);
+    Request.prototype.clone = function (this: Request) {
+      const clone = cloneRequest.call(this);
+      preCloneSignal.set(clone, this.signal);
+      return clone;
+    };
   });
   afterEach(() => {
+    Request.prototype.clone = cloneRequest;
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
   });
@@ -578,11 +593,12 @@ describe('canonical Google Interactions protocol', () => {
         const failure = new Error('Late background body failure');
         fetchModel.mockImplementation(async (input) => {
           const request = input as Request;
+          const signal = preCloneSignal.get(request) ?? request.signal;
           return new Response(
             new ReadableStream<Uint8Array>(
               {
                 start(controller) {
-                  request.signal.addEventListener(
+                  signal.addEventListener(
                     'abort',
                     () => {
                       aborted.release();

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -327,32 +327,55 @@ describe('ExecutionsTool', () => {
       }
     }));
 
-  it('keeps completed wait summary reports inline when parent delivery cannot be confirmed', async () => {
-    mocks.readMeta.mockResolvedValue({
-      ...toolUseMeta,
-      parentExecutionId: 'parent123',
-    });
-    mocks.readConfig.mockResolvedValue(config);
-    mocks.readReport.mockResolvedValue(
-      '<subagent-result>full report</subagent-result>',
-    );
+  // A completed run has no live handle, so nothing proves the caller is the
+  // parent stream that already received the report as a follow-up. The wait
+  // summary must therefore keep the report inline rather than eliding it.
+  it('keeps completed wait summary reports inline when parent delivery cannot be confirmed', () =>
+    withTempStorage(async () => {
+      const session = createTestSession();
+      const executionId = 'abc123' as ExecutionId;
+      const childStreamId = `codex#${executionId}` as StreamTabId;
+      const callerStreamId = 'stream:unrelated-report-reader' as StreamTabId;
 
-    const waitResult = await new ExecutionsTool().call({
-      path: '/executions/abc123',
-      action: 'wait',
-    });
-    const reportResult = await new ExecutionsTool().call({
-      path: '/executions/abc123/report',
-    });
+      try {
+        publishTestRunStart(session, childStreamId, executionId);
+        await session.settlePublications();
+        mocks.readMeta.mockResolvedValue({
+          ...toolUseMeta,
+          identity: { kind: 'agent', agent: 'review' },
+          streamId: childStreamId,
+          parentExecutionId: 'parent123',
+        });
+        mocks.readConfig.mockResolvedValue(config);
+        mocks.readReport.mockResolvedValue(
+          '<subagent-result>full report</subagent-result>',
+        );
 
-    expect(waitResult.output).toContain(
-      '<subagent-result>full report</subagent-result>',
-    );
-    expect(waitResult.output).not.toContain('delivered automatically');
-    expect(reportResult.output).toBe(
-      '<subagent-result>full report</subagent-result>',
-    );
-  });
+        const [waitResult, reportResult] = await withRunContext(
+          createRunContext({ streamId: callerStreamId, session }),
+          () =>
+            Promise.all([
+              new ExecutionsTool().call({
+                path: `/executions/${executionId}`,
+                action: 'wait',
+              }),
+              new ExecutionsTool().call({
+                path: `/executions/${executionId}/report`,
+              }),
+            ]),
+        );
+
+        expect(waitResult.output).toContain(
+          '<subagent-result>full report</subagent-result>',
+        );
+        expect(waitResult.output).not.toContain('delivered automatically');
+        expect(reportResult.output).toBe(
+          '<subagent-result>full report</subagent-result>',
+        );
+      } finally {
+        session.dispose();
+      }
+    }));
 
   it.each([
     {


### PR DESCRIPTION
Two suites fail on clean `main` and are red on every open pull request. Both are stale fixtures, not product defects. No assertion was weakened, no timeout raised, no test skipped.

## ExecutionsToolWorkspaceFiles

`keeps completed wait summary reports inline when parent delivery cannot be confirmed` asserted on `waitResult.output`, which was `undefined`. The tool call was actually returning:

```
{ status: 'error',
  error: 'Invalid input:\n✖ Expected a canonical [kind, logicalId] aggregate key' }
```

`toolUseMeta` omits `streamId`, which `ExecutionMetaSchema` requires. On the completed-execution branch the summary resolves a stream from that missing id, builds the aggregate key `["stream",null]`, and `AggregateIdSchema` rejects it.

The case also ran outside a run context, unlike every passing sibling in the file, so nothing established who the caller was. It now publishes a run start, gives the meta a `streamId` and `identity`, and issues the call from an unrelated caller stream. That is precisely the situation the test name describes: the caller is not the parent, so the report cannot have been auto-delivered and must stay inline.

All three original assertions are unchanged. The agent confirmed the assertion is non-vacuous by temporarily asserting a sentinel, which printed the real completed-branch summary with the report present and no `delivered automatically` marker.

## GoogleInteractions

`aborts and joins the full background %s body without cancelling remote work` timed out after the full 10 seconds.

The fixture watched the wrong `AbortSignal`. The Google SDK calls `request.clone()` before handing the request to `fetch`, so the mock received a clone. Node links a cloned request's signal to its parent only through a weakly held dependent `AbortController`. Once that controller is collected, aborting the parent never reaches the clone, so the fixture's abort listener never fired, the mocked body never errored, and the uninterruptible cleanup blocked until the timeout.

That garbage-collection dependence is why this was flaky rather than always-red, and why the variant that lost varied between runs. Measured at roughly 50 to 60 percent failure across about 20 runs.

The fixture now records the pre-clone signal and restores `Request.prototype.clone` in `afterEach`.

## A production hazard this exposed, deliberately not patched here

The product's abort contract is correct: `googleInteractions.ts` passes `fetchOptions: { signal }` and Effect aborts it on interrupt or deadline. The link breaks one hop later, inside the SDK's clone, in Node. So an interrupted or deadline-expired Google Interactions call may not cancel its in-flight HTTP request, and cleanup then waits for the server to answer on its own.

In production that is bounded by the server response rather than an infinite hang, and it is not fixable in our code since we already hand the SDK the only signal it accepts. A workaround here would be a band-aid around third-party behavior, so none was added. This belongs upstream against `@google/genai`.

## Verification

| Check | Result |
| --- | --- |
| `npm test` | 763 files passed, 1 skipped; 9260 tests passed, 6 skipped; **0 failures** |
| The two suites, 5 consecutive runs | 93 passed every time |
| `prettier --check` on both files | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QtWawFHNreKY2RkrRRHg4