### PR TITLE
Convert the LaTeX toolchain to Effect

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -35,7 +35,6 @@
       "src/controllers/session/workspaceFileOptions.ts": 1,
       "src/controllers/settingsView/SettingsProfileKeyController.ts": 2,
       "src/housekeeping/runDirOps.ts": 2,
-      "src/latex/LatexMediaManager.ts": 2,
       "src/latex/latexParsingUtils.ts": 1,
       "src/model/codingPlanSubscriptions.ts": 2,
       "src/model/computeModelOptions.ts": 3,
@@ -91,9 +90,7 @@
       "src/utils/core/perKeyQueue.ts": 1
     },
     "import:p-map": {
-      "src/agent/modelHandlers/support/MediaAttachmentProcessor.ts": 1,
-      "src/latex/LatexMediaManager.ts": 1,
-      "src/latex/extractFileDependencies.ts": 1
+      "src/agent/modelHandlers/support/MediaAttachmentProcessor.ts": 1
     },
     "import:p-retry": {
       "src/agent/core/flows/ModelInvocationNode.ts": 1,
@@ -117,11 +114,15 @@
     },
     "Effect.run*": {
       "packages/extension/src/progressView/frontend/sessionTransport.ts": 4,
+      "src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts": 2,
+      "src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts": 1,
+      "src/agent/implementations/flows/reflection/output/LatexDiffManager.ts": 2,
       "src/agent/runtime/SessionHandle.ts": 3,
       "src/controllers/session/SessionBridge.ts": 6,
       "src/controllers/session/sessionLayer.ts": 3,
       "src/platform/defaults/jsonStore.ts": 1,
       "src/shared/signals.ts": 2,
+      "src/tools/approval/latexPreview.ts": 1,
       "src/tools/lean/direct/directLspAdapter.ts": 3
     },
     "catch:effect-importer": {
@@ -175,11 +176,15 @@
   },
   "debtLanes": {
     "packages/extension/src/progressView/frontend/sessionTransport.ts": "webview frontends — the progress view subscribes through an Effect-typed session plane instead of running fibers in the view",
+    "src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts": "PocketFlow-to-Effect (PRD R4 / 2026-09-04-agent-runtime-on-effect §4) — the LaTeX toolchain converted leaf-to-root ahead of the flow engine, so each of these carries one Promise seam against a node/manager the reflection-flow rewrite deletes outright",
+    "src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts": "PocketFlow-to-Effect (PRD R4 / 2026-09-04-agent-runtime-on-effect §4) — the LaTeX toolchain converted leaf-to-root ahead of the flow engine, so each of these carries one Promise seam against a node/manager the reflection-flow rewrite deletes outright",
+    "src/agent/implementations/flows/reflection/output/LatexDiffManager.ts": "PocketFlow-to-Effect (PRD R4 / 2026-09-04-agent-runtime-on-effect §4) — the LaTeX toolchain converted leaf-to-root ahead of the flow engine, so each of these carries one Promise seam against a node/manager the reflection-flow rewrite deletes outright",
     "src/agent/runtime/SessionHandle.ts": "Phase 3 — run lifecycle and cancellation",
     "src/controllers/session/SessionBridge.ts": "lane D — host composition root and session graph",
     "src/controllers/session/sessionLayer.ts": "lane D — host composition root and session graph",
     "src/platform/defaults/jsonStore.ts": "lane D — Platform ports become Effect-typed",
     "src/shared/signals.ts": "lane D — host composition root and session graph",
+    "src/tools/approval/latexPreview.ts": "PocketFlow-to-Effect (PRD R4) — the approval preview runs LaTeXdiffService from a callback-shaped entry; the run moves when ToolEditApprovalController owns the preview as an Effect",
     "src/tools/lean/direct/directLspAdapter.ts": "Lean LSP follow-up — the port is Effect-typed and the tool-facing runs moved to the tools' execute(); what remains is pool construction/disposal (the platform-lifetime seam) and the run-end hook's Promise seam, both owned by lane D"
   }
 }

--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -2,6 +2,7 @@
 import { mkdir, readdir, realpath } from 'node:fs/promises';
 import { resolve } from 'node:path';
 // Third-party imports
+import { Effect } from 'effect';
 import { execa } from 'execa';
 
 // Internal imports
@@ -16,12 +17,14 @@ import {
   parseLatexGitUrl,
   type OverleafRemote,
 } from '@latex/overleafProject';
+import { effectRuntime } from '@platform/processRuntime';
 import { executeCommandSync } from '@utils/system/execUtils';
 import { makeMachineGitEnv } from '@utils/system/gitEnv';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - runtime
 import { CliUsageError, type CliContext } from '../runtime/cliContext';
+
 import { installCliProcessRuntime } from '../runtime/cliProcessRuntime';
 import { getCliSecrets } from '../runtime/cliSecrets';
 import { CliExitCode } from '../runtime/exitCodes';
@@ -43,93 +46,108 @@ function buildOverleafClonePorts(
   const secrets = getCliSecrets();
   let canonicalWorkspacePath = workspacePath;
   return {
-    getStoredToken: (key) => secrets.get(key),
-    deleteStoredToken: (key) => secrets.delete(key),
-    storeToken: (key, token) => secrets.set(key, token),
-    promptToken: async (spec) => {
-      const tokenGuidance = remote.isOverleaf
-        ? `${spec.tokenHint ?? ''} Create or copy a token at ${OVERLEAF_GIT_TOKEN_URL}. Instructions: ${OVERLEAF_TOKEN_DOCS_URL}`.trim()
-        : spec.tokenHint;
-      if (context.mode !== 'interactive' || context.outputFormat !== 'text') {
-        throw new CliUsageError(
-          `No saved ${spec.tokenTitle} is available. ${tokenGuidance ? `${tokenGuidance} ` : ''}Run this command in an interactive terminal to enter and save one.`,
+    getStoredToken: (key) => Effect.promise(() => secrets.get(key)),
+    deleteStoredToken: (key) => Effect.promise(() => secrets.delete(key)),
+    storeToken: (key, token) => Effect.promise(() => secrets.set(key, token)),
+    promptToken: (spec) =>
+      Effect.gen(function* () {
+        const tokenGuidance = remote.isOverleaf
+          ? `${spec.tokenHint ?? ''} Create or copy a token at ${OVERLEAF_GIT_TOKEN_URL}. Instructions: ${OVERLEAF_TOKEN_DOCS_URL}`.trim()
+          : spec.tokenHint;
+        if (context.mode !== 'interactive' || context.outputFormat !== 'text') {
+          return yield* Effect.fail(
+            new CliUsageError(
+              `No saved ${spec.tokenTitle} is available. ${tokenGuidance ? `${tokenGuidance} ` : ''}Run this command in an interactive terminal to enter and save one.`,
+            ),
+          );
+        }
+        if (tokenGuidance) writeTextStderr(tokenGuidance);
+        const token = yield* Effect.promise(() =>
+          askCliQuestion(`${spec.tokenTitle}: `, { hidden: true }),
         );
-      }
-      if (tokenGuidance) writeTextStderr(tokenGuidance);
-      const token = (
-        await askCliQuestion(`${spec.tokenTitle}: `, { hidden: true })
-      ).trim();
-      return token || null;
-    },
-    showInvalidToken: async (_spec, message) => {
-      writeTextStderr(message);
-      writeTextStderr(`Token instructions: ${OVERLEAF_TOKEN_DOCS_URL}`);
-    },
+        return token.trim() || null;
+      }),
+    showInvalidToken: (_spec, message) =>
+      Effect.sync(() => {
+        writeTextStderr(message);
+        writeTextStderr(`Token instructions: ${OVERLEAF_TOKEN_DOCS_URL}`);
+      }),
 
     isGitAvailable: () =>
-      executeCommandSync(['git', '--version'], { quiet: true }).success,
-    showGitMissing: async () => {
-      writeTextStderr(
-        `Git is not installed or is not on PATH. Install it from ${GIT_DOWNLOAD_URL}.`,
-      );
-    },
-    listWorkspaceEntries: async (dir) => {
-      try {
-        return await readdir(dir);
-      } catch (error) {
-        if (isFileNotFoundError(error)) return [];
-        throw error;
-      }
-    },
-    showWorkspaceUnreadable: (error) => {
-      writeTextStderr(
-        `Cannot read destination directory: ${toErrorMessage(error)}`,
-      );
-    },
-    showWorkspaceNotEmpty: () => {
-      writeTextStderr(
-        `The destination directory ${workspacePath} is not empty. Create or choose an empty directory, then pass it as the second argument; for example: texra clone 0123456789abcdef01234567 ./paper`,
-      );
-    },
+      Effect.sync(
+        () => executeCommandSync(['git', '--version'], { quiet: true }).success,
+      ),
+    showGitMissing: () =>
+      Effect.sync(() => {
+        writeTextStderr(
+          `Git is not installed or is not on PATH. Install it from ${GIT_DOWNLOAD_URL}.`,
+        );
+      }),
+    listWorkspaceEntries: (dir) =>
+      Effect.tryPromise({ try: () => readdir(dir), catch: ensureError }).pipe(
+        // A destination that does not exist yet is an empty destination, not
+        // an unreadable one: `runClone` creates it.
+        Effect.catchIf(isFileNotFoundError, () => Effect.succeed<string[]>([])),
+      ),
+    showWorkspaceUnreadable: (error) =>
+      Effect.sync(() => {
+        writeTextStderr(
+          `Cannot read destination directory: ${toErrorMessage(error)}`,
+        );
+      }),
+    showWorkspaceNotEmpty: () =>
+      Effect.sync(() => {
+        writeTextStderr(
+          `The destination directory ${workspacePath} is not empty. Create or choose an empty directory, then pass it as the second argument; for example: texra clone 0123456789abcdef01234567 ./paper`,
+        );
+      }),
 
-    runClone: async (remoteUrl, workspacePath) => {
-      await mkdir(workspacePath, { recursive: true });
-      canonicalWorkspacePath = await realpath(workspacePath);
-      await execa('git', ['clone', remoteUrl, '.'], {
-        cwd: canonicalWorkspacePath,
-        // extendEnv: false is required — makeMachineGitEnv omits the
-        // helper-invoking keys, and execa's default merge re-adds them.
-        env: makeMachineGitEnv(),
-        extendEnv: false,
-      });
-    },
-    showCloneSucceeded: (label) => {
-      const result = {
-        cloned: true,
-        provider: remote.isOverleaf ? 'overleaf' : 'sharelatex',
-        host: remote.host,
-        destination: canonicalWorkspacePath,
-      };
-      emitCliResult(context, {
-        json: result,
-        ndjson: { kind: 'result', result: { command: 'clone', ...result } },
-        text: `${label} project cloned into ${canonicalWorkspacePath}.`,
-      });
-    },
-    showAuthFailure: async (failedRemote) => {
-      const detail = failedRemote.isOverleaf
-        ? `Generate a new token at ${OVERLEAF_GIT_TOKEN_URL}, then rerun the command.`
-        : 'Check the ShareLaTeX credentials for this host, then rerun the command.';
-      writeTextStderr(`Clone failed: authentication error. ${detail}`);
-    },
-    showCloneFailed: (message) => {
-      writeTextStderr(message);
-    },
-    logCloneError: (message) => {
-      if (!context.quietLogs) {
-        writeTextStderr(`Git clone error: ${message}`);
-      }
-    },
+    runClone: (remoteUrl, cloneInto) =>
+      Effect.tryPromise({
+        try: async () => {
+          await mkdir(cloneInto, { recursive: true });
+          canonicalWorkspacePath = await realpath(cloneInto);
+          await execa('git', ['clone', remoteUrl, '.'], {
+            cwd: canonicalWorkspacePath,
+            // extendEnv: false is required — makeMachineGitEnv omits the
+            // helper-invoking keys, and execa's default merge re-adds them.
+            env: makeMachineGitEnv(),
+            extendEnv: false,
+          });
+        },
+        catch: ensureError,
+      }),
+    showCloneSucceeded: (label) =>
+      Effect.sync(() => {
+        const result = {
+          cloned: true,
+          provider: remote.isOverleaf ? 'overleaf' : 'sharelatex',
+          host: remote.host,
+          destination: canonicalWorkspacePath,
+        };
+        emitCliResult(context, {
+          json: result,
+          ndjson: { kind: 'result', result: { command: 'clone', ...result } },
+          text: `${label} project cloned into ${canonicalWorkspacePath}.`,
+        });
+      }),
+    showAuthFailure: (failedRemote) =>
+      Effect.sync(() => {
+        const detail = failedRemote.isOverleaf
+          ? `Generate a new token at ${OVERLEAF_GIT_TOKEN_URL}, then rerun the command.`
+          : 'Check the ShareLaTeX credentials for this host, then rerun the command.';
+        writeTextStderr(`Clone failed: authentication error. ${detail}`);
+      }),
+    showCloneFailed: (message) =>
+      Effect.sync(() => {
+        writeTextStderr(message);
+      }),
+    logCloneError: (message) =>
+      Effect.sync(() => {
+        if (!context.quietLogs) {
+          writeTextStderr(`Git clone error: ${message}`);
+        }
+      }),
   };
 }
 
@@ -181,10 +199,12 @@ export const cloneCommand = withUsageSections(
       // way the update check does for the entry that precedes any platform.
       await installCliProcessRuntime(context.storageRoot);
 
-      const outcome = await cloneOverleafProject(
-        remote,
-        workspacePath,
-        buildOverleafClonePorts(context, remote, workspacePath),
+      const outcome = await effectRuntime().runPromise(
+        cloneOverleafProject(
+          remote,
+          workspacePath,
+          buildOverleafClonePorts(context, remote, workspacePath),
+        ),
       );
       switch (outcome.status) {
         case 'success':

--- a/packages/desktop/src/main/desktopHostRequests.ts
+++ b/packages/desktop/src/main/desktopHostRequests.ts
@@ -469,9 +469,8 @@ export function createDesktopHostRequests(
     }
     const base = pathToLocation(baseFile);
     if (action === 'latexdiffvc') {
-      const result = await new LaTeXdiffService(LATEXDIFF_CHANNEL).runDiffVc(
-        base,
-        commit,
+      const result = await effectRuntime().runPromise(
+        new LaTeXdiffService(LATEXDIFF_CHANNEL).runDiffVc(base, commit),
       );
       if (!result.success) throw new Rejected({ reason: result.message });
       await host.openBuildDisplay(createExternalLocation(result.diffPath));

--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -173,11 +173,13 @@ export class DesktopProgressFileActions {
 
   async runLatexdiffFile(baseFile: string, editedFile: string): Promise<void> {
     const service = new LaTeXdiffService(DESKTOP_LATEXDIFF_CHANNEL);
-    const result = await service.runDiff(
-      pathToLocation(baseFile),
-      pathToLocation(editedFile),
-      '_diff',
-      DEFAULT_MATH_MARKUP,
+    const result = await effectRuntime().runPromise(
+      service.runDiff(
+        pathToLocation(baseFile),
+        pathToLocation(editedFile),
+        '_diff',
+        DEFAULT_MATH_MARKUP,
+      ),
     );
 
     if (!result.success) {

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { execa } from 'execa';
 import * as vscode from 'vscode';
 
@@ -16,10 +17,11 @@ import {
   type OverleafRemote,
 } from '@latex/overleafProject';
 import { createLog } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import type { PlatformSecrets } from '@platform/secrets';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { readPlatformSetting } from '@utils/config/platformSettings';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import { COMMIT_HASH_PATTERN } from '@utils/git/commitHashPattern';
 import { COMMIT_LABEL_FORMAT } from '@utils/git/commitLogFormat';
 import { readRecentCommitLabels } from '@utils/git/repositoryOverview';
@@ -181,83 +183,107 @@ function buildOverleafClonePorts(
   return {
     // `getStored` (not `get`): the clone token is a persisted credential the
     // user manages here, never an environment override.
-    getStoredToken: (key) => secrets.getStored(key),
-    deleteStoredToken: (key) => secrets.delete(key),
-    storeToken: (key, token) => secrets.set(key, token),
+    getStoredToken: (key) => Effect.promise(() => secrets.getStored(key)),
+    deleteStoredToken: (key) => Effect.promise(() => secrets.delete(key)),
+    storeToken: (key, token) => Effect.promise(() => secrets.set(key, token)),
     promptToken: (spec) =>
-      promptInput(
-        spec.tokenTitle,
-        spec.tokenHint ?? 'Enter your Git authentication token.',
-        true,
+      Effect.promise(() =>
+        promptInput(
+          spec.tokenTitle,
+          spec.tokenHint ?? 'Enter your Git authentication token.',
+          true,
+        ),
       ),
-    showInvalidToken: async (spec, message) => {
-      log.error(message);
-      const action = await vscode.window.showErrorMessage(
-        message,
-        ...(spec.tokenHint ? (['How to get a token'] as const) : []),
-      );
-      if (action === 'How to get a token') {
-        void vscode.env.openExternal(vscode.Uri.parse(OVERLEAF_TOKEN_DOCS_URL));
-      }
-    },
+    showInvalidToken: (spec, message) =>
+      Effect.promise(async () => {
+        log.error(message);
+        const action = await vscode.window.showErrorMessage(
+          message,
+          ...(spec.tokenHint ? (['How to get a token'] as const) : []),
+        );
+        if (action === 'How to get a token') {
+          void vscode.env.openExternal(
+            vscode.Uri.parse(OVERLEAF_TOKEN_DOCS_URL),
+          );
+        }
+      }),
 
-    isGitAvailable: () => executeCommandSync(['git', '--version']).success,
-    showGitMissing: promptGitMissing,
-    listWorkspaceEntries: async (workspacePath) =>
-      (await WorkspaceFS.readDir(workspacePath)).map(([name]) => name),
-    showWorkspaceUnreadable: (e) => {
-      log.error(`readDir failed: ${toErrorMessage(e)}`);
-      void vscode.window.showErrorMessage('Cannot read workspace folder.');
-    },
-    showWorkspaceNotEmpty: () => {
-      void showLoggedMessage(CHANNEL, 'Workspace folder must be empty.');
-    },
+    isGitAvailable: () =>
+      Effect.sync(() => executeCommandSync(['git', '--version']).success),
+    showGitMissing: () => Effect.promise(() => promptGitMissing()),
+    listWorkspaceEntries: (workspacePath) =>
+      Effect.tryPromise({
+        try: async () =>
+          (await WorkspaceFS.readDir(workspacePath)).map(([name]) => name),
+        catch: ensureError,
+      }),
+    showWorkspaceUnreadable: (e) =>
+      Effect.sync(() => {
+        log.error(`readDir failed: ${toErrorMessage(e)}`);
+        void vscode.window.showErrorMessage('Cannot read workspace folder.');
+      }),
+    showWorkspaceNotEmpty: () =>
+      Effect.sync(() => {
+        void showLoggedMessage(CHANNEL, 'Workspace folder must be empty.');
+      }),
 
-    runClone: async (remoteUrl, workspacePath) => {
-      await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: `Cloning ${remote.isOverleaf ? 'Overleaf' : 'ShareLaTeX'}…`,
-        },
-        () =>
-          execa('git', ['clone', remoteUrl, '.'], {
-            cwd: workspacePath,
-            // Same extended PATH as the executeCommandSync preflight above, so
-            // the probe can't pass while the clone misses git (bot review).
-            // extendEnv: false is required — makeMachineGitEnv omits the
-            // helper-invoking keys, and execa's default merge re-adds them.
-            env: makeMachineGitEnv(),
-            extendEnv: false,
-          }),
-      );
-    },
-    showCloneSucceeded: (label) => {
-      vscode.window.showInformationMessage(`${label} project cloned.`);
-    },
-    showAuthFailure: async (r) => {
-      const detail = r.isOverleaf
-        ? 'Your git token may be invalid or expired.'
-        : 'Check your credentials.';
-      const actions = r.isOverleaf
-        ? (['Get New Token', 'How to get a token'] as const)
-        : (['Retry'] as const);
-      const authErrorMessage = `Clone failed: authentication error. ${detail}`;
-      const selected = await vscode.window.showErrorMessage(
-        authErrorMessage,
-        ...actions,
-      );
-      if (selected === 'Get New Token') {
-        void vscode.env.openExternal(vscode.Uri.parse(OVERLEAF_GIT_TOKEN_URL));
-      } else if (selected === 'How to get a token') {
-        void vscode.env.openExternal(vscode.Uri.parse(OVERLEAF_TOKEN_DOCS_URL));
-      }
-    },
-    showCloneFailed: (message) => {
-      void vscode.window.showErrorMessage(message);
-    },
-    logCloneError: (message) => {
-      log.error(`Clone failed: ${message}`);
-    },
+    runClone: (remoteUrl, workspacePath) =>
+      Effect.tryPromise({
+        try: () =>
+          vscode.window.withProgress(
+            {
+              location: vscode.ProgressLocation.Notification,
+              title: `Cloning ${remote.isOverleaf ? 'Overleaf' : 'ShareLaTeX'}…`,
+            },
+            () =>
+              execa('git', ['clone', remoteUrl, '.'], {
+                cwd: workspacePath,
+                // Same extended PATH as the executeCommandSync preflight
+                // above, so the probe can't pass while the clone misses git
+                // (bot review). extendEnv: false is required —
+                // makeMachineGitEnv omits the helper-invoking keys, and
+                // execa's default merge re-adds them.
+                env: makeMachineGitEnv(),
+                extendEnv: false,
+              }),
+          ),
+        catch: ensureError,
+      }).pipe(Effect.asVoid),
+    showCloneSucceeded: (label) =>
+      Effect.sync(() => {
+        vscode.window.showInformationMessage(`${label} project cloned.`);
+      }),
+    showAuthFailure: (r) =>
+      Effect.promise(async () => {
+        const detail = r.isOverleaf
+          ? 'Your git token may be invalid or expired.'
+          : 'Check your credentials.';
+        const actions = r.isOverleaf
+          ? (['Get New Token', 'How to get a token'] as const)
+          : (['Retry'] as const);
+        const authErrorMessage = `Clone failed: authentication error. ${detail}`;
+        const selected = await vscode.window.showErrorMessage(
+          authErrorMessage,
+          ...actions,
+        );
+        if (selected === 'Get New Token') {
+          void vscode.env.openExternal(
+            vscode.Uri.parse(OVERLEAF_GIT_TOKEN_URL),
+          );
+        } else if (selected === 'How to get a token') {
+          void vscode.env.openExternal(
+            vscode.Uri.parse(OVERLEAF_TOKEN_DOCS_URL),
+          );
+        }
+      }),
+    showCloneFailed: (message) =>
+      Effect.sync(() => {
+        void vscode.window.showErrorMessage(message);
+      }),
+    logCloneError: (message) =>
+      Effect.sync(() => {
+        log.error(`Clone failed: ${message}`);
+      }),
   };
 }
 
@@ -282,9 +308,11 @@ export async function cloneOverleafProject(
     return;
   }
 
-  await runOverleafClone(
-    remote,
-    workspacePath,
-    buildOverleafClonePorts(secrets, remote),
+  await effectRuntime().runPromise(
+    runOverleafClone(
+      remote,
+      workspacePath,
+      buildOverleafClonePorts(secrets, remote),
+    ),
   );
 }

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -21,6 +21,7 @@ import { runLatexFormatter } from '@latex/formatter/texFormatter';
 import { indentLatexFilesInDirectory } from '@latex/formatter/indentDirectory';
 import { buildLatexdiffAwareFixInstruction } from '@latex/latexdiff/diffFileNameManager';
 import { createLog } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import { AgentCategory } from '@shared/schemas';
 
 import {
@@ -138,10 +139,12 @@ export async function handleGetTeXCount(): Promise<void> {
         async (progress) => {
           progress.report({ message: 'Running texcount...' });
 
-          const { output, errors } = await getTeXCount(relativePath, {
-            mode: countingMode.value,
-            channel: CHANNEL,
-          });
+          const { output, errors } = await effectRuntime().runPromise(
+            getTeXCount(relativePath, {
+              mode: countingMode.value,
+              channel: CHANNEL,
+            }),
+          );
 
           if (!output) {
             const message =

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -51,6 +51,7 @@ import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { pathToLocation } from '@utils/files/fileLocation';
 import { checkToolInstalled } from '@utils/system/toolUtils';
+import type { Effect } from 'effect';
 
 const log = createLog(CHANNEL);
 
@@ -243,13 +244,13 @@ async function prepareLatexdiffResultsAndScheduleViewer(
  */
 async function runDiffAndOpen(
   toolLabel: string,
-  runDiff: (mathMarkup: MathMarkupOption) => Promise<LaTeXdiffResult>,
+  runDiff: (mathMarkup: MathMarkupOption) => Effect.Effect<LaTeXdiffResult>,
 ): Promise<void> {
   const mathMarkup = await promptForLatexdiffMathMarkup();
   if (!mathMarkup) return;
   log.info(`Running ${toolLabel} with math markup mode: ${mathMarkup}`);
 
-  const result = await runDiff(mathMarkup);
+  const result = await effectRuntime().runPromise(runDiff(mathMarkup));
   if (!result.success) {
     throw new Error(result.message);
   }

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -1,7 +1,10 @@
+import { Effect } from 'effect';
+
 import { BaseNode } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
+import { effectRuntime } from '@platform/processRuntime';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 
 import { getFilesForRound } from '../helpers';
@@ -54,22 +57,29 @@ export class MediaExtractionNode extends BaseNode<
       return null;
     }
 
+    // The one Promise seam left in this node: the media manager is Effect
+    // below this line, and the flow engine above it is not. The run goes when
+    // the reflection flow itself becomes a plain Effect loop (PRD R4).
     if (prepRes.currentRound === 0) {
-      await latexMediaManager.processInputFiles(
-        prepRes.files,
-        prepRes.workspaceState,
-        config.toolConfig,
-        prepRes.extraMediaFiles,
+      await effectRuntime().runPromise(
+        latexMediaManager.processInputFiles(
+          prepRes.files,
+          prepRes.workspaceState,
+          config.toolConfig,
+          prepRes.extraMediaFiles,
+        ),
       );
     } else {
       // Output files live at `runDir/r{round}/…`; mirror mirrored-workspace
       // deps (cls/sty/bib, local \input targets) as symlinks inside the
       // round dir so pdflatex/latexmk can resolve them during auto-compile.
       await fileService.ensureMirroredInRoundDir(prepRes.currentRound);
-      await latexMediaManager.processOutputFiles(
-        prepRes.files,
-        prepRes.workspaceState,
-        config.toolConfig,
+      await effectRuntime().runPromise(
+        latexMediaManager.processOutputFiles(
+          prepRes.files,
+          prepRes.workspaceState,
+          config.toolConfig,
+        ),
       );
     }
 

--- a/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
@@ -1,6 +1,9 @@
+import { Effect } from 'effect';
+
 import { BaseNode } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { getTeXCountStats } from '@latex/texcount';
+import { effectRuntime } from '@platform/processRuntime';
 import type { FileLocation } from '@shared/schemas';
 
 import { getFilesForRound } from '../helpers';
@@ -26,7 +29,12 @@ export class TeXCountNode extends BaseNode<
     if (!config.toolConfig.attachTeXCount || files.length === 0) {
       return null;
     }
-    return getTeXCountStats(files.map((f) => f.absolutePath));
+    // The one Promise seam left in this node: texcount is Effect below this
+    // line and the flow engine above it is not. The run goes when the
+    // reflection flow itself becomes a plain Effect loop (PRD R4).
+    return effectRuntime().runPromise(
+      getTeXCountStats(files.map((f) => f.absolutePath)),
+    );
   }
 
   override async execFallback(

--- a/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
+++ b/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import type { AgentTrace } from '@agent/trace';
 import { LaTeXdiffResult, LaTeXdiffService } from '@latex/latexdiff';
 import { compileLatex2Pdf } from '@latex/texTools';
+import { effectRuntime } from '@platform/processRuntime';
 import { platform } from '@platform/platform';
 import {
   fileLocationDisplayPath,
@@ -192,13 +193,18 @@ export class LatexDiffManager {
               outputByPath,
               originalLocation: baseLocation,
               baseRound: null,
+              // The one Promise seam left in this manager: the diff service
+              // is Effect below this line and the reflection flow above it is
+              // not. The run goes when the flow becomes an Effect loop (R4).
               runDiff: (base, revised, cwd) =>
-                this.latexdiffService.runDiffForRound(
-                  base,
-                  revised,
-                  currRound,
-                  undefined,
-                  { cwd, outputDirectory: diffDirectory.absolutePath },
+                effectRuntime().runPromise(
+                  this.latexdiffService.runDiffForRound(
+                    base,
+                    revised,
+                    currRound,
+                    undefined,
+                    { cwd, outputDirectory: diffDirectory.absolutePath },
+                  ),
                 ),
               label: 'round-diff',
               pdfStemSuffix: '-diff',
@@ -229,16 +235,18 @@ export class LatexDiffManager {
               originalLocation,
               baseRound: currRound - 1,
               runDiff: (base, revised, cwd) =>
-                this.latexdiffService.runDiffBetweenRounds(
-                  base,
-                  revised,
-                  currRound - 1,
-                  currRound,
-                  undefined,
-                  {
-                    cwd,
-                    outputDirectory: diffDirectory.absolutePath,
-                  },
+                effectRuntime().runPromise(
+                  this.latexdiffService.runDiffBetweenRounds(
+                    base,
+                    revised,
+                    currRound - 1,
+                    currRound,
+                    undefined,
+                    {
+                      cwd,
+                      outputDirectory: diffDirectory.absolutePath,
+                    },
+                  ),
                 ),
               label: 'between-rounds-diff',
               pdfStemSuffix: '-round-diff',

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -2,17 +2,16 @@
 import * as path from 'node:path';
 
 // Third-party imports
-import pMap from 'p-map';
+import { Effect } from 'effect';
 
 // Local imports
-import { platform } from '@platform/platform';
 import type { FileLocation } from '@shared/schemas';
 import { ToolConfig } from '@shared/schemas';
 import { filterNotNullish } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { pathToLocation } from '@utils/files/fileLocation';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import { isFile } from '@utils/files/fsEntryType';
 import { getExtensionLowercase, hasExtension } from '@utils/core/pathCore';
 
@@ -67,6 +66,10 @@ export interface LatexTrace {
   error(message: string, options?: LatexLogOptions): void;
 }
 
+/** Run `effect`, reading a filesystem promise as a typed failure. */
+const fsCall = <A>(thunk: () => Promise<A>): Effect.Effect<A, Error> =>
+  Effect.tryPromise({ try: thunk, catch: ensureError });
+
 /**
  * Handles LaTeX related media extraction and compilation for agents.
  */
@@ -80,163 +83,189 @@ export class LatexMediaManager {
    * Run `task` over `items` at the LaTeX concurrency limit, keeping going when
    * an individual item fails. Mirroring is best-effort by design — a deleted
    * figure or a dependency outside the workspace must not take the surviving
-   * files down with it — so the failure is swallowed, and logged here with the
-   * offending path rather than at each call site.
+   * files down with it — so an item's typed failure is recovered here and
+   * logged with the offending path rather than at each call site. Defects and
+   * interruption still propagate: a bug or a cancelled run is not a skipped
+   * file.
    */
-  private async forEachFile<T>(
+  private forEachFile<T, E>(
     items: readonly T[],
     pathOf: (item: T) => string,
     failureMessage: string,
-    task: (item: T) => Promise<unknown>,
-  ): Promise<void> {
-    await pMap(
+    task: (item: T) => Effect.Effect<unknown, E>,
+  ): Effect.Effect<void> {
+    return Effect.forEach(
       items,
-      async (item) => {
-        try {
-          await task(item);
-        } catch (error) {
-          this.logger.debug(failureMessage, {
-            data: { path: pathOf(item), error },
-          });
-        }
-      },
-      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
+      (item) =>
+        task(item).pipe(
+          Effect.catch((error) =>
+            Effect.sync(() => {
+              this.logger.debug(failureMessage, {
+                data: { path: pathOf(item), error },
+              });
+            }),
+          ),
+        ),
+      { concurrency: LATEX_CONCURRENCY, discard: true },
     );
   }
 
-  private async mirrorFigureDependencies(
+  private mirrorFigureDependencies(
     latexFile: FileLocation,
-    figures: string[],
+    figures: readonly string[],
     baseDir?: string,
-  ): Promise<void> {
-    const fileService = this.fileService;
-    if (!fileService || figures.length === 0) {
-      return;
-    }
-
-    // Resolve against the workspace directory so figure paths from a
-    // run-storage symlink map back to real workspace files (otherwise
-    // mirrorWorkspaceFile would classify them as external and skip).
-    // Callers that already resolved this for their own purposes (e.g.
-    // extractFiguresFromFiles) pass it in to avoid a redundant async lookup.
-    const resolvedBaseDir =
-      baseDir ?? (await resolveLatexDir(latexFile.absolutePath));
-    const absolutePaths = new Set<string>();
-    for (const relative of figures) {
-      const trimmed = relative.trim();
-      if (trimmed) {
-        absolutePaths.add(path.normalize(path.join(resolvedBaseDir, trimmed)));
+  ): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      const fileService = this.fileService;
+      if (!fileService || figures.length === 0) {
+        return;
       }
-    }
 
-    if (absolutePaths.size === 0) {
-      return;
-    }
+      // Resolve against the workspace directory so figure paths from a
+      // run-storage symlink map back to real workspace files (otherwise
+      // mirrorWorkspaceFile would classify them as external and skip).
+      // Callers that already resolved this for their own purposes (e.g.
+      // extractFiguresFromFiles) pass it in to avoid a redundant lookup.
+      const resolvedBaseDir =
+        baseDir ?? (yield* resolveLatexDir(latexFile.absolutePath));
+      const absolutePaths = new Set<string>();
+      for (const relative of figures) {
+        const trimmed = relative.trim();
+        if (trimmed) {
+          absolutePaths.add(
+            path.normalize(path.join(resolvedBaseDir, trimmed)),
+          );
+        }
+      }
 
-    await this.forEachFile(
-      [...absolutePaths],
-      (absolutePath) => absolutePath,
-      'Unable to mirror figure dependency',
-      (absolutePath) =>
-        fileService.mirrorWorkspaceFile(pathToLocation(absolutePath)),
-    );
+      if (absolutePaths.size === 0) {
+        return;
+      }
+
+      yield* this.forEachFile(
+        [...absolutePaths],
+        (absolutePath) => absolutePath,
+        'Unable to mirror figure dependency',
+        (absolutePath) =>
+          fsCall(() =>
+            fileService.mirrorWorkspaceFile(pathToLocation(absolutePath)),
+          ),
+      );
+    });
+  }
+
+  /**
+   * Compile one LaTeX file to PDF, returning the PDF's location or `undefined`
+   * when the compile, the write, or the size check disqualifies it.
+   */
+  private compileOnePdf(
+    file: FileLocation,
+  ): Effect.Effect<FileLocation | undefined, Error> {
+    return Effect.gen({ self: this }, function* () {
+      const buildDir = path.join(path.dirname(file.absolutePath), 'build');
+      yield* fsCall(() => AbsoluteFS.ensureDir(buildDir));
+      const compiled = yield* fsCall(() =>
+        compileLatex2Pdf(file, { outputDirectory: buildDir }),
+      );
+      if (!compiled.ok) {
+        this.logger.warn(
+          `Failed to compile LaTeX to PDF:\n${compiled.logTail}`,
+          {
+            data: { sourceFile: file.absolutePath, logTail: compiled.logTail },
+          },
+        );
+        return undefined;
+      }
+
+      const pdfLocation = pathToLocation(compiled.pdfPath);
+      const written = yield* fsCall(() =>
+        AbsoluteFS.exists(pdfLocation.absolutePath),
+      );
+      if (!written) {
+        this.logger.warn(
+          'LaTeX reported success but no PDF was written; skipping',
+          {
+            data: {
+              sourceFile: file.absolutePath,
+              pdfFile: pdfLocation.absolutePath,
+            },
+          },
+        );
+        return undefined;
+      }
+
+      // Stat failures are noisier than other compile failures because an
+      // existing-but-unreadable PDF likely indicates a permissions/IO bug.
+      const stats = yield* fsCall(() =>
+        AbsoluteFS.stat(pdfLocation.absolutePath),
+      ).pipe(
+        Effect.catch((err) =>
+          Effect.sync(() => {
+            this.logger.error(
+              `Failed to stat compiled PDF ${pdfLocation.absolutePath}: ${toErrorMessage(err)}`,
+              { data: { path: pdfLocation.absolutePath, error: err } },
+            );
+            return undefined;
+          }),
+        ),
+      );
+      if (!stats) return undefined;
+      if (stats.size === 0) {
+        this.logger.warn('Compiled PDF is empty', {
+          data: {
+            sourceFile: file.absolutePath,
+            pdfFile: pdfLocation.absolutePath,
+          },
+        });
+        return undefined;
+      }
+
+      this.logger.info('Compiled PDF', {
+        data: {
+          sourceFile: file.absolutePath,
+          pdfFile: pdfLocation.absolutePath,
+        },
+      });
+      return pdfLocation;
+    });
   }
 
   /**
    * Compile LaTeX files to PDF and add them to the tool state.
    */
-  private async compilePdfs(
-    files: FileLocation[],
+  private compilePdfs(
+    files: readonly FileLocation[],
     workspaceState: MediaWorkspaceState,
-  ): Promise<void> {
-    const texFiles = files.filter((file) =>
-      hasExtension(file.absolutePath, '.tex'),
-    );
+  ): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      const texFiles = files.filter((file) =>
+        hasExtension(file.absolutePath, '.tex'),
+      );
 
-    const compileResults = await pMap(
-      texFiles,
-      async (file): Promise<FileLocation | undefined> => {
-        try {
-          const buildDir = path.join(path.dirname(file.absolutePath), 'build');
-          await AbsoluteFS.ensureDir(buildDir);
-          const compiled = await compileLatex2Pdf(file, {
-            outputDirectory: buildDir,
-          });
-          if (!compiled.ok) {
-            this.logger.warn(
-              `Failed to compile LaTeX to PDF:\n${compiled.logTail}`,
-              {
-                data: {
-                  sourceFile: file.absolutePath,
-                  logTail: compiled.logTail,
-                },
-              },
-            );
-            return undefined;
-          }
+      const compileResults = yield* Effect.forEach(
+        texFiles,
+        (file) =>
+          // The build-directory and existence-probe I/O (and path resolution)
+          // fail here; a compile that merely returns { ok: false } is logged
+          // inside compileOnePdf. Either way the remaining files continue.
+          this.compileOnePdf(file).pipe(
+            Effect.catch((error) =>
+              Effect.sync(() => {
+                this.logger.warn(
+                  `Skipping PDF compile for ${file.absolutePath}: ${toErrorMessage(error)}`,
+                  { data: { sourceFile: file.absolutePath, error } },
+                );
+                return undefined;
+              }),
+            ),
+          ),
+        { concurrency: LATEX_CONCURRENCY },
+      );
 
-          const pdfLocation = pathToLocation(compiled.pdfPath);
-          if (!(await AbsoluteFS.exists(pdfLocation.absolutePath))) {
-            this.logger.warn(
-              'LaTeX reported success but no PDF was written; skipping',
-              {
-                data: {
-                  sourceFile: file.absolutePath,
-                  pdfFile: pdfLocation.absolutePath,
-                },
-              },
-            );
-            return undefined;
-          }
-
-          // Stat failures are noisier than other compile failures because an
-          // existing-but-unreadable PDF likely indicates a permissions/IO bug.
-          const stats = await AbsoluteFS.stat(pdfLocation.absolutePath).catch(
-            (err) => {
-              this.logger.error(
-                `Failed to stat compiled PDF ${pdfLocation.absolutePath}: ${toErrorMessage(err)}`,
-                { data: { path: pdfLocation.absolutePath, error: err } },
-              );
-              return undefined;
-            },
-          );
-          if (!stats) return undefined;
-          if (stats.size === 0) {
-            this.logger.warn('Compiled PDF is empty', {
-              data: {
-                sourceFile: file.absolutePath,
-                pdfFile: pdfLocation.absolutePath,
-              },
-            });
-            return undefined;
-          }
-
-          this.logger.info('Compiled PDF', {
-            data: {
-              sourceFile: file.absolutePath,
-              pdfFile: pdfLocation.absolutePath,
-            },
-          });
-          return pdfLocation;
-        } catch (error) {
-          // Compile failures do not land here: compileLatex2Pdf returns
-          // { ok: false } and is logged above. This arm catches the
-          // build-directory and existence-probe I/O (and path resolution),
-          // so it must be loud; pMap's stopOnError: false then carries on
-          // to the remaining files.
-          this.logger.warn(
-            `Skipping PDF compile for ${file.absolutePath}: ${toErrorMessage(error)}`,
-            { data: { sourceFile: file.absolutePath, error } },
-          );
-          return undefined;
-        }
-      },
-      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
-    );
-
-    for (const result of compileResults.filter(filterNotNullish)) {
-      workspaceState.media.addMediaFiles([result]);
-    }
+      for (const result of compileResults.filter(filterNotNullish)) {
+        workspaceState.media.addMediaFiles([result]);
+      }
+    });
   }
 
   /**
@@ -248,71 +277,70 @@ export class LatexMediaManager {
    * that transitive includes (e.g. main.tex → chapters/ch1.tex →
    * chapters/figures/fig1.tex) are all brought along.
    */
-  private async mirrorLatexFileDependencies(
-    files: FileLocation[],
-  ): Promise<void> {
-    const fileService = this.fileService;
-    if (!fileService || files.length === 0) {
-      return;
-    }
+  private mirrorLatexFileDependencies(
+    files: readonly FileLocation[],
+  ): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      const fileService = this.fileService;
+      if (!fileService || files.length === 0) {
+        return;
+      }
 
-    const texFiles = files.filter((file) =>
-      hasExtension(file.absolutePath, '.tex'),
-    );
-    if (texFiles.length === 0) return;
-
-    const visited = new Set<string>();
-    const worklist: FileLocation[] = [...texFiles];
-
-    // Sweep siblings of every root input file up front. Resolve the real
-    // path first so a mirrored symlink inside run storage points back to
-    // the original workspace tree — otherwise project-local .cls/.sty/.bst/
-    // latexmkrc files that live beside the real source are invisible.
-    await pMap(
-      texFiles,
-      async (file) => {
-        let siblingDir = path.dirname(file.absolutePath);
-        try {
-          siblingDir = path.dirname(
-            await platform().fs.realPath(file.absolutePath),
-          );
-        } catch (error) {
-          this.logger.debug('Unable to resolve real path', {
-            data: { path: file.absolutePath, error },
-          });
-        }
-        await this.mirrorProjectSiblings(siblingDir);
-      },
-      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
-    );
-
-    while (worklist.length > 0) {
-      const file = worklist.shift()!;
-      if (visited.has(file.absolutePath)) continue;
-      visited.add(file.absolutePath);
-
-      const deps = await this.collectDependencies(file);
-      if (deps.length === 0) continue;
-
-      await this.forEachFile(
-        deps,
-        (absolutePath) => absolutePath,
-        'Unable to mirror LaTeX dependency',
-        async (absolutePath) => {
-          const depLocation = pathToLocation(absolutePath);
-          const isTex = hasExtension(absolutePath, '.tex');
-          await fileService.mirrorWorkspaceFile(depLocation, {
-            snapshot: isTex,
-          });
-          if (isTex) {
-            worklist.push(depLocation);
-          }
-        },
+      const texFiles = files.filter((file) =>
+        hasExtension(file.absolutePath, '.tex'),
       );
-      this.logger.debug('Mirrored LaTeX dependencies', {
-        data: { count: deps.length, from: file.absolutePath },
-      });
-    }
+      if (texFiles.length === 0) return;
+
+      const visited = new Set<string>();
+      const worklist: FileLocation[] = [...texFiles];
+
+      // Sweep siblings of every root input file up front. `resolveLatexDir`
+      // follows the symlink first, so a mirrored .tex inside run storage
+      // points back at the original workspace tree — otherwise project-local
+      // .cls/.sty/.bst/latexmkrc files that live beside the real source are
+      // invisible — and falls back to the literal dirname when it can't.
+      yield* Effect.forEach(
+        texFiles,
+        (file) =>
+          resolveLatexDir(file.absolutePath).pipe(
+            Effect.flatMap((siblingDir) =>
+              this.mirrorProjectSiblings(siblingDir),
+            ),
+          ),
+        { concurrency: LATEX_CONCURRENCY, discard: true },
+      );
+
+      while (worklist.length > 0) {
+        const file = worklist.shift()!;
+        if (visited.has(file.absolutePath)) continue;
+        visited.add(file.absolutePath);
+
+        const deps = yield* this.collectDependencies(file);
+        if (deps.length === 0) continue;
+
+        yield* this.forEachFile(
+          deps,
+          (absolutePath) => absolutePath,
+          'Unable to mirror LaTeX dependency',
+          (absolutePath) =>
+            Effect.gen(function* () {
+              const depLocation = pathToLocation(absolutePath);
+              const isTex = hasExtension(absolutePath, '.tex');
+              yield* fsCall(() =>
+                fileService.mirrorWorkspaceFile(depLocation, {
+                  snapshot: isTex,
+                }),
+              );
+              if (isTex) {
+                worklist.push(depLocation);
+              }
+            }),
+        );
+        this.logger.debug('Mirrored LaTeX dependencies', {
+          data: { count: deps.length, from: file.absolutePath },
+        });
+      }
+    });
   }
 
   /**
@@ -320,45 +348,66 @@ export class LatexMediaManager {
    * \usepackage{name} whose `name.sty` sits beside the current file or its
    * project root.
    */
-  private async collectDependencies(
+  private collectDependencies(
     latexFile: FileLocation,
-  ): Promise<string[]> {
-    const found = new Set<string>();
+  ): Effect.Effect<string[]> {
+    return Effect.gen({ self: this }, function* () {
+      const found = new Set<string>();
 
-    try {
-      const direct = await extractLatexFileDependencies(latexFile);
+      const direct = yield* extractLatexFileDependencies(latexFile).pipe(
+        Effect.catch((error) =>
+          Effect.sync((): readonly string[] => {
+            this.logger.debug('Unable to extract LaTeX dependencies', {
+              data: { path: latexFile.absolutePath, error },
+            });
+            return [];
+          }),
+        ),
+      );
       for (const abs of direct) {
         found.add(abs);
       }
-    } catch (error) {
-      this.logger.debug('Unable to extract LaTeX dependencies', {
-        data: { path: latexFile.absolutePath, error },
-      });
-    }
 
-    try {
-      const realPath = await platform().fs.realPath(latexFile.absolutePath);
-      const content = await AbsoluteFS.read(latexFile.absolutePath);
-      const uncommented = stripLatexComments(content);
-      const baseDir = path.dirname(realPath);
+      const local = yield* Effect.gen({ self: this }, function* () {
+        // `resolveLatexDir` follows the symlink and falls back to the literal
+        // dirname, so a file whose real path can't be resolved still gets its
+        // sibling `.sty` files probed instead of skipping the probe entirely.
+        const baseDir = yield* resolveLatexDir(latexFile.absolutePath);
+        const content = yield* fsCall(() =>
+          AbsoluteFS.read(latexFile.absolutePath),
+        );
+        const uncommented = stripLatexComments(content);
 
-      const packageNames = collectCommaSeparatedMatches(
-        uncommented,
-        USEPACKAGE_PATTERN,
+        const candidates = collectCommaSeparatedMatches(
+          uncommented,
+          USEPACKAGE_PATTERN,
+        ).map((name) => path.join(baseDir, `${name}.sty`));
+
+        const probed = yield* Effect.forEach(
+          candidates,
+          (candidate) =>
+            fsCall(() => AbsoluteFS.exists(candidate)).pipe(
+              Effect.map((exists) => (exists ? candidate : undefined)),
+            ),
+          { concurrency: LATEX_CONCURRENCY },
+        );
+        return probed.filter(filterNotNullish);
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.sync((): readonly string[] => {
+            this.logger.debug('Unable to probe \\usepackage targets', {
+              data: { path: latexFile.absolutePath, error },
+            });
+            return [];
+          }),
+        ),
       );
-      for (const name of packageNames) {
-        const candidate = path.join(baseDir, `${name}.sty`);
-        if (await AbsoluteFS.exists(candidate)) {
-          found.add(candidate);
-        }
+      for (const abs of local) {
+        found.add(abs);
       }
-    } catch (error) {
-      this.logger.debug('Unable to probe \\usepackage targets', {
-        data: { path: latexFile.absolutePath, error },
-      });
-    }
 
-    return [...found];
+      return [...found];
+    });
   }
 
   /**
@@ -366,43 +415,51 @@ export class LatexMediaManager {
    * (*.cls, *.sty, *.bst, latexmkrc, .latexindentrc) and mirror them into
    * run storage so the compiled document can find its project-local style.
    */
-  private async mirrorProjectSiblings(projectDir: string): Promise<void> {
-    const fileService = this.fileService;
-    if (!fileService) return;
+  private mirrorProjectSiblings(projectDir: string): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      const fileService = this.fileService;
+      if (!fileService) return;
 
-    let entries: string[];
-    try {
-      entries = (await AbsoluteFS.readDir(projectDir)).map(([name]) => name);
-    } catch (error) {
-      this.logger.debug('Unable to scan project siblings', {
-        data: { path: projectDir, error },
-      });
-      return;
-    }
+      const entries = yield* fsCall(() => AbsoluteFS.readDir(projectDir)).pipe(
+        Effect.map((read) => read.map(([name]) => name)),
+        Effect.catch((error) =>
+          Effect.sync((): string[] | undefined => {
+            this.logger.debug('Unable to scan project siblings', {
+              data: { path: projectDir, error },
+            });
+            return undefined;
+          }),
+        ),
+      );
+      if (!entries) return;
 
-    const candidates: string[] = [];
-    for (const name of entries) {
-      const ext = getExtensionLowercase(name);
-      if (
-        PROJECT_SIBLING_EXTENSIONS.has(ext) ||
-        PROJECT_SIBLING_NAMES.has(name)
-      ) {
-        candidates.push(path.join(projectDir, name));
+      const candidates: string[] = [];
+      for (const name of entries) {
+        const ext = getExtensionLowercase(name);
+        if (
+          PROJECT_SIBLING_EXTENSIONS.has(ext) ||
+          PROJECT_SIBLING_NAMES.has(name)
+        ) {
+          candidates.push(path.join(projectDir, name));
+        }
       }
-    }
 
-    if (candidates.length === 0) return;
+      if (candidates.length === 0) return;
 
-    await this.forEachFile(
-      candidates,
-      (absolutePath) => absolutePath,
-      'Unable to mirror project sibling',
-      async (absolutePath) => {
-        const stats = await AbsoluteFS.stat(absolutePath);
-        if (!isFile(stats.type)) return;
-        await fileService.mirrorWorkspaceFile(pathToLocation(absolutePath));
-      },
-    );
+      yield* this.forEachFile(
+        candidates,
+        (absolutePath) => absolutePath,
+        'Unable to mirror project sibling',
+        (absolutePath) =>
+          Effect.gen(function* () {
+            const stats = yield* fsCall(() => AbsoluteFS.stat(absolutePath));
+            if (!isFile(stats.type)) return;
+            yield* fsCall(() =>
+              fileService.mirrorWorkspaceFile(pathToLocation(absolutePath)),
+            );
+          }),
+      );
+    });
   }
 
   /**
@@ -411,126 +468,139 @@ export class LatexMediaManager {
    * (round 1+) so newly-referenced figures are available for PDF compilation
    * but not re-sent to the model on every round.
    */
-  private async mirrorFiguresForFiles(files: FileLocation[]): Promise<void> {
-    if (!this.fileService || files.length === 0) {
-      return;
-    }
-
-    const texFiles = files.filter((file) =>
-      hasExtension(file.absolutePath, '.tex'),
-    );
-    if (texFiles.length === 0) return;
-
-    await this.forEachFile(
-      texFiles,
-      (file) => file.absolutePath,
-      'Unable to mirror figures',
-      async (file) => {
-        const figures = await extractFigurePathsFromLatex(file);
-        if (figures.length === 0) return;
-        await this.mirrorFigureDependencies(file, figures);
-      },
-    );
-  }
-
-  private async extractFiguresFromFiles(
-    files: FileLocation[],
-    workspaceState: MediaWorkspaceState,
-  ): Promise<void> {
-    const figureResults = await pMap(
-      files,
-      async (file): Promise<{ file: FileLocation; figures: string[] }> => {
-        try {
-          const figures = await extractFigurePathsFromLatex(file);
-          return { file, figures };
-        } catch {
-          // Silent skip: malformed or unreadable .tex files should not abort
-          // the surrounding pMap. Existence/format errors here are common
-          // (e.g. file deleted mid-run) and not worth user-visible noise.
-          return { file, figures: [] };
-        }
-      },
-      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
-    );
-
-    const mirrorTasks: Promise<void>[] = [];
-
-    for (const { file, figures } of figureResults) {
-      if (figures.length === 0) {
-        continue;
+  private mirrorFiguresForFiles(
+    files: readonly FileLocation[],
+  ): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      if (!this.fileService || files.length === 0) {
+        return;
       }
 
-      this.logger.debug('Extracted figures', {
-        data: { count: figures.length, from: file.absolutePath },
-      });
+      const texFiles = files.filter((file) =>
+        hasExtension(file.absolutePath, '.tex'),
+      );
+      if (texFiles.length === 0) return;
 
-      // Match the resolution in extractFigurePathsFromLatex so the returned
-      // figure paths (relative to the real latexDir) map back to workspace
-      // files when the .tex is symlinked into run storage.
-      const baseDir = await resolveLatexDir(file.absolutePath);
-      const fileLocations = figures.map((relativePath) =>
-        pathToLocation(path.normalize(path.join(baseDir, relativePath))),
+      yield* this.forEachFile(
+        texFiles,
+        (file) => file.absolutePath,
+        'Unable to mirror figures',
+        (file) =>
+          Effect.gen({ self: this }, function* () {
+            const figures = yield* extractFigurePathsFromLatex(file);
+            if (figures.length === 0) return;
+            yield* this.mirrorFigureDependencies(file, figures);
+          }),
+      );
+    });
+  }
+
+  private extractFiguresFromFiles(
+    files: readonly FileLocation[],
+    workspaceState: MediaWorkspaceState,
+  ): Effect.Effect<void, Error> {
+    return Effect.gen({ self: this }, function* () {
+      const figureResults = yield* Effect.forEach(
+        files,
+        (file) =>
+          extractFigurePathsFromLatex(file).pipe(
+            // Silent skip: malformed or unreadable .tex files should not abort
+            // the surrounding fan-out. Existence/format errors here are common
+            // (e.g. file deleted mid-run) and not worth user-visible noise.
+            Effect.catch(() => Effect.succeed<readonly string[]>([])),
+            Effect.map((figures) => ({ file, figures })),
+          ),
+        { concurrency: LATEX_CONCURRENCY },
       );
 
-      // A figure that no longer exists cannot be compiled into the PDF or
-      // attached to vision context, so it must not enter media. The resolution
-      // above re-derives baseDir (unlike extractFigurePathsFromLatex, whose
-      // paths were checked against the original latexDir), so this filter is a
-      // real gate, not a re-check of already-known data.
-      const existingLocations: FileLocation[] = [];
-      for (const loc of fileLocations) {
-        if (!(await AbsoluteFS.exists(loc.absolutePath))) {
-          this.logger.debug('Extracted figure path does not exist', {
-            data: { figurePath: loc.absolutePath, from: file.absolutePath },
-          });
+      const mirrors: Effect.Effect<void>[] = [];
+
+      for (const { file, figures } of figureResults) {
+        if (figures.length === 0) {
           continue;
         }
-        existingLocations.push(loc);
+
+        this.logger.debug('Extracted figures', {
+          data: { count: figures.length, from: file.absolutePath },
+        });
+
+        // Match the resolution in extractFigurePathsFromLatex so the returned
+        // figure paths (relative to the real latexDir) map back to workspace
+        // files when the .tex is symlinked into run storage.
+        const baseDir = yield* resolveLatexDir(file.absolutePath);
+        const fileLocations = figures.map((relativePath) =>
+          pathToLocation(path.normalize(path.join(baseDir, relativePath))),
+        );
+
+        // A figure that no longer exists cannot be compiled into the PDF or
+        // attached to vision context, so it must not enter media. The
+        // resolution above re-derives baseDir (unlike
+        // extractFigurePathsFromLatex, whose paths were checked against the
+        // original latexDir), so this filter is a real gate, not a re-check of
+        // already-known data.
+        const probed = yield* Effect.forEach(
+          fileLocations,
+          (loc) =>
+            fsCall(() => AbsoluteFS.exists(loc.absolutePath)).pipe(
+              Effect.map((exists) => ({ loc, exists })),
+            ),
+          { concurrency: LATEX_CONCURRENCY },
+        );
+        const existingLocations: FileLocation[] = [];
+        for (const { loc, exists } of probed) {
+          if (!exists) {
+            this.logger.debug('Extracted figure path does not exist', {
+              data: { figurePath: loc.absolutePath, from: file.absolutePath },
+            });
+            continue;
+          }
+          existingLocations.push(loc);
+        }
+
+        workspaceState.media.addMediaFiles(existingLocations);
+        mirrors.push(this.mirrorFigureDependencies(file, figures, baseDir));
       }
 
-      workspaceState.media.addMediaFiles(existingLocations);
-      mirrorTasks.push(this.mirrorFigureDependencies(file, figures, baseDir));
-    }
-
-    if (mirrorTasks.length > 0) {
-      await Promise.all(mirrorTasks);
-    }
+      yield* Effect.all(mirrors, {
+        concurrency: LATEX_CONCURRENCY,
+        discard: true,
+      });
+    });
   }
 
-  private async compileTikzFigures(
-    files: FileLocation[],
+  private compileTikzFigures(
+    files: readonly FileLocation[],
     workspaceState: MediaWorkspaceState,
     logSummary: boolean,
-  ): Promise<void> {
-    const tikzResults = await pMap(
-      files,
-      async (file): Promise<FileLocation[]> => {
-        try {
-          return await TikzPictureManager.compile(file);
-        } catch {
-          // Silent skip: TikZ compilation failures are reported by the
-          // TikzPictureManager itself; pMap with stopOnError: false must
-          // continue past individual failures.
-          return [];
+  ): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      const tikzResults = yield* Effect.forEach(
+        files,
+        (file) =>
+          fsCall(() => TikzPictureManager.compile(file)).pipe(
+            // Silent skip: TikZ compilation failures are reported by the
+            // TikzPictureManager itself; the fan-out must continue past
+            // individual failures.
+            Effect.catch(() => Effect.succeed<FileLocation[]>([])),
+          ),
+        { concurrency: LATEX_CONCURRENCY },
+      );
+
+      for (const r of tikzResults) {
+        if (r.length > 0) {
+          workspaceState.media.addMediaFiles(r);
         }
-      },
-      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
-    );
-
-    for (const r of tikzResults) {
-      if (r.length > 0) {
-        workspaceState.media.addMediaFiles(r);
       }
-    }
 
-    if (logSummary) {
-      const totalFigures = tikzResults.reduce((sum, r) => sum + r.length, 0);
-      this.logger.debug(`Extracted ${totalFigures} TikZ figures`);
-    }
+      if (logSummary) {
+        const totalFigures = tikzResults.reduce((sum, r) => sum + r.length, 0);
+        this.logger.debug(`Extracted ${totalFigures} TikZ figures`);
+      }
+    });
   }
 
-  private async processFiles(
-    files: FileLocation[],
+  private processFiles(
+    files: readonly FileLocation[],
     workspaceState: MediaWorkspaceState,
     cfg: ToolConfig,
     {
@@ -548,52 +618,52 @@ export class LatexMediaManager {
       extraMediaFiles?: readonly FileLocation[];
       logTikzSummary?: boolean;
     },
-  ): Promise<void> {
-    if (files.length === 0) {
-      return;
-    }
-
-    const existingFilesInfo = await pMap(
-      files,
-      async (file) => ({
-        file,
-        exists: await AbsoluteFS.exists(file.absolutePath),
-      }),
-      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
-    );
-    const existingFiles = existingFilesInfo
-      .filter((f) => f.exists)
-      .map((f) => f.file);
-
-    if (existingFiles.length === 0) {
-      return;
-    }
-
-    if (extraMediaFiles.length > 0) {
-      workspaceState.media.addMediaFiles(extraMediaFiles);
-    }
-
-    if (cfg.autoExtractFigure) {
-      if (figureMode === 'extract') {
-        await this.extractFiguresFromFiles(existingFiles, workspaceState);
-      } else {
-        await this.mirrorFiguresForFiles(existingFiles);
+  ): Effect.Effect<void, Error> {
+    return Effect.gen({ self: this }, function* () {
+      if (files.length === 0) {
+        return;
       }
-    }
 
-    await this.mirrorLatexFileDependencies(existingFiles);
-
-    if (cfg.autoExtractTikzFigure) {
-      await this.compileTikzFigures(
-        existingFiles,
-        workspaceState,
-        logTikzSummary,
+      const probed = yield* Effect.forEach(
+        files,
+        (file) =>
+          fsCall(() => AbsoluteFS.exists(file.absolutePath)).pipe(
+            Effect.map((exists) => ({ file, exists })),
+          ),
+        { concurrency: LATEX_CONCURRENCY },
       );
-    }
+      const existingFiles = probed
+        .filter((entry) => entry.exists)
+        .map((entry) => entry.file);
 
-    if (cfg.autoCompileInputPdf) {
-      await this.compilePdfs(existingFiles, workspaceState);
-    }
+      if (existingFiles.length === 0) {
+        return;
+      }
+
+      if (extraMediaFiles.length > 0) {
+        workspaceState.media.addMediaFiles(extraMediaFiles);
+      }
+
+      if (cfg.autoExtractFigure) {
+        yield* figureMode === 'extract'
+          ? this.extractFiguresFromFiles(existingFiles, workspaceState)
+          : this.mirrorFiguresForFiles(existingFiles);
+      }
+
+      yield* this.mirrorLatexFileDependencies(existingFiles);
+
+      if (cfg.autoExtractTikzFigure) {
+        yield* this.compileTikzFigures(
+          existingFiles,
+          workspaceState,
+          logTikzSummary,
+        );
+      }
+
+      if (cfg.autoCompileInputPdf) {
+        yield* this.compilePdfs(existingFiles, workspaceState);
+      }
+    });
   }
 
   /**
@@ -603,13 +673,13 @@ export class LatexMediaManager {
    * @param extraMediaFiles - Additional media files to include, typically the
    *   user-provided `mediaFiles` from the agent config.
    */
-  async processInputFiles(
-    inputFiles: FileLocation[],
+  processInputFiles(
+    inputFiles: readonly FileLocation[],
     workspaceState: MediaWorkspaceState,
     cfg: ToolConfig,
     extraMediaFiles: readonly FileLocation[] = [],
-  ): Promise<void> {
-    await this.processFiles(inputFiles, workspaceState, cfg, {
+  ): Effect.Effect<void, Error> {
+    return this.processFiles(inputFiles, workspaceState, cfg, {
       figureMode: 'extract',
       extraMediaFiles,
       logTikzSummary: true,
@@ -623,12 +693,12 @@ export class LatexMediaManager {
    * so agent-introduced references compile outside the workspace. Figures are
    * mirrored only (not added to vision context) — they were sent on round 0.
    */
-  async processOutputFiles(
-    outputFiles: FileLocation[],
+  processOutputFiles(
+    outputFiles: readonly FileLocation[],
     workspaceState: MediaWorkspaceState,
     cfg: ToolConfig,
-  ): Promise<void> {
-    await this.processFiles(outputFiles, workspaceState, cfg, {
+  ): Effect.Effect<void, Error> {
+    return this.processFiles(outputFiles, workspaceState, cfg, {
       figureMode: 'mirror',
     });
   }

--- a/src/latex/README.md
+++ b/src/latex/README.md
@@ -5,6 +5,30 @@ documents. No file here imports `vscode`; host wiring (commands, UI prompts)
 stays in the extension/desktop/CLI layers and reaches this code through typed
 ports (see `overleafClone.ts`) rather than the other way around.
 
+## The subsystem is Effect-native
+
+The subprocess-and-filesystem lane — `texcount.ts`, `latexdiff.ts` and
+`latexdiff/`, the three extractors, `overleafClone.ts`, `arxivProcessor.ts`
+and `LatexMediaManager.ts` — returns `Effect` programs, not Promises. Two
+consequences worth knowing before you touch a file here:
+
+- **Nothing in this directory runs a fiber.** A caller runs the program at
+  its own boundary: a tool's `execute()`, a VS Code command, a desktop
+  request handler, or a CLI command. The exceptions are named debt, not a
+  pattern to copy — `MediaExtractionNode`, `TeXCountNode`, `LatexDiffManager`
+  and `tools/approval/latexPreview.ts` each keep one `runPromise` against the
+  Promise-shaped reflection flow, and `config/ratchets/effect-migration-baseline.json`
+  names the lane that deletes them.
+- **Cancellation is interruption, not a threaded `AbortSignal`.** `texcount`
+  and the latexdiff executors spawn their subprocess inside
+  `Effect.tryPromise`, whose thunk receives the signal that aborts when the
+  running fiber is interrupted. Do not add a `signal` parameter to a function
+  here so a caller can pass one down.
+
+A new function in this directory converts together with its callers up to one
+of those boundaries, or it waits — a Promise → Effect → Promise sandwich is
+rejected in review (migration PRD, execution rule 1).
+
 The files have distinct roles:
 
 - **Compilation** — `texTools.ts` builds the kpathsea search path and runs

--- a/src/latex/README.md
+++ b/src/latex/README.md
@@ -25,6 +25,17 @@ consequences worth knowing before you touch a file here:
   running fiber is interrupted. Do not add a `signal` parameter to a function
   here so a caller can pass one down.
 
+- **Diagnostics are `Effect.log*`, not `createLog`.** A program names its
+  channel once with `withLogChannel` from `@logger/effectLog` and every entry
+  below it inherits that channel, so no helper takes a channel parameter just
+  to log. Both producers end at the same host sink, so a test asserts on the
+  entries the sink received (`@test/support/logSinkCapture`) rather than on a
+  logger-namespace spy. One consequence to know: the Effect logger drops
+  `Debug` entries unless `texra.logger.debugMode` is on, where `createLog`
+  emitted them and let the host's level filter decide. `LatexMediaManager`'s
+  injected `LatexTrace` is not this — that is the run's product trace and
+  stays as it is (migration PRD, R9).
+
 A new function in this directory converts together with its callers up to one
 of those boundaries, or it waits — a Promise → Effect → Promise sandwich is
 rejected in review (migration PRD, execution rule 1).

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -8,7 +8,7 @@ import { Cause, Clock, Data, Duration, Effect, Random, Schedule } from 'effect';
 import { StatusCodes } from 'http-status-codes';
 import * as tar from 'tar';
 
-import { createLog } from '@logger/logUtils';
+import { withLogChannel, withLogData } from '@logger/effectLog';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { isTransientHttpStatus } from '@utils/core/httpStatus';
@@ -198,15 +198,16 @@ function getExtensionFromContentType(contentType: string): string {
   return '';
 }
 
-class ArxivSourceProcessor {
-  // NOTE: The channel string stays 'arxivProcessor' (lowercase) even
-  // though the exported singleton was renamed to PascalCase in #7347. It is used
-  // directly as the logger channel and prefixes every log line as
-  // `[arxivProcessor] ...`, so keep it stable for anything filtering on the
-  // channel name — a class-identifier rename must not change this value.
-  private readonly channel = 'arxivProcessor';
-  private readonly log = createLog(this.channel);
+/**
+ * NOTE: The channel string stays 'arxivProcessor' (lowercase) even though the
+ * exported singleton was renamed to PascalCase in #7347. It is used directly as
+ * the logger channel and prefixes every log line as `[arxivProcessor] ...`, so
+ * keep it stable for anything filtering on the channel name — a class-identifier
+ * rename must not change this value.
+ */
+const ARXIV_CHANNEL = 'arxivProcessor';
 
+class ArxivSourceProcessor {
   /** Best-effort delete that logs failures at debug level instead of failing. */
   private cleanUpBestEffort(
     target: string,
@@ -218,12 +219,11 @@ class ArxivSourceProcessor {
       catch: (error) => error,
     }).pipe(
       Effect.catch((error) =>
-        Effect.sync(() => {
-          this.log.debug(`Failed to clean up ${description} ${target}`, {
-            data: error,
-          });
-        }),
+        Effect.logDebug(`Failed to clean up ${description} ${target}`).pipe(
+          withLogData(error),
+        ),
       ),
+      withLogChannel(ARXIV_CHANNEL),
     );
   }
 
@@ -252,7 +252,6 @@ class ArxivSourceProcessor {
     destBasePath: string,
     timeout = 30000,
   ): Effect.Effect<string, ArxivSourceError> {
-    const log = this.log;
     return this.downloadFileOnce(url, destBasePath, timeout).pipe(
       // Retry the whole ordinary failure, never a mixed cleanup cause. Effect's
       // typed-error retry otherwise selects one failure and drops its siblings.
@@ -269,7 +268,7 @@ class ArxivSourceProcessor {
           )
             return;
           const { attempt } = yield* Schedule.CurrentMetadata;
-          log.debug(
+          yield* Effect.logDebug(
             `Download attempt failed (${DOWNLOAD_RETRIES - attempt} retries left): ${reason.error.message}`,
           );
         }),
@@ -283,6 +282,7 @@ class ArxivSourceProcessor {
           cause.reasons[0].error._tag === 'ArxivSourceTransientError',
       }),
       Effect.catch((cause) => Effect.failCause(cause)),
+      withLogChannel(ARXIV_CHANNEL),
     );
   }
 
@@ -291,7 +291,6 @@ class ArxivSourceProcessor {
     destBasePath: string,
     timeout: number,
   ): Effect.Effect<string, ArxivSourceError> {
-    const log = this.log;
     let destPath = destBasePath;
     return Effect.gen(function* () {
       const deadline = (yield* Clock.currentTimeMillis) + timeout;
@@ -340,19 +339,16 @@ class ArxivSourceProcessor {
           catch: (error) => error,
         }).pipe(
           Effect.catch((error) =>
-            Effect.sync(() => {
-              // Malformed header; the content-type fallback below handles it.
-              log.debug(
-                'Ignoring malformed Content-Disposition header from arXiv source download',
-                {
-                  data: {
-                    header: disposition,
-                    error: toErrorMessage(error),
-                  },
-                },
-              );
-              return undefined;
-            }),
+            // Malformed header; the content-type fallback below handles it.
+            Effect.logDebug(
+              'Ignoring malformed Content-Disposition header from arXiv source download',
+            ).pipe(
+              withLogData({
+                header: disposition,
+                error: toErrorMessage(error),
+              }),
+              Effect.as(undefined),
+            ),
           ),
         );
       }
@@ -410,24 +406,27 @@ class ArxivSourceProcessor {
     destDir: string,
     options: ExtractOptions = {},
   ): Effect.Effect<ExtractResult> {
-    const log = this.log;
-    log.debug(`Extracting tar file: ${tarPath} to ${destDir}`);
-
-    return joinedStream(
-      (signal) =>
-        // tar has no abort option. Stop admitting entries and join its public
-        // promise. This is unbounded; rejection need not mean all writes closed.
-        tar.x({ file: tarPath, cwd: destDir, filter: () => !signal.aborted }),
-      (cause) =>
-        Effect.sync((): ExtractResult => {
-          const error = Cause.isTimeoutError(cause)
-            ? 'Extraction timed out'
-            : toErrorMessage(cause);
-          log.error(`Failed to extract tar file: ${error}`);
-          return { success: false, error };
-        }),
-      options.timeout,
-    ).pipe(Effect.map((result) => result ?? { success: true }));
+    return Effect.gen(function* () {
+      yield* Effect.logDebug(`Extracting tar file: ${tarPath} to ${destDir}`);
+      const result = yield* joinedStream(
+        (signal) =>
+          // tar has no abort option. Stop admitting entries and join its
+          // public promise. This is unbounded; rejection need not mean all
+          // writes closed.
+          tar.x({ file: tarPath, cwd: destDir, filter: () => !signal.aborted }),
+        (cause) =>
+          Effect.suspend((): Effect.Effect<ExtractResult> => {
+            const error = Cause.isTimeoutError(cause)
+              ? 'Extraction timed out'
+              : toErrorMessage(cause);
+            return Effect.logError(`Failed to extract tar file: ${error}`).pipe(
+              Effect.as({ success: false, error }),
+            );
+          }),
+        options.timeout,
+      );
+      return result ?? { success: true };
+    }).pipe(withLogChannel(ARXIV_CHANNEL));
   }
 
   public readonly downloadSource = Effect.fn('arxivProcessor.downloadSource')(
@@ -442,7 +441,6 @@ class ArxivSourceProcessor {
         autoIndent = true,
         destination = 'references',
       } = options;
-      const log = this.log;
       // Normalize input (URL or ID) to plain arXiv ID
       const id = normalizeArxivInput(input);
       if (!id) {
@@ -451,7 +449,7 @@ class ArxivSourceProcessor {
         );
       }
 
-      log.info(`Downloading arXiv source for ID: ${id}`);
+      yield* Effect.logInfo(`Downloading arXiv source for ID: ${id}`);
 
       if (!WorkspaceFS.getPath()) {
         return yield* Effect.fail(
@@ -499,10 +497,11 @@ class ArxivSourceProcessor {
 
       progressCallback?.('arXiv source downloaded successfully!', 100);
 
-      log.info(`arXiv source downloaded to: ${paperDirFull}`);
+      yield* Effect.logInfo(`arXiv source downloaded to: ${paperDirFull}`);
 
       return { path: paperDirFull, alreadyExisted: !needsDownload };
     },
+    withLogChannel(ARXIV_CHANNEL),
   );
 
   /**
@@ -515,7 +514,6 @@ class ArxivSourceProcessor {
     isRoot: boolean,
     paperDirFull: string,
   ): Effect.Effect<boolean, ArxivSourceError> {
-    const log = this.log;
     return Effect.gen(function* () {
       if (isRoot) {
         return false;
@@ -528,10 +526,12 @@ class ArxivSourceProcessor {
       );
       const hasTexFiles = entries.some(([name]) => hasExtension(name, '.tex'));
       if (hasTexFiles) {
-        log.info(`arXiv source already exists at: ${paperDirFull}`);
+        yield* Effect.logInfo(
+          `arXiv source already exists at: ${paperDirFull}`,
+        );
       }
       return hasTexFiles;
-    });
+    }).pipe(withLogChannel(ARXIV_CHANNEL));
   }
 
   /**

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -2,12 +2,15 @@
 import * as path from 'node:path';
 
 // Third-party imports
+import { Effect } from 'effect';
+
 // Named import only: bibtex's UMD exports carry `__esModule: true`, so a
 // default import bundles to `undefined` under esbuild's ESM interop and the
 // destructure crashes at module init (0.39.10 startup-crash).
 import { parseBibFile } from 'bibtex';
 
 // Local imports - utils
+import { ensureError } from '@utils/errors/errorMessage';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
 // Local file imports
@@ -43,24 +46,40 @@ interface BibliographyEntriesResult {
   missingKeys: string[];
 }
 
-export async function extractBibliographyContext(
+/** Bibliography probes hit the filesystem, so bound the fan-out. */
+const PROBE_CONCURRENCY = 8;
+
+/** Read a workspace-relative file, surfacing the read failure as a typed error. */
+const readWorkspaceFile = Effect.fn('latex.readWorkspaceFile')(function* (
+  filePath: string,
+) {
+  return yield* Effect.tryPromise({
+    try: () => WorkspaceFS.read(filePath),
+    catch: ensureError,
+  });
+});
+
+export const extractBibliographyContext = Effect.fn(
+  'latex.extractBibliographyContext',
+)(function* (
   texPath: string,
-): Promise<BibliographyReferenceResult> {
+): Effect.fn.Return<BibliographyReferenceResult, Error> {
   const texDir = path.dirname(texPath);
-  const content = await WorkspaceFS.read(texPath);
+  const content = yield* readWorkspaceFile(texPath);
   const uncommented = stripLatexComments(content);
 
   const referencedPaths = collectBibliographyPaths(texDir, uncommented);
-  const existing: string[] = [];
-  const missing: string[] = [];
-
-  for (const candidate of referencedPaths) {
-    if (await WorkspaceFS.exists(candidate)) {
-      existing.push(candidate);
-    } else {
-      missing.push(candidate);
-    }
-  }
+  const probed = yield* Effect.forEach(
+    referencedPaths,
+    (candidate) =>
+      Effect.tryPromise({
+        try: () => WorkspaceFS.exists(candidate),
+        catch: ensureError,
+      }).pipe(Effect.map((exists) => ({ candidate, exists }))),
+    { concurrency: PROBE_CONCURRENCY },
+  );
+  const pathsWhere = (exists: boolean): string[] =>
+    probed.filter((entry) => entry.exists === exists).map((e) => e.candidate);
 
   const citationKeys = collectCommaSeparatedMatches(
     uncommented,
@@ -68,11 +87,11 @@ export async function extractBibliographyContext(
   );
 
   return {
-    bibliographyFiles: existing,
-    missingBibliographyFiles: missing,
+    bibliographyFiles: pathsWhere(true),
+    missingBibliographyFiles: pathsWhere(false),
     citationKeys,
   };
-}
+});
 
 function formatFieldValue(value: unknown): string {
   if (value == null) {
@@ -142,15 +161,21 @@ function parseBibEntries(content: string): Map<string, string> {
   return entries;
 }
 
-export async function loadBibliographyEntries(
-  bibliographyFiles: string[],
-  citationKeys: string[],
-): Promise<BibliographyEntriesResult> {
+export const loadBibliographyEntries = Effect.fn(
+  'latex.loadBibliographyEntries',
+)(function* (
+  bibliographyFiles: readonly string[],
+  citationKeys: readonly string[],
+): Effect.fn.Return<BibliographyEntriesResult, Error> {
   // Citation keys are matched case-insensitively; the first definition of a
-  // key across the bibliography files wins.
+  // key across the bibliography files wins, so the files are read as one
+  // bounded fan-out and folded back in their declared order.
+  const contents = yield* Effect.forEach(bibliographyFiles, readWorkspaceFile, {
+    concurrency: PROBE_CONCURRENCY,
+  });
+
   const parsedEntries = new Map<string, { key: string; value: string }>();
-  for (const filePath of bibliographyFiles) {
-    const content = await WorkspaceFS.read(filePath);
+  for (const content of contents) {
     for (const [key, value] of parseBibEntries(content)) {
       const normalizedKey = key.toLowerCase();
       if (!parsedEntries.has(normalizedKey)) {
@@ -181,7 +206,7 @@ export async function loadBibliographyEntries(
   }
 
   return { entries, missingKeys };
-}
+});
 
 export function summarizeBibliographyEntries(
   entries: Map<string, string>,

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -1,8 +1,13 @@
 // Standard library imports
 import * as path from 'node:path';
 
+// Third-party imports
+import { Effect } from 'effect';
+
 import type { FileLocation } from '@shared/schemas';
+import { filterNotNull } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { ensureError } from '@utils/errors/errorMessage';
 import { joinLatexPath } from '@utils/core/pathCore';
 
 import {
@@ -12,6 +17,9 @@ import {
 } from './latexParsingUtils';
 
 const FIGURE_EXTENSIONS = ['.pdf', '.png', '.jpg', '.jpeg'];
+
+/** Figure lookups run against the filesystem, so bound the fan-out. */
+const RESOLVE_CONCURRENCY = 8;
 
 /**
  * Parse graphicspath commands supporting both single and multiple path formats.
@@ -41,29 +49,30 @@ function parseGraphicspath(content: string): string[] {
  * Resolve a figure path by searching through possible base paths and
  * extensions. Returns a path relative to `latexDir`, or null.
  */
-async function resolveFigurePath(
+const resolveFigurePath = Effect.fn('latex.resolveFigurePath')(function* (
   figPath: string,
-  searchPaths: string[],
+  searchPaths: readonly string[],
   latexDir: string,
-): Promise<string | null> {
+) {
   const extensions = figPath.includes('.') ? [''] : FIGURE_EXTENSIONS;
-  const absolute = await findExistingLatexPath(
+  const absolute = yield* findExistingLatexPath(
     figPath,
     searchPaths,
     extensions,
   );
   return absolute === null ? null : path.relative(latexDir, absolute);
-}
+});
 
 /**
- * Extract figure paths from a LaTeX file
- * @param latexFile Path to the LaTeX file
- * @returns Array of relative paths to figures
+ * Extract figure paths from a LaTeX file.
+ *
+ * The resolutions run concurrently but `Effect.forEach` hands their results
+ * back in source order, so the de-duplicated output stays deterministic.
  */
-export async function extractFigurePathsFromLatex(
-  latexFileLocation: FileLocation,
-): Promise<string[]> {
-  const latexDir = await resolveLatexDir(latexFileLocation.absolutePath);
+export const extractFigurePathsFromLatex = Effect.fn(
+  'latex.extractFigurePathsFromLatex',
+)(function* (latexFileLocation: FileLocation) {
+  const latexDir = yield* resolveLatexDir(latexFileLocation.absolutePath);
   const graphicspaths = [latexDir]; // Start with the directory of the LaTeX file
 
   // Regular expressions to match figure inclusion commands
@@ -72,33 +81,29 @@ export async function extractFigurePathsFromLatex(
     /\\begin\{overpic\}(?:\[.*?\])?\{(.+?)\}/g,
   ];
 
-  const content = await AbsoluteFS.read(latexFileLocation.absolutePath);
+  const content = yield* Effect.tryPromise({
+    try: () => AbsoluteFS.read(latexFileLocation.absolutePath),
+    catch: ensureError,
+  });
 
   // Pre-process content to remove commented-out text (including inline
   // comments and escaped `\%`, unlike a naive whole-line strip).
   const processedContent = stripLatexComments(content);
 
   // Parse graphicspaths
-  const paths = parseGraphicspath(processedContent);
-  for (const p of paths) {
+  for (const p of parseGraphicspath(processedContent)) {
     graphicspaths.push(joinLatexPath(latexDir, p));
   }
 
-  // Find all matches in the processed content for both patterns
-  const discovered = new Set<string>();
+  const referenced = figurePatterns.flatMap((pattern) =>
+    [...processedContent.matchAll(pattern)].map((match) => match[1]),
+  );
 
-  for (const pattern of figurePatterns) {
-    for (const match of processedContent.matchAll(pattern)) {
-      const resolved = await resolveFigurePath(
-        match[1],
-        graphicspaths,
-        latexDir,
-      );
-      if (resolved) {
-        discovered.add(resolved);
-      }
-    }
-  }
+  const resolved = yield* Effect.forEach(
+    referenced,
+    (figPath) => resolveFigurePath(figPath, graphicspaths, latexDir),
+    { concurrency: RESOLVE_CONCURRENCY },
+  );
 
-  return [...discovered];
-}
+  return [...new Set(resolved.filter(filterNotNull))];
+});

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -8,12 +8,13 @@
  */
 
 // Third-party imports
-import pMap from 'p-map';
+import { Effect } from 'effect';
 
 // Local imports
 import type { FileLocation } from '@shared/schemas';
 import { filterNotNull, unique } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { ensureError } from '@utils/errors/errorMessage';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
 // Local file imports
@@ -27,6 +28,9 @@ import {
 const INPUT_PATTERN = /\\input\s*\{([^}]+)\}/g;
 const INCLUDE_PATTERN = /\\include\s*\{([^}]+)\}/g;
 
+/** Dependency probes hit the filesystem, so bound the fan-out. */
+const RESOLVE_CONCURRENCY = 8;
+
 /**
  * Resolve a TeX input path (\input / \include argument) to an existing
  * absolute path. Tries the literal path first, then with `.tex` appended
@@ -37,21 +41,21 @@ const INCLUDE_PATTERN = /\\include\s*\{([^}]+)\}/g;
  * are stripped and absolute paths are preserved, matching LaTeX's own
  * `\input` resolution.
  */
-async function resolveTexInputPath(
+const resolveTexInputPath = Effect.fn('latex.resolveTexInputPath')(function* (
   rawPath: string,
   baseDir: string,
-): Promise<string | null> {
+) {
   const trimmed = rawPath.trim();
   if (!trimmed) return null;
 
   const absolute = joinLatexPath(baseDir, trimmed);
-  const hit = await existingExternalPath(absolute);
+  const hit = yield* existingExternalPath(absolute);
   if (hit) return hit;
 
   const withExt = ensureExtension(absolute, '.tex');
   if (withExt === absolute) return null;
-  return existingExternalPath(withExt);
-}
+  return yield* existingExternalPath(withExt);
+});
 
 /**
  * Extract file dependencies (\input, \include, \bibliography, \addbibresource)
@@ -61,13 +65,16 @@ async function resolveTexInputPath(
  * run storage (as a symlink to the workspace), dependencies are resolved
  * relative to the original workspace location where they actually exist.
  */
-export async function extractLatexFileDependencies(
-  latexFileLocation: FileLocation,
-): Promise<string[]> {
+export const extractLatexFileDependencies = Effect.fn(
+  'latex.extractLatexFileDependencies',
+)(function* (latexFileLocation: FileLocation) {
   // Follow symlinks so run-storage paths resolve against the workspace
-  const latexDir = await resolveLatexDir(latexFileLocation.absolutePath);
+  const latexDir = yield* resolveLatexDir(latexFileLocation.absolutePath);
 
-  const content = await AbsoluteFS.read(latexFileLocation.absolutePath);
+  const content = yield* Effect.tryPromise({
+    try: () => AbsoluteFS.read(latexFileLocation.absolutePath),
+    catch: ensureError,
+  });
   const uncommented = stripLatexComments(content);
 
   const texInputPaths = [INPUT_PATTERN, INCLUDE_PATTERN].flatMap((pattern) =>
@@ -76,16 +83,22 @@ export async function extractLatexFileDependencies(
 
   const bibCandidates = collectBibliographyPaths(latexDir, uncommented);
 
-  const [texResolved, bibResolved] = await Promise.all([
-    pMap(texInputPaths, (raw) => resolveTexInputPath(raw, latexDir), {
-      concurrency: 8,
-      stopOnError: false,
-    }),
-    pMap(bibCandidates, (absolute) => existingExternalPath(absolute), {
-      concurrency: 8,
-      stopOnError: false,
-    }),
-  ]);
+  // The two probe sets run as one bounded fan-out under the calling fiber:
+  // a failure interrupts the siblings instead of leaving them running behind
+  // a settled aggregate, which is what `stopOnError: false` used to do.
+  const [texResolved, bibResolved] = yield* Effect.all(
+    [
+      Effect.forEach(
+        texInputPaths,
+        (raw) => resolveTexInputPath(raw, latexDir),
+        { concurrency: RESOLVE_CONCURRENCY },
+      ),
+      Effect.forEach(bibCandidates, existingExternalPath, {
+        concurrency: RESOLVE_CONCURRENCY,
+      }),
+    ],
+    { concurrency: 2 },
+  );
 
   return unique([...texResolved, ...bibResolved].filter(filterNotNull));
-}
+});

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -6,9 +6,12 @@
 
 import * as path from 'node:path';
 
+import { Effect } from 'effect';
+
 import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { ensureError } from '@utils/errors/errorMessage';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
 const log = createLog('LatexParsing');
@@ -71,57 +74,70 @@ const BIB_DIRECTIVE_PATTERN = new RegExp(
  * inside a file mirrored into run storage resolve against the workspace.
  * Falls back to the literal dirname if the file can't be realpath'd.
  */
-export async function resolveLatexDir(absolutePath: string): Promise<string> {
-  const resolved = await platform()
-    .fs.realPath(absolutePath)
-    .catch((error: unknown) => {
-      log.debug(
-        `realPath failed for ${absolutePath}; falling back to literal dirname`,
-        { data: error },
-      );
-      return absolutePath;
-    });
+export const resolveLatexDir = Effect.fn('latex.resolveLatexDir')(function* (
+  absolutePath: string,
+) {
+  const resolved = yield* Effect.tryPromise({
+    try: () => platform().fs.realPath(absolutePath),
+    catch: ensureError,
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.sync(() => {
+        log.debug(
+          `realPath failed for ${absolutePath}; falling back to literal dirname`,
+          { data: error },
+        );
+        return absolutePath;
+      }),
+    ),
+  );
   return path.dirname(resolved);
-}
+});
 
 /**
  * Return `absolutePath` if it exists on disk, otherwise null. Centralizes
  * the `AbsoluteFS.exists(...)` boilerplate used by the various LaTeX
  * dependency resolvers.
  */
-export async function existingExternalPath(
-  absolutePath: string,
-): Promise<string | null> {
-  if (await AbsoluteFS.exists(absolutePath)) {
-    return absolutePath;
-  }
-  return null;
-}
+export const existingExternalPath = Effect.fn('latex.existingExternalPath')(
+  function* (absolutePath: string) {
+    const exists = yield* Effect.tryPromise({
+      try: () => AbsoluteFS.exists(absolutePath),
+      catch: ensureError,
+    });
+    return exists ? absolutePath : null;
+  },
+);
 
 /**
- * Search `searchPaths × extensions` for the first existing file and return
+ * Search `searchPaths x extensions` for the first existing file and return
  * its normalized absolute path, or null if nothing exists.
  *
  * - `relativePath` is joined against each entry in `searchPaths`.
  * - Each `extensions` entry is appended to the joined path; pass `''` to test
  *   the path as-is.
  * - The search is ordered: outer loop over `searchPaths`, inner over
- *   `extensions`. The first hit wins.
+ *   `extensions`. The first hit wins, and the candidates after it are never
+ *   probed, so the walk stays sequential rather than a concurrent race.
  */
-export async function findExistingLatexPath(
-  relativePath: string,
-  searchPaths: string[],
-  extensions: string[],
-): Promise<string | null> {
-  for (const basePath of searchPaths) {
-    const joined = path.normalize(path.join(basePath, relativePath));
-    for (const ext of extensions) {
-      const hit = await existingExternalPath(ext ? `${joined}${ext}` : joined);
-      if (hit !== null) return hit;
+export const findExistingLatexPath = Effect.fn('latex.findExistingLatexPath')(
+  function* (
+    relativePath: string,
+    searchPaths: readonly string[],
+    extensions: readonly string[],
+  ) {
+    for (const basePath of searchPaths) {
+      const joined = path.normalize(path.join(basePath, relativePath));
+      for (const ext of extensions) {
+        const hit = yield* existingExternalPath(
+          ext ? `${joined}${ext}` : joined,
+        );
+        if (hit !== null) return hit;
+      }
     }
-  }
-  return null;
-}
+    return null;
+  },
+);
 
 /**
  * Match `pattern` against `content` and split each match's first capture

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -8,13 +8,13 @@ import * as path from 'node:path';
 
 import { Effect } from 'effect';
 
-import { createLog } from '@logger/logUtils';
+import { withLogChannel, withLogData } from '@logger/effectLog';
 import { platform } from '@platform/platform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { ensureError } from '@utils/errors/errorMessage';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
-const log = createLog('LatexParsing');
+const CHANNEL = 'LatexParsing';
 
 /**
  * Every citation macro TeXRA recognizes, natbib and biblatex alike, in both
@@ -82,13 +82,13 @@ export const resolveLatexDir = Effect.fn('latex.resolveLatexDir')(function* (
     catch: ensureError,
   }).pipe(
     Effect.catch((error) =>
-      Effect.sync(() => {
-        log.debug(
-          `realPath failed for ${absolutePath}; falling back to literal dirname`,
-          { data: error },
-        );
-        return absolutePath;
-      }),
+      Effect.logDebug(
+        `realPath failed for ${absolutePath}; falling back to literal dirname`,
+      ).pipe(
+        withLogData(error),
+        withLogChannel(CHANNEL),
+        Effect.as(absolutePath),
+      ),
     ),
   );
   return path.dirname(resolved);

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { Effect } from 'effect';
 
 import { formatError, isFileNotFoundError } from '@common/errors';
-import { createLog } from '@logger/logUtils';
+import { withLogChannel } from '@logger/effectLog';
 import type { FileLocation } from '@shared/schemas';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { ensureError } from '@utils/errors/errorMessage';
@@ -54,8 +54,6 @@ export class LaTeXdiffService {
   private readonly fileProcessor: DiffFileProcessor;
   private readonly commandExecutor: DiffCommandExecutor;
 
-  private readonly log = createLog(this.channel);
-
   constructor(private readonly channel: string) {
     this.fileProcessor = new DiffFileProcessor();
     this.commandExecutor = new DiffCommandExecutor(channel);
@@ -70,10 +68,9 @@ export class LaTeXdiffService {
     context: string,
   ): (err: unknown) => Effect.Effect<LaTeXdiffResult> {
     return (err) =>
-      Effect.sync(() => {
+      Effect.suspend(() => {
         const message = formatError(context, err);
-        this.log.error(message);
-        return failed(message);
+        return Effect.logError(message).pipe(Effect.as(failed(message)));
       });
   }
 
@@ -114,7 +111,7 @@ export class LaTeXdiffService {
       const editedFile = editedLocation.absolutePath;
 
       if (!inputFile) {
-        this.log.warn('Input file is empty or undefined');
+        yield* Effect.logWarning('Input file is empty or undefined');
         return failed('Input file is empty or undefined');
       }
 
@@ -127,7 +124,7 @@ export class LaTeXdiffService {
       );
       if (!contents) {
         const message = `One or both files do not exist. Input: ${inputFile}, Edited: ${editedFile}`;
-        this.log.warn(message);
+        yield* Effect.logWarning(message);
         return failed(message);
       }
       if (!contents.every(hasDocumentEnvironment)) {
@@ -139,7 +136,7 @@ export class LaTeXdiffService {
         options?.outputDirectory ?? path.dirname(inputFile);
       const outputPath = path.join(outputDirectory, diffFileName);
 
-      this.log.debug(
+      yield* Effect.logDebug(
         `Running latexdiff for ${inputLocation.absolutePath} and ${editedLocation.absolutePath}`,
       );
 
@@ -163,7 +160,7 @@ export class LaTeXdiffService {
       });
       yield* this.fileProcessor.processDiffFile(outputLocation, editedLocation);
 
-      this.log.debug(
+      yield* Effect.logDebug(
         `Latexdiff succeeded: ${inputLocation.absolutePath} -> ${editedLocation.absolutePath}`,
       );
 
@@ -173,13 +170,12 @@ export class LaTeXdiffService {
       );
     }).pipe(
       Effect.tapError(() =>
-        Effect.sync(() => {
-          this.log.debug(
-            `Latexdiff failed: ${inputLocation.absolutePath} -> ${editedLocation.absolutePath}`,
-          );
-        }),
+        Effect.logDebug(
+          `Latexdiff failed: ${inputLocation.absolutePath} -> ${editedLocation.absolutePath}`,
+        ),
       ),
       Effect.catch(this.failure('Error running LaTeX diff')),
+      withLogChannel(this.channel),
     );
   }
 
@@ -193,7 +189,7 @@ export class LaTeXdiffService {
       if (!hasDocumentEnvironment(yield* this.read(inputFile))) {
         const message =
           'File missing document environment (must contain \\begin{document} and \\end{document})';
-        this.log.error(message);
+        yield* Effect.logError(message);
         return failed(message);
       }
 
@@ -234,7 +230,10 @@ export class LaTeXdiffService {
         outputPath,
         `LaTeXdiff VC completed successfully: ${diffFileName}`,
       );
-    }).pipe(Effect.catch(this.failure('Error running LaTeX diff VC')));
+    }).pipe(
+      Effect.catch(this.failure('Error running LaTeX diff VC')),
+      withLogChannel(this.channel),
+    );
   }
 
   runDiffForRound(
@@ -247,7 +246,7 @@ export class LaTeXdiffService {
     return Effect.gen({ self: this }, function* () {
       if (!(yield* this.bothFilesExist(baseLocation, outputLocation))) {
         const message = `Could not generate latexdiff for round ${round}. Files not found: ${baseLocation.absolutePath} or ${outputLocation.absolutePath}`;
-        this.log.warn(message);
+        yield* Effect.logWarning(message);
         return failed(message);
       }
 
@@ -258,7 +257,10 @@ export class LaTeXdiffService {
         mathMarkup,
         options,
       );
-    }).pipe(Effect.catch(this.failure('Error in runDiffForRound')));
+    }).pipe(
+      Effect.catch(this.failure('Error in runDiffForRound')),
+      withLogChannel(this.channel),
+    );
   }
 
   runDiffBetweenRounds(
@@ -272,7 +274,7 @@ export class LaTeXdiffService {
     return Effect.gen({ self: this }, function* () {
       if (!(yield* this.bothFilesExist(firstLocation, secondLocation))) {
         const message = `Could not generate latexdiff between rounds. Files not found: ${firstLocation.absolutePath} or ${secondLocation.absolutePath}`;
-        this.log.warn(message);
+        yield* Effect.logWarning(message);
         return failed(message);
       }
 
@@ -284,7 +286,10 @@ export class LaTeXdiffService {
         mathMarkup,
         options,
       );
-    }).pipe(Effect.catch(this.failure('Error in runDiffBetweenRounds')));
+    }).pipe(
+      Effect.catch(this.failure('Error in runDiffBetweenRounds')),
+      withLogChannel(this.channel),
+    );
   }
 
   private bothFilesExist(

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -1,9 +1,12 @@
 import * as path from 'node:path';
 
+import { Effect } from 'effect';
+
 import { formatError, isFileNotFoundError } from '@common/errors';
 import { createLog } from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { ensureError } from '@utils/errors/errorMessage';
 import { pathToLocation } from '@utils/files/fileLocation';
 import { executeCommand } from '@utils/system/execUtils';
 import {
@@ -32,6 +35,15 @@ export type LaTeXdiffResult =
       message: string;
     };
 
+/** A failed diff, as the value every entry point resolves to. */
+function failed(message: string): LaTeXdiffResult {
+  return { success: false, message };
+}
+
+function succeeded(diffPath: string, message: string): LaTeXdiffResult {
+  return { success: true, diffPath, message };
+}
+
 function hasDocumentEnvironment(content: string): boolean {
   return (
     content.includes('\\begin{document}') && content.includes('\\end{document}')
@@ -49,58 +61,77 @@ export class LaTeXdiffService {
     this.commandExecutor = new DiffCommandExecutor(channel);
   }
 
-  private logDiffError(context: string, err: unknown): LaTeXdiffResult {
-    const message = formatError(context, err);
-    this.log.error(message);
-    return { success: false, message };
+  /**
+   * Turn a diff failure into the service's own result value. Every public
+   * entry point ends here, so a caller never has to distinguish "latexdiff
+   * refused" from "the run threw".
+   */
+  private failure(
+    context: string,
+  ): (err: unknown) => Effect.Effect<LaTeXdiffResult> {
+    return (err) =>
+      Effect.sync(() => {
+        const message = formatError(context, err);
+        this.log.error(message);
+        return failed(message);
+      });
+  }
+
+  private read(absolutePath: string): Effect.Effect<string, Error> {
+    return Effect.tryPromise({
+      try: () => AbsoluteFS.read(absolutePath),
+      catch: ensureError,
+    });
   }
 
   /** Read both diff inputs, returning null when either input no longer exists. */
-  private async readDiffInputs(
+  private readDiffInputs(
     inputLocation: FileLocation,
     editedLocation: FileLocation,
-  ): Promise<[string, string] | null> {
-    try {
-      return await Promise.all([
-        AbsoluteFS.read(inputLocation.absolutePath),
-        AbsoluteFS.read(editedLocation.absolutePath),
-      ]);
-    } catch (error) {
-      if (isFileNotFoundError(error)) return null;
-      throw error;
-    }
+  ): Effect.Effect<[string, string] | null, Error> {
+    return Effect.all(
+      [
+        this.read(inputLocation.absolutePath),
+        this.read(editedLocation.absolutePath),
+      ],
+      { concurrency: 2 },
+    ).pipe(
+      Effect.catchIf(isFileNotFoundError, () =>
+        Effect.succeed<[string, string] | null>(null),
+      ),
+    );
   }
 
-  async runDiff(
+  runDiff(
     inputLocation: FileLocation,
     editedLocation: FileLocation,
     suffix = '_diff',
     mathMarkup?: MathMarkupOption,
     options?: { cwd?: string; subtype?: string; outputDirectory?: string },
-  ): Promise<LaTeXdiffResult> {
-    try {
+  ): Effect.Effect<LaTeXdiffResult> {
+    return Effect.gen({ self: this }, function* () {
       const inputFile = inputLocation.absolutePath;
       const editedFile = editedLocation.absolutePath;
 
       if (!inputFile) {
         this.log.warn('Input file is empty or undefined');
-        return { success: false, message: 'Input file is empty or undefined' };
+        return failed('Input file is empty or undefined');
       }
 
       // Direct callers use one read pass for both existence and document
       // structure validation. Round-specific wrappers keep their earlier
       // exists checks so they can report round-specific error messages.
-      const contents = await this.readDiffInputs(inputLocation, editedLocation);
+      const contents = yield* this.readDiffInputs(
+        inputLocation,
+        editedLocation,
+      );
       if (!contents) {
         const message = `One or both files do not exist. Input: ${inputFile}, Edited: ${editedFile}`;
         this.log.warn(message);
-        return { success: false, message };
+        return failed(message);
       }
       if (!contents.every(hasDocumentEnvironment)) {
-        return {
-          success: false,
-          message: 'Files missing document environment',
-        };
+        return failed('Files missing document environment');
       }
 
       const diffFileName = generateDiffFileName(inputFile, editedFile, suffix);
@@ -112,64 +143,71 @@ export class LaTeXdiffService {
         `Running latexdiff for ${inputLocation.absolutePath} and ${editedLocation.absolutePath}`,
       );
 
-      // Execute latexdiff command
-      const result = await this.commandExecutor.executeDiff(
+      const result = yield* this.commandExecutor.executeDiff(
         inputFile,
         editedFile,
         { mathMarkup, subtype: options?.subtype, cwd: options?.cwd },
       );
       if (!result.stdout) {
-        throw new Error('Latexdiff produced no output');
+        return yield* Effect.fail(new Error('Latexdiff produced no output'));
       }
 
       // Write and process output
-      await AbsoluteFS.ensureDir(outputDirectory);
       const outputLocation = pathToLocation(outputPath);
-      await AbsoluteFS.write(outputLocation.absolutePath, result.stdout);
-      await this.fileProcessor.processDiffFile(outputLocation, editedLocation);
+      yield* Effect.tryPromise({
+        try: async () => {
+          await AbsoluteFS.ensureDir(outputDirectory);
+          await AbsoluteFS.write(outputLocation.absolutePath, result.stdout);
+        },
+        catch: ensureError,
+      });
+      yield* this.fileProcessor.processDiffFile(outputLocation, editedLocation);
 
       this.log.debug(
         `Latexdiff succeeded: ${inputLocation.absolutePath} -> ${editedLocation.absolutePath}`,
       );
 
-      return {
-        success: true,
-        diffPath: outputLocation.absolutePath,
-        message: `LaTeXdiff completed successfully: ${diffFileName}`,
-      };
-    } catch (err) {
-      this.log.debug(
-        `Latexdiff failed: ${inputLocation.absolutePath} -> ${editedLocation.absolutePath}`,
+      return succeeded(
+        outputLocation.absolutePath,
+        `LaTeXdiff completed successfully: ${diffFileName}`,
       );
-      return this.logDiffError('Error running LaTeX diff', err);
-    }
+    }).pipe(
+      Effect.tapError(() =>
+        Effect.sync(() => {
+          this.log.debug(
+            `Latexdiff failed: ${inputLocation.absolutePath} -> ${editedLocation.absolutePath}`,
+          );
+        }),
+      ),
+      Effect.catch(this.failure('Error running LaTeX diff')),
+    );
   }
 
-  async runDiffVc(
+  runDiffVc(
     inputLocation: FileLocation,
     commitHash: string,
     mathMarkup?: MathMarkupOption,
-  ): Promise<LaTeXdiffResult> {
-    try {
+  ): Effect.Effect<LaTeXdiffResult> {
+    return Effect.gen({ self: this }, function* () {
       const inputFile = inputLocation.absolutePath;
-      if (!hasDocumentEnvironment(await AbsoluteFS.read(inputFile))) {
+      if (!hasDocumentEnvironment(yield* this.read(inputFile))) {
         const message =
           'File missing document environment (must contain \\begin{document} and \\end{document})';
         this.log.error(message);
-        return { success: false, message };
+        return failed(message);
       }
 
       // latexdiff-vc --git runs `git show <commit>:<file>`, which expects
       // a path relative to the repo root. Absolute paths break its temp
       // path construction. Resolve via git rev-parse to get the repo root.
       const fileDir = path.dirname(inputFile);
-      const gitRoot = await this.getGitRoot(fileDir);
+      const gitRoot = yield* this.getGitRoot(fileDir);
       const cwd = gitRoot ?? fileDir;
       const filePath = gitRoot
         ? path.relative(gitRoot, inputFile)
         : path.basename(inputFile);
 
-      await this.commandExecutor.executeDiffVc(filePath, commitHash, {
+      yield* this.commandExecutor.executeDiffVc(filePath, commitHash, {
         mathMarkup,
         cwd,
       });
@@ -185,96 +223,97 @@ export class LaTeXdiffService {
         `${parsedFilePath.name}-diff${commitHash}${parsedFilePath.ext}`,
       );
       const outputPath = path.join(cwd, diffFilePath);
-      await this.fileProcessor.processDiffFile(
+      yield* this.fileProcessor.processDiffFile(
         pathToLocation(outputPath),
         inputLocation,
       );
 
       const diffFileName = path.basename(diffFilePath);
 
-      return {
-        success: true,
-        diffPath: outputPath,
-        message: `LaTeXdiff VC completed successfully: ${diffFileName}`,
-      };
-    } catch (err) {
-      return this.logDiffError('Error running LaTeX diff VC', err);
-    }
+      return succeeded(
+        outputPath,
+        `LaTeXdiff VC completed successfully: ${diffFileName}`,
+      );
+    }).pipe(Effect.catch(this.failure('Error running LaTeX diff VC')));
   }
 
-  async runDiffForRound(
+  runDiffForRound(
     baseLocation: FileLocation,
     outputLocation: FileLocation,
     round: number,
     mathMarkup?: MathMarkupOption,
     options?: { cwd?: string; outputDirectory?: string },
-  ): Promise<LaTeXdiffResult> {
-    try {
-      if (!(await this.bothFilesExist(baseLocation, outputLocation))) {
+  ): Effect.Effect<LaTeXdiffResult> {
+    return Effect.gen({ self: this }, function* () {
+      if (!(yield* this.bothFilesExist(baseLocation, outputLocation))) {
         const message = `Could not generate latexdiff for round ${round}. Files not found: ${baseLocation.absolutePath} or ${outputLocation.absolutePath}`;
         this.log.warn(message);
-        return { success: false, message };
+        return failed(message);
       }
 
-      return await this.runDiff(
+      return yield* this.runDiff(
         baseLocation,
         outputLocation,
         '_diff',
         mathMarkup,
         options,
       );
-    } catch (err) {
-      return this.logDiffError('Error in runDiffForRound', err);
-    }
+    }).pipe(Effect.catch(this.failure('Error in runDiffForRound')));
   }
 
-  async runDiffBetweenRounds(
+  runDiffBetweenRounds(
     firstLocation: FileLocation,
     secondLocation: FileLocation,
     fromRound: number,
     toRound: number,
     mathMarkup?: MathMarkupOption,
     options?: { cwd?: string; outputDirectory?: string },
-  ): Promise<LaTeXdiffResult> {
-    try {
-      if (!(await this.bothFilesExist(firstLocation, secondLocation))) {
+  ): Effect.Effect<LaTeXdiffResult> {
+    return Effect.gen({ self: this }, function* () {
+      if (!(yield* this.bothFilesExist(firstLocation, secondLocation))) {
         const message = `Could not generate latexdiff between rounds. Files not found: ${firstLocation.absolutePath} or ${secondLocation.absolutePath}`;
         this.log.warn(message);
-        return { success: false, message };
+        return failed(message);
       }
 
       const diffSuffix = buildBetweenRoundDiffSuffix(toRound, fromRound);
-      return await this.runDiff(
+      return yield* this.runDiff(
         firstLocation,
         secondLocation,
         diffSuffix,
         mathMarkup,
         options,
       );
-    } catch (err) {
-      return this.logDiffError('Error in runDiffBetweenRounds', err);
-    }
+    }).pipe(Effect.catch(this.failure('Error in runDiffBetweenRounds')));
   }
 
-  private async bothFilesExist(
+  private bothFilesExist(
     first: FileLocation,
     second: FileLocation,
-  ): Promise<boolean> {
-    const [firstExists, secondExists] = await Promise.all([
-      AbsoluteFS.exists(first.absolutePath),
-      AbsoluteFS.exists(second.absolutePath),
-    ]);
-    return firstExists && secondExists;
+  ): Effect.Effect<boolean, Error> {
+    const exists = (location: FileLocation) =>
+      Effect.tryPromise({
+        try: () => AbsoluteFS.exists(location.absolutePath),
+        catch: ensureError,
+      });
+    return Effect.all([exists(first), exists(second)], {
+      concurrency: 2,
+    }).pipe(Effect.map(([a, b]) => a && b));
   }
 
-  private async getGitRoot(cwd: string): Promise<string | null> {
-    const result = await executeCommand(
-      ['git', 'rev-parse', '--show-toplevel'],
-      {
-        channel: this.channel,
-        cwd,
-      },
+  private getGitRoot(cwd: string): Effect.Effect<string | null, Error> {
+    return Effect.tryPromise({
+      try: (signal) =>
+        executeCommand(['git', 'rev-parse', '--show-toplevel'], {
+          channel: this.channel,
+          cwd,
+          signal,
+        }),
+      catch: ensureError,
+    }).pipe(
+      Effect.map((result) =>
+        result.success && result.stdout ? result.stdout.trim() : null,
+      ),
     );
-    return result.success && result.stdout ? result.stdout.trim() : null;
   }
 }

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -1,7 +1,11 @@
+// Third-party imports
+import { Effect } from 'effect';
+
 // Internal imports
 import { createLog } from '@logger/logUtils';
 import type { ExecResult } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { ensureError } from '@utils/errors/errorMessage';
 import { executeCommand } from '@utils/system/execUtils';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
@@ -56,11 +60,11 @@ export class DiffCommandExecutor {
 
   constructor(private readonly channel: string) {}
 
-  async executeDiff(
+  executeDiff(
     inputFile: string,
     editedFile: string,
     options?: DiffExecutionOptions,
-  ): Promise<ExecResult> {
+  ): Effect.Effect<ExecResult, Error> {
     return this.executeWithFallback(
       (useFlatten) =>
         this.buildLatexdiffCommand(inputFile, editedFile, useFlatten, options),
@@ -69,11 +73,11 @@ export class DiffCommandExecutor {
     );
   }
 
-  async executeDiffVc(
+  executeDiffVc(
     inputFile: string,
     commitHash: string,
     options?: DiffExecutionOptions,
-  ): Promise<ExecResult> {
+  ): Effect.Effect<ExecResult, Error> {
     return this.executeWithFallback(
       (useFlatten) =>
         this.buildLatexdiffVcCommand(
@@ -143,77 +147,112 @@ export class DiffCommandExecutor {
     ];
   }
 
-  private async executeWithFallback(
+  /**
+   * Run `commandBuilder(true)`, and on a bibliography failure retry it without
+   * `--flatten`. The subprocess is torn down by the fiber's own interruption:
+   * `Effect.tryPromise` hands the thunk the `AbortSignal` that `executeCommand`
+   * uses to kill the process group.
+   */
+  private executeWithFallback(
     commandBuilder: (useFlatten: boolean) => string[],
     commandType: string,
     cwd?: string,
-  ): Promise<ExecResult> {
-    // Snapshot the timeout once per invocation so the value stays consistent
-    // across the --flatten attempt and any retry, while still picking up any
-    // updates the user has made between successive diff runs. Reading per diff
-    // also matters because `LaTeXdiffService` is constructed at module scope
-    // (before `initPlatform()` runs); a value captured at construction would
-    // permanently freeze at whatever the default was at activation-zero.
-    const timeoutMs = readPlatformSetting<number>(
-      WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS,
-    );
-    const execOptions: CommandExecOptions = {
-      channel: this.channel,
-      timeout: timeoutMs,
-      cwd,
-    };
-
-    this.log.debug(`Attempting ${commandType} with --flatten flag`);
-    const result = await executeCommand(commandBuilder(true), execOptions);
-
-    if (result.success) {
-      this.log.debug(`${commandType} completed successfully (with --flatten)`);
-      return result;
-    }
-
-    if (result.timedOut) {
-      throw new Error(
-        `${commandType} operation timed out after ${timeoutMs}ms`,
+  ): Effect.Effect<ExecResult, Error> {
+    return Effect.gen({ self: this }, function* () {
+      // Snapshot the timeout once per invocation so the value stays consistent
+      // across the --flatten attempt and any retry, while still picking up any
+      // updates the user has made between successive diff runs. Reading per
+      // diff also matters because `LaTeXdiffService` is constructed at module
+      // scope (before `initPlatform()` runs); a value captured at construction
+      // would permanently freeze at whatever the default was at activation-zero.
+      const timeoutMs = readPlatformSetting<number>(
+        WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS,
       );
-    }
+      const execOptions: CommandExecOptions = {
+        channel: this.channel,
+        timeout: timeoutMs,
+        cwd,
+      };
 
-    if (!this.isBibliographyError(result.stderr)) {
-      throw new Error(
-        result.stderr
-          ? `Failed to run ${commandType}: ${result.stderr}`
-          : `Failed to run ${commandType}`,
+      this.log.debug(`Attempting ${commandType} with --flatten flag`);
+      const result = yield* this.exec(commandBuilder(true), execOptions);
+
+      if (result.success) {
+        this.log.debug(
+          `${commandType} completed successfully (with --flatten)`,
+        );
+        return result;
+      }
+
+      if (result.timedOut) {
+        return yield* Effect.fail(
+          new Error(`${commandType} operation timed out after ${timeoutMs}ms`),
+        );
+      }
+
+      if (!this.isBibliographyError(result.stderr)) {
+        return yield* Effect.fail(
+          new Error(
+            result.stderr
+              ? `Failed to run ${commandType}: ${result.stderr}`
+              : `Failed to run ${commandType}`,
+          ),
+        );
+      }
+
+      return yield* this.retryWithoutFlatten(
+        commandBuilder,
+        commandType,
+        execOptions,
       );
-    }
-
-    return this.retryWithoutFlatten(commandBuilder, commandType, execOptions);
+    });
   }
 
-  private async retryWithoutFlatten(
+  /** One `executeCommand` invocation, cancelled by the running fiber. */
+  private exec(
+    command: string[],
+    execOptions: CommandExecOptions,
+  ): Effect.Effect<ExecResult, Error> {
+    return Effect.tryPromise({
+      try: (signal) => executeCommand(command, { ...execOptions, signal }),
+      catch: ensureError,
+    });
+  }
+
+  private retryWithoutFlatten(
     commandBuilder: (useFlatten: boolean) => string[],
     commandType: string,
     execOptions: CommandExecOptions,
-  ): Promise<ExecResult> {
-    this.log.warn(
-      'Bibliography compilation failed with --flatten, retrying without --flatten',
-    );
-    this.log.debug(`Retrying ${commandType} without --flatten flag`);
-
-    const result = await executeCommand(commandBuilder(false), execOptions);
-
-    if (result.timedOut) {
-      throw new Error(
-        `${commandType} operation timed out after ${execOptions.timeout}ms (retry)`,
+  ): Effect.Effect<ExecResult, Error> {
+    return Effect.gen({ self: this }, function* () {
+      this.log.warn(
+        'Bibliography compilation failed with --flatten, retrying without --flatten',
       );
-    }
+      this.log.debug(`Retrying ${commandType} without --flatten flag`);
 
-    if (!result.success) {
-      throw new Error(
-        `Failed to run ${commandType} (both with and without --flatten)`,
+      const result = yield* this.exec(commandBuilder(false), execOptions);
+
+      if (result.timedOut) {
+        return yield* Effect.fail(
+          new Error(
+            `${commandType} operation timed out after ${execOptions.timeout}ms (retry)`,
+          ),
+        );
+      }
+
+      if (!result.success) {
+        return yield* Effect.fail(
+          new Error(
+            `Failed to run ${commandType} (both with and without --flatten)`,
+          ),
+        );
+      }
+
+      this.log.debug(
+        `${commandType} completed successfully (without --flatten)`,
       );
-    }
-
-    this.log.debug(`${commandType} completed successfully (without --flatten)`);
-    return result;
+      return result;
+    });
   }
 
   private isBibliographyError(errorOutput: string): boolean {

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -2,7 +2,7 @@
 import { Effect } from 'effect';
 
 // Internal imports
-import { createLog } from '@logger/logUtils';
+import { withLogChannel } from '@logger/effectLog';
 import type { ExecResult } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { ensureError } from '@utils/errors/errorMessage';
@@ -56,8 +56,6 @@ interface DiffExecutionOptions {
 type CommandExecOptions = { channel: string; timeout: number; cwd?: string };
 
 export class DiffCommandExecutor {
-  private readonly log = createLog(this.channel);
-
   constructor(private readonly channel: string) {}
 
   executeDiff(
@@ -70,7 +68,7 @@ export class DiffCommandExecutor {
         this.buildLatexdiffCommand(inputFile, editedFile, useFlatten, options),
       'latexdiff',
       options?.cwd,
-    );
+    ).pipe(withLogChannel(this.channel));
   }
 
   executeDiffVc(
@@ -88,7 +86,7 @@ export class DiffCommandExecutor {
         ),
       'latexdiff-vc',
       options?.cwd,
-    );
+    ).pipe(withLogChannel(this.channel));
   }
 
   /** Markup-related flags shared by the latexdiff and latexdiff-vc commands. */
@@ -174,11 +172,11 @@ export class DiffCommandExecutor {
         cwd,
       };
 
-      this.log.debug(`Attempting ${commandType} with --flatten flag`);
+      yield* Effect.logDebug(`Attempting ${commandType} with --flatten flag`);
       const result = yield* this.exec(commandBuilder(true), execOptions);
 
       if (result.success) {
-        this.log.debug(
+        yield* Effect.logDebug(
           `${commandType} completed successfully (with --flatten)`,
         );
         return result;
@@ -225,10 +223,10 @@ export class DiffCommandExecutor {
     execOptions: CommandExecOptions,
   ): Effect.Effect<ExecResult, Error> {
     return Effect.gen({ self: this }, function* () {
-      this.log.warn(
+      yield* Effect.logWarning(
         'Bibliography compilation failed with --flatten, retrying without --flatten',
       );
-      this.log.debug(`Retrying ${commandType} without --flatten flag`);
+      yield* Effect.logDebug(`Retrying ${commandType} without --flatten flag`);
 
       const result = yield* this.exec(commandBuilder(false), execOptions);
 
@@ -248,7 +246,7 @@ export class DiffCommandExecutor {
         );
       }
 
-      this.log.debug(
+      yield* Effect.logDebug(
         `${commandType} completed successfully (without --flatten)`,
       );
       return result;

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -1,6 +1,9 @@
+import { Effect } from 'effect';
+
 import replacementEngine from '@replacement/engine';
 import type { FileLocation } from '@shared/schemas';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { ensureError } from '@utils/errors/errorMessage';
 
 /** LaTeX starred math environments that need label removal during diff processing. */
 const STAR_ENVIRONMENTS = [
@@ -51,28 +54,40 @@ const BIBITEM_START = /(?:^|\n)\s*(?:\\DIF(?:add|del)\{)?\\bibitem\b/;
 
 export class DiffFileProcessor {
   // Intentionally does not swallow failures: a read/transform/write error here
-  // means the diff output is missing or corrupt, so it must propagate to the
-  // caller (LaTeXdiffService.runDiff*/), whose catch turns it into a
-  // `{ success: false }` result. Swallowing it would falsely report success.
-  async processDiffFile(
+  // means the diff output is missing or corrupt, so it must stay in the error
+  // channel for the caller (LaTeXdiffService.runDiff*/) to turn into a
+  // `{ success: false }` result. Recovering here would falsely report success.
+  processDiffFile(
     diffFileLocation: FileLocation,
     editedFileLocation?: FileLocation,
-  ): Promise<void> {
-    const content = await AbsoluteFS.read(diffFileLocation.absolutePath);
-    const editedContent = editedFileLocation
-      ? await AbsoluteFS.read(editedFileLocation.absolutePath)
-      : undefined;
-    let processedContent = this.restoreFlattenedBibliography(
-      content,
-      editedContent,
-    );
-    processedContent = this.processStarEnvironments(processedContent);
-    processedContent = this.processLineByLine(processedContent);
-    processedContent = replacementEngine.applyAll(processedContent);
-    for (const [pattern, replacement] of DOCUMENT_END_FIXES) {
-      processedContent = processedContent.replace(pattern, replacement);
-    }
-    await AbsoluteFS.write(diffFileLocation.absolutePath, processedContent);
+  ): Effect.Effect<void, Error> {
+    return Effect.gen({ self: this }, function* () {
+      const content = yield* Effect.tryPromise({
+        try: () => AbsoluteFS.read(diffFileLocation.absolutePath),
+        catch: ensureError,
+      });
+      const editedContent = editedFileLocation
+        ? yield* Effect.tryPromise({
+            try: () => AbsoluteFS.read(editedFileLocation.absolutePath),
+            catch: ensureError,
+          })
+        : undefined;
+      let processedContent = this.restoreFlattenedBibliography(
+        content,
+        editedContent,
+      );
+      processedContent = this.processStarEnvironments(processedContent);
+      processedContent = this.processLineByLine(processedContent);
+      processedContent = replacementEngine.applyAll(processedContent);
+      for (const [pattern, replacement] of DOCUMENT_END_FIXES) {
+        processedContent = processedContent.replace(pattern, replacement);
+      }
+      yield* Effect.tryPromise({
+        try: () =>
+          AbsoluteFS.write(diffFileLocation.absolutePath, processedContent),
+        catch: ensureError,
+      });
+    });
   }
 
   private restoreFlattenedBibliography(

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -6,6 +6,9 @@
 // Node imports
 import * as path from 'node:path';
 
+// Third-party imports
+import { Effect } from 'effect';
+
 // Local imports
 import type { MathMarkupOption } from '@latex/latexdiff/mathMarkup';
 import { createLog } from '@logger/logUtils';
@@ -22,6 +25,7 @@ import {
 } from '@shared/constants/workflowOutput';
 import { getSafeDocumentRelativePath } from '@utils/files/outputFileUtils';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { ensureError } from '@utils/errors/errorMessage';
 import { pathToLocation } from '@utils/files/fileLocation';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { hasExtension } from '@utils/core/pathCore';
@@ -36,144 +40,174 @@ import type {
   LatexdiffRuntime,
 } from './types';
 
-async function executeDiffOperations(
-  operations: DiffOperation[],
-  mathMarkup: MathMarkupOption | undefined,
-  latexdiff: LatexdiffRuntime,
-  progress: DiffProgressReporter,
-  immediateResults: DiffRunResult[] = [],
-): Promise<DiffRunOutcome> {
-  const results: DiffRunResult[] = [...immediateResults];
-  // Zero operations never enter the loop, so the bare division is safe.
-  const incrementPct = 100 / operations.length;
-  const log = createLog(latexdiff.channel);
+const executeDiffOperations = Effect.fn('latexdiff.executeDiffOperations')(
+  function* (
+    operations: readonly DiffOperation[],
+    mathMarkup: MathMarkupOption | undefined,
+    latexdiff: LatexdiffRuntime,
+    progress: DiffProgressReporter,
+    immediateResults: DiffRunResult[] = [],
+  ): Effect.fn.Return<DiffRunOutcome, Error> {
+    const results: DiffRunResult[] = [...immediateResults];
+    // Zero operations never enter the loop, so the bare division is safe.
+    const incrementPct = 100 / operations.length;
+    const log = createLog(latexdiff.channel);
 
-  for (const operation of operations) {
-    progress.report({
-      increment: incrementPct,
-      message: `Running ${operation.type} diff for ${operation.description}`,
-    });
-
-    const [baseExists, revisedExists] = await Promise.all([
-      AbsoluteFS.exists(operation.base.absolutePath),
-      AbsoluteFS.exists(operation.revised.absolutePath),
-    ]);
-
-    if (!baseExists || !revisedExists) {
-      results.push({
-        success: false,
-        message: 'Required files are missing on disk',
-        description: operation.description,
+    // Sequential by design: each latexdiff is a whole TeX run, and the
+    // progress reporter narrates them one at a time.
+    for (const operation of operations) {
+      progress.report({
+        increment: incrementPct,
+        message: `Running ${operation.type} diff for ${operation.description}`,
       });
-      continue;
-    }
 
-    log.debug(`Running ${operation.type} diff: ${operation.description}`);
+      const [baseExists, revisedExists] = yield* Effect.all(
+        [
+          exists(operation.base.absolutePath),
+          exists(operation.revised.absolutePath),
+        ],
+        { concurrency: 2 },
+      );
 
-    const diffResult =
-      operation.type === 'round'
-        ? await latexdiff.service.runDiffForRound(
-            operation.base,
-            operation.revised,
-            operation.round,
-            mathMarkup,
-            { cwd: operation.cwd },
-          )
-        : await latexdiff.service.runDiffBetweenRounds(
-            operation.base,
-            operation.revised,
-            operation.fromRound,
-            operation.toRound,
-            mathMarkup,
-            { cwd: operation.cwd },
-          );
-
-    results.push({ ...diffResult, description: operation.description });
-  }
-
-  return { results };
-}
-
-export async function runLatexdiffFromMetadata(params: {
-  rounds: ReadonlyRoundIndexed<OutputFileInfo>;
-  mathMarkup?: MathMarkupOption;
-  generateBetweenRoundDiffs: boolean;
-  latexdiff: LatexdiffRuntime;
-  progress: DiffProgressReporter;
-}): Promise<DiffRunOutcome> {
-  const { rounds, mathMarkup, generateBetweenRoundDiffs, latexdiff, progress } =
-    params;
-
-  const workspaceCwd = WorkspaceFS.getPath();
-  const immediateResults: DiffRunResult[] = [];
-  const operations: DiffOperation[] = [];
-  const groupedBySource = new Map<
-    string,
-    Array<{ round: number; info: OutputFileInfo }>
-  >();
-
-  for (const [round, infos] of roundIndexedEntries(rounds)) {
-    for (const info of infos) {
-      const base = getEffectiveDiffBase(info.lineage);
-      const source = getSafeDocumentRelativePath(info.source);
-      const description = `${source} (r${round})`;
-
-      if (!base) {
-        immediateResults.push({
+      if (!baseExists || !revisedExists) {
+        results.push({
           success: false,
-          message: 'Missing base file path',
-          description,
+          message: 'Required files are missing on disk',
+          description: operation.description,
         });
         continue;
       }
 
-      operations.push({
-        type: 'round',
-        base,
-        revised: info.location,
-        description,
-        cwd: workspaceCwd ?? path.dirname(base.absolutePath),
-        round,
-      });
+      log.debug(`Running ${operation.type} diff: ${operation.description}`);
 
-      const group = groupedBySource.get(source) ?? [];
-      group.push({ round, info });
-      groupedBySource.set(source, group);
+      const diffResult =
+        operation.type === 'round'
+          ? yield* latexdiff.service.runDiffForRound(
+              operation.base,
+              operation.revised,
+              operation.round,
+              mathMarkup,
+              { cwd: operation.cwd },
+            )
+          : yield* latexdiff.service.runDiffBetweenRounds(
+              operation.base,
+              operation.revised,
+              operation.fromRound,
+              operation.toRound,
+              mathMarkup,
+              { cwd: operation.cwd },
+            );
+
+      results.push({ ...diffResult, description: operation.description });
     }
-  }
 
-  if (generateBetweenRoundDiffs) {
-    for (const group of groupedBySource.values()) {
-      group.sort((a, b) => a.round - b.round);
-      for (const [index, current] of group.slice(1).entries()) {
-        const previous = group[index];
-        const base = previous.info.location;
-        const revised = current.info.location;
-        const description = `${getSafeDocumentRelativePath(current.info.source)} (r${previous.round}→r${current.round})`;
+    return { results };
+  },
+);
+
+const exists = (absolutePath: string): Effect.Effect<boolean, Error> =>
+  Effect.tryPromise({
+    try: () => AbsoluteFS.exists(absolutePath),
+    catch: ensureError,
+  });
+
+const readDir = (
+  absolutePath: string,
+): Effect.Effect<[string, number][], Error> =>
+  Effect.tryPromise({
+    try: () => AbsoluteFS.readDir(absolutePath),
+    catch: ensureError,
+  });
+
+export const runLatexdiffFromMetadata = Effect.fn('latexdiff.runFromMetadata')(
+  function* (params: {
+    rounds: ReadonlyRoundIndexed<OutputFileInfo>;
+    mathMarkup?: MathMarkupOption;
+    generateBetweenRoundDiffs: boolean;
+    latexdiff: LatexdiffRuntime;
+    progress: DiffProgressReporter;
+  }): Effect.fn.Return<DiffRunOutcome, Error> {
+    const {
+      rounds,
+      mathMarkup,
+      generateBetweenRoundDiffs,
+      latexdiff,
+      progress,
+    } = params;
+
+    const workspaceCwd = WorkspaceFS.getPath();
+    const immediateResults: DiffRunResult[] = [];
+    const operations: DiffOperation[] = [];
+    const groupedBySource = new Map<
+      string,
+      Array<{ round: number; info: OutputFileInfo }>
+    >();
+
+    for (const [round, infos] of roundIndexedEntries(rounds)) {
+      for (const info of infos) {
+        const base = getEffectiveDiffBase(info.lineage);
+        const source = getSafeDocumentRelativePath(info.source);
+        const description = `${source} (r${round})`;
+
+        if (!base) {
+          immediateResults.push({
+            success: false,
+            message: 'Missing base file path',
+            description,
+          });
+          continue;
+        }
 
         operations.push({
-          type: 'between-rounds',
+          type: 'round',
           base,
-          revised,
+          revised: info.location,
           description,
           cwd: workspaceCwd ?? path.dirname(base.absolutePath),
-          fromRound: previous.round,
-          toRound: current.round,
+          round,
         });
+
+        const group = groupedBySource.get(source) ?? [];
+        group.push({ round, info });
+        groupedBySource.set(source, group);
       }
     }
-  }
 
-  return executeDiffOperations(
-    operations,
-    mathMarkup,
-    latexdiff,
-    progress,
-    immediateResults,
-  );
-}
+    if (generateBetweenRoundDiffs) {
+      for (const group of groupedBySource.values()) {
+        group.sort((a, b) => a.round - b.round);
+        for (const [index, current] of group.slice(1).entries()) {
+          const previous = group[index];
+          const base = previous.info.location;
+          const revised = current.info.location;
+          const description = `${getSafeDocumentRelativePath(current.info.source)} (r${previous.round}→r${current.round})`;
 
-export async function runLatexdiffViaWorkspaceScan(params: {
+          operations.push({
+            type: 'between-rounds',
+            base,
+            revised,
+            description,
+            cwd: workspaceCwd ?? path.dirname(base.absolutePath),
+            fromRound: previous.round,
+            toRound: current.round,
+          });
+        }
+      }
+    }
+
+    return yield* executeDiffOperations(
+      operations,
+      mathMarkup,
+      latexdiff,
+      progress,
+      immediateResults,
+    );
+  },
+);
+
+export const runLatexdiffViaWorkspaceScan = Effect.fn(
+  'latexdiff.runViaWorkspaceScan',
+)(function* (params: {
   agent: string;
   model: string;
   inputFile: string;
@@ -182,7 +216,7 @@ export async function runLatexdiffViaWorkspaceScan(params: {
   generateBetweenRoundDiffs: boolean;
   latexdiff: LatexdiffRuntime;
   progress: DiffProgressReporter;
-}): Promise<DiffRunOutcome> {
+}): Effect.fn.Return<DiffRunOutcome, Error> {
   const {
     agent,
     model,
@@ -197,7 +231,7 @@ export async function runLatexdiffViaWorkspaceScan(params: {
 
   const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
-    throw new Error('No workspace path found');
+    return yield* Effect.fail(new Error('No workspace path found'));
   }
 
   const toAbsolute = (file: string): string =>
@@ -224,7 +258,7 @@ export async function runLatexdiffViaWorkspaceScan(params: {
     );
 
     const absoluteDir = path.join(workspacePath, outputDirPath);
-    const dirEntries = await AbsoluteFS.readDir(absoluteDir);
+    const dirEntries = yield* readDir(absoluteDir);
 
     const roundOutputs = new Map<number, string>();
 
@@ -269,15 +303,17 @@ export async function runLatexdiffViaWorkspaceScan(params: {
       if (roundOutputs.has(round)) continue;
 
       const roundAbsoluteDir = path.join(absoluteDir, entryName);
-      let roundEntries: [string, number][];
-      try {
-        roundEntries = await AbsoluteFS.readDir(roundAbsoluteDir);
-      } catch (error) {
-        // Skip unreadable round dirs but record which one so a missing
-        // round output isn't silently invisible during diagnosis.
-        log.debug(`Skipping round dir '${roundAbsoluteDir}': ${error}`);
-        continue;
-      }
+      // Skip unreadable round dirs but record which one so a missing round
+      // output isn't silently invisible during diagnosis.
+      const roundEntries = yield* readDir(roundAbsoluteDir).pipe(
+        Effect.catch((error) =>
+          Effect.sync((): [string, number][] | null => {
+            log.debug(`Skipping round dir '${roundAbsoluteDir}': ${error}`);
+            return null;
+          }),
+        ),
+      );
+      if (roundEntries === null) continue;
       const match = roundEntries.find(
         ([fileName, nestedType]) =>
           isFile(nestedType) &&
@@ -350,5 +386,10 @@ export async function runLatexdiffViaWorkspaceScan(params: {
     }
   }
 
-  return executeDiffOperations(operations, mathMarkup, latexdiff, progress);
-}
+  return yield* executeDiffOperations(
+    operations,
+    mathMarkup,
+    latexdiff,
+    progress,
+  );
+});

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -11,7 +11,7 @@ import { Effect } from 'effect';
 
 // Local imports
 import type { MathMarkupOption } from '@latex/latexdiff/mathMarkup';
-import { createLog } from '@logger/logUtils';
+import { withLogChannel } from '@logger/effectLog';
 import {
   getEffectiveDiffBase,
   roundIndexedEntries,
@@ -51,7 +51,6 @@ const executeDiffOperations = Effect.fn('latexdiff.executeDiffOperations')(
     const results: DiffRunResult[] = [...immediateResults];
     // Zero operations never enter the loop, so the bare division is safe.
     const incrementPct = 100 / operations.length;
-    const log = createLog(latexdiff.channel);
 
     // Sequential by design: each latexdiff is a whole TeX run, and the
     // progress reporter narrates them one at a time.
@@ -78,7 +77,9 @@ const executeDiffOperations = Effect.fn('latexdiff.executeDiffOperations')(
         continue;
       }
 
-      log.debug(`Running ${operation.type} diff: ${operation.description}`);
+      yield* Effect.logDebug(
+        `Running ${operation.type} diff: ${operation.description}`,
+      );
 
       const diffResult =
         operation.type === 'round'
@@ -203,193 +204,202 @@ export const runLatexdiffFromMetadata = Effect.fn('latexdiff.runFromMetadata')(
       immediateResults,
     );
   },
+  // One channel for the whole run, named once here instead of threaded
+  // through each helper below.
+  (effect, params) => withLogChannel(params.latexdiff.channel)(effect),
 );
 
 export const runLatexdiffViaWorkspaceScan = Effect.fn(
   'latexdiff.runViaWorkspaceScan',
-)(function* (params: {
-  agent: string;
-  model: string;
-  inputFile: string;
-  outputFiles?: string[];
-  mathMarkup?: MathMarkupOption;
-  generateBetweenRoundDiffs: boolean;
-  latexdiff: LatexdiffRuntime;
-  progress: DiffProgressReporter;
-}): Effect.fn.Return<DiffRunOutcome, Error> {
-  const {
-    agent,
-    model,
-    inputFile,
-    outputFiles,
-    mathMarkup,
-    generateBetweenRoundDiffs,
-    latexdiff,
-    progress,
-  } = params;
-  const log = createLog(latexdiff.channel);
-
-  const workspacePath = WorkspaceFS.getPath();
-  if (!workspacePath) {
-    return yield* Effect.fail(new Error('No workspace path found'));
-  }
-
-  const toAbsolute = (file: string): string =>
-    path.isAbsolute(file) ? file : path.join(workspacePath, file);
-
-  const configuredInputFiles =
-    outputFiles && outputFiles.length > 0 ? outputFiles : [inputFile];
-
-  log.debug(`Input files: ${configuredInputFiles.join(', ')}`);
-
-  // Per input file: round number → workspace-relative output path. A round
-  // matched more than once (e.g. two legacy files matching the same round
-  // regex) keeps a single entry, last match wins.
-  const inputToOutputsMap = new Map<
-    string,
-    Array<{ round: number; outputPath: string }>
-  >();
-
-  for (const candidateInput of configuredInputFiles) {
-    const outputDirPath = path.dirname(candidateInput);
-    const baseInputName = path.basename(
-      candidateInput,
-      path.extname(candidateInput),
-    );
-
-    const absoluteDir = path.join(workspacePath, outputDirPath);
-    const dirEntries = yield* readDir(absoluteDir);
-
-    const roundOutputs = new Map<number, string>();
-
-    // Legacy flat layout: files sit directly under outputDirPath as
-    // `<base>_<chunk>_r{round}_<model>.tex`.
-    const legacyPattern = legacyWorkflowOutputRoundRegex(
-      baseInputName,
+)(
+  function* (params: {
+    agent: string;
+    model: string;
+    inputFile: string;
+    outputFiles?: string[];
+    mathMarkup?: MathMarkupOption;
+    generateBetweenRoundDiffs: boolean;
+    latexdiff: LatexdiffRuntime;
+    progress: DiffProgressReporter;
+  }): Effect.fn.Return<DiffRunOutcome, Error> {
+    const {
       agent,
       model,
-    );
-    for (const [fileName, fileType] of dirEntries) {
-      // Skip symlinks (mirrored dependency copies, not revised outputs) so
-      // behavior matches the prior strict `=== FileType.File` check; the
-      // platform FS reports a symlink as `SymbolicLink | targetType`.
-      if (
-        !isFile(fileType) ||
-        isSymlink(fileType) ||
-        !hasExtension(fileName, '.tex') ||
-        fileName.includes('_diff')
-      ) {
-        continue;
-      }
-      const match = fileName.match(legacyPattern);
-      if (!match) continue;
-      const round = RoundKeySchema.safeParse(match[1]);
-      if (!round.success) continue;
-      roundOutputs.set(round.data, path.join(outputDirPath, fileName));
+      inputFile,
+      outputFiles,
+      mathMarkup,
+      generateBetweenRoundDiffs,
+      latexdiff,
+      progress,
+    } = params;
+
+    const workspacePath = WorkspaceFS.getPath();
+    if (!workspacePath) {
+      return yield* Effect.fail(new Error('No workspace path found'));
     }
 
-    // Mid-era layout: outputs under `r{round}/<base>_<cleanAgent>_<model>.tex`.
-    // Some upgraded workspaces may still hold these files. Only look in
-    // known `r{round}/` subdirectories so we don't descend the whole tree.
-    const midEraFilename = `${midEraWorkflowOutputStem({
-      base: baseInputName,
-      agent,
-      model,
-    })}.tex`;
-    for (const [entryName, entryType] of dirEntries) {
-      if (!isDirectory(entryType) || isSymlink(entryType)) continue;
-      const round = parseWorkflowOutputRoundDir(entryName);
-      if (round == null) continue;
-      if (roundOutputs.has(round)) continue;
+    const toAbsolute = (file: string): string =>
+      path.isAbsolute(file) ? file : path.join(workspacePath, file);
 
-      const roundAbsoluteDir = path.join(absoluteDir, entryName);
-      // Skip unreadable round dirs but record which one so a missing round
-      // output isn't silently invisible during diagnosis.
-      const roundEntries = yield* readDir(roundAbsoluteDir).pipe(
-        Effect.catch((error) =>
-          Effect.sync((): [string, number][] | null => {
-            log.debug(`Skipping round dir '${roundAbsoluteDir}': ${error}`);
-            return null;
-          }),
-        ),
-      );
-      if (roundEntries === null) continue;
-      const match = roundEntries.find(
-        ([fileName, nestedType]) =>
-          isFile(nestedType) &&
-          !isSymlink(nestedType) &&
-          fileName === midEraFilename,
-      );
-      if (!match) continue;
-      roundOutputs.set(
-        round,
-        path.join(outputDirPath, entryName, midEraFilename),
-      );
-    }
+    const configuredInputFiles =
+      outputFiles && outputFiles.length > 0 ? outputFiles : [inputFile];
 
-    // New-layout workflow outputs live inside task-run storage
-    // (`executions/{id}/r{round}/output.tex`), not in the workspace. That
-    // path is driven by execution metadata (`OutputFileInfo.outputsByRound`)
-    // via `runLatexdiffFromMetadata`; the workspace scan here only covers
-    // pre-refactor files.
+    yield* Effect.logDebug(`Input files: ${configuredInputFiles.join(', ')}`);
 
-    if (roundOutputs.size > 0) {
-      inputToOutputsMap.set(
+    // Per input file: round number → workspace-relative output path. A round
+    // matched more than once (e.g. two legacy files matching the same round
+    // regex) keeps a single entry, last match wins.
+    const inputToOutputsMap = new Map<
+      string,
+      Array<{ round: number; outputPath: string }>
+    >();
+
+    for (const candidateInput of configuredInputFiles) {
+      const outputDirPath = path.dirname(candidateInput);
+      const baseInputName = path.basename(
         candidateInput,
-        [...roundOutputs].map(([round, outputPath]) => ({ round, outputPath })),
+        path.extname(candidateInput),
       );
-      log.debug(
-        `Found ${roundOutputs.size} matching outputs for ${candidateInput}`,
+
+      const absoluteDir = path.join(workspacePath, outputDirPath);
+      const dirEntries = yield* readDir(absoluteDir);
+
+      const roundOutputs = new Map<number, string>();
+
+      // Legacy flat layout: files sit directly under outputDirPath as
+      // `<base>_<chunk>_r{round}_<model>.tex`.
+      const legacyPattern = legacyWorkflowOutputRoundRegex(
+        baseInputName,
+        agent,
+        model,
       );
-    } else {
-      log.debug(`No matching outputs found for ${candidateInput}`);
+      for (const [fileName, fileType] of dirEntries) {
+        // Skip symlinks (mirrored dependency copies, not revised outputs) so
+        // behavior matches the prior strict `=== FileType.File` check; the
+        // platform FS reports a symlink as `SymbolicLink | targetType`.
+        if (
+          !isFile(fileType) ||
+          isSymlink(fileType) ||
+          !hasExtension(fileName, '.tex') ||
+          fileName.includes('_diff')
+        ) {
+          continue;
+        }
+        const match = fileName.match(legacyPattern);
+        if (!match) continue;
+        const round = RoundKeySchema.safeParse(match[1]);
+        if (!round.success) continue;
+        roundOutputs.set(round.data, path.join(outputDirPath, fileName));
+      }
+
+      // Mid-era layout: outputs under `r{round}/<base>_<cleanAgent>_<model>.tex`.
+      // Some upgraded workspaces may still hold these files. Only look in
+      // known `r{round}/` subdirectories so we don't descend the whole tree.
+      const midEraFilename = `${midEraWorkflowOutputStem({
+        base: baseInputName,
+        agent,
+        model,
+      })}.tex`;
+      for (const [entryName, entryType] of dirEntries) {
+        if (!isDirectory(entryType) || isSymlink(entryType)) continue;
+        const round = parseWorkflowOutputRoundDir(entryName);
+        if (round == null) continue;
+        if (roundOutputs.has(round)) continue;
+
+        const roundAbsoluteDir = path.join(absoluteDir, entryName);
+        // Skip unreadable round dirs but record which one so a missing round
+        // output isn't silently invisible during diagnosis.
+        const roundEntries = yield* readDir(roundAbsoluteDir).pipe(
+          Effect.catch((error) =>
+            Effect.logDebug(
+              `Skipping round dir '${roundAbsoluteDir}': ${error}`,
+            ).pipe(Effect.as<[string, number][] | null>(null)),
+          ),
+        );
+        if (roundEntries === null) continue;
+        const match = roundEntries.find(
+          ([fileName, nestedType]) =>
+            isFile(nestedType) &&
+            !isSymlink(nestedType) &&
+            fileName === midEraFilename,
+        );
+        if (!match) continue;
+        roundOutputs.set(
+          round,
+          path.join(outputDirPath, entryName, midEraFilename),
+        );
+      }
+
+      // New-layout workflow outputs live inside task-run storage
+      // (`executions/{id}/r{round}/output.tex`), not in the workspace. That
+      // path is driven by execution metadata (`OutputFileInfo.outputsByRound`)
+      // via `runLatexdiffFromMetadata`; the workspace scan here only covers
+      // pre-refactor files.
+
+      if (roundOutputs.size > 0) {
+        inputToOutputsMap.set(
+          candidateInput,
+          [...roundOutputs].map(([round, outputPath]) => ({
+            round,
+            outputPath,
+          })),
+        );
+        yield* Effect.logDebug(
+          `Found ${roundOutputs.size} matching outputs for ${candidateInput}`,
+        );
+      } else {
+        yield* Effect.logDebug(
+          `No matching outputs found for ${candidateInput}`,
+        );
+      }
     }
-  }
 
-  if (inputToOutputsMap.size === 0) {
-    return { results: [] };
-  }
-
-  const operations: DiffOperation[] = [];
-
-  for (const [baseFile, roundOutputs] of inputToOutputsMap.entries()) {
-    const sorted = roundOutputs.toSorted((a, b) => a.round - b.round);
-
-    for (const { round, outputPath } of sorted) {
-      const resolvedOutput = toAbsolute(outputPath);
-
-      operations.push({
-        type: 'round',
-        base: pathToLocation(toAbsolute(baseFile)),
-        revised: pathToLocation(resolvedOutput),
-        description: `${path.basename(baseFile)} (r${round})`,
-        cwd: path.dirname(resolvedOutput),
-        round,
-      });
+    if (inputToOutputsMap.size === 0) {
+      return { results: [] };
     }
 
-    if (generateBetweenRoundDiffs) {
-      for (const [index, current] of sorted.slice(1).entries()) {
-        const previous = sorted[index];
-        const resolvedPrevious = toAbsolute(previous.outputPath);
+    const operations: DiffOperation[] = [];
+
+    for (const [baseFile, roundOutputs] of inputToOutputsMap.entries()) {
+      const sorted = roundOutputs.toSorted((a, b) => a.round - b.round);
+
+      for (const { round, outputPath } of sorted) {
+        const resolvedOutput = toAbsolute(outputPath);
 
         operations.push({
-          type: 'between-rounds',
-          base: pathToLocation(resolvedPrevious),
-          revised: pathToLocation(toAbsolute(current.outputPath)),
-          description: `${path.basename(previous.outputPath)} (r${previous.round}→r${current.round})`,
-          cwd: path.dirname(resolvedPrevious),
-          fromRound: previous.round,
-          toRound: current.round,
+          type: 'round',
+          base: pathToLocation(toAbsolute(baseFile)),
+          revised: pathToLocation(resolvedOutput),
+          description: `${path.basename(baseFile)} (r${round})`,
+          cwd: path.dirname(resolvedOutput),
+          round,
         });
       }
-    }
-  }
 
-  return yield* executeDiffOperations(
-    operations,
-    mathMarkup,
-    latexdiff,
-    progress,
-  );
-});
+      if (generateBetweenRoundDiffs) {
+        for (const [index, current] of sorted.slice(1).entries()) {
+          const previous = sorted[index];
+          const resolvedPrevious = toAbsolute(previous.outputPath);
+
+          operations.push({
+            type: 'between-rounds',
+            base: pathToLocation(resolvedPrevious),
+            revised: pathToLocation(toAbsolute(current.outputPath)),
+            description: `${path.basename(previous.outputPath)} (r${previous.round}→r${current.round})`,
+            cwd: path.dirname(resolvedPrevious),
+            fromRound: previous.round,
+            toRound: current.round,
+          });
+        }
+      }
+    }
+
+    return yield* executeDiffOperations(
+      operations,
+      mathMarkup,
+      latexdiff,
+      progress,
+    );
+  },
+  (effect, params) => withLogChannel(params.latexdiff.channel)(effect),
+);

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -9,7 +9,6 @@ import type {
 } from '@shared/schemas';
 import type { StreamSnapshotStore } from '@transcript/StreamSnapshotStore';
 import { toNewestFirstByTimestamp } from '@utils/core';
-import { ensureError } from '@utils/errors/errorMessage';
 import {
   scanRunDirForOutputs,
   type RunOutputFilesystem,
@@ -74,17 +73,13 @@ export const discoverLatestExecutionOutputs = Effect.fn(
     }
     // Generated files remain discoverable when no output facts were recorded.
     // Use all configured input files as diff bases, as the pinned-run path does.
-    const scanned = yield* Effect.tryPromise({
-      try: () =>
-        scanRunDirForOutputs(
-          candidate.id,
-          query.inputFile,
-          candidate.inputFiles.slice(1),
-          channel,
-          filesystem,
-        ),
-      catch: ensureError,
-    });
+    const scanned = yield* scanRunDirForOutputs(
+      candidate.id,
+      query.inputFile,
+      candidate.inputFiles.slice(1),
+      channel,
+      filesystem,
+    );
     if (scanned) {
       return { executionId: candidate.id, rounds: scanned };
     }

--- a/src/latex/latexdiff/runLatexdiff.ts
+++ b/src/latex/latexdiff/runLatexdiff.ts
@@ -25,7 +25,6 @@ import type {
 } from '@shared/schemas';
 
 import type { StreamSnapshotStore } from '@transcript/StreamSnapshotStore';
-import { ensureError } from '@utils/errors/errorMessage';
 import {
   runLatexdiffFromMetadata,
   runLatexdiffViaWorkspaceScan,
@@ -125,17 +124,13 @@ export const runLatexdiffForExecution = Effect.fn('runLatexdiffForExecution')(
     if (!outputsByRound && runId) {
       const parsedRunId = ExecutionIdSchema.safeParse(runId);
       if (parsedRunId.success) {
-        const scanned = yield* Effect.tryPromise({
-          try: () =>
-            scanRunDirForOutputs(
-              parsedRunId.data,
-              inputFile,
-              outputFiles,
-              latexdiff.channel,
-              params.filesystem,
-            ),
-          catch: ensureError,
-        });
+        const scanned = yield* scanRunDirForOutputs(
+          parsedRunId.data,
+          inputFile,
+          outputFiles,
+          latexdiff.channel,
+          params.filesystem,
+        );
         if (scanned) {
           outputsByRound = scanned;
           source = 'run-dir-scan';
@@ -175,28 +170,24 @@ export const runLatexdiffForExecution = Effect.fn('runLatexdiffForExecution')(
     }
 
     const rounds = outputsByRound;
-    const outcome = yield* Effect.tryPromise({
-      try: () =>
-        rounds
-          ? runLatexdiffFromMetadata({
-              rounds,
-              mathMarkup,
-              generateBetweenRoundDiffs,
-              latexdiff,
-              progress,
-            })
-          : runLatexdiffViaWorkspaceScan({
-              agent,
-              model,
-              inputFile,
-              outputFiles,
-              mathMarkup,
-              generateBetweenRoundDiffs,
-              latexdiff,
-              progress,
-            }),
-      catch: ensureError,
-    });
+    const outcome = yield* rounds
+      ? runLatexdiffFromMetadata({
+          rounds,
+          mathMarkup,
+          generateBetweenRoundDiffs,
+          latexdiff,
+          progress,
+        })
+      : runLatexdiffViaWorkspaceScan({
+          agent,
+          model,
+          inputFile,
+          outputFiles,
+          mathMarkup,
+          generateBetweenRoundDiffs,
+          latexdiff,
+          progress,
+        });
 
     return { outcome, executionId: discoveredExecutionId, source };
   },

--- a/src/latex/latexdiff/runLatexdiff.ts
+++ b/src/latex/latexdiff/runLatexdiff.ts
@@ -11,7 +11,7 @@
 
 import { Effect } from 'effect';
 
-import { createLog } from '@logger/logUtils';
+import { withLogChannel } from '@logger/effectLog';
 import {
   ExecutionIdSchema,
   OutputFileInfoSchema,
@@ -109,7 +109,6 @@ export const runLatexdiffForExecution = Effect.fn('runLatexdiffForExecution')(
       progress,
     } = params;
     const runId = params.runId ?? undefined;
-    const log = createLog(latexdiff.channel);
 
     let outputsByRound = params.outputsByRound ?? null;
     let source: LatexdiffOutputsSource = outputsByRound
@@ -135,7 +134,7 @@ export const runLatexdiffForExecution = Effect.fn('runLatexdiffForExecution')(
           outputsByRound = scanned;
           source = 'run-dir-scan';
           discoveredExecutionId = parsedRunId.data;
-          log.debug(
+          yield* Effect.logDebug(
             `Using run-dir scan outputs from execution ${parsedRunId.data}`,
           );
         }
@@ -163,7 +162,7 @@ export const runLatexdiffForExecution = Effect.fn('runLatexdiffForExecution')(
         outputsByRound = discovered.rounds;
         source = 'metadata';
         discoveredExecutionId = discovered.executionId;
-        log.debug(
+        yield* Effect.logDebug(
           `Using metadata outputs from execution ${discovered.executionId}`,
         );
       }
@@ -191,4 +190,7 @@ export const runLatexdiffForExecution = Effect.fn('runLatexdiffForExecution')(
 
     return { outcome, executionId: discoveredExecutionId, source };
   },
+  // One channel for the whole run, so the discovery steps and the diff engine
+  // below both land on the caller's channel.
+  (effect, params) => withLogChannel(params.latexdiff.channel)(effect),
 );

--- a/src/latex/latexdiff/runOutputFiles.ts
+++ b/src/latex/latexdiff/runOutputFiles.ts
@@ -11,7 +11,7 @@ import { Effect } from 'effect';
 
 // Local imports
 import { isFileNotFoundError } from '@common/errors';
-import { createLog } from '@logger/logUtils';
+import { withLogChannel } from '@logger/effectLog';
 import type { FileSystemProvider } from '@platform/interfaces';
 import {
   type ExecutionId,
@@ -36,8 +36,6 @@ import { isDirectory, isFile } from '@utils/files/fsEntryType';
 // Local file imports
 import { hasBetweenRoundDiffSuffix } from './diffFileNameManager';
 
-/** Logger handle shared by the discovery scan (created once per scan). */
-type Log = ReturnType<typeof createLog>;
 export type RunOutputFilesystem = Pick<
   FileSystemProvider,
   'readDirectory' | 'isSymlink'
@@ -59,7 +57,6 @@ const isSymlink = (
  */
 const collectTexFiles = Effect.fn('latexdiff.collectTexFiles')(function* (
   dir: string,
-  log: Log,
   fs: RunOutputFilesystem,
   prefix = '',
 ): Effect.fn.Return<string[], never> {
@@ -70,12 +67,11 @@ const collectTexFiles = Effect.fn('latexdiff.collectTexFiles')(function* (
     catch: ensureError,
   }).pipe(
     Effect.catch((error) =>
-      Effect.sync((): [string, number][] => {
-        if (!isFileNotFoundError(error)) {
-          log.warn(`Skipping unreadable directory '${dir}': ${error}`);
-        }
-        return [];
-      }),
+      isFileNotFoundError(error)
+        ? Effect.succeed<[string, number][]>([])
+        : Effect.logWarning(
+            `Skipping unreadable directory '${dir}': ${error}`,
+          ).pipe(Effect.as<[string, number][]>([])),
     ),
   );
   const results: string[] = [];
@@ -88,7 +84,7 @@ const collectTexFiles = Effect.fn('latexdiff.collectTexFiles')(function* (
     if (isFile(type) && hasExtension(name, '.tex')) {
       results.push(relative);
     } else if (isDirectory(type)) {
-      results.push(...(yield* collectTexFiles(absPath, log, fs, relative)));
+      results.push(...(yield* collectTexFiles(absPath, fs, relative)));
     }
   }
   return results;
@@ -112,7 +108,6 @@ export const scanRunDirForOutputs = Effect.fn('latexdiff.scanRunDir')(
     channel: string,
     fs: RunOutputFilesystem,
   ): Effect.fn.Return<RoundIndexed<OutputFileInfo> | null, never> {
-    const log = createLog(channel);
     const scan = Effect.gen(function* () {
       const runDirAbsolute = yield* Effect.tryPromise({
         try: () => findRunDir(executionId),
@@ -162,7 +157,7 @@ export const scanRunDirForOutputs = Effect.fn('latexdiff.scanRunDir')(
         const outputs: OutputFileInfo[] = [];
         // Collect .tex files recursively: extracted docs may live in subdirs
         // (e.g. r0/chapters/main.tex) when source names include path segments.
-        const allTexFiles = yield* collectTexFiles(roundDirAbsolute, log, fs);
+        const allTexFiles = yield* collectTexFiles(roundDirAbsolute, fs);
         // Between-round artifacts written to run storage always carry both round
         // numbers (e.g. output_diffr1r0.tex). The bare _diff suffix only appears
         // in workspace-side diffs, never here, so a legitimately-named source
@@ -217,13 +212,11 @@ export const scanRunDirForOutputs = Effect.fn('latexdiff.scanRunDir')(
     // discipline (review checklist §15) forbids logging it below warn.
     return yield* scan.pipe(
       Effect.catch((error) =>
-        Effect.sync((): RoundIndexed<OutputFileInfo> | null => {
-          log.warn(
-            `RunDir scan for ${executionId} failed: ${toErrorMessage(error)}`,
-          );
-          return null;
-        }),
+        Effect.logWarning(
+          `RunDir scan for ${executionId} failed: ${toErrorMessage(error)}`,
+        ).pipe(Effect.as<RoundIndexed<OutputFileInfo> | null>(null)),
       ),
+      withLogChannel(channel),
     );
   },
 );

--- a/src/latex/latexdiff/runOutputFiles.ts
+++ b/src/latex/latexdiff/runOutputFiles.ts
@@ -6,6 +6,9 @@
 // Node imports
 import * as path from 'node:path';
 
+// Third-party imports
+import { Effect } from 'effect';
+
 // Local imports
 import { isFileNotFoundError } from '@common/errors';
 import { createLog } from '@logger/logUtils';
@@ -26,7 +29,7 @@ import {
 } from '@utils/files/fileLocation';
 import { findRunDir } from '@utils/files/runStorageFs';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
 import { isDirectory, isFile } from '@utils/files/fsEntryType';
 
@@ -40,41 +43,56 @@ export type RunOutputFilesystem = Pick<
   'readDirectory' | 'isSymlink'
 >;
 
+/** Whether `absPath` is a symlink; an unreadable entry counts as "not one". */
+const isSymlink = (
+  fs: RunOutputFilesystem,
+  absPath: string,
+): Effect.Effect<boolean> =>
+  Effect.tryPromise({
+    try: () => fs.isSymlink(absPath),
+    catch: ensureError,
+  }).pipe(Effect.orElseSucceed(() => false));
+
 /**
  * Recursively collect all `.tex` file paths under `dir`, returned as paths
  * relative to `dir` using forward slashes (e.g. `"chapters/main.tex"`).
  */
-async function collectTexFiles(
+const collectTexFiles = Effect.fn('latexdiff.collectTexFiles')(function* (
   dir: string,
   log: Log,
   fs: RunOutputFilesystem,
   prefix = '',
-): Promise<string[]> {
-  let entries: [string, number][];
-  try {
-    entries = await fs.readDirectory(dir);
-  } catch (error) {
-    // This is a recovery scan: a missing/unreadable subtree means this subtree
-    // contributes no outputs, but other rounds/subtrees may still be useful.
-    if (isFileNotFoundError(error)) return [];
-    log.warn(`Skipping unreadable directory '${dir}': ${error}`);
-    return [];
-  }
+): Effect.fn.Return<string[], never> {
+  // This is a recovery scan: a missing/unreadable subtree means this subtree
+  // contributes no outputs, but other rounds/subtrees may still be useful.
+  const entries = yield* Effect.tryPromise({
+    try: () => fs.readDirectory(dir),
+    catch: ensureError,
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.sync((): [string, number][] => {
+        if (!isFileNotFoundError(error)) {
+          log.warn(`Skipping unreadable directory '${dir}': ${error}`);
+        }
+        return [];
+      }),
+    ),
+  );
   const results: string[] = [];
   for (const [name, type] of entries) {
     const absPath = path.join(dir, name);
     // Skip symlinks: they are mirrored dependency copies placed by
     // ensureMirroredInRoundDir, not revised outputs.
-    if (await fs.isSymlink(absPath).catch(() => false)) continue;
+    if (yield* isSymlink(fs, absPath)) continue;
     const relative = prefix ? `${prefix}/${name}` : name;
     if (isFile(type) && hasExtension(name, '.tex')) {
       results.push(relative);
     } else if (isDirectory(type)) {
-      results.push(...(await collectTexFiles(absPath, log, fs, relative)));
+      results.push(...(yield* collectTexFiles(absPath, log, fs, relative)));
     }
   }
   return results;
-}
+});
 
 /**
  * Read `executions/{runId}/r{round}/output.*` directly from disk and build
@@ -86,108 +104,126 @@ async function collectTexFiles(
  * Lineage `original` is set to the configured `inputFile` so latexdiff has
  * a base to compare against.
  */
-export async function scanRunDirForOutputs(
-  executionId: ExecutionId,
-  inputFile: string,
-  extraBaseFiles: string[] | undefined,
-  channel: string,
-  fs: RunOutputFilesystem,
-): Promise<RoundIndexed<OutputFileInfo> | null> {
-  const log = createLog(channel);
-  try {
-    const runDirAbsolute = await findRunDir(executionId);
-    if (!runDirAbsolute) return null;
+export const scanRunDirForOutputs = Effect.fn('latexdiff.scanRunDir')(
+  function* (
+    executionId: ExecutionId,
+    inputFile: string,
+    extraBaseFiles: string[] | undefined,
+    channel: string,
+    fs: RunOutputFilesystem,
+  ): Effect.fn.Return<RoundIndexed<OutputFileInfo> | null, never> {
+    const log = createLog(channel);
+    const scan = Effect.gen(function* () {
+      const runDirAbsolute = yield* Effect.tryPromise({
+        try: () => findRunDir(executionId),
+        catch: ensureError,
+      });
+      if (!runDirAbsolute) return null;
 
-    const dirEntries = await fs.readDirectory(runDirAbsolute);
+      const dirEntries = yield* Effect.tryPromise({
+        try: () => fs.readDirectory(runDirAbsolute),
+        catch: ensureError,
+      });
 
-    const workspacePath = WorkspaceFS.getPath() ?? '';
-    const toAbs = (f: string): string =>
-      path.isAbsolute(f) ? f : path.join(workspacePath, f);
-    // Normalize to a forward-slash, extension-less relative key so base files
-    // and recovered round outputs can be matched regardless of path format.
-    const toRelKey = (p: string): string =>
-      p.replaceAll('\\', '/').replace(/\.tex$/i, '');
+      const workspacePath = WorkspaceFS.getPath() ?? '';
+      const toAbs = (f: string): string =>
+        path.isAbsolute(f) ? f : path.join(workspacePath, f);
+      // Normalize to a forward-slash, extension-less relative key so base files
+      // and recovered round outputs can be matched regardless of path format.
+      const toRelKey = (p: string): string =>
+        p.replaceAll('\\', '/').replace(/\.tex$/i, '');
 
-    // Build a relative-path (no extension) → workspace location map so
-    // multi-output runs with duplicate basenames (e.g. chapters/main.tex and
-    // appendix/main.tex) don't collide. fileRelToRound mirrors the workspace
-    // relative path for XML-extracted files, so the keys match directly.
-    const baseLocationByRelPath = new Map<string, FileLocation>();
-    for (const bf of [inputFile, ...(extraBaseFiles ?? [])]) {
-      const abs = toAbs(bf);
-      const relSource = workspacePath ? path.relative(workspacePath, abs) : bf;
-      baseLocationByRelPath.set(toRelKey(relSource), pathToLocation(abs));
-    }
-    const defaultBaseLocation = pathToLocation(toAbs(inputFile));
+      // Build a relative-path (no extension) → workspace location map so
+      // multi-output runs with duplicate basenames (e.g. chapters/main.tex and
+      // appendix/main.tex) don't collide. fileRelToRound mirrors the workspace
+      // relative path for XML-extracted files, so the keys match directly.
+      const baseLocationByRelPath = new Map<string, FileLocation>();
+      for (const bf of [inputFile, ...(extraBaseFiles ?? [])]) {
+        const abs = toAbs(bf);
+        const relSource = workspacePath
+          ? path.relative(workspacePath, abs)
+          : bf;
+        baseLocationByRelPath.set(toRelKey(relSource), pathToLocation(abs));
+      }
+      const defaultBaseLocation = pathToLocation(toAbs(inputFile));
 
-    const rounds: RoundIndexed<OutputFileInfo> = {};
+      const rounds: RoundIndexed<OutputFileInfo> = {};
 
-    for (const [entryName, fileType] of dirEntries) {
-      if (!isDirectory(fileType)) continue;
-      const round = parseWorkflowOutputRoundDir(entryName);
-      if (round == null) continue;
+      for (const [entryName, fileType] of dirEntries) {
+        if (!isDirectory(fileType)) continue;
+        const round = parseWorkflowOutputRoundDir(entryName);
+        if (round == null) continue;
 
-      const roundDirAbsolute = path.join(runDirAbsolute, entryName);
-      // Skip symlinked round dirs. Use lstat through the platform because
-      // readDirectory FileType values do not reliably include SymbolicLink.
-      if (await fs.isSymlink(roundDirAbsolute).catch(() => false)) continue;
+        const roundDirAbsolute = path.join(runDirAbsolute, entryName);
+        // Skip symlinked round dirs. Use lstat through the platform because
+        // readDirectory FileType values do not reliably include SymbolicLink.
+        if (yield* isSymlink(fs, roundDirAbsolute)) continue;
 
-      const outputs: OutputFileInfo[] = [];
-      // Collect .tex files recursively: extracted docs may live in subdirs
-      // (e.g. r0/chapters/main.tex) when source names include path segments.
-      const allTexFiles = await collectTexFiles(roundDirAbsolute, log, fs);
-      // Between-round artifacts written to run storage always carry both round
-      // numbers (e.g. output_diffr1r0.tex). The bare _diff suffix only appears
-      // in workspace-side diffs, never here, so a legitimately-named source
-      // like "chapter_diff.tex" is not mistakenly dropped.
-      const nonArtifact = allTexFiles.filter(
-        (f) => !hasBetweenRoundDiffSuffix(path.parse(f).name),
-      );
-      for (const fileRelToRound of nonArtifact) {
-        const relativePath = path.join(entryName, fileRelToRound);
-        const location = createRunStorageLocation(
-          path.join(runDirAbsolute, relativePath),
-          relativePath,
-          executionId,
+        const outputs: OutputFileInfo[] = [];
+        // Collect .tex files recursively: extracted docs may live in subdirs
+        // (e.g. r0/chapters/main.tex) when source names include path segments.
+        const allTexFiles = yield* collectTexFiles(roundDirAbsolute, log, fs);
+        // Between-round artifacts written to run storage always carry both round
+        // numbers (e.g. output_diffr1r0.tex). The bare _diff suffix only appears
+        // in workspace-side diffs, never here, so a legitimately-named source
+        // like "chapter_diff.tex" is not mistakenly dropped.
+        const nonArtifact = allTexFiles.filter(
+          (f) => !hasBetweenRoundDiffSuffix(path.parse(f).name),
         );
-        // Preserve subdirectory in source (e.g. "chapters/main") so
-        // traceFileLineage can match it back to the workspace original.
-        // For the generic "output" stem, fall back to the input file basename
-        // so progress labels show the meaningful name instead of "output".
-        const sourceNoExt = fileRelToRound.replace(/\.tex$/i, '');
-        const source =
-          sourceNoExt === WORKFLOW_OUTPUT_BASENAME
-            ? path.basename(inputFile)
-            : sourceNoExt;
-        // Match recovered file to its base by relative path. Fall back to the
-        // single configured base only when there's no ambiguity (one candidate);
-        // in multi-file runs an unmatched file gets null so it surfaces as a
-        // "missing base" error rather than silently diffing against the wrong doc.
-        const fileKey = toRelKey(fileRelToRound);
-        const originalLocation =
-          baseLocationByRelPath.get(fileKey) ??
-          (baseLocationByRelPath.size === 1 ? defaultBaseLocation : null);
-        outputs.push({
-          source,
-          round,
-          location,
-          lineage: {
-            original: originalLocation,
-            diffBase: null,
-          },
-          diff: null,
-        });
+        for (const fileRelToRound of nonArtifact) {
+          const relativePath = path.join(entryName, fileRelToRound);
+          const location = createRunStorageLocation(
+            path.join(runDirAbsolute, relativePath),
+            relativePath,
+            executionId,
+          );
+          // Preserve subdirectory in source (e.g. "chapters/main") so
+          // traceFileLineage can match it back to the workspace original.
+          // For the generic "output" stem, fall back to the input file basename
+          // so progress labels show the meaningful name instead of "output".
+          const sourceNoExt = fileRelToRound.replace(/\.tex$/i, '');
+          const source =
+            sourceNoExt === WORKFLOW_OUTPUT_BASENAME
+              ? path.basename(inputFile)
+              : sourceNoExt;
+          // Match recovered file to its base by relative path. Fall back to the
+          // single configured base only when there's no ambiguity (one candidate);
+          // in multi-file runs an unmatched file gets null so it surfaces as a
+          // "missing base" error rather than silently diffing against the wrong doc.
+          const fileKey = toRelKey(fileRelToRound);
+          const originalLocation =
+            baseLocationByRelPath.get(fileKey) ??
+            (baseLocationByRelPath.size === 1 ? defaultBaseLocation : null);
+          outputs.push({
+            source,
+            round,
+            location,
+            lineage: {
+              original: originalLocation,
+              diffBase: null,
+            },
+            diff: null,
+          });
+        }
+
+        if (outputs.length > 0) rounds[round] = outputs;
       }
 
-      if (outputs.length > 0) rounds[round] = outputs;
-    }
+      return Object.keys(rounds).length > 0 ? rounds : null;
+    });
 
-    return Object.keys(rounds).length > 0 ? rounds : null;
-  } catch (error) {
     // A failed run-storage read degrades a pinned-runId invocation to the
     // plain workspace scan: a behavior-changing fallback, so fallback
     // discipline (review checklist §15) forbids logging it below warn.
-    log.warn(`RunDir scan for ${executionId} failed: ${toErrorMessage(error)}`);
-    return null;
-  }
-}
+    return yield* scan.pipe(
+      Effect.catch((error) =>
+        Effect.sync((): RoundIndexed<OutputFileInfo> | null => {
+          log.warn(
+            `RunDir scan for ${executionId} failed: ${toErrorMessage(error)}`,
+          );
+          return null;
+        }),
+      ),
+    );
+  },
+);

--- a/src/latex/overleafClone.ts
+++ b/src/latex/overleafClone.ts
@@ -6,7 +6,13 @@
  * prompts, the actual `git clone`, and user-facing messages) through
  * `ports`, so the decision logic is unit-testable and reusable by any host —
  * not just the VS Code command it was extracted from.
+ *
+ * Every port is an Effect: the workflow is one program the host runs at its
+ * own entry, so a cancelled clone interrupts the prompt and the subprocess
+ * instead of running them out.
  */
+
+import { Effect } from 'effect';
 
 import {
   buildAuthenticatedRemoteUrl,
@@ -22,27 +28,41 @@ import {
 const IGNORED_CLONE_FILES = new Set(['.DS_Store', 'Thumbs.db']);
 
 export interface OverleafCloneWorkflowPorts {
-  getStoredToken(key: string): Promise<string | undefined>;
-  deleteStoredToken(key: string): Promise<void>;
-  storeToken(key: string, token: string): Promise<void>;
-  /** Prompt for a new token; null when the user cancels. */
-  promptToken(spec: OverleafTokenSpec): Promise<string | null>;
+  getStoredToken(key: string): Effect.Effect<string | undefined>;
+  deleteStoredToken(key: string): Effect.Effect<void>;
+  storeToken(key: string, token: string): Effect.Effect<void>;
+  /**
+   * Prompt for a new token; null when the user cancels. Fails when the host
+   * cannot prompt at all (a non-interactive CLI run, say) — that is a usage
+   * error for the caller to report, not a cancelled clone.
+   */
+  promptToken(spec: OverleafTokenSpec): Effect.Effect<string | null, Error>;
   /** Surface an invalid-token-format error for the given spec. */
-  showInvalidToken(spec: OverleafTokenSpec, message: string): Promise<void>;
+  showInvalidToken(
+    spec: OverleafTokenSpec,
+    message: string,
+  ): Effect.Effect<void>;
 
-  isGitAvailable(): boolean;
+  isGitAvailable(): Effect.Effect<boolean>;
   /** `git` isn't on PATH — surface install guidance. */
-  showGitMissing(): Promise<void>;
-  listWorkspaceEntries(workspacePath: string): Promise<Iterable<string>>;
-  showWorkspaceUnreadable(error: unknown): void;
-  showWorkspaceNotEmpty(): void;
+  showGitMissing(): Effect.Effect<void>;
+  /** Fails when the directory can't be read at all. */
+  listWorkspaceEntries(
+    workspacePath: string,
+  ): Effect.Effect<Iterable<string>, Error>;
+  showWorkspaceUnreadable(error: unknown): Effect.Effect<void>;
+  showWorkspaceNotEmpty(): Effect.Effect<void>;
 
-  runClone(remoteUrl: string, workspacePath: string): Promise<void>;
-  showCloneSucceeded(label: string): void;
+  /** Fails when `git clone` does. */
+  runClone(
+    remoteUrl: string,
+    workspacePath: string,
+  ): Effect.Effect<void, Error>;
+  showCloneSucceeded(label: string): Effect.Effect<void>;
   /** The clone failed for what looks like an auth reason (bad/expired token). */
-  showAuthFailure(remote: OverleafRemote): Promise<void>;
-  showCloneFailed(message: string): void;
-  logCloneError(message: string): void;
+  showAuthFailure(remote: OverleafRemote): Effect.Effect<void>;
+  showCloneFailed(message: string): Effect.Effect<void>;
+  logCloneError(message: string): Effect.Effect<void>;
 }
 
 type OverleafCloneOutcome =
@@ -65,58 +85,63 @@ type ClonePreconditionFailure =
   | { status: 'workspaceUnreadable' }
   | { status: 'workspaceNotEmpty' };
 
-async function resolveOverleafToken(
+const resolveOverleafToken = Effect.fn('overleaf.resolveToken')(function* (
   remote: OverleafRemote,
   ports: OverleafCloneWorkflowPorts,
-): Promise<TokenResolution> {
+): Effect.fn.Return<TokenResolution, Error> {
   const spec = overleafTokenSpec(remote);
   const isValid = (t: string): boolean => spec.tokenValidator?.(t) ?? true;
 
-  const stored = (await ports.getStoredToken(spec.tokenKey))?.trim() ?? '';
+  const stored = (yield* ports.getStoredToken(spec.tokenKey))?.trim() ?? '';
   if (stored && isValid(stored)) {
     return { status: 'ready', credential: buildGitCredential(stored) };
   }
-  if (stored) await ports.deleteStoredToken(spec.tokenKey);
+  if (stored) yield* ports.deleteStoredToken(spec.tokenKey);
 
-  const input = await ports.promptToken(spec);
+  const input = yield* ports.promptToken(spec);
   if (!input) return { status: 'cancelled' };
 
   if (!isValid(input)) {
     const message = spec.tokenHint
       ? `Invalid token format. ${spec.tokenHint}`
       : 'Invalid token format.';
-    await ports.showInvalidToken(spec, message);
+    yield* ports.showInvalidToken(spec, message);
     return { status: 'invalidToken' };
   }
 
-  await ports.storeToken(spec.tokenKey, input);
+  yield* ports.storeToken(spec.tokenKey, input);
   return { status: 'ready', credential: buildGitCredential(input) };
-}
+});
 
-async function checkOverleafClonePreconditions(
+const checkOverleafClonePreconditions = Effect.fn(
+  'overleaf.checkClonePreconditions',
+)(function* (
   workspacePath: string,
   ports: OverleafCloneWorkflowPorts,
-): Promise<ClonePreconditionFailure | null> {
-  if (!ports.isGitAvailable()) {
-    await ports.showGitMissing();
+): Effect.fn.Return<ClonePreconditionFailure | null, never> {
+  if (!(yield* ports.isGitAvailable())) {
+    yield* ports.showGitMissing();
     return { status: 'gitMissing' };
   }
 
-  let entries: Iterable<string>;
-  try {
-    entries = await ports.listWorkspaceEntries(workspacePath);
-  } catch (e) {
-    ports.showWorkspaceUnreadable(e);
-    return { status: 'workspaceUnreadable' };
-  }
+  const entries = yield* ports
+    .listWorkspaceEntries(workspacePath)
+    .pipe(
+      Effect.catch((error) =>
+        ports
+          .showWorkspaceUnreadable(error)
+          .pipe(Effect.as<Iterable<string> | null>(null)),
+      ),
+    );
+  if (entries === null) return { status: 'workspaceUnreadable' };
 
   if ([...entries].some((name) => !IGNORED_CLONE_FILES.has(name))) {
-    ports.showWorkspaceNotEmpty();
+    yield* ports.showWorkspaceNotEmpty();
     return { status: 'workspaceNotEmpty' };
   }
 
   return null;
-}
+});
 
 function isCloneAuthError(e: unknown): boolean {
   return (
@@ -131,40 +156,49 @@ function isCloneAuthError(e: unknown): boolean {
  * workspace-selection stay with the caller, since those are trivial,
  * host-specific guard clauses rather than shared workflow logic.
  */
-export async function cloneOverleafProject(
-  remote: OverleafRemote,
-  workspacePath: string,
-  ports: OverleafCloneWorkflowPorts,
-): Promise<OverleafCloneOutcome> {
-  const preconditionFailure = await checkOverleafClonePreconditions(
-    workspacePath,
-    ports,
-  );
-  if (preconditionFailure) return preconditionFailure;
+export const cloneOverleafProject = Effect.fn('overleaf.cloneProject')(
+  function* (
+    remote: OverleafRemote,
+    workspacePath: string,
+    ports: OverleafCloneWorkflowPorts,
+  ): Effect.fn.Return<OverleafCloneOutcome, Error> {
+    const preconditionFailure = yield* checkOverleafClonePreconditions(
+      workspacePath,
+      ports,
+    );
+    if (preconditionFailure) return preconditionFailure;
 
-  const token = await resolveOverleafToken(remote, ports);
-  if (token.status !== 'ready') return token;
+    const token = yield* resolveOverleafToken(remote, ports);
+    if (token.status !== 'ready') return token;
 
-  const remoteUrl = buildAuthenticatedRemoteUrl(remote, token.credential);
-  const label = remote.isOverleaf ? 'Overleaf' : 'ShareLaTeX';
+    const remoteUrl = buildAuthenticatedRemoteUrl(remote, token.credential);
+    const label = remote.isOverleaf ? 'Overleaf' : 'ShareLaTeX';
 
-  try {
-    await ports.runClone(remoteUrl, workspacePath);
-    ports.showCloneSucceeded(label);
-    return { status: 'success' };
-  } catch (e) {
-    const authError = isCloneAuthError(e);
-    if (authError) {
-      await ports.deleteStoredToken(overleafTokenSpec(remote).tokenKey);
-      await ports.showAuthFailure(remote);
-    } else {
-      ports.showCloneFailed('Clone failed. Check credentials and connection.');
-    }
-    if (e instanceof Error) {
-      ports.logCloneError(
-        redactSensitive(e.message, token.credential.sensitive),
-      );
-    }
-    return { status: authError ? 'authFailure' : 'cloneFailed' };
-  }
-}
+    return yield* ports.runClone(remoteUrl, workspacePath).pipe(
+      Effect.flatMap(() =>
+        ports
+          .showCloneSucceeded(label)
+          .pipe(Effect.as<OverleafCloneOutcome>({ status: 'success' })),
+      ),
+      Effect.catch((error) =>
+        Effect.gen(function* () {
+          const authError = isCloneAuthError(error);
+          if (authError) {
+            yield* ports.deleteStoredToken(overleafTokenSpec(remote).tokenKey);
+            yield* ports.showAuthFailure(remote);
+          } else {
+            yield* ports.showCloneFailed(
+              'Clone failed. Check credentials and connection.',
+            );
+          }
+          yield* ports.logCloneError(
+            redactSensitive(error.message, token.credential.sensitive),
+          );
+          return {
+            status: authError ? 'authFailure' : 'cloneFailed',
+          } satisfies OverleafCloneOutcome;
+        }),
+      ),
+    );
+  },
+);

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -1,6 +1,6 @@
 import { Effect } from 'effect';
 
-import { createLog } from '@logger/logUtils';
+import { withLogChannel } from '@logger/effectLog';
 import { filterNotNull, filterNotNullish, ensureArray } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { pathToLocation } from '@utils/files/fileLocation';
@@ -8,8 +8,6 @@ import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
 import { runToolWithCheck } from '@utils/system/toolUtils';
 import { LATEX_COMMANDS_CHANNEL as CHANNEL } from './latexLogging';
-
-const log = createLog(CHANNEL);
 
 const CHINESE_PACKAGES = [
   'xeCJK',
@@ -38,10 +36,9 @@ const hasChinesePackages = Effect.fn('texcount.hasChinesePackages')(function* (
       ),
     ),
     Effect.catch((err) =>
-      Effect.sync(() => {
-        log.error(`Error checking Chinese packages: ${toErrorMessage(err)}`);
-        return false;
-      }),
+      Effect.logError(
+        `Error checking Chinese packages: ${toErrorMessage(err)}`,
+      ).pipe(Effect.as(false)),
     ),
   );
 });
@@ -61,22 +58,20 @@ interface TexcountResult {
 /** Returns why the file cannot be counted, or null when it is countable. */
 const rejectionReason = Effect.fn('texcount.rejectionReason')(function* (
   filePath: string,
-  channel: string,
 ) {
-  const log = createLog(channel);
   const exists = yield* Effect.tryPromise({
     try: () => AbsoluteFS.exists(filePath),
     catch: ensureError,
   });
   if (!exists) {
     const reason = `File ${filePath} does not exist.`;
-    log.warn(reason);
+    yield* Effect.logWarning(reason);
     return reason;
   }
 
   if (!hasExtension(filePath, '.tex')) {
     const reason = `Error: File ${filePath} is not a LaTeX file. Skipping.`;
-    log.warn(reason);
+    yield* Effect.logWarning(reason);
     return reason;
   }
 
@@ -87,13 +82,16 @@ const rejectionReason = Effect.fn('texcount.rejectionReason')(function* (
  * Invoke `texcount`. The subprocess is cancelled by the fiber's own
  * interruption: `Effect.tryPromise` hands the thunk an `AbortSignal` that
  * aborts when the fiber is interrupted, so no caller threads a signal in.
+ *
+ * `channel` is still a parameter because `runToolWithCheck` logs the command
+ * itself through the Promise-shaped writers; this function's own entries take
+ * the channel the whole count was annotated with.
  */
 const runTexcount = Effect.fn('texcount.runTexcount')(function* (
   args: string[],
   channel: string,
   context: string,
 ): Effect.fn.Return<{ stdout: string | null; error?: string }, Error> {
-  const log = createLog(channel);
   const result = yield* Effect.tryPromise({
     try: (signal) =>
       runToolWithCheck('texcount', args, {
@@ -113,16 +111,16 @@ const runTexcount = Effect.fn('texcount.runTexcount')(function* (
   }
 
   if (result.success && result.stdout) {
-    log.debug(`Successfully counted ${context}`);
+    yield* Effect.logDebug(`Successfully counted ${context}`);
     return { stdout: result.stdout };
   }
 
-  log.error(`Error getting tex count for ${context}`);
+  yield* Effect.logError(`Error getting tex count for ${context}`);
   if (result.stdout) {
-    log.error(`Stdout: ${result.stdout}`);
+    yield* Effect.logError(`Stdout: ${result.stdout}`);
   }
   if (result.stderr) {
-    log.error(`Stderr: ${result.stderr}`);
+    yield* Effect.logError(`Stderr: ${result.stderr}`);
   }
 
   return {
@@ -144,7 +142,7 @@ const getIndividualCounts = Effect.fn('texcount.getIndividualCounts')(
       (filePath) =>
         Effect.gen(function* () {
           const absolutePath = pathToLocation(filePath).absolutePath;
-          const reason = yield* rejectionReason(absolutePath, channel);
+          const reason = yield* rejectionReason(absolutePath);
           if (reason) {
             return { output: null, error: reason };
           }
@@ -180,7 +178,6 @@ const getSummedCount = Effect.fn('texcount.getSummedCount')(function* (
   paths: readonly string[],
   channel: string,
 ) {
-  const log = createLog(channel);
   const errors: string[] = [];
 
   // The per-file probes fan out; the sum itself is a single texcount call
@@ -190,7 +187,7 @@ const getSummedCount = Effect.fn('texcount.getSummedCount')(function* (
     (filePath) =>
       Effect.gen(function* () {
         const absolutePath = pathToLocation(filePath).absolutePath;
-        const reason = yield* rejectionReason(absolutePath, channel);
+        const reason = yield* rejectionReason(absolutePath);
         if (reason) return { filePath, reason, chinese: false };
         return {
           filePath,
@@ -211,7 +208,7 @@ const getSummedCount = Effect.fn('texcount.getSummedCount')(function* (
     validPaths.push(entry.filePath);
     if (!enableChineseMode && entry.chinese) {
       enableChineseMode = true;
-      log.debug(
+      yield* Effect.logDebug(
         `Chinese packages detected in ${entry.filePath}, enabling Chinese character counting`,
       );
     }
@@ -256,7 +253,6 @@ export const getTeXCount = Effect.fn('texcount.getTeXCount')(function* (
   { mode = 'separate', channel }: TexcountOptions = {},
 ): Effect.fn.Return<TexcountResult, never> {
   const resolvedChannel = channel ?? CHANNEL;
-  const log = createLog(resolvedChannel);
 
   const counted = Effect.gen(function* () {
     const trimmedPaths = ensureArray(filePaths)
@@ -265,7 +261,7 @@ export const getTeXCount = Effect.fn('texcount.getTeXCount')(function* (
 
     if (trimmedPaths.length === 0) {
       const message = 'No LaTeX files provided for texcount.';
-      log.warn(message);
+      yield* Effect.logWarning(message);
       return { output: null, errors: [message] };
     }
 
@@ -275,7 +271,7 @@ export const getTeXCount = Effect.fn('texcount.getTeXCount')(function* (
         resolvedChannel,
       );
       if (output) {
-        log.info(`Combined TeX Count Results:\n${output}`);
+        yield* Effect.logInfo(`Combined TeX Count Results:\n${output}`);
       }
       return { output, errors };
     }
@@ -293,7 +289,7 @@ export const getTeXCount = Effect.fn('texcount.getTeXCount')(function* (
     }
 
     const combinedOutput = outputs.join('\n\n');
-    log.info(`Combined TeX Count Results:\n${combinedOutput}`);
+    yield* Effect.logInfo(`Combined TeX Count Results:\n${combinedOutput}`);
     return { output: combinedOutput, errors };
   });
 
@@ -302,12 +298,16 @@ export const getTeXCount = Effect.fn('texcount.getTeXCount')(function* (
   // and the reason, not a thrown run.
   return yield* counted.pipe(
     Effect.catch((err) =>
-      Effect.sync((): TexcountResult => {
+      Effect.suspend(() => {
         const errorMessage = `Error in getTeXCount: ${toErrorMessage(err)}`;
-        log.error(errorMessage);
-        return { output: null, errors: [errorMessage] };
+        return Effect.logError(errorMessage).pipe(
+          Effect.as<TexcountResult>({ output: null, errors: [errorMessage] }),
+        );
       }),
     ),
+    // One channel for the whole count: every helper below logs into it
+    // instead of taking the channel as a parameter of its own.
+    withLogChannel(resolvedChannel),
   );
 });
 

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -1,8 +1,10 @@
+import { Effect } from 'effect';
+
 import { createLog } from '@logger/logUtils';
 import { filterNotNull, filterNotNullish, ensureArray } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { pathToLocation } from '@utils/files/fileLocation';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
 import { runToolWithCheck } from '@utils/system/toolUtils';
 import { LATEX_COMMANDS_CHANNEL as CHANNEL } from './latexLogging';
@@ -18,19 +20,31 @@ const CHINESE_PACKAGES = [
   'ctexbook',
 ];
 
-async function hasChinesePackages(absolutePath: string): Promise<boolean> {
-  try {
-    const content = await AbsoluteFS.read(absolutePath);
-    return CHINESE_PACKAGES.some(
-      (pkg) =>
-        content.includes(`\\usepackage{${pkg}}`) ||
-        content.includes(`\\documentclass{${pkg}}`),
-    );
-  } catch (err) {
-    log.error(`Error checking Chinese packages: ${toErrorMessage(err)}`);
-    return false;
-  }
-}
+/** texcount runs one subprocess per file, so bound the fan-out. */
+const COUNT_CONCURRENCY = 4;
+
+const hasChinesePackages = Effect.fn('texcount.hasChinesePackages')(function* (
+  absolutePath: string,
+) {
+  return yield* Effect.tryPromise({
+    try: () => AbsoluteFS.read(absolutePath),
+    catch: ensureError,
+  }).pipe(
+    Effect.map((content) =>
+      CHINESE_PACKAGES.some(
+        (pkg) =>
+          content.includes(`\\usepackage{${pkg}}`) ||
+          content.includes(`\\documentclass{${pkg}}`),
+      ),
+    ),
+    Effect.catch((err) =>
+      Effect.sync(() => {
+        log.error(`Error checking Chinese packages: ${toErrorMessage(err)}`);
+        return false;
+      }),
+    ),
+  );
+});
 
 export type TexcountMode = 'separate' | 'include' | 'sum';
 
@@ -45,12 +59,16 @@ interface TexcountResult {
 }
 
 /** Returns why the file cannot be counted, or null when it is countable. */
-async function rejectionReason(
+const rejectionReason = Effect.fn('texcount.rejectionReason')(function* (
   filePath: string,
   channel: string,
-): Promise<string | null> {
+) {
   const log = createLog(channel);
-  if (!(await AbsoluteFS.exists(filePath))) {
+  const exists = yield* Effect.tryPromise({
+    try: () => AbsoluteFS.exists(filePath),
+    catch: ensureError,
+  });
+  if (!exists) {
     const reason = `File ${filePath} does not exist.`;
     log.warn(reason);
     return reason;
@@ -63,20 +81,28 @@ async function rejectionReason(
   }
 
   return null;
-}
+});
 
-async function runTexcount(
+/**
+ * Invoke `texcount`. The subprocess is cancelled by the fiber's own
+ * interruption: `Effect.tryPromise` hands the thunk an `AbortSignal` that
+ * aborts when the fiber is interrupted, so no caller threads a signal in.
+ */
+const runTexcount = Effect.fn('texcount.runTexcount')(function* (
   args: string[],
   channel: string,
   context: string,
-  signal?: AbortSignal,
-): Promise<{ stdout: string | null; error?: string }> {
+): Effect.fn.Return<{ stdout: string | null; error?: string }, Error> {
   const log = createLog(channel);
-  const result = await runToolWithCheck('texcount', args, {
-    channel,
-    truncate: false,
-    showError: true,
-    signal,
+  const result = yield* Effect.tryPromise({
+    try: (signal) =>
+      runToolWithCheck('texcount', args, {
+        channel,
+        truncate: false,
+        showError: true,
+        signal,
+      }),
+    catch: ensureError,
   });
 
   if (!result) {
@@ -105,74 +131,88 @@ async function runTexcount(
       `texcount failed while processing ${context}.` +
       (result.stderr ? ` Details: ${result.stderr}` : ''),
   };
-}
+});
 
-async function getIndividualCounts(
-  paths: string[],
+const getIndividualCounts = Effect.fn('texcount.getIndividualCounts')(
+  function* (
+    paths: readonly string[],
+    channel: string,
+    includeReferenced: boolean,
+  ) {
+    const results = yield* Effect.forEach(
+      paths,
+      (filePath) =>
+        Effect.gen(function* () {
+          const absolutePath = pathToLocation(filePath).absolutePath;
+          const reason = yield* rejectionReason(absolutePath, channel);
+          if (reason) {
+            return { output: null, error: reason };
+          }
+
+          const args: string[] = [];
+          if (includeReferenced) {
+            args.push('-inc');
+          }
+          if (yield* hasChinesePackages(absolutePath)) {
+            args.push('-ch-only');
+          }
+          args.push(filePath);
+
+          const { stdout, error } = yield* runTexcount(args, channel, filePath);
+          return {
+            output: stdout
+              ? `TeX Count Results for ${filePath}:\n${stdout}`
+              : null,
+            error,
+          };
+        }),
+      { concurrency: COUNT_CONCURRENCY },
+    );
+
+    return {
+      outputs: results.map((result) => result.output).filter(filterNotNull),
+      errors: results.map((result) => result.error).filter(filterNotNullish),
+    };
+  },
+);
+
+const getSummedCount = Effect.fn('texcount.getSummedCount')(function* (
+  paths: readonly string[],
   channel: string,
-  includeReferenced: boolean,
-  signal?: AbortSignal,
-): Promise<{ outputs: string[]; errors: string[] }> {
-  const results = await Promise.all(
-    paths.map(async (filePath) => {
-      const absolutePath = pathToLocation(filePath).absolutePath;
-      const reason = await rejectionReason(absolutePath, channel);
-      if (reason) {
-        return { output: null, error: reason };
-      }
+) {
+  const log = createLog(channel);
+  const errors: string[] = [];
 
-      const args: string[] = [];
-      if (includeReferenced) {
-        args.push('-inc');
-      }
-      if (await hasChinesePackages(absolutePath)) {
-        args.push('-ch-only');
-      }
-      args.push(filePath);
-
-      const { stdout, error } = await runTexcount(
-        args,
-        channel,
-        filePath,
-        signal,
-      );
-      return {
-        output: stdout ? `TeX Count Results for ${filePath}:\n${stdout}` : null,
-        error,
-      };
-    }),
+  // The per-file probes fan out; the sum itself is a single texcount call
+  // over whatever survived, so the results are folded back in input order.
+  const screened = yield* Effect.forEach(
+    paths,
+    (filePath) =>
+      Effect.gen(function* () {
+        const absolutePath = pathToLocation(filePath).absolutePath;
+        const reason = yield* rejectionReason(absolutePath, channel);
+        if (reason) return { filePath, reason, chinese: false };
+        return {
+          filePath,
+          reason: null,
+          chinese: yield* hasChinesePackages(absolutePath),
+        };
+      }),
+    { concurrency: COUNT_CONCURRENCY },
   );
 
-  return {
-    outputs: results.map((result) => result.output).filter(filterNotNull),
-    errors: results.map((result) => result.error).filter(filterNotNullish),
-  };
-}
-
-async function getSummedCount(
-  paths: string[],
-  channel: string,
-  signal?: AbortSignal,
-): Promise<{ output: string | null; errors: string[] }> {
-  const log = createLog(channel);
   const validPaths: string[] = [];
-  const errors: string[] = [];
   let enableChineseMode = false;
-
-  for (const filePath of paths) {
-    const absolutePath = pathToLocation(filePath).absolutePath;
-    const reason = await rejectionReason(absolutePath, channel);
-    if (reason) {
-      errors.push(reason);
+  for (const entry of screened) {
+    if (entry.reason) {
+      errors.push(entry.reason);
       continue;
     }
-
-    validPaths.push(filePath);
-
-    if (!enableChineseMode && (await hasChinesePackages(absolutePath))) {
+    validPaths.push(entry.filePath);
+    if (!enableChineseMode && entry.chinese) {
       enableChineseMode = true;
       log.debug(
-        `Chinese packages detected in ${filePath}, enabling Chinese character counting`,
+        `Chinese packages detected in ${entry.filePath}, enabling Chinese character counting`,
       );
     }
   }
@@ -193,11 +233,10 @@ async function getSummedCount(
   }
   args.push(...validPaths);
 
-  const { stdout, error } = await runTexcount(
+  const { stdout, error } = yield* runTexcount(
     args,
     channel,
     `sum for ${validPaths.join(', ')}`,
-    signal,
   );
   if (!stdout) {
     if (error) {
@@ -210,24 +249,17 @@ async function getSummedCount(
     output: `Combined TeX Count Results (sum):\n${stdout}`,
     errors,
   };
-}
+});
 
-export async function getTeXCount(
+export const getTeXCount = Effect.fn('texcount.getTeXCount')(function* (
   filePaths: string | string[],
-  // `signal` rides alongside the schema-derived options: it's a runtime
-  // capability, not data, so it stays out of the Zod schema.
-  {
-    mode = 'separate',
-    channel,
-    signal,
-  }: TexcountOptions & { signal?: AbortSignal } = {},
-): Promise<TexcountResult> {
+  { mode = 'separate', channel }: TexcountOptions = {},
+): Effect.fn.Return<TexcountResult, never> {
   const resolvedChannel = channel ?? CHANNEL;
   const log = createLog(resolvedChannel);
 
-  try {
-    const paths = ensureArray(filePaths);
-    const trimmedPaths = paths
+  const counted = Effect.gen(function* () {
+    const trimmedPaths = ensureArray(filePaths)
       .map((filePath) => filePath.trim())
       .filter((filePath) => filePath.length > 0);
 
@@ -238,10 +270,9 @@ export async function getTeXCount(
     }
 
     if (mode === 'sum') {
-      const { output, errors } = await getSummedCount(
+      const { output, errors } = yield* getSummedCount(
         trimmedPaths,
         resolvedChannel,
-        signal,
       );
       if (output) {
         log.info(`Combined TeX Count Results:\n${output}`);
@@ -249,12 +280,10 @@ export async function getTeXCount(
       return { output, errors };
     }
 
-    const includeReferenced = mode === 'include';
-    const { outputs, errors } = await getIndividualCounts(
+    const { outputs, errors } = yield* getIndividualCounts(
       trimmedPaths,
       resolvedChannel,
-      includeReferenced,
-      signal,
+      mode === 'include',
     );
     if (outputs.length === 0) {
       if (errors.length === 0) {
@@ -266,12 +295,21 @@ export async function getTeXCount(
     const combinedOutput = outputs.join('\n\n');
     log.info(`Combined TeX Count Results:\n${combinedOutput}`);
     return { output: combinedOutput, errors };
-  } catch (err) {
-    const errorMessage = `Error in getTeXCount: ${toErrorMessage(err)}`;
-    log.error(errorMessage);
-    return { output: null, errors: [errorMessage] };
-  }
-}
+  });
+
+  // Every failure below is a counting failure, reported in `errors` rather
+  // than raised: a caller asking for a word count wants the partial answer
+  // and the reason, not a thrown run.
+  return yield* counted.pipe(
+    Effect.catch((err) =>
+      Effect.sync((): TexcountResult => {
+        const errorMessage = `Error in getTeXCount: ${toErrorMessage(err)}`;
+        log.error(errorMessage);
+        return { output: null, errors: [errorMessage] };
+      }),
+    ),
+  );
+});
 
 interface TeXCountStat {
   label: string;
@@ -294,12 +332,11 @@ export function parseTeXCountStats(output: string): TeXCountStat[] {
   }).filter(filterNotNull);
 }
 
-export async function getTeXCountStats(
-  filePaths: string | string[],
-  channel: string = CHANNEL,
-): Promise<string | null> {
-  const { output } = await getTeXCount(filePaths, { channel });
-  return output
-    ? `TeX Count Statistics:<texcount>\n${output}\n</texcount>\n\n`
-    : null;
-}
+export const getTeXCountStats = Effect.fn('texcount.getTeXCountStats')(
+  function* (filePaths: string | string[], channel: string = CHANNEL) {
+    const { output } = yield* getTeXCount(filePaths, { channel });
+    return output
+      ? `TeX Count Statistics:<texcount>\n${output}\n</texcount>\n\n`
+      : null;
+  },
+);

--- a/src/logger/effectLog.ts
+++ b/src/logger/effectLog.ts
@@ -1,0 +1,49 @@
+/**
+ * Channel-annotated diagnostics for code that can yield an Effect.
+ *
+ * `@logger/logUtils` is the same thing for the Promise-shaped subsystems that
+ * cannot; both write one structured entry to the single host sink in
+ * `@logger/logSink`, so a subsystem converting to Effect keeps its channel and
+ * its debug payload without a host learning a second entry shape. A converted
+ * file calls `Effect.log*` and names its channel once for the whole program
+ * rather than threading a channel string through every helper.
+ *
+ * The one behavioural difference is the Effect logger's own, not this
+ * module's: `effectDiagnosticsLayer` drops `Debug` and `Trace` entries unless
+ * `texra.logger.debugMode` is on, where `logUtils` emits them and lets the
+ * host's level filter decide.
+ */
+// Third-party imports
+import { Effect } from 'effect';
+
+// Local imports
+import { LOG_CHANNEL } from '@logger/logSink';
+import { formatLogData, isDebugModeEnabled } from '@logger/logUtils';
+
+/**
+ * Name the channel every `Effect.log*` inside `self` belongs to. Annotations
+ * nest, so a callee that names its own channel keeps it: this sets the channel
+ * for the entries that don't.
+ */
+export const withLogChannel =
+  (channel: string) =>
+  <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+    Effect.annotateLogs(self, { [LOG_CHANNEL]: channel });
+
+/**
+ * Attach a debug payload to the entries inside `self`, on the same terms as
+ * `createLog`'s `{ data }` option: rendered with Errors flattened, and only
+ * when debug mode is on, so an ordinary session's diagnostics stay readable.
+ * The setting is read when the effect runs, not when it is built, so a program
+ * composed once still honours a mode the user changed since.
+ */
+export const withLogData =
+  (data: unknown) =>
+  <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+    data == null
+      ? self
+      : Effect.suspend(() =>
+          isDebugModeEnabled()
+            ? Effect.annotateLogs(self, { data: formatLogData(data) })
+            : self,
+        );

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -50,9 +50,10 @@ export function isDebugModeEnabled(): boolean {
 /**
  * Render a debug payload for display. Errors don't survive `JSON.stringify`,
  * so they're flattened here; `safe-stable-stringify` already renders circular
- * references as `"[Circular]"`.
+ * references as `"[Circular]"`. Shared with `@logger/effectLog`, so an entry
+ * carries the same rendered payload whichever producer wrote it.
  */
-function formatLogData(data: unknown): string {
+export function formatLogData(data: unknown): string {
   if (typeof data !== 'object' || data === null) return String(data);
   return (
     safeStringify(

--- a/src/test-kernel/desktop/DesktopProgressFileActions.vitest.ts
+++ b/src/test-kernel/desktop/DesktopProgressFileActions.vitest.ts
@@ -90,13 +90,14 @@ async function loadFileActions(options: {
         }),
   );
 
-  const runDiff = vi.fn(
-    async (): Promise<LaTeXdiffResult> =>
+  const runDiff = vi.fn((): Effect.Effect<LaTeXdiffResult> =>
+    Effect.succeed(
       options.fallbackResult ?? {
         success: true,
         diffPath: absolutePath('workspace', 'main_diff.tex'),
         message: 'diff written',
       },
+    ),
   );
 
   mocks.doMock('@platform/platform', () => ({

--- a/src/test-kernel/latex/ArxivProcessor.vitest.ts
+++ b/src/test-kernel/latex/ArxivProcessor.vitest.ts
@@ -12,9 +12,11 @@ import {
   ArxivProcessor,
   resolveArxivPaperDirectoryRelative,
 } from '@latex/arxivProcessor';
-import * as logger from '@logger/logUtils';
+import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
+import { setLogSink } from '@logger/logSink';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { setupPlatform } from '@test/support/setupPlatform';
+import { captureLogEntries } from '@test/support/logSinkCapture';
+import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 
@@ -22,6 +24,7 @@ const tempDirs = useTempDirs();
 const SOURCE_URL = 'https://arxiv.org/src/2404.12175';
 
 afterEach(async () => {
+  setLogSink(null);
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
@@ -58,52 +61,56 @@ describe('arXiv processor paths', () => {
 });
 
 describe('arXiv processor logger channel', () => {
-  it('defaults the log channel to "arxivProcessor" (stable across the #7347 PascalCase rename)', () => {
-    // `channel` is private, but it is the exact value passed to
-    // logger.info(this.channel, ...) and rendered as the `[channel]` prefix on
-    // every log line this class emits. #7347 renamed the exported singleton to
-    // PascalCase and accidentally changed this string too; the channel value
-    // must stay lowercase so log filters keep matching `[arxivProcessor]`.
-    const channel = (ArxivProcessor as unknown as { channel: string }).channel;
-    expect(channel).toBe('arxivProcessor');
-  });
+  /**
+   * Debug mode on: the Effect logger drops `Debug` entries otherwise, and
+   * these assertions are about which channel an entry lands on, not that gate.
+   */
+  const withDebugPlatform = Effect.promise(() =>
+    installPlatform({ config: { 'texra.logger.debugMode': true } }),
+  ).pipe(Effect.asVoid);
 
-  // Spy seam (#10635): the owner getter binds `this.channel` through createLog
-  // per call, so a logger-namespace spy must observe the owner channel.
+  /** The logger production installs, so entries reach the captured sink. */
+  const withDiagnostics = <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> => Effect.provide(self, effectDiagnosticsLayer);
+
+  // #7347 renamed the exported singleton to PascalCase and accidentally
+  // changed the channel string too. It is rendered as the `[channel]` prefix
+  // on every line this class emits, so it must stay lowercase for log filters
+  // that match `[arxivProcessor]`.
+  //
   // `it.live`: the 429 retry backoff sleeps on the effect clock, which the
   // TestClock `it.effect` installs never advances on its own.
-  it.live(
-    'emits download retry logs through the logger namespace on the owner channel',
-    () =>
-      Effect.gen(function* () {
-        const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
-        const destBasePath = yield* tempSourceBase;
-        let attempt = 0;
-        const fetchMock = vi.fn(async () => {
-          attempt += 1;
-          return attempt === 1
-            ? new Response(null, { status: 429 })
-            : sourceResponse();
-        });
-        vi.stubGlobal('fetch', fetchMock);
+  it.live('emits download retry logs on the "arxivProcessor" channel', () =>
+    Effect.gen(function* () {
+      yield* withDebugPlatform;
+      const logs = captureLogEntries();
+      const destBasePath = yield* tempSourceBase;
+      let attempt = 0;
+      const fetchMock = vi.fn(async () => {
+        attempt += 1;
+        return attempt === 1
+          ? new Response(null, { status: 429 })
+          : sourceResponse();
+      });
+      vi.stubGlobal('fetch', fetchMock);
 
-        const downloadedPath = yield* ArxivProcessor.downloadFile(
-          SOURCE_URL,
-          destBasePath,
-          5000,
-        );
+      const downloadedPath = yield* ArxivProcessor.downloadFile(
+        SOURCE_URL,
+        destBasePath,
+        5000,
+      );
 
-        expect(downloadedPath).toBe(destBasePath);
-        expect(debug).toHaveBeenCalledWith(
-          'arxivProcessor',
-          expect.stringContaining('Download attempt failed'),
-        );
-      }),
+      expect(downloadedPath).toBe(destBasePath);
+      expect(
+        logs.has('DEBUG', 'arxivProcessor', 'Download attempt failed'),
+      ).toBe(true);
+    }).pipe(withDiagnostics),
   );
 
   it.effect('logs extraction failures on the owner channel', () =>
     Effect.gen(function* () {
-      const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+      const logs = captureLogEntries();
       const dir = yield* Effect.promise(() =>
         makeTempDir('texra-arxiv-', tempDirs),
       );
@@ -112,11 +119,10 @@ describe('arXiv processor logger channel', () => {
       const fallback = yield* ArxivProcessor.extractTarFile(missingTar, dir);
 
       expect(fallback.success).toBe(false);
-      expect(error).toHaveBeenCalledWith(
-        'arxivProcessor',
-        expect.stringContaining('Failed to extract tar file'),
-      );
-    }),
+      expect(
+        logs.has('ERROR', 'arxivProcessor', 'Failed to extract tar file'),
+      ).toBe(true);
+    }).pipe(withDiagnostics),
   );
 });
 

--- a/src/test-kernel/latex/DiffOperations.vitest.ts
+++ b/src/test-kernel/latex/DiffOperations.vitest.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { afterEach, describe, expect, vi } from 'vitest';
 
 import type { LaTeXdiffService } from '@latex/latexdiff';
 import {
@@ -26,76 +28,91 @@ describe('diffOperations logger seam', () => {
     vi.restoreAllMocks();
   });
 
-  it('logs each executed diff on the latexdiff runtime channel', async () => {
-    await installPlatform({
-      workspacePath: '/workspace',
-      files: {
-        '/workspace/paper.tex': '\\documentclass{article}\n',
-        '/workspace/r1/paper.tex': '\\documentclass{article}\n',
-      },
-    });
-    const runDiffForRound = vi.fn(async () => ({
-      success: true as const,
-      diffPath: '/workspace/r1/paper_diff.tex',
-      message: 'diff written',
-    }));
-    const base = createWorkspaceLocation('/workspace/paper.tex', 'paper.tex');
-    const revised = createWorkspaceLocation(
-      '/workspace/r1/paper.tex',
-      'r1/paper.tex',
-    );
-    const output: OutputFileInfo = {
-      source: 'paper.tex',
-      location: revised,
-      round: 1,
-      lineage: { original: base, diffBase: null },
-      diff: null,
-    };
-    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+  it.effect('logs each executed diff on the latexdiff runtime channel', () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() =>
+        installPlatform({
+          workspacePath: '/workspace',
+          files: {
+            '/workspace/paper.tex': '\\documentclass{article}\n',
+            '/workspace/r1/paper.tex': '\\documentclass{article}\n',
+          },
+        }),
+      );
+      const runDiffForRound = vi.fn(() =>
+        Effect.succeed({
+          success: true as const,
+          diffPath: '/workspace/r1/paper_diff.tex',
+          message: 'diff written',
+        }),
+      );
+      const base = createWorkspaceLocation('/workspace/paper.tex', 'paper.tex');
+      const revised = createWorkspaceLocation(
+        '/workspace/r1/paper.tex',
+        'r1/paper.tex',
+      );
+      const output: OutputFileInfo = {
+        source: 'paper.tex',
+        location: revised,
+        round: 1,
+        lineage: { original: base, diffBase: null },
+        diff: null,
+      };
+      const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
-    const outcome = await runLatexdiffFromMetadata({
-      rounds: { 1: [output] },
-      generateBetweenRoundDiffs: false,
-      latexdiff: runtimeWith({ runDiffForRound }),
-      progress,
-    });
+      const outcome = yield* runLatexdiffFromMetadata({
+        rounds: { 1: [output] },
+        generateBetweenRoundDiffs: false,
+        latexdiff: runtimeWith({ runDiffForRound }),
+        progress,
+      });
 
-    expect(outcome.results).toEqual([
-      expect.objectContaining({ success: true, description: 'paper.tex (r1)' }),
-    ]);
-    expect(runDiffForRound).toHaveBeenCalledOnce();
-    expect(debug).toHaveBeenCalledWith(
-      CHANNEL,
-      expect.stringContaining('Running round diff: paper.tex (r1)'),
-    );
-  });
+      expect(outcome.results).toEqual([
+        expect.objectContaining({
+          success: true,
+          description: 'paper.tex (r1)',
+        }),
+      ]);
+      expect(runDiffForRound).toHaveBeenCalledOnce();
+      expect(debug).toHaveBeenCalledWith(
+        CHANNEL,
+        expect.stringContaining('Running round diff: paper.tex (r1)'),
+      );
+    }),
+  );
 
-  it('logs workspace-scan progress on the latexdiff runtime channel', async () => {
-    await installPlatform({
-      workspacePath: '/workspace',
-      files: { '/workspace/paper.tex': '\\documentclass{article}\n' },
-    });
-    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+  it.effect(
+    'logs workspace-scan progress on the latexdiff runtime channel',
+    () =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() =>
+          installPlatform({
+            workspacePath: '/workspace',
+            files: { '/workspace/paper.tex': '\\documentclass{article}\n' },
+          }),
+        );
+        const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
-    const outcome = await runLatexdiffViaWorkspaceScan({
-      agent: 'revise',
-      model: 'claude-opus-4-8',
-      inputFile: 'paper.tex',
-      generateBetweenRoundDiffs: false,
-      latexdiff: runtimeWith({}),
-      progress,
-    });
+        const outcome = yield* runLatexdiffViaWorkspaceScan({
+          agent: 'revise',
+          model: 'claude-opus-4-8',
+          inputFile: 'paper.tex',
+          generateBetweenRoundDiffs: false,
+          latexdiff: runtimeWith({}),
+          progress,
+        });
 
-    // A bare source name matches no legacy/mid-era round layout, so the scan
-    // reports the empty outcome instead of dispatching diff operations.
-    expect(outcome).toEqual({ results: [] });
-    expect(debug).toHaveBeenCalledWith(
-      CHANNEL,
-      expect.stringContaining('Input files: paper.tex'),
-    );
-    expect(debug).toHaveBeenCalledWith(
-      CHANNEL,
-      expect.stringContaining('No matching outputs found for paper.tex'),
-    );
-  });
+        // A bare source name matches no legacy/mid-era round layout, so the scan
+        // reports the empty outcome instead of dispatching diff operations.
+        expect(outcome).toEqual({ results: [] });
+        expect(debug).toHaveBeenCalledWith(
+          CHANNEL,
+          expect.stringContaining('Input files: paper.tex'),
+        );
+        expect(debug).toHaveBeenCalledWith(
+          CHANNEL,
+          expect.stringContaining('No matching outputs found for paper.tex'),
+        );
+      }),
+  );
 });

--- a/src/test-kernel/latex/DiffOperations.vitest.ts
+++ b/src/test-kernel/latex/DiffOperations.vitest.ts
@@ -8,13 +8,15 @@ import {
   runLatexdiffViaWorkspaceScan,
 } from '@latex/latexdiff/diffOperations';
 import type { LatexdiffRuntime } from '@latex/latexdiff/types';
-import * as logger from '@logger/logUtils';
+import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
+import { setLogSink } from '@logger/logSink';
 import type { OutputFileInfo } from '@shared/schemas';
+import { captureLogEntries } from '@test/support/logSinkCapture';
 import { installPlatform } from '@test/support/setupPlatform';
 import { createWorkspaceLocation } from '@utils/files/fileLocation';
 
-// #10635: diffOperations resolves its logger per function from the latexdiff
-// runtime channel — a logger-namespace spy must observe that channel.
+// #10635: diffOperations names the latexdiff runtime channel once for the
+// whole run, so every entry its helpers write lands on that channel.
 const CHANNEL = 'pinnedDiffChannel';
 
 const progress = { report: () => undefined };
@@ -23,8 +25,9 @@ function runtimeWith(service: Partial<LaTeXdiffService>): LatexdiffRuntime {
   return { channel: CHANNEL, service: service as LaTeXdiffService };
 }
 
-describe('diffOperations logger seam', () => {
+describe('diffOperations diagnostics', () => {
   afterEach(() => {
+    setLogSink(null);
     vi.restoreAllMocks();
   });
 
@@ -33,6 +36,7 @@ describe('diffOperations logger seam', () => {
       yield* Effect.promise(() =>
         installPlatform({
           workspacePath: '/workspace',
+          config: { 'texra.logger.debugMode': true },
           files: {
             '/workspace/paper.tex': '\\documentclass{article}\n',
             '/workspace/r1/paper.tex': '\\documentclass{article}\n',
@@ -58,7 +62,7 @@ describe('diffOperations logger seam', () => {
         lineage: { original: base, diffBase: null },
         diff: null,
       };
-      const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+      const logs = captureLogEntries();
 
       const outcome = yield* runLatexdiffFromMetadata({
         rounds: { 1: [output] },
@@ -74,11 +78,10 @@ describe('diffOperations logger seam', () => {
         }),
       ]);
       expect(runDiffForRound).toHaveBeenCalledOnce();
-      expect(debug).toHaveBeenCalledWith(
-        CHANNEL,
-        expect.stringContaining('Running round diff: paper.tex (r1)'),
-      );
-    }),
+      expect(
+        logs.has('DEBUG', CHANNEL, 'Running round diff: paper.tex (r1)'),
+      ).toBe(true);
+    }).pipe(Effect.provide(effectDiagnosticsLayer)),
   );
 
   it.effect(
@@ -88,10 +91,11 @@ describe('diffOperations logger seam', () => {
         yield* Effect.promise(() =>
           installPlatform({
             workspacePath: '/workspace',
+            config: { 'texra.logger.debugMode': true },
             files: { '/workspace/paper.tex': '\\documentclass{article}\n' },
           }),
         );
-        const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+        const logs = captureLogEntries();
 
         const outcome = yield* runLatexdiffViaWorkspaceScan({
           agent: 'revise',
@@ -105,14 +109,10 @@ describe('diffOperations logger seam', () => {
         // A bare source name matches no legacy/mid-era round layout, so the scan
         // reports the empty outcome instead of dispatching diff operations.
         expect(outcome).toEqual({ results: [] });
-        expect(debug).toHaveBeenCalledWith(
-          CHANNEL,
-          expect.stringContaining('Input files: paper.tex'),
-        );
-        expect(debug).toHaveBeenCalledWith(
-          CHANNEL,
-          expect.stringContaining('No matching outputs found for paper.tex'),
-        );
-      }),
+        expect(logs.has('DEBUG', CHANNEL, 'Input files: paper.tex')).toBe(true);
+        expect(
+          logs.has('DEBUG', CHANNEL, 'No matching outputs found for paper.tex'),
+        ).toBe(true);
+      }).pipe(Effect.provide(effectDiagnosticsLayer)),
   );
 });

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -1,6 +1,7 @@
 import { lstat, mkdir, readlink, realpath, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
@@ -139,10 +140,12 @@ describe('LatexMediaManager PDF compilation', () => {
 
     const workspaceState = AgentWorkspaceState.create();
     const manager = new LatexMediaManager(logger);
-    await manager.processInputFiles(
-      inputPaths.map(createExternalLocation),
-      workspaceState,
-      compilePdfConfig,
+    await Effect.runPromise(
+      manager.processInputFiles(
+        inputPaths.map(createExternalLocation),
+        workspaceState,
+        compilePdfConfig,
+      ),
     );
 
     expect(mocks.compileLatex2Pdf).toHaveBeenCalledTimes(2);
@@ -156,8 +159,8 @@ type LatexMediaManagerFigureInternals = {
   extractFiguresFromFiles(
     files: FileLocation[],
     workspaceState: MediaWorkspaceState,
-  ): Promise<void>;
-  mirrorFiguresForFiles(files: FileLocation[]): Promise<void>;
+  ): Effect.Effect<void, Error>;
+  mirrorFiguresForFiles(files: FileLocation[]): Effect.Effect<void>;
 };
 
 describe('LatexMediaManager figure baseDir resolution (issue #7228)', () => {
@@ -217,9 +220,11 @@ describe('LatexMediaManager figure baseDir resolution (issue #7228)', () => {
       logger,
       new TaskRunFileService(executionId),
     ) as unknown as LatexMediaManagerFigureInternals;
-    await manager.extractFiguresFromFiles(
-      [createWorkspaceLocation(texPath, 'main.tex')],
-      workspaceState,
+    await Effect.runPromise(
+      manager.extractFiguresFromFiles(
+        [createWorkspaceLocation(texPath, 'main.tex')],
+        workspaceState,
+      ),
     );
 
     // Before the fix this was 3: once inside extractFigurePathsFromLatex,
@@ -242,9 +247,11 @@ describe('LatexMediaManager figure baseDir resolution (issue #7228)', () => {
       logger,
       new TaskRunFileService(executionId),
     ) as unknown as LatexMediaManagerFigureInternals;
-    await manager.mirrorFiguresForFiles([
-      createWorkspaceLocation(texPath, 'main.tex'),
-    ]);
+    await Effect.runPromise(
+      manager.mirrorFiguresForFiles([
+        createWorkspaceLocation(texPath, 'main.tex'),
+      ]),
+    );
 
     // Unchanged by the fix: mirrorFiguresForFiles has no precomputed baseDir,
     // so mirrorFigureDependencies still resolves it itself (once inside

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -2,7 +2,8 @@ import { lstat, mkdir, readlink, realpath, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { Effect } from 'effect';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { afterEach, describe, expect, vi } from 'vitest';
 
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
@@ -107,52 +108,55 @@ describe('DiffFileProcessor line formatting', () => {
 });
 
 describe('LatexMediaManager PDF compilation', () => {
-  it('filters nullish compile results before adding media files', async () => {
-    const workspaceDir = await makeTempDir('texra-latex-media-', tempDirs);
-    await installPlatform(
-      { workspacePath: workspaceDir },
-      { fs: nodeFilesystem },
-    );
+  it.effect('filters nullish compile results before adding media files', () =>
+    Effect.gen(function* () {
+      const { inputPaths, compiledPdfPath } = yield* Effect.promise(
+        async () => {
+          const dir = await makeTempDir('texra-latex-media-', tempDirs);
+          await installPlatform({ workspacePath: dir }, { fs: nodeFilesystem });
+          const paths = [
+            path.join(dir, 'compiled.tex'),
+            path.join(dir, 'missing-result.tex'),
+          ];
+          await Promise.all(
+            paths.map(async (filePath) => {
+              await mkdir(path.dirname(filePath), { recursive: true });
+              await writeFile(filePath, '\\documentclass{article}\n');
+            }),
+          );
+          return {
+            inputPaths: paths,
+            compiledPdfPath: path.join(dir, 'build', 'compiled.pdf'),
+          };
+        },
+      );
 
-    const inputPaths = [
-      path.join(workspaceDir, 'compiled.tex'),
-      path.join(workspaceDir, 'missing-result.tex'),
-    ];
-    await Promise.all(
-      inputPaths.map(async (filePath) => {
-        await mkdir(path.dirname(filePath), { recursive: true });
-        await writeFile(filePath, '\\documentclass{article}\n');
-      }),
-    );
+      mocks.compileLatex2Pdf.mockImplementation(
+        async (file: FileLocation, options: { outputDirectory?: string }) => {
+          if (path.basename(file.absolutePath) === 'missing-result.tex') {
+            return { ok: false, logTail: 'simulated compile failure' };
+          }
+          const outputDirectory = options.outputDirectory!;
+          await mkdir(outputDirectory, { recursive: true });
+          await writeFile(compiledPdfPath, 'compiled pdf');
+          return { ok: true, pdfPath: compiledPdfPath };
+        },
+      );
 
-    const compiledPdfPath = path.join(workspaceDir, 'build', 'compiled.pdf');
-    mocks.compileLatex2Pdf.mockImplementation(
-      async (file: FileLocation, options: { outputDirectory?: string }) => {
-        if (path.basename(file.absolutePath) === 'missing-result.tex') {
-          return { ok: false, logTail: 'simulated compile failure' };
-        }
-        const outputDirectory = options.outputDirectory!;
-        await mkdir(outputDirectory, { recursive: true });
-        await writeFile(compiledPdfPath, 'compiled pdf');
-        return { ok: true, pdfPath: compiledPdfPath };
-      },
-    );
-
-    const workspaceState = AgentWorkspaceState.create();
-    const manager = new LatexMediaManager(logger);
-    await Effect.runPromise(
-      manager.processInputFiles(
+      const workspaceState = AgentWorkspaceState.create();
+      const manager = new LatexMediaManager(logger);
+      yield* manager.processInputFiles(
         inputPaths.map(createExternalLocation),
         workspaceState,
         compilePdfConfig,
-      ),
-    );
+      );
 
-    expect(mocks.compileLatex2Pdf).toHaveBeenCalledTimes(2);
-    expect(workspaceState.media.files.map((file) => file.absolutePath)).toEqual(
-      [compiledPdfPath],
-    );
-  });
+      expect(mocks.compileLatex2Pdf).toHaveBeenCalledTimes(2);
+      expect(
+        workspaceState.media.files.map((file) => file.absolutePath),
+      ).toEqual([compiledPdfPath]);
+    }),
+  );
 });
 
 type LatexMediaManagerFigureInternals = {
@@ -211,53 +215,61 @@ describe('LatexMediaManager figure baseDir resolution (issue #7228)', () => {
     ).toBe(await realpath(figurePath));
   }
 
-  it('extractFiguresFromFiles reuses its resolved baseDir instead of re-resolving it in mirrorFigureDependencies', async () => {
-    const executionId = 'extract-basedir-dedup';
-    const { texPath, figurePath } = await writeFixture();
+  it.effect(
+    'extractFiguresFromFiles reuses its resolved baseDir instead of re-resolving it in mirrorFigureDependencies',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'extract-basedir-dedup';
+        const { texPath, figurePath } = yield* Effect.promise(writeFixture);
 
-    const workspaceState = AgentWorkspaceState.create();
-    const manager = new LatexMediaManager(
-      logger,
-      new TaskRunFileService(executionId),
-    ) as unknown as LatexMediaManagerFigureInternals;
-    await Effect.runPromise(
-      manager.extractFiguresFromFiles(
-        [createWorkspaceLocation(texPath, 'main.tex')],
-        workspaceState,
-      ),
-    );
+        const workspaceState = AgentWorkspaceState.create();
+        const manager = new LatexMediaManager(
+          logger,
+          new TaskRunFileService(executionId),
+        ) as unknown as LatexMediaManagerFigureInternals;
+        yield* manager.extractFiguresFromFiles(
+          [createWorkspaceLocation(texPath, 'main.tex')],
+          workspaceState,
+        );
 
-    // Before the fix this was 3: once inside extractFigurePathsFromLatex,
-    // once in extractFiguresFromFiles, and once more (redundantly) in
-    // mirrorFigureDependencies. The mirror call now reuses the baseDir
-    // extractFiguresFromFiles already resolved.
-    expect(mocks.resolveLatexDir).toHaveBeenCalledTimes(2);
+        // Before the fix this was 3: once inside extractFigurePathsFromLatex,
+        // once in extractFiguresFromFiles, and once more (redundantly) in
+        // mirrorFigureDependencies. The mirror call now reuses the baseDir
+        // extractFiguresFromFiles already resolved.
+        expect(mocks.resolveLatexDir).toHaveBeenCalledTimes(2);
 
-    expect(workspaceState.media.files.map((f) => f.absolutePath)).toEqual([
-      figurePath,
-    ]);
-    await expectFigureMirrored(executionId, figurePath);
-  });
+        expect(workspaceState.media.files.map((f) => f.absolutePath)).toEqual([
+          figurePath,
+        ]);
+        yield* Effect.promise(() =>
+          expectFigureMirrored(executionId, figurePath),
+        );
+      }),
+  );
 
-  it('mirrorFiguresForFiles (no precomputed baseDir) still resolves and mirrors the correct path', async () => {
-    const executionId = 'mirror-basedir-fallback';
-    const { texPath, figurePath } = await writeFixture();
+  it.effect(
+    'mirrorFiguresForFiles (no precomputed baseDir) still resolves and mirrors the correct path',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'mirror-basedir-fallback';
+        const { texPath, figurePath } = yield* Effect.promise(writeFixture);
 
-    const manager = new LatexMediaManager(
-      logger,
-      new TaskRunFileService(executionId),
-    ) as unknown as LatexMediaManagerFigureInternals;
-    await Effect.runPromise(
-      manager.mirrorFiguresForFiles([
-        createWorkspaceLocation(texPath, 'main.tex'),
-      ]),
-    );
+        const manager = new LatexMediaManager(
+          logger,
+          new TaskRunFileService(executionId),
+        ) as unknown as LatexMediaManagerFigureInternals;
+        yield* manager.mirrorFiguresForFiles([
+          createWorkspaceLocation(texPath, 'main.tex'),
+        ]);
 
-    // Unchanged by the fix: mirrorFiguresForFiles has no precomputed baseDir,
-    // so mirrorFigureDependencies still resolves it itself (once inside
-    // extractFigurePathsFromLatex, once as the fallback resolution).
-    expect(mocks.resolveLatexDir).toHaveBeenCalledTimes(2);
+        // Unchanged by the fix: mirrorFiguresForFiles has no precomputed
+        // baseDir, so mirrorFigureDependencies still resolves it itself (once
+        // inside extractFigurePathsFromLatex, once as the fallback).
+        expect(mocks.resolveLatexDir).toHaveBeenCalledTimes(2);
 
-    await expectFigureMirrored(executionId, figurePath);
-  });
+        yield* Effect.promise(() =>
+          expectFigureMirrored(executionId, figurePath),
+        );
+      }),
+  );
 });

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -4,12 +4,14 @@ import * as path from 'node:path';
 import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as logger from '@logger/logUtils';
+import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
+import { setLogSink } from '@logger/logSink';
 import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import type { ExecutionId, OutputFileInfo } from '@shared/schemas';
 import { getCoreSettingDefault } from '@shared/schemas';
+import { captureLogEntries } from '@test/support/logSinkCapture';
 import { installPlatform } from '@test/support/setupPlatform';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import {
@@ -336,27 +338,33 @@ describe('LaTeXdiffService shadow output', () => {
 
 describe('LaTeXdiffService logger channel', () => {
   afterEach(() => {
+    setLogSink(null);
     vi.restoreAllMocks();
   });
 
-  // Spy seam (#10635): the owner getter binds the constructor channel through
-  // createLog per call, so a logger-namespace spy must observe that channel.
+  // #10635: every entry a diff writes carries the channel the service was
+  // constructed with, whichever helper below it wrote the line.
   it('binds log lines to the constructor channel', async () => {
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const logs = captureLogEntries();
     const { LaTeXdiffService } = await import('@latex/latexdiff');
     const service = new LaTeXdiffService('pinnedLatexdiffChannel');
 
     const result = await Effect.runPromise(
-      service.runDiff(
-        createExternalLocation('/missing/base.tex'),
-        createExternalLocation('/missing/revised.tex'),
-      ),
+      service
+        .runDiff(
+          createExternalLocation('/missing/base.tex'),
+          createExternalLocation('/missing/revised.tex'),
+        )
+        .pipe(Effect.provide(effectDiagnosticsLayer)),
     );
 
     expect(result.success).toBe(false);
-    expect(warn).toHaveBeenCalledWith(
-      'pinnedLatexdiffChannel',
-      expect.stringContaining('One or both files do not exist'),
-    );
+    expect(
+      logs.has(
+        'WARN',
+        'pinnedLatexdiffChannel',
+        'One or both files do not exist',
+      ),
+    ).toBe(true);
   });
 });

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as logger from '@logger/logUtils';
@@ -71,15 +72,19 @@ describe('LaTeXdiffService shadow output', () => {
     return { sourceDir, shadowDir };
   }
 
+  // This suite drives the real filesystem through Promise fs helpers, so the
+  // diff programs are run here rather than threaded through an Effect test.
   async function runShadowDiff(sourceDir: string, shadowDir: string) {
     const { LaTeXdiffService } = await import('@latex/latexdiff');
     const service = new LaTeXdiffService('test');
-    return service.runDiff(
-      createExternalLocation(path.join(sourceDir, 'base.tex')),
-      createExternalLocation(path.join(sourceDir, 'revised.tex')),
-      '_diff',
-      undefined,
-      { outputDirectory: shadowDir },
+    return Effect.runPromise(
+      service.runDiff(
+        createExternalLocation(path.join(sourceDir, 'base.tex')),
+        createExternalLocation(path.join(sourceDir, 'revised.tex')),
+        '_diff',
+        undefined,
+        { outputDirectory: shadowDir },
+      ),
     );
   }
 
@@ -170,15 +175,20 @@ describe('LaTeXdiffService shadow output', () => {
       await import('@latex/latexdiff/diffOperations');
 
     const { LaTeXdiffService } = await import('@latex/latexdiff');
-    const result = await runLatexdiffFromMetadata({
-      rounds: { 1: [output(1, first)], 2: [output(2, second, './paper.tex')] },
-      generateBetweenRoundDiffs: true,
-      latexdiff: {
-        channel: 'test',
-        service: new LaTeXdiffService('test'),
-      },
-      progress: { report: vi.fn() },
-    });
+    const result = await Effect.runPromise(
+      runLatexdiffFromMetadata({
+        rounds: {
+          1: [output(1, first)],
+          2: [output(2, second, './paper.tex')],
+        },
+        generateBetweenRoundDiffs: true,
+        latexdiff: {
+          channel: 'test',
+          service: new LaTeXdiffService('test'),
+        },
+        progress: { report: vi.fn() },
+      }),
+    );
 
     expect(result.results).toHaveLength(3);
     expect(result.results).toEqual(
@@ -283,8 +293,8 @@ describe('LaTeXdiffService shadow output', () => {
       ].join('\n'),
     );
 
-    await new DiffFileProcessor().processDiffFile(
-      createExternalLocation(diffPath),
+    await Effect.runPromise(
+      new DiffFileProcessor().processDiffFile(createExternalLocation(diffPath)),
     );
 
     const diff = await readFile(diffPath, 'utf8');
@@ -336,9 +346,11 @@ describe('LaTeXdiffService logger channel', () => {
     const { LaTeXdiffService } = await import('@latex/latexdiff');
     const service = new LaTeXdiffService('pinnedLatexdiffChannel');
 
-    const result = await service.runDiff(
-      createExternalLocation('/missing/base.tex'),
-      createExternalLocation('/missing/revised.tex'),
+    const result = await Effect.runPromise(
+      service.runDiff(
+        createExternalLocation('/missing/base.tex'),
+        createExternalLocation('/missing/revised.tex'),
+      ),
     );
 
     expect(result.success).toBe(false);

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -1,8 +1,9 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
 import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
 import { setLogSink } from '@logger/logSink';
@@ -74,21 +75,21 @@ describe('LaTeXdiffService shadow output', () => {
     return { sourceDir, shadowDir };
   }
 
-  // This suite drives the real filesystem through Promise fs helpers, so the
-  // diff programs are run here rather than threaded through an Effect test.
-  async function runShadowDiff(sourceDir: string, shadowDir: string) {
-    const { LaTeXdiffService } = await import('@latex/latexdiff');
-    const service = new LaTeXdiffService('test');
-    return Effect.runPromise(
-      service.runDiff(
-        createExternalLocation(path.join(sourceDir, 'base.tex')),
-        createExternalLocation(path.join(sourceDir, 'revised.tex')),
-        '_diff',
-        undefined,
-        { outputDirectory: shadowDir },
-      ),
+  const runShadowDiff = Effect.fn('runShadowDiff')(function* (
+    sourceDir: string,
+    shadowDir: string,
+  ) {
+    const { LaTeXdiffService } = yield* Effect.promise(
+      () => import('@latex/latexdiff'),
     );
-  }
+    return yield* new LaTeXdiffService('test').runDiff(
+      createExternalLocation(path.join(sourceDir, 'base.tex')),
+      createExternalLocation(path.join(sourceDir, 'revised.tex')),
+      '_diff',
+      undefined,
+      { outputDirectory: shadowDir },
+    );
+  });
 
   beforeEach(() => {
     mocks.executeCommand.mockResolvedValue({
@@ -103,82 +104,103 @@ describe('LaTeXdiffService shadow output', () => {
     vi.clearAllMocks();
   });
 
-  it('writes generated diff sources to the requested output directory', async () => {
-    const { sourceDir, shadowDir } = await prepareDiffWorkspace(
-      'texra-latexdiff-',
-      '\\documentclass{article}\n\\begin{document}\nold\n\\end{document}\n',
-      '\\documentclass{article}\n\\begin{document}\nnew\n\\end{document}\n',
-    );
+  it.effect(
+    'writes generated diff sources to the requested output directory',
+    () =>
+      Effect.gen(function* () {
+        const { sourceDir, shadowDir } = yield* Effect.promise(() =>
+          prepareDiffWorkspace(
+            'texra-latexdiff-',
+            '\\documentclass{article}\n\\begin{document}\nold\n\\end{document}\n',
+            '\\documentclass{article}\n\\begin{document}\nnew\n\\end{document}\n',
+          ),
+        );
 
-    const result = await runShadowDiff(sourceDir, shadowDir);
+        const result = yield* runShadowDiff(sourceDir, shadowDir);
 
-    if (!result.success) {
-      throw new Error(`Expected diff run to succeed: ${result.message}`);
-    }
-    expect(path.basename(result.diffPath)).toBe('revised_diff.tex');
-    await expect(
-      readFile(path.join(shadowDir, 'revised_diff.tex'), 'utf8'),
-    ).resolves.toContain('changed');
-    await expect(
-      readFile(path.join(sourceDir, 'revised_diff.tex'), 'utf8'),
-    ).rejects.toMatchObject({ code: 'ENOENT' });
-  });
+        if (!result.success) {
+          throw new Error(`Expected diff run to succeed: ${result.message}`);
+        }
+        expect(path.basename(result.diffPath)).toBe('revised_diff.tex');
+        expect(
+          yield* Effect.promise(() =>
+            readFile(path.join(shadowDir, 'revised_diff.tex'), 'utf8'),
+          ),
+        ).toContain('changed');
+        // The diff must not land beside the sources.
+        expect(
+          yield* Effect.promise(() =>
+            readFile(path.join(sourceDir, 'revised_diff.tex'), 'utf8').then(
+              () => null,
+              (error: NodeJS.ErrnoException) => error.code,
+            ),
+          ),
+        ).toBe('ENOENT');
+      }),
+  );
 
-  it('generates between-round diffs for modern run-storage paths', async () => {
-    const tempDir = await makeTempDir('texra-latexdiff-rounds-', tempDirs);
-    const workspaceDir = path.join(tempDir, 'workspace');
-    const executionId: ExecutionId = 'abcdef';
-    const firstDir = path.join(tempDir, 'executions', executionId, 'r1');
-    const secondDir = path.join(tempDir, 'executions', executionId, 'r2');
-    const basePath = path.join(workspaceDir, 'paper.tex');
-    const firstPath = path.join(firstDir, 'paper.tex');
-    const secondPath = path.join(secondDir, 'paper.tex');
-    const document = (body: string) =>
-      `\\documentclass{article}\n\\begin{document}\n${body}\n\\end{document}\n`;
+  it.effect('generates between-round diffs for modern run-storage paths', () =>
+    Effect.gen(function* () {
+      const tempDir = yield* Effect.promise(() =>
+        makeTempDir('texra-latexdiff-rounds-', tempDirs),
+      );
+      const workspaceDir = path.join(tempDir, 'workspace');
+      const executionId: ExecutionId = 'abcdef';
+      const firstDir = path.join(tempDir, 'executions', executionId, 'r1');
+      const secondDir = path.join(tempDir, 'executions', executionId, 'r2');
+      const basePath = path.join(workspaceDir, 'paper.tex');
+      const firstPath = path.join(firstDir, 'paper.tex');
+      const secondPath = path.join(secondDir, 'paper.tex');
+      const document = (body: string) =>
+        `\\documentclass{article}\n\\begin{document}\n${body}\n\\end{document}\n`;
 
-    await Promise.all([
-      mkdir(workspaceDir, { recursive: true }),
-      mkdir(firstDir, { recursive: true }),
-      mkdir(secondDir, { recursive: true }),
-    ]);
-    await Promise.all([
-      writeFile(basePath, document('base')),
-      writeFile(firstPath, document('round one')),
-      writeFile(secondPath, document('round two')),
-    ]);
-    await installNodeBackedPlatform(
-      workspaceDir,
-      path.join(tempDir, 'storage'),
-    );
+      yield* Effect.promise(async () => {
+        await Promise.all([
+          mkdir(workspaceDir, { recursive: true }),
+          mkdir(firstDir, { recursive: true }),
+          mkdir(secondDir, { recursive: true }),
+        ]);
+        await Promise.all([
+          writeFile(basePath, document('base')),
+          writeFile(firstPath, document('round one')),
+          writeFile(secondPath, document('round two')),
+        ]);
+        await installNodeBackedPlatform(
+          workspaceDir,
+          path.join(tempDir, 'storage'),
+        );
+      });
 
-    const base = createWorkspaceLocation(basePath, 'paper.tex');
-    const first = createRunStorageLocation(
-      firstPath,
-      'r1/paper.tex',
-      executionId,
-    );
-    const second = createRunStorageLocation(
-      secondPath,
-      'r2/paper.tex',
-      executionId,
-    );
-    const output = (
-      round: number,
-      location: typeof first,
-      source = 'paper.tex',
-    ): OutputFileInfo => ({
-      source,
-      location,
-      round,
-      lineage: { original: base, diffBase: null },
-      diff: null,
-    });
-    const { runLatexdiffFromMetadata } =
-      await import('@latex/latexdiff/diffOperations');
-
-    const { LaTeXdiffService } = await import('@latex/latexdiff');
-    const result = await Effect.runPromise(
-      runLatexdiffFromMetadata({
+      const base = createWorkspaceLocation(basePath, 'paper.tex');
+      const first = createRunStorageLocation(
+        firstPath,
+        'r1/paper.tex',
+        executionId,
+      );
+      const second = createRunStorageLocation(
+        secondPath,
+        'r2/paper.tex',
+        executionId,
+      );
+      const output = (
+        round: number,
+        location: typeof first,
+        source = 'paper.tex',
+      ): OutputFileInfo => ({
+        source,
+        location,
+        round,
+        lineage: { original: base, diffBase: null },
+        diff: null,
+      });
+      const [{ runLatexdiffFromMetadata }, { LaTeXdiffService }] =
+        yield* Effect.promise(() =>
+          Promise.all([
+            import('@latex/latexdiff/diffOperations'),
+            import('@latex/latexdiff'),
+          ]),
+        );
+      const result = yield* runLatexdiffFromMetadata({
         rounds: {
           1: [output(1, first)],
           2: [output(2, second, './paper.tex')],
@@ -189,126 +211,144 @@ describe('LaTeXdiffService shadow output', () => {
           service: new LaTeXdiffService('test'),
         },
         progress: { report: vi.fn() },
-      }),
-    );
+      });
 
-    expect(result.results).toHaveLength(3);
-    expect(result.results).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
+      expect(result.results).toHaveLength(3);
+      expect(result.results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            success: true,
+            description: 'paper.tex (r1→r2)',
+            diffPath: path.join(firstDir, 'paper_diffr2r1.tex'),
+          }),
+        ]),
+      );
+      expect(
+        yield* Effect.promise(() =>
+          readFile(path.join(firstDir, 'paper_diffr2r1.tex'), 'utf8'),
+        ),
+      ).toContain('changed');
+    }),
+  );
+
+  it.effect(
+    'restores flattened BibTeX blocks to the source bibliography directive',
+    () =>
+      Effect.gen(function* () {
+        const { sourceDir, shadowDir } = yield* Effect.promise(() =>
+          prepareDiffWorkspace(
+            'texra-latexdiff-bib-',
+            [
+              '\\documentclass{article}',
+              '\\begin{document}',
+              'old \\cite{a}',
+              '\\bibliographystyle{plain}',
+              '\\bibliography{library}',
+              '\\end{document}',
+              '',
+            ].join('\n'),
+            [
+              '\\documentclass{article}',
+              '\\begin{document}',
+              'new \\cite{a}',
+              '\\bibliographystyle{plain}',
+              '\\bibliography{library}',
+              '\\end{document}',
+              '',
+            ].join('\n'),
+          ),
+        );
+        mocks.executeCommand.mockResolvedValueOnce({
           success: true,
-          description: 'paper.tex (r1→r2)',
-          diffPath: path.join(firstDir, 'paper_diffr2r1.tex'),
-        }),
-      ]),
-    );
-    await expect(
-      readFile(path.join(firstDir, 'paper_diffr2r1.tex'), 'utf8'),
-    ).resolves.toContain('changed');
-  });
+          stdout: [
+            '\\documentclass{article}',
+            '\\begin{document}',
+            'new \\cite{a}',
+            '\\bibliographystyle{plain}',
+            '\\begin{thebibliography}{}',
+            '\\providecommand \\@ifxundefined [\\DIFadd{1}]{% corrupted bbl macro',
+            '\\end{thebibliography}',
+            '\\end{document}',
+            '',
+          ].join('\n'),
+          stderr: '',
+        });
 
-  it('restores flattened BibTeX blocks to the source bibliography directive', async () => {
-    const { sourceDir, shadowDir } = await prepareDiffWorkspace(
-      'texra-latexdiff-bib-',
-      [
-        '\\documentclass{article}',
-        '\\begin{document}',
-        'old \\cite{a}',
-        '\\bibliographystyle{plain}',
-        '\\bibliography{library}',
-        '\\end{document}',
-        '',
-      ].join('\n'),
-      [
-        '\\documentclass{article}',
-        '\\begin{document}',
-        'new \\cite{a}',
-        '\\bibliographystyle{plain}',
-        '\\bibliography{library}',
-        '\\end{document}',
-        '',
-      ].join('\n'),
-    );
-    mocks.executeCommand.mockResolvedValueOnce({
-      success: true,
-      stdout: [
-        '\\documentclass{article}',
-        '\\begin{document}',
-        'new \\cite{a}',
-        '\\bibliographystyle{plain}',
-        '\\begin{thebibliography}{}',
-        '\\providecommand \\@ifxundefined [\\DIFadd{1}]{% corrupted bbl macro',
-        '\\end{thebibliography}',
-        '\\end{document}',
-        '',
-      ].join('\n'),
-      stderr: '',
-    });
+        const result = yield* runShadowDiff(sourceDir, shadowDir);
 
-    const result = await runShadowDiff(sourceDir, shadowDir);
+        expect(result).toMatchObject({ success: true });
+        const diff = yield* Effect.promise(() =>
+          readFile(path.join(shadowDir, 'revised_diff.tex'), 'utf8'),
+        );
+        expect(diff).toContain('\\bibliography{library}');
+        expect(diff).not.toContain('\\begin{thebibliography}');
+        expect(diff).not.toContain('\\DIFadd{1}');
+      }),
+  );
 
-    expect(result).toMatchObject({ success: true });
-    const diff = await readFile(
-      path.join(shadowDir, 'revised_diff.tex'),
-      'utf8',
-    );
-    expect(diff).toContain('\\bibliography{library}');
-    expect(diff).not.toContain('\\begin{thebibliography}');
-    expect(diff).not.toContain('\\DIFadd{1}');
-  });
+  it.effect(
+    'sanitizes latexdiff markers from flattened bibliography macro preambles',
+    () =>
+      Effect.gen(function* () {
+        const { DiffFileProcessor } = yield* Effect.promise(
+          () => import('@latex/latexdiff/diffFileProcessor'),
+        );
+        const tempDir = yield* Effect.promise(() =>
+          makeTempDir('texra-latexdiff-bbl-preamble-', tempDirs),
+        );
+        const sourceDir = path.join(tempDir, 'workspace');
+        const diffPath = path.join(sourceDir, 'main-diff.tex');
+        yield* Effect.promise(async () => {
+          await mkdir(sourceDir, { recursive: true });
+          await installNodeBackedPlatform(
+            sourceDir,
+            path.join(tempDir, 'storage'),
+          );
+          await writeFile(
+            diffPath,
+            [
+              '\\documentclass{article}',
+              '\\begin{document}',
+              '\\begin{thebibliography}{}',
+              '\\makeatletter',
+              '\\providecommand \\@ifxundefined [\\DIFadd{1}]{%DIF >',
+              ' \\@ifx{#1\\undefined}',
+              '}%DIF >',
+              '\\providecommand \\@ifnum [\\DIFadd{1}]{%DIF >',
+              ' \\ifnum \\DIFadd{#1}\\expandafter \\@firstoftwo',
+              ' \\else \\expandafter \\@secondoftwo',
+              ' \\fi',
+              '}%DIF >',
+              '\\providecommand \\DIFadd{\\mbox{%DIFAUXCMD',
+              '\\citenamefont }\\hskip0pt%DIFAUXCMD',
+              '}[\\DIFadd{1}]{\\DIFadd{#1}}%DIF >',
+              '\\providecommand \\DIFadd{\\bibinfo  }[\\DIFadd{0}]{\\@secondoftwo}%DIF >',
+              '\\bibitem{sample}',
+              '\\DIFadd{added citation text}',
+              '\\end{thebibliography}',
+              '\\end{document}',
+              '',
+            ].join('\n'),
+          );
+        });
 
-  it('sanitizes latexdiff markers from flattened bibliography macro preambles', async () => {
-    const { DiffFileProcessor } =
-      await import('@latex/latexdiff/diffFileProcessor');
-    const tempDir = await makeTempDir(
-      'texra-latexdiff-bbl-preamble-',
-      tempDirs,
-    );
-    const sourceDir = path.join(tempDir, 'workspace');
-    await mkdir(sourceDir, { recursive: true });
-    await installNodeBackedPlatform(sourceDir, path.join(tempDir, 'storage'));
-    const diffPath = path.join(sourceDir, 'main-diff.tex');
-    await writeFile(
-      diffPath,
-      [
-        '\\documentclass{article}',
-        '\\begin{document}',
-        '\\begin{thebibliography}{}',
-        '\\makeatletter',
-        '\\providecommand \\@ifxundefined [\\DIFadd{1}]{%DIF >',
-        ' \\@ifx{#1\\undefined}',
-        '}%DIF >',
-        '\\providecommand \\@ifnum [\\DIFadd{1}]{%DIF >',
-        ' \\ifnum \\DIFadd{#1}\\expandafter \\@firstoftwo',
-        ' \\else \\expandafter \\@secondoftwo',
-        ' \\fi',
-        '}%DIF >',
-        '\\providecommand \\DIFadd{\\mbox{%DIFAUXCMD',
-        '\\citenamefont }\\hskip0pt%DIFAUXCMD',
-        '}[\\DIFadd{1}]{\\DIFadd{#1}}%DIF >',
-        '\\providecommand \\DIFadd{\\bibinfo  }[\\DIFadd{0}]{\\@secondoftwo}%DIF >',
-        '\\bibitem{sample}',
-        '\\DIFadd{added citation text}',
-        '\\end{thebibliography}',
-        '\\end{document}',
-        '',
-      ].join('\n'),
-    );
+        yield* new DiffFileProcessor().processDiffFile(
+          createExternalLocation(diffPath),
+        );
 
-    await Effect.runPromise(
-      new DiffFileProcessor().processDiffFile(createExternalLocation(diffPath)),
-    );
-
-    const diff = await readFile(diffPath, 'utf8');
-    expect(diff).toContain('\\providecommand \\@ifxundefined [1]{%');
-    expect(diff).toContain('\\ifnum #1\\expandafter \\@firstoftwo');
-    expect(diff).toContain('\\providecommand \\citenamefont [1]{#1}%');
-    expect(diff).toContain('\\providecommand \\bibinfo  [0]{\\@secondoftwo}%');
-    expect(diff).toContain('\\DIFadd{added citation text}');
-    expect(diff).not.toContain('\\DIFadd{1}');
-    expect(diff).not.toContain('DIFAUXCMD');
-    expect(diff).not.toContain('\\providecommand \\DIFadd');
-  });
+        const diff = yield* Effect.promise(() => readFile(diffPath, 'utf8'));
+        expect(diff).toContain('\\providecommand \\@ifxundefined [1]{%');
+        expect(diff).toContain('\\ifnum #1\\expandafter \\@firstoftwo');
+        expect(diff).toContain('\\providecommand \\citenamefont [1]{#1}%');
+        expect(diff).toContain(
+          '\\providecommand \\bibinfo  [0]{\\@secondoftwo}%',
+        );
+        expect(diff).toContain('\\DIFadd{added citation text}');
+        expect(diff).not.toContain('\\DIFadd{1}');
+        expect(diff).not.toContain('DIFAUXCMD');
+        expect(diff).not.toContain('\\providecommand \\DIFadd');
+      }),
+  );
 
   it('mirrors workspace dependencies into diff round storage', async () => {
     const tempDir = await makeTempDir('texra-diff-mirror-', tempDirs);
@@ -344,27 +384,28 @@ describe('LaTeXdiffService logger channel', () => {
 
   // #10635: every entry a diff writes carries the channel the service was
   // constructed with, whichever helper below it wrote the line.
-  it('binds log lines to the constructor channel', async () => {
-    const logs = captureLogEntries();
-    const { LaTeXdiffService } = await import('@latex/latexdiff');
-    const service = new LaTeXdiffService('pinnedLatexdiffChannel');
+  it.effect('binds log lines to the constructor channel', () =>
+    Effect.gen(function* () {
+      const logs = captureLogEntries();
+      const { LaTeXdiffService } = yield* Effect.promise(
+        () => import('@latex/latexdiff'),
+      );
 
-    const result = await Effect.runPromise(
-      service
-        .runDiff(
-          createExternalLocation('/missing/base.tex'),
-          createExternalLocation('/missing/revised.tex'),
-        )
-        .pipe(Effect.provide(effectDiagnosticsLayer)),
-    );
-
-    expect(result.success).toBe(false);
-    expect(
-      logs.has(
-        'WARN',
+      const result = yield* new LaTeXdiffService(
         'pinnedLatexdiffChannel',
-        'One or both files do not exist',
-      ),
-    ).toBe(true);
-  });
+      ).runDiff(
+        createExternalLocation('/missing/base.tex'),
+        createExternalLocation('/missing/revised.tex'),
+      );
+
+      expect(result.success).toBe(false);
+      expect(
+        logs.has(
+          'WARN',
+          'pinnedLatexdiffChannel',
+          'One or both files do not exist',
+        ),
+      ).toBe(true);
+    }).pipe(Effect.provide(effectDiagnosticsLayer)),
+  );
 });

--- a/src/test-kernel/latex/OutputDiscovery.vitest.ts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.ts
@@ -2,7 +2,8 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { Effect } from 'effect';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
 import type { LatexExecutionDiscoveryPort } from '@latex/latexdiff/executionDiscovery';
 import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
@@ -79,99 +80,136 @@ describe('discoverLatestExecutionOutputs', () => {
     vi.restoreAllMocks();
   });
 
-  it('falls back to an on-disk run-dir scan when the stream-tab snapshot is empty', async () => {
-    const runDir = await makeTempDir('texra-latexdiff-', tempDirs);
-    for (const round of ['r0', 'r1']) {
-      await mkdir(path.join(runDir, round), { recursive: true });
-      await writeFile(
-        path.join(runDir, round, 'paper.tex'),
-        `\\documentclass{article}\\begin{document}${round}\\end{document}`,
-      );
-    }
+  it.effect(
+    'falls back to an on-disk run-dir scan when the stream-tab snapshot is empty',
+    () =>
+      Effect.gen(function* () {
+        const runDir = yield* Effect.promise(async () => {
+          const dir = await makeTempDir('texra-latexdiff-', tempDirs);
+          for (const round of ['r0', 'r1']) {
+            await mkdir(path.join(dir, round), { recursive: true });
+            await writeFile(
+              path.join(dir, round, 'paper.tex'),
+              `\\documentclass{article}\\begin{document}${round}\\end{document}`,
+            );
+          }
+          return dir;
+        });
 
-    const { discovery } = discoveryWith([matchingExecution('exec-headless')]);
-    mocks.findRunDir.mockResolvedValue(runDir);
+        const { discovery } = discoveryWith([
+          matchingExecution('exec-headless'),
+        ]);
+        mocks.findRunDir.mockResolvedValue(runDir);
 
-    const result = await Effect.runPromise(
-      discoverLatestExecutionOutputs(
-        discovery,
-        snapshots,
-        MATCHING_QUERY,
-        'test',
-        platform().fs,
-      ),
-    );
+        const result = yield* discoverLatestExecutionOutputs(
+          discovery,
+          snapshots,
+          MATCHING_QUERY,
+          'test',
+          platform().fs,
+        );
 
-    expect(result?.executionId).toBe('exec-headless');
-    expect(
-      Object.keys(result?.rounds ?? {})
-        .map(Number)
-        .sort((a, b) => a - b),
-    ).toEqual([0, 1]);
-    expect(mocks.findRunDir).toHaveBeenCalledWith('exec-headless');
-  });
+        expect(result?.executionId).toBe('exec-headless');
+        expect(
+          Object.keys(result?.rounds ?? {})
+            .map(Number)
+            .sort((a, b) => a - b),
+        ).toEqual([0, 1]);
+        expect(mocks.findRunDir).toHaveBeenCalledWith('exec-headless');
+      }),
+  );
 
-  it('reads outputs under the registered stream identity instead of rebuilding it from configuration (#9590 A1)', async () => {
-    const { discovery, readStreamId } = discoveryWith([
-      matchingExecution('exec-registered'),
-    ]);
-    // Registered under a stream the agent/model config would NOT derive.
-    readStreamId.mockResolvedValue('polish@earlierModel#exec-registered');
-    const rounds = { 0: [] };
-    mocks.read.mockReturnValue(Effect.succeed({ outputFilesByRound: rounds }));
+  it.effect(
+    'reads outputs under the registered stream identity instead of rebuilding it from configuration (#9590 A1)',
+    () =>
+      Effect.gen(function* () {
+        const { discovery, readStreamId } = discoveryWith([
+          matchingExecution('exec-registered'),
+        ]);
+        // Registered under a stream the agent/model config would NOT derive.
+        readStreamId.mockResolvedValue('polish@earlierModel#exec-registered');
+        const rounds = { 0: [] };
+        mocks.read.mockReturnValue(
+          Effect.succeed({ outputFilesByRound: rounds }),
+        );
 
-    const result = await Effect.runPromise(
-      discoverLatestExecutionOutputs(
-        discovery,
-        snapshots,
-        MATCHING_QUERY,
-        'test',
-        platform().fs,
-      ),
-    );
+        const result = yield* discoverLatestExecutionOutputs(
+          discovery,
+          snapshots,
+          MATCHING_QUERY,
+          'test',
+          platform().fs,
+        );
 
-    expect(readStreamId).toHaveBeenCalledWith('exec-registered');
-    expect(mocks.read).toHaveBeenCalledWith(
-      'polish@earlierModel#exec-registered',
-    );
-    expect(result).toEqual({ executionId: 'exec-registered', rounds });
-    expect(mocks.findRunDir).not.toHaveBeenCalled();
-  });
+        expect(readStreamId).toHaveBeenCalledWith('exec-registered');
+        expect(mocks.read).toHaveBeenCalledWith(
+          'polish@earlierModel#exec-registered',
+        );
+        expect(result).toEqual({ executionId: 'exec-registered', rounds });
+        expect(mocks.findRunDir).not.toHaveBeenCalled();
+      }),
+  );
 
-  it('returns null when neither the snapshot nor the run directory has outputs', async () => {
-    const emptyDir = await makeTempDir('texra-latexdiff-', tempDirs);
+  it.effect(
+    'returns null when neither the snapshot nor the run directory has outputs',
+    () =>
+      Effect.gen(function* () {
+        const emptyDir = yield* Effect.promise(() =>
+          makeTempDir('texra-latexdiff-', tempDirs),
+        );
 
-    const { discovery } = discoveryWith([matchingExecution('exec-empty')]);
-    mocks.findRunDir.mockResolvedValue(emptyDir);
+        const { discovery } = discoveryWith([matchingExecution('exec-empty')]);
+        mocks.findRunDir.mockResolvedValue(emptyDir);
 
-    const result = await Effect.runPromise(
-      discoverLatestExecutionOutputs(
-        discovery,
-        snapshots,
-        MATCHING_QUERY,
-        'test',
-        platform().fs,
-      ),
-    );
+        const result = yield* discoverLatestExecutionOutputs(
+          discovery,
+          snapshots,
+          MATCHING_QUERY,
+          'test',
+          platform().fs,
+        );
 
-    expect(result).toBeNull();
-  });
+        expect(result).toBeNull();
+      }),
+  );
+
+  it.effect(
+    'propagates an unreadable execution index instead of choosing different outputs',
+    () =>
+      Effect.gen(function* () {
+        const discovery: LatexExecutionDiscoveryPort = {
+          listAgentRuns: () =>
+            Effect.fail(new Error('execution index unreadable')),
+          readStreamId: () => Effect.succeed(undefined),
+        };
+
+        const failure = yield* Effect.flip(
+          discoverLatestExecutionOutputs(
+            discovery,
+            snapshots,
+            MATCHING_QUERY,
+            'test',
+            platform().fs,
+          ),
+        );
+
+        expect(failure.message).toBe('execution index unreadable');
+      }),
+  );
 });
 
 describe('outputDiscovery diagnostics', () => {
   const tempDirs = useTempDirs();
 
   /** The scan under the logger production installs, so entries reach the sink. */
-  const runScan = (): Promise<unknown> =>
-    Effect.runPromise(
-      scanRunDirForOutputs(
-        'abc123',
-        'paper.tex',
-        undefined,
-        'test',
-        platform().fs,
-      ).pipe(Effect.provide(effectDiagnosticsLayer)),
-    );
+  const runScan = (): Effect.Effect<unknown> =>
+    scanRunDirForOutputs(
+      'abc123',
+      'paper.tex',
+      undefined,
+      'test',
+      platform().fs,
+    ).pipe(Effect.provide(effectDiagnosticsLayer));
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -188,76 +226,74 @@ describe('outputDiscovery diagnostics', () => {
 
   // #10634: a failed persisted-state read degrades the invocation to the
   // workspace scan — fallback discipline requires warn, not debug.
-  it('warns on the pinned channel when the run-dir scan cannot read run storage', async () => {
-    mocks.findRunDir.mockRejectedValue(new Error('storage index corrupt'));
-    const logs = captureLogEntries();
+  it.effect(
+    'warns on the pinned channel when the run-dir scan cannot read run storage',
+    () =>
+      Effect.gen(function* () {
+        mocks.findRunDir.mockRejectedValue(new Error('storage index corrupt'));
+        const logs = captureLogEntries();
 
-    const result = await runScan();
+        const result = yield* runScan();
 
-    expect(result).toBeNull();
-    expect(
-      logs.has(
-        'WARN',
-        'test',
-        'RunDir scan for abc123 failed: storage index corrupt',
-      ),
-    ).toBe(true);
-    expect(logs.at('DEBUG')).toHaveLength(0);
-  });
+        expect(result).toBeNull();
+        expect(
+          logs.has(
+            'WARN',
+            'test',
+            'RunDir scan for abc123 failed: storage index corrupt',
+          ),
+        ).toBe(true);
+        expect(logs.at('DEBUG')).toHaveLength(0);
+      }),
+  );
 
-  it('propagates an unreadable execution index instead of choosing different outputs', async () => {
-    const discovery: LatexExecutionDiscoveryPort = {
-      listAgentRuns: () => Effect.fail(new Error('execution index unreadable')),
-      readStreamId: () => Effect.succeed(undefined),
-    };
-    await expect(
-      Effect.runPromise(
-        discoverLatestExecutionOutputs(
-          discovery,
-          snapshots,
-          MATCHING_QUERY,
-          'test',
-          platform().fs,
-        ),
-      ),
-    ).rejects.toThrow('execution index unreadable');
-  });
+  // #10635: an unreadable round subtree warns while the remaining rounds
+  // still scan, on the channel the whole scan was annotated with.
+  it.effect(
+    'warns on the pinned channel for an unreadable round dir and keeps the readable rounds',
+    () =>
+      Effect.gen(function* () {
+        const { runDir, unreadable } = yield* Effect.promise(async () => {
+          const dir = await makeTempDir('texra-latexdiff-', tempDirs);
+          await mkdir(path.join(dir, 'r0'), { recursive: true });
+          await mkdir(path.join(dir, 'r1'), { recursive: true });
+          await writeFile(
+            path.join(dir, 'r1', 'paper.tex'),
+            '\\documentclass{article}\\begin{document}x\\end{document}',
+          );
+          return { runDir: dir, unreadable: path.join(dir, 'r0') };
+        });
+        // Hand-rolled because FakeFileSystemProvider cannot inject a per-path
+        // readDirectory failure — it seeds files, not fault rules.
+        yield* Effect.promise(() =>
+          installPlatform(
+            {},
+            {
+              fs: {
+                ...nodeFilesystem,
+                readDirectory: async (target: string) => {
+                  if (target === unreadable) {
+                    throw new Error('EACCES: permission denied');
+                  }
+                  return nodeFilesystem.readDirectory(target);
+                },
+              },
+            },
+          ),
+        );
+        mocks.findRunDir.mockResolvedValue(runDir);
+        const logs = captureLogEntries();
 
-  // #10635: collectTexFiles keeps its own per-function createLog(channel) —
-  // an unreadable round subtree warns while the remaining rounds still scan.
-  it('warns on the pinned channel for an unreadable round dir and keeps the readable rounds', async () => {
-    const runDir = await makeTempDir('texra-latexdiff-', tempDirs);
-    await mkdir(path.join(runDir, 'r0'), { recursive: true });
-    await mkdir(path.join(runDir, 'r1'), { recursive: true });
-    await writeFile(
-      path.join(runDir, 'r1', 'paper.tex'),
-      '\\documentclass{article}\\begin{document}x\\end{document}',
-    );
-    const unreadable = path.join(runDir, 'r0');
-    // Hand-rolled because FakeFileSystemProvider cannot inject a per-path
-    // readDirectory failure — it seeds files, not fault rules.
-    await installPlatform(
-      {},
-      {
-        fs: {
-          ...nodeFilesystem,
-          readDirectory: async (target: string) => {
-            if (target === unreadable) {
-              throw new Error('EACCES: permission denied');
-            }
-            return nodeFilesystem.readDirectory(target);
-          },
-        },
-      },
-    );
-    mocks.findRunDir.mockResolvedValue(runDir);
-    const logs = captureLogEntries();
+        const result = yield* runScan();
 
-    const result = await runScan();
-
-    expect(Object.keys((result as object) ?? {}).map(Number)).toEqual([1]);
-    expect(
-      logs.has('WARN', 'test', `Skipping unreadable directory '${unreadable}'`),
-    ).toBe(true);
-  });
+        expect(Object.keys((result as object) ?? {}).map(Number)).toEqual([1]);
+        expect(
+          logs.has(
+            'WARN',
+            'test',
+            `Skipping unreadable directory '${unreadable}'`,
+          ),
+        ).toBe(true);
+      }),
+  );
 });

--- a/src/test-kernel/latex/OutputDiscovery.vitest.ts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.ts
@@ -178,12 +178,14 @@ describe('outputDiscovery logger seam', () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
-    const result = await scanRunDirForOutputs(
-      'abc123',
-      'paper.tex',
-      undefined,
-      'test',
-      platform().fs,
+    const result = await Effect.runPromise(
+      scanRunDirForOutputs(
+        'abc123',
+        'paper.tex',
+        undefined,
+        'test',
+        platform().fs,
+      ),
     );
 
     expect(result).toBeNull();
@@ -244,12 +246,14 @@ describe('outputDiscovery logger seam', () => {
     mocks.findRunDir.mockResolvedValue(runDir);
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
-    const result = await scanRunDirForOutputs(
-      'abc123',
-      'paper.tex',
-      undefined,
-      'test',
-      platform().fs,
+    const result = await Effect.runPromise(
+      scanRunDirForOutputs(
+        'abc123',
+        'paper.tex',
+        undefined,
+        'test',
+        platform().fs,
+      ),
     );
 
     expect(Object.keys(result ?? {}).map(Number)).toEqual([1]);

--- a/src/test-kernel/latex/OutputDiscovery.vitest.ts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.ts
@@ -5,9 +5,11 @@ import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { LatexExecutionDiscoveryPort } from '@latex/latexdiff/executionDiscovery';
-import * as logger from '@logger/logUtils';
+import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
+import { setLogSink } from '@logger/logSink';
 import { platform } from '@platform/platform';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { captureLogEntries } from '@test/support/logSinkCapture';
 import { installPlatform } from '@test/support/setupPlatform';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
@@ -156,8 +158,20 @@ describe('discoverLatestExecutionOutputs', () => {
   });
 });
 
-describe('outputDiscovery logger seam', () => {
+describe('outputDiscovery diagnostics', () => {
   const tempDirs = useTempDirs();
+
+  /** The scan under the logger production installs, so entries reach the sink. */
+  const runScan = (): Promise<unknown> =>
+    Effect.runPromise(
+      scanRunDirForOutputs(
+        'abc123',
+        'paper.tex',
+        undefined,
+        'test',
+        platform().fs,
+      ).pipe(Effect.provide(effectDiagnosticsLayer)),
+    );
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -168,6 +182,7 @@ describe('outputDiscovery logger seam', () => {
   });
 
   afterEach(async () => {
+    setLogSink(null);
     vi.restoreAllMocks();
   });
 
@@ -175,27 +190,19 @@ describe('outputDiscovery logger seam', () => {
   // workspace scan — fallback discipline requires warn, not debug.
   it('warns on the pinned channel when the run-dir scan cannot read run storage', async () => {
     mocks.findRunDir.mockRejectedValue(new Error('storage index corrupt'));
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    const logs = captureLogEntries();
 
-    const result = await Effect.runPromise(
-      scanRunDirForOutputs(
-        'abc123',
-        'paper.tex',
-        undefined,
-        'test',
-        platform().fs,
-      ),
-    );
+    const result = await runScan();
 
     expect(result).toBeNull();
-    expect(warn).toHaveBeenCalledWith(
-      'test',
-      expect.stringContaining(
+    expect(
+      logs.has(
+        'WARN',
+        'test',
         'RunDir scan for abc123 failed: storage index corrupt',
       ),
-    );
-    expect(debug).not.toHaveBeenCalled();
+    ).toBe(true);
+    expect(logs.at('DEBUG')).toHaveLength(0);
   });
 
   it('propagates an unreadable execution index instead of choosing different outputs', async () => {
@@ -244,22 +251,13 @@ describe('outputDiscovery logger seam', () => {
       },
     );
     mocks.findRunDir.mockResolvedValue(runDir);
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const logs = captureLogEntries();
 
-    const result = await Effect.runPromise(
-      scanRunDirForOutputs(
-        'abc123',
-        'paper.tex',
-        undefined,
-        'test',
-        platform().fs,
-      ),
-    );
+    const result = await runScan();
 
-    expect(Object.keys(result ?? {}).map(Number)).toEqual([1]);
-    expect(warn).toHaveBeenCalledWith(
-      'test',
-      expect.stringContaining(`Skipping unreadable directory '${unreadable}'`),
-    );
+    expect(Object.keys((result as object) ?? {}).map(Number)).toEqual([1]);
+    expect(
+      logs.has('WARN', 'test', `Skipping unreadable directory '${unreadable}'`),
+    ).toBe(true);
   });
 });

--- a/src/test-kernel/latex/OverleafClone.vitest.ts
+++ b/src/test-kernel/latex/OverleafClone.vitest.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { describe, expect, vi } from 'vitest';
 
 import {
   cloneOverleafProject,
@@ -16,21 +18,23 @@ function createPorts(
   overrides: Partial<OverleafCloneWorkflowPorts> = {},
 ): OverleafCloneWorkflowPorts {
   return {
-    getStoredToken: vi.fn(async () => 'olp_saved'),
-    deleteStoredToken: vi.fn(async () => undefined),
-    storeToken: vi.fn(async () => undefined),
-    promptToken: vi.fn(async () => null),
-    showInvalidToken: vi.fn(async () => undefined),
-    isGitAvailable: vi.fn(() => true),
-    showGitMissing: vi.fn(async () => undefined),
-    listWorkspaceEntries: vi.fn(async () => []),
-    showWorkspaceUnreadable: vi.fn(),
-    showWorkspaceNotEmpty: vi.fn(),
-    runClone: vi.fn(async () => undefined),
-    showCloneSucceeded: vi.fn(),
-    showAuthFailure: vi.fn(async () => undefined),
-    showCloneFailed: vi.fn(),
-    logCloneError: vi.fn(),
+    getStoredToken: vi.fn(() =>
+      Effect.succeed<string | undefined>('olp_saved'),
+    ),
+    deleteStoredToken: vi.fn(() => Effect.void),
+    storeToken: vi.fn(() => Effect.void),
+    promptToken: vi.fn(() => Effect.succeed<string | null>(null)),
+    showInvalidToken: vi.fn(() => Effect.void),
+    isGitAvailable: vi.fn(() => Effect.succeed(true)),
+    showGitMissing: vi.fn(() => Effect.void),
+    listWorkspaceEntries: vi.fn(() => Effect.succeed<Iterable<string>>([])),
+    showWorkspaceUnreadable: vi.fn(() => Effect.void),
+    showWorkspaceNotEmpty: vi.fn(() => Effect.void),
+    runClone: vi.fn(() => Effect.void),
+    showCloneSucceeded: vi.fn(() => Effect.void),
+    showAuthFailure: vi.fn(() => Effect.void),
+    showCloneFailed: vi.fn(() => Effect.void),
+    logCloneError: vi.fn(() => Effect.void),
     ...overrides,
   };
 }
@@ -40,114 +44,162 @@ function clone(ports: OverleafCloneWorkflowPorts) {
 }
 
 describe('cloneOverleafProject', () => {
-  it('clones with a stored token and returns success', async () => {
-    const ports = createPorts();
+  it.effect('clones with a stored token and returns success', () =>
+    Effect.gen(function* () {
+      const ports = createPorts();
 
-    await expect(clone(ports)).resolves.toEqual({ status: 'success' });
+      expect(yield* clone(ports)).toEqual({ status: 'success' });
 
-    expect(ports.runClone).toHaveBeenCalledWith(
-      `https://git:olp_saved@git.overleaf.com${REMOTE.path}`,
-      '/workspace',
-    );
-    expect(ports.promptToken).not.toHaveBeenCalled();
-    expect(ports.showCloneSucceeded).toHaveBeenCalledWith('Overleaf');
-  });
+      expect(ports.runClone).toHaveBeenCalledWith(
+        `https://git:olp_saved@git.overleaf.com${REMOTE.path}`,
+        '/workspace',
+      );
+      expect(ports.promptToken).not.toHaveBeenCalled();
+      expect(ports.showCloneSucceeded).toHaveBeenCalledWith('Overleaf');
+    }),
+  );
 
-  it('replaces an invalid stored token with a valid prompted token', async () => {
-    const ports = createPorts({
-      getStoredToken: vi.fn(async () => 'invalid'),
-      promptToken: vi.fn(async () => 'olp_replacement'),
-    });
+  it.effect(
+    'replaces an invalid stored token with a valid prompted token',
+    () =>
+      Effect.gen(function* () {
+        const ports = createPorts({
+          getStoredToken: vi.fn(() =>
+            Effect.succeed<string | undefined>('invalid'),
+          ),
+          promptToken: vi.fn(() =>
+            Effect.succeed<string | null>('olp_replacement'),
+          ),
+        });
 
-    await expect(clone(ports)).resolves.toEqual({ status: 'success' });
+        expect(yield* clone(ports)).toEqual({ status: 'success' });
 
-    expect(ports.deleteStoredToken).toHaveBeenCalledWith('overleaf.gitToken');
-    expect(ports.storeToken).toHaveBeenCalledWith(
-      'overleaf.gitToken',
-      'olp_replacement',
-    );
-  });
-
-  it('reports invalid prompted tokens without running git', async () => {
-    const ports = createPorts({
-      getStoredToken: vi.fn(async () => undefined),
-      promptToken: vi.fn(async () => 'not-an-overleaf-token'),
-    });
-
-    await expect(clone(ports)).resolves.toEqual({ status: 'invalidToken' });
-
-    expect(ports.showInvalidToken).toHaveBeenCalledWith(
-      expect.objectContaining({ tokenKey: 'overleaf.gitToken' }),
-      expect.stringContaining('Invalid token format.'),
-    );
-    expect(ports.runClone).not.toHaveBeenCalled();
-  });
-
-  it('allows platform metadata files but rejects a nonempty workspace', async () => {
-    const allowedPorts = createPorts({
-      listWorkspaceEntries: vi.fn(async () => ['.DS_Store', 'Thumbs.db']),
-    });
-    await expect(clone(allowedPorts)).resolves.toEqual({ status: 'success' });
-
-    const blockedPorts = createPorts({
-      getStoredToken: vi.fn(async () => undefined),
-      listWorkspaceEntries: vi.fn(async () => ['paper.tex']),
-      promptToken: vi.fn(async () => 'olp_prompted'),
-    });
-    await expect(clone(blockedPorts)).resolves.toEqual({
-      status: 'workspaceNotEmpty',
-    });
-    expect(blockedPorts.showWorkspaceNotEmpty).toHaveBeenCalledOnce();
-    expect(blockedPorts.promptToken).not.toHaveBeenCalled();
-    expect(blockedPorts.storeToken).not.toHaveBeenCalled();
-    expect(blockedPorts.runClone).not.toHaveBeenCalled();
-  });
-
-  it('returns explicit outcomes for unavailable git and unreadable workspaces', async () => {
-    const gitMissingPorts = createPorts({
-      getStoredToken: vi.fn(async () => undefined),
-      isGitAvailable: vi.fn(() => false),
-      promptToken: vi.fn(async () => 'olp_prompted'),
-    });
-    await expect(clone(gitMissingPorts)).resolves.toEqual({
-      status: 'gitMissing',
-    });
-    expect(gitMissingPorts.promptToken).not.toHaveBeenCalled();
-    expect(gitMissingPorts.storeToken).not.toHaveBeenCalled();
-
-    const unreadablePorts = createPorts({
-      getStoredToken: vi.fn(async () => undefined),
-      listWorkspaceEntries: vi.fn(async () => {
-        throw new Error('permission denied');
-      }),
-      promptToken: vi.fn(async () => 'olp_prompted'),
-    });
-    await expect(clone(unreadablePorts)).resolves.toEqual({
-      status: 'workspaceUnreadable',
-    });
-    expect(unreadablePorts.promptToken).not.toHaveBeenCalled();
-    expect(unreadablePorts.storeToken).not.toHaveBeenCalled();
-    expect(unreadablePorts.showWorkspaceUnreadable).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'permission denied' }),
-    );
-  });
-
-  it('clears failed credentials and redacts them from logs', async () => {
-    const ports = createPorts({
-      getStoredToken: vi.fn(async () => 'olp_secret'),
-      runClone: vi.fn(async () => {
-        throw new Error(
-          'fatal: auth failed for https://git:olp_secret@git.overleaf.com',
+        expect(ports.deleteStoredToken).toHaveBeenCalledWith(
+          'overleaf.gitToken',
+        );
+        expect(ports.storeToken).toHaveBeenCalledWith(
+          'overleaf.gitToken',
+          'olp_replacement',
         );
       }),
-    });
+  );
 
-    await expect(clone(ports)).resolves.toEqual({ status: 'authFailure' });
+  it.effect('reports invalid prompted tokens without running git', () =>
+    Effect.gen(function* () {
+      const ports = createPorts({
+        getStoredToken: vi.fn(() =>
+          Effect.succeed<string | undefined>(undefined),
+        ),
+        promptToken: vi.fn(() =>
+          Effect.succeed<string | null>('not-an-overleaf-token'),
+        ),
+      });
 
-    expect(ports.deleteStoredToken).toHaveBeenCalledWith('overleaf.gitToken');
-    expect(ports.showAuthFailure).toHaveBeenCalledWith(REMOTE);
-    expect(ports.logCloneError).toHaveBeenCalledWith(
-      expect.not.stringContaining('olp_secret'),
-    );
-  });
+      expect(yield* clone(ports)).toEqual({ status: 'invalidToken' });
+
+      expect(ports.showInvalidToken).toHaveBeenCalledWith(
+        expect.objectContaining({ tokenKey: 'overleaf.gitToken' }),
+        expect.stringContaining('Invalid token format.'),
+      );
+      expect(ports.runClone).not.toHaveBeenCalled();
+    }),
+  );
+
+  it.effect(
+    'allows platform metadata files but rejects a nonempty workspace',
+    () =>
+      Effect.gen(function* () {
+        const allowedPorts = createPorts({
+          listWorkspaceEntries: vi.fn(() =>
+            Effect.succeed<Iterable<string>>(['.DS_Store', 'Thumbs.db']),
+          ),
+        });
+        expect(yield* clone(allowedPorts)).toEqual({ status: 'success' });
+
+        const blockedPorts = createPorts({
+          getStoredToken: vi.fn(() =>
+            Effect.succeed<string | undefined>(undefined),
+          ),
+          listWorkspaceEntries: vi.fn(() =>
+            Effect.succeed<Iterable<string>>(['paper.tex']),
+          ),
+          promptToken: vi.fn(() =>
+            Effect.succeed<string | null>('olp_prompted'),
+          ),
+        });
+        expect(yield* clone(blockedPorts)).toEqual({
+          status: 'workspaceNotEmpty',
+        });
+        expect(blockedPorts.showWorkspaceNotEmpty).toHaveBeenCalledOnce();
+        expect(blockedPorts.promptToken).not.toHaveBeenCalled();
+        expect(blockedPorts.storeToken).not.toHaveBeenCalled();
+        expect(blockedPorts.runClone).not.toHaveBeenCalled();
+      }),
+  );
+
+  it.effect(
+    'returns explicit outcomes for unavailable git and unreadable workspaces',
+    () =>
+      Effect.gen(function* () {
+        const gitMissingPorts = createPorts({
+          getStoredToken: vi.fn(() =>
+            Effect.succeed<string | undefined>(undefined),
+          ),
+          isGitAvailable: vi.fn(() => Effect.succeed(false)),
+          promptToken: vi.fn(() =>
+            Effect.succeed<string | null>('olp_prompted'),
+          ),
+        });
+        expect(yield* clone(gitMissingPorts)).toEqual({
+          status: 'gitMissing',
+        });
+        expect(gitMissingPorts.promptToken).not.toHaveBeenCalled();
+        expect(gitMissingPorts.storeToken).not.toHaveBeenCalled();
+
+        const unreadablePorts = createPorts({
+          getStoredToken: vi.fn(() =>
+            Effect.succeed<string | undefined>(undefined),
+          ),
+          listWorkspaceEntries: vi.fn(() =>
+            Effect.fail(new Error('permission denied')),
+          ),
+          promptToken: vi.fn(() =>
+            Effect.succeed<string | null>('olp_prompted'),
+          ),
+        });
+        expect(yield* clone(unreadablePorts)).toEqual({
+          status: 'workspaceUnreadable',
+        });
+        expect(unreadablePorts.promptToken).not.toHaveBeenCalled();
+        expect(unreadablePorts.storeToken).not.toHaveBeenCalled();
+        expect(unreadablePorts.showWorkspaceUnreadable).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'permission denied' }),
+        );
+      }),
+  );
+
+  it.effect('clears failed credentials and redacts them from logs', () =>
+    Effect.gen(function* () {
+      const ports = createPorts({
+        getStoredToken: vi.fn(() =>
+          Effect.succeed<string | undefined>('olp_secret'),
+        ),
+        runClone: vi.fn(() =>
+          Effect.fail(
+            new Error(
+              'fatal: auth failed for https://git:olp_secret@git.overleaf.com',
+            ),
+          ),
+        ),
+      });
+
+      expect(yield* clone(ports)).toEqual({ status: 'authFailure' });
+
+      expect(ports.deleteStoredToken).toHaveBeenCalledWith('overleaf.gitToken');
+      expect(ports.showAuthFailure).toHaveBeenCalledWith(REMOTE);
+      expect(ports.logCloneError).toHaveBeenCalledWith(
+        expect.not.stringContaining('olp_secret'),
+      );
+    }),
+  );
 });

--- a/src/test-kernel/latex/RunLatexdiff.vitest.ts
+++ b/src/test-kernel/latex/RunLatexdiff.vitest.ts
@@ -64,8 +64,12 @@ const baseRequest = {
 describe('runLatexdiffForExecution', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.runLatexdiffFromMetadata.mockResolvedValue(METADATA_OUTCOME);
-    mocks.runLatexdiffViaWorkspaceScan.mockResolvedValue(SCAN_OUTCOME);
+    mocks.runLatexdiffFromMetadata.mockReturnValue(
+      Effect.succeed(METADATA_OUTCOME),
+    );
+    mocks.runLatexdiffViaWorkspaceScan.mockReturnValue(
+      Effect.succeed(SCAN_OUTCOME),
+    );
   });
 
   it('uses caller-supplied outputs without any discovery', async () => {
@@ -86,7 +90,7 @@ describe('runLatexdiffForExecution', () => {
   });
 
   it('scopes a valid runId to a run-dir scan before metadata discovery', async () => {
-    mocks.scanRunDirForOutputs.mockResolvedValue(roundMap());
+    mocks.scanRunDirForOutputs.mockReturnValue(Effect.succeed(roundMap()));
 
     const result = await Effect.runPromise(
       runLatexdiffForExecution({
@@ -109,7 +113,7 @@ describe('runLatexdiffForExecution', () => {
   });
 
   it('does not fall back to auto-discovery when a pinned runId scan misses', async () => {
-    mocks.scanRunDirForOutputs.mockResolvedValue(null);
+    mocks.scanRunDirForOutputs.mockReturnValue(Effect.succeed(null));
 
     const result = await Effect.runPromise(
       runLatexdiffForExecution({
@@ -188,8 +192,12 @@ describe('runLatexdiffForExecution', () => {
 describe('runLatexdiffForExecution logger seam', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.runLatexdiffFromMetadata.mockResolvedValue(METADATA_OUTCOME);
-    mocks.runLatexdiffViaWorkspaceScan.mockResolvedValue(SCAN_OUTCOME);
+    mocks.runLatexdiffFromMetadata.mockReturnValue(
+      Effect.succeed(METADATA_OUTCOME),
+    );
+    mocks.runLatexdiffViaWorkspaceScan.mockReturnValue(
+      Effect.succeed(SCAN_OUTCOME),
+    );
   });
 
   afterEach(() => {
@@ -197,7 +205,7 @@ describe('runLatexdiffForExecution logger seam', () => {
   });
 
   it('logs the run-dir scan resolution on the latexdiff runtime channel', async () => {
-    mocks.scanRunDirForOutputs.mockResolvedValue(roundMap());
+    mocks.scanRunDirForOutputs.mockReturnValue(Effect.succeed(roundMap()));
     const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
     const result = await Effect.runPromise(

--- a/src/test-kernel/latex/RunLatexdiff.vitest.ts
+++ b/src/test-kernel/latex/RunLatexdiff.vitest.ts
@@ -3,8 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LaTeXdiffService } from '@latex/latexdiff';
 import type { LatexExecutionDiscoveryPort } from '@latex/latexdiff/executionDiscovery';
 import { normalizeRunLatexdiffOutputsByRound } from '@latex/latexdiff/runLatexdiff';
-import * as logger from '@logger/logUtils';
+import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
+import { setLogSink } from '@logger/logSink';
 import type { OutputFileInfo, RoundIndexed } from '@shared/schemas';
+import { captureLogEntries } from '@test/support/logSinkCapture';
+import { installPlatform } from '@test/support/setupPlatform';
+
 import { createOutputFile } from '../support/ProgressControllerHarnesses';
 
 const mocks = vi.hoisted(() => ({
@@ -187,11 +191,24 @@ describe('runLatexdiffForExecution', () => {
   });
 });
 
-// #10635: runLatexdiffForExecution resolves its logger per call from the
-// latexdiff runtime channel — a logger-namespace spy must observe that channel.
-describe('runLatexdiffForExecution logger seam', () => {
-  beforeEach(() => {
+// #10635: runLatexdiffForExecution names the latexdiff runtime channel once
+// for the whole run, so its discovery lines land on that channel.
+describe('runLatexdiffForExecution diagnostics', () => {
+  /** The run under the logger production installs, so entries reach the sink. */
+  const run = (
+    params: Parameters<typeof runLatexdiffForExecution>[0],
+  ): Promise<{ source: string }> =>
+    Effect.runPromise(
+      runLatexdiffForExecution(params).pipe(
+        Effect.provide(effectDiagnosticsLayer),
+      ),
+    );
+
+  beforeEach(async () => {
     vi.clearAllMocks();
+    // Debug mode on: the Effect logger drops `Debug` entries otherwise, and
+    // these assertions are about the channel, not that gate.
+    await installPlatform({ config: { 'texra.logger.debugMode': true } });
     mocks.runLatexdiffFromMetadata.mockReturnValue(
       Effect.succeed(METADATA_OUTCOME),
     );
@@ -201,27 +218,24 @@ describe('runLatexdiffForExecution logger seam', () => {
   });
 
   afterEach(() => {
+    setLogSink(null);
     vi.restoreAllMocks();
   });
 
   it('logs the run-dir scan resolution on the latexdiff runtime channel', async () => {
     mocks.scanRunDirForOutputs.mockReturnValue(Effect.succeed(roundMap()));
-    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    const logs = captureLogEntries();
 
-    const result = await Effect.runPromise(
-      runLatexdiffForExecution({
-        ...baseRequest,
-        runId: 'abc123',
-      }),
-    );
+    const result = await run({ ...baseRequest, runId: 'abc123' });
 
     expect(result.source).toBe('run-dir-scan');
-    expect(debug).toHaveBeenCalledWith(
-      'test',
-      expect.stringContaining(
+    expect(
+      logs.has(
+        'DEBUG',
+        'test',
         'Using run-dir scan outputs from execution abc123',
       ),
-    );
+    ).toBe(true);
   });
 
   it('logs the metadata discovery resolution on the latexdiff runtime channel', async () => {
@@ -231,17 +245,14 @@ describe('runLatexdiffForExecution logger seam', () => {
         rounds: roundMap(),
       }),
     );
-    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    const logs = captureLogEntries();
 
-    const result = await Effect.runPromise(
-      runLatexdiffForExecution({ ...baseRequest }),
-    );
+    const result = await run({ ...baseRequest });
 
     expect(result.source).toBe('metadata');
-    expect(debug).toHaveBeenCalledWith(
-      'test',
-      expect.stringContaining('Using metadata outputs from execution def456'),
-    );
+    expect(
+      logs.has('DEBUG', 'test', 'Using metadata outputs from execution def456'),
+    ).toBe(true);
   });
 });
 

--- a/src/test-kernel/latex/RunLatexdiff.vitest.ts
+++ b/src/test-kernel/latex/RunLatexdiff.vitest.ts
@@ -1,7 +1,9 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 import type { LaTeXdiffService } from '@latex/latexdiff';
 import type { LatexExecutionDiscoveryPort } from '@latex/latexdiff/executionDiscovery';
+import type { DiffRunOutcome } from '@latex/latexdiff/types';
 import { normalizeRunLatexdiffOutputsByRound } from '@latex/latexdiff/runLatexdiff';
 import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
 import { setLogSink } from '@logger/logSink';
@@ -39,8 +41,12 @@ const latexdiff = {
   service: {} as LaTeXdiffService,
 };
 
-const METADATA_OUTCOME = { results: [], totalOperations: 1 };
-const SCAN_OUTCOME = { results: [], totalOperations: 2 };
+/**
+ * The diff engines are mocked here, so the outcome is a placeholder: these
+ * tests assert which engine ran and how the outputs were resolved, never what
+ * the engine returned.
+ */
+const EMPTY_OUTCOME: DiffRunOutcome = { results: [] };
 
 function roundMap(): RoundIndexed<OutputFileInfo> {
   return { 1: [] as OutputFileInfo[] };
@@ -69,151 +75,148 @@ describe('runLatexdiffForExecution', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.runLatexdiffFromMetadata.mockReturnValue(
-      Effect.succeed(METADATA_OUTCOME),
+      Effect.succeed(EMPTY_OUTCOME),
     );
     mocks.runLatexdiffViaWorkspaceScan.mockReturnValue(
-      Effect.succeed(SCAN_OUTCOME),
+      Effect.succeed(EMPTY_OUTCOME),
     );
   });
 
-  it('uses caller-supplied outputs without any discovery', async () => {
-    const rounds = roundMap();
-    const result = await Effect.runPromise(
-      runLatexdiffForExecution({
+  it.effect('uses caller-supplied outputs without any discovery', () =>
+    Effect.gen(function* () {
+      const rounds = roundMap();
+      const result = yield* runLatexdiffForExecution({
         ...baseRequest,
         outputsByRound: rounds,
+      });
+
+      expect(result.source).toBe('metadata');
+      expect(mocks.runLatexdiffFromMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({ rounds }),
+      );
+      expect(mocks.scanRunDirForOutputs).not.toHaveBeenCalled();
+      expect(mocks.discoverLatestExecutionOutputs).not.toHaveBeenCalled();
+    }),
+  );
+
+  it.effect(
+    'scopes a valid runId to a run-dir scan before metadata discovery',
+    () =>
+      Effect.gen(function* () {
+        mocks.scanRunDirForOutputs.mockReturnValue(Effect.succeed(roundMap()));
+
+        const result = yield* runLatexdiffForExecution({
+          ...baseRequest,
+          runId: 'abc123',
+        });
+
+        expect(result.source).toBe('run-dir-scan');
+        expect(result.executionId).toBe('abc123');
+        expect(mocks.scanRunDirForOutputs).toHaveBeenCalledWith(
+          'abc123',
+          'paper.tex',
+          undefined,
+          'test',
+          baseRequest.filesystem,
+        );
+        expect(mocks.discoverLatestExecutionOutputs).not.toHaveBeenCalled();
+        expect(mocks.runLatexdiffFromMetadata).toHaveBeenCalled();
       }),
-    );
+  );
 
-    expect(result.source).toBe('metadata');
-    expect(mocks.runLatexdiffFromMetadata).toHaveBeenCalledWith(
-      expect.objectContaining({ rounds }),
-    );
-    expect(mocks.scanRunDirForOutputs).not.toHaveBeenCalled();
-    expect(mocks.discoverLatestExecutionOutputs).not.toHaveBeenCalled();
-  });
+  it.effect(
+    'does not fall back to auto-discovery when a pinned runId scan misses',
+    () =>
+      Effect.gen(function* () {
+        mocks.scanRunDirForOutputs.mockReturnValue(Effect.succeed(null));
 
-  it('scopes a valid runId to a run-dir scan before metadata discovery', async () => {
-    mocks.scanRunDirForOutputs.mockReturnValue(Effect.succeed(roundMap()));
+        const result = yield* runLatexdiffForExecution({
+          ...baseRequest,
+          runId: 'abc123',
+        });
 
-    const result = await Effect.runPromise(
-      runLatexdiffForExecution({
-        ...baseRequest,
-        runId: 'abc123',
+        expect(result.source).toBe('workspace-scan');
+        expect(mocks.discoverLatestExecutionOutputs).not.toHaveBeenCalled();
+        expect(mocks.runLatexdiffViaWorkspaceScan).toHaveBeenCalled();
       }),
-    );
+  );
 
-    expect(result.source).toBe('run-dir-scan');
-    expect(result.executionId).toBe('abc123');
-    expect(mocks.scanRunDirForOutputs).toHaveBeenCalledWith(
-      'abc123',
-      'paper.tex',
-      undefined,
-      'test',
-      baseRequest.filesystem,
-    );
-    expect(mocks.discoverLatestExecutionOutputs).not.toHaveBeenCalled();
-    expect(mocks.runLatexdiffFromMetadata).toHaveBeenCalled();
-  });
+  it.effect(
+    'ignores an invalid runId without scanning or auto-discovering',
+    () =>
+      Effect.gen(function* () {
+        const result = yield* runLatexdiffForExecution({
+          ...baseRequest,
+          runId: 'not-hex!',
+        });
 
-  it('does not fall back to auto-discovery when a pinned runId scan misses', async () => {
-    mocks.scanRunDirForOutputs.mockReturnValue(Effect.succeed(null));
-
-    const result = await Effect.runPromise(
-      runLatexdiffForExecution({
-        ...baseRequest,
-        runId: 'abc123',
+        expect(result.source).toBe('workspace-scan');
+        expect(mocks.scanRunDirForOutputs).not.toHaveBeenCalled();
+        expect(mocks.discoverLatestExecutionOutputs).not.toHaveBeenCalled();
+        expect(mocks.runLatexdiffViaWorkspaceScan).toHaveBeenCalled();
       }),
-    );
+  );
 
-    expect(result.source).toBe('workspace-scan');
-    expect(mocks.discoverLatestExecutionOutputs).not.toHaveBeenCalled();
-    expect(mocks.runLatexdiffViaWorkspaceScan).toHaveBeenCalled();
-  });
+  it.effect('auto-discovers by agent/model/input when no runId is given', () =>
+    Effect.gen(function* () {
+      mocks.discoverLatestExecutionOutputs.mockReturnValue(
+        Effect.succeed({
+          executionId: 'def456',
+          rounds: roundMap(),
+        }),
+      );
 
-  it('ignores an invalid runId without scanning or auto-discovering', async () => {
-    const result = await Effect.runPromise(
-      runLatexdiffForExecution({
-        ...baseRequest,
-        runId: 'not-hex!',
+      const result = yield* runLatexdiffForExecution({ ...baseRequest });
+
+      expect(result.source).toBe('metadata');
+      expect(result.executionId).toBe('def456');
+      expect(mocks.discoverLatestExecutionOutputs).toHaveBeenCalledWith(
+        executionDiscovery,
+        snapshots,
+        {
+          agent: 'revise',
+          model: 'claude-opus-4-8',
+          inputFile: 'paper.tex',
+        },
+        'test',
+        baseRequest.filesystem,
+      );
+      expect(mocks.runLatexdiffFromMetadata).toHaveBeenCalled();
+    }),
+  );
+
+  it.effect(
+    'falls back to a workspace scan when auto-discovery finds nothing',
+    () =>
+      Effect.gen(function* () {
+        mocks.discoverLatestExecutionOutputs.mockReturnValue(
+          Effect.succeed(null),
+        );
+
+        const result = yield* runLatexdiffForExecution({ ...baseRequest });
+
+        expect(result.source).toBe('workspace-scan');
+        expect(mocks.runLatexdiffViaWorkspaceScan).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agent: 'revise',
+            model: 'claude-opus-4-8',
+            inputFile: 'paper.tex',
+          }),
+        );
       }),
-    );
-
-    expect(result.source).toBe('workspace-scan');
-    expect(mocks.scanRunDirForOutputs).not.toHaveBeenCalled();
-    expect(mocks.discoverLatestExecutionOutputs).not.toHaveBeenCalled();
-    expect(mocks.runLatexdiffViaWorkspaceScan).toHaveBeenCalled();
-  });
-
-  it('auto-discovers by agent/model/input when no runId is given', async () => {
-    mocks.discoverLatestExecutionOutputs.mockReturnValue(
-      Effect.succeed({
-        executionId: 'def456',
-        rounds: roundMap(),
-      }),
-    );
-
-    const result = await Effect.runPromise(
-      runLatexdiffForExecution({ ...baseRequest }),
-    );
-
-    expect(result.source).toBe('metadata');
-    expect(result.executionId).toBe('def456');
-    expect(mocks.discoverLatestExecutionOutputs).toHaveBeenCalledWith(
-      executionDiscovery,
-      snapshots,
-      {
-        agent: 'revise',
-        model: 'claude-opus-4-8',
-        inputFile: 'paper.tex',
-      },
-      'test',
-      baseRequest.filesystem,
-    );
-    expect(mocks.runLatexdiffFromMetadata).toHaveBeenCalled();
-  });
-
-  it('falls back to a workspace scan when auto-discovery finds nothing', async () => {
-    mocks.discoverLatestExecutionOutputs.mockReturnValue(Effect.succeed(null));
-
-    const result = await Effect.runPromise(
-      runLatexdiffForExecution({ ...baseRequest }),
-    );
-
-    expect(result.source).toBe('workspace-scan');
-    expect(mocks.runLatexdiffViaWorkspaceScan).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agent: 'revise',
-        model: 'claude-opus-4-8',
-        inputFile: 'paper.tex',
-      }),
-    );
-  });
+  );
 });
 
 // #10635: runLatexdiffForExecution names the latexdiff runtime channel once
-// for the whole run, so its discovery lines land on that channel.
+// for the whole run, so a line any discovery step writes lands on it.
 describe('runLatexdiffForExecution diagnostics', () => {
-  /** The run under the logger production installs, so entries reach the sink. */
-  const run = (
-    params: Parameters<typeof runLatexdiffForExecution>[0],
-  ): Promise<{ source: string }> =>
-    Effect.runPromise(
-      runLatexdiffForExecution(params).pipe(
-        Effect.provide(effectDiagnosticsLayer),
-      ),
-    );
-
   beforeEach(async () => {
     vi.clearAllMocks();
     // Debug mode on: the Effect logger drops `Debug` entries otherwise, and
-    // these assertions are about the channel, not that gate.
+    // this assertion is about the channel, not that gate.
     await installPlatform({ config: { 'texra.logger.debugMode': true } });
     mocks.runLatexdiffFromMetadata.mockReturnValue(
-      Effect.succeed(METADATA_OUTCOME),
-    );
-    mocks.runLatexdiffViaWorkspaceScan.mockReturnValue(
-      Effect.succeed(SCAN_OUTCOME),
+      Effect.succeed(EMPTY_OUTCOME),
     );
   });
 
@@ -222,38 +225,26 @@ describe('runLatexdiffForExecution diagnostics', () => {
     vi.restoreAllMocks();
   });
 
-  it('logs the run-dir scan resolution on the latexdiff runtime channel', async () => {
-    mocks.scanRunDirForOutputs.mockReturnValue(Effect.succeed(roundMap()));
-    const logs = captureLogEntries();
+  it.effect('names the latexdiff runtime channel on discovery lines', () =>
+    Effect.gen(function* () {
+      mocks.scanRunDirForOutputs.mockReturnValue(Effect.succeed(roundMap()));
+      const logs = captureLogEntries();
 
-    const result = await run({ ...baseRequest, runId: 'abc123' });
+      const result = yield* runLatexdiffForExecution({
+        ...baseRequest,
+        runId: 'abc123',
+      });
 
-    expect(result.source).toBe('run-dir-scan');
-    expect(
-      logs.has(
-        'DEBUG',
-        'test',
-        'Using run-dir scan outputs from execution abc123',
-      ),
-    ).toBe(true);
-  });
-
-  it('logs the metadata discovery resolution on the latexdiff runtime channel', async () => {
-    mocks.discoverLatestExecutionOutputs.mockReturnValue(
-      Effect.succeed({
-        executionId: 'def456',
-        rounds: roundMap(),
-      }),
-    );
-    const logs = captureLogEntries();
-
-    const result = await run({ ...baseRequest });
-
-    expect(result.source).toBe('metadata');
-    expect(
-      logs.has('DEBUG', 'test', 'Using metadata outputs from execution def456'),
-    ).toBe(true);
-  });
+      expect(result.source).toBe('run-dir-scan');
+      expect(
+        logs.has(
+          'DEBUG',
+          'test',
+          'Using run-dir scan outputs from execution abc123',
+        ),
+      ).toBe(true);
+    }).pipe(Effect.provide(effectDiagnosticsLayer)),
+  );
 });
 
 describe('normalizeRunLatexdiffOutputsByRound', () => {

--- a/src/test-kernel/latex/Texcount.vitest.ts
+++ b/src/test-kernel/latex/Texcount.vitest.ts
@@ -4,8 +4,10 @@ import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
 import { LATEX_COMMANDS_CHANNEL } from '@latex/latexLogging';
 import { getTeXCount } from '@latex/texcount';
-import * as logger from '@logger/logUtils';
+import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
+import { setLogSink } from '@logger/logSink';
 import { platform } from '@platform/platform';
+import { captureLogEntries } from '@test/support/logSinkCapture';
 import { installPlatform } from '@test/support/setupPlatform';
 
 const mocks = vi.hoisted(() => ({
@@ -18,27 +20,44 @@ vi.mock('@utils/system/toolUtils', async (importOriginal) => {
   return { ...actual, runToolWithCheck: mocks.runToolWithCheck };
 });
 
-/** The memfs platform install, as a step inside an `it.effect` program. */
+/**
+ * The memfs platform, with debug mode on: the Effect logger drops `Debug`
+ * entries otherwise, and these assertions are about which channel an entry
+ * lands on, not about that gate.
+ */
 const withPlatform = (
-  options: Parameters<typeof installPlatform>[0],
+  files: Record<string, string> = {},
 ): Effect.Effect<void> =>
-  Effect.promise(() => installPlatform(options)).pipe(Effect.asVoid);
+  Effect.promise(() =>
+    installPlatform({
+      workspacePath: '/workspace',
+      config: { 'texra.logger.debugMode': true },
+      files,
+    }),
+  ).pipe(Effect.asVoid);
 
-// #10635: texcount's helpers resolve their logger per function from the
-// threaded channel — a logger-namespace spy must observe the resolved channel.
-describe('texcount logger seam', () => {
+/** The logger production installs, so entries reach the captured sink. */
+const withDiagnostics = <A, E, R>(
+  self: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> => Effect.provide(self, effectDiagnosticsLayer);
+
+// #10635: getTeXCount names its channel once for the whole count, so every
+// entry a helper writes carries the caller's channel rather than the module
+// default it was declared with.
+describe('texcount diagnostics', () => {
   beforeEach(() => {
     mocks.runToolWithCheck.mockReset();
   });
 
   afterEach(() => {
+    setLogSink(null);
     vi.restoreAllMocks();
   });
 
   it.effect('warns on the resolved channel when no files are provided', () =>
     Effect.gen(function* () {
-      yield* withPlatform({ workspacePath: '/workspace' });
-      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      yield* withPlatform();
+      const logs = captureLogEntries();
 
       const pinned = yield* getTeXCount('   ', { channel: 'pinnedTexcount' });
       const defaulted = yield* getTeXCount('');
@@ -48,21 +67,27 @@ describe('texcount logger seam', () => {
         errors: ['No LaTeX files provided for texcount.'],
       });
       expect(defaulted).toEqual(pinned);
-      expect(warn).toHaveBeenCalledWith(
-        'pinnedTexcount',
-        'No LaTeX files provided for texcount.',
-      );
-      expect(warn).toHaveBeenCalledWith(
-        LATEX_COMMANDS_CHANNEL,
-        'No LaTeX files provided for texcount.',
-      );
-    }),
+      expect(
+        logs.has(
+          'WARN',
+          'pinnedTexcount',
+          'No LaTeX files provided for texcount.',
+        ),
+      ).toBe(true);
+      expect(
+        logs.has(
+          'WARN',
+          LATEX_COMMANDS_CHANNEL,
+          'No LaTeX files provided for texcount.',
+        ),
+      ).toBe(true);
+    }).pipe(withDiagnostics),
   );
 
   it.effect('warns on the resolved channel when a file does not exist', () =>
     Effect.gen(function* () {
-      yield* withPlatform({ workspacePath: '/workspace' });
-      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      yield* withPlatform();
+      const logs = captureLogEntries();
 
       const result = yield* getTeXCount('missing.tex', {
         channel: 'pinnedTexcount',
@@ -70,24 +95,18 @@ describe('texcount logger seam', () => {
 
       expect(result.output).toBeNull();
       expect(result.errors).toHaveLength(1);
-      expect(warn).toHaveBeenCalledWith(
-        'pinnedTexcount',
-        expect.stringContaining('does not exist'),
-      );
-    }),
+      expect(logs.has('WARN', 'pinnedTexcount', 'does not exist')).toBe(true);
+    }).pipe(withDiagnostics),
   );
 
-  // The module-level `const log = createLog(CHANNEL)` in texcount.ts is bound
-  // at import time, before this suite's spy exists — exactly the case
-  // createLog's per-call loggerSelf lookup exists for. A read failure inside
-  // hasChinesePackages must still reach the spied namespace.
+  // The Chinese-package probe is best-effort, and its failure is reported on
+  // the count's own channel rather than on a channel the helper picked.
   it.effect(
-    'emits through the import-time module binding when the Chinese-package check fails',
+    'reports a failed Chinese-package check on the resolved channel',
     () =>
       Effect.gen(function* () {
         yield* withPlatform({
-          workspacePath: '/workspace',
-          files: { '/workspace/main.tex': '\\documentclass{article}\n' },
+          '/workspace/main.tex': '\\documentclass{article}\n',
         });
         // The first (and only) AbsoluteFS.read here is hasChinesePackages'.
         vi.spyOn(platform().fs, 'readFile').mockRejectedValueOnce(
@@ -99,19 +118,22 @@ describe('texcount logger seam', () => {
           stderr: '',
           exitCode: 0,
         });
-        const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+        const logs = captureLogEntries();
 
-        const result = yield* getTeXCount('main.tex');
+        const result = yield* getTeXCount('main.tex', {
+          channel: 'pinnedTexcount',
+        });
 
-        // The failed Chinese-package probe is best-effort: the count runs.
+        // The failed probe is best-effort: the count still runs.
         expect(result.output).toContain('Words in text: 5');
-        expect(error).toHaveBeenCalledWith(
-          LATEX_COMMANDS_CHANNEL,
-          expect.stringContaining(
+        expect(
+          logs.has(
+            'ERROR',
+            'pinnedTexcount',
             'Error checking Chinese packages: disk flutter',
           ),
-        );
-      }),
+        ).toBe(true);
+      }).pipe(withDiagnostics),
   );
 
   it.effect(
@@ -119,8 +141,7 @@ describe('texcount logger seam', () => {
     () =>
       Effect.gen(function* () {
         yield* withPlatform({
-          workspacePath: '/workspace',
-          files: { '/workspace/main.tex': '\\documentclass{article}\n' },
+          '/workspace/main.tex': '\\documentclass{article}\n',
         });
         mocks.runToolWithCheck.mockResolvedValue({
           success: false,
@@ -128,7 +149,7 @@ describe('texcount logger seam', () => {
           stderr: 'texcount exploded',
           exitCode: 1,
         });
-        const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+        const logs = captureLogEntries();
 
         const result = yield* getTeXCount('main.tex', {
           channel: 'pinnedTexcount',
@@ -136,31 +157,23 @@ describe('texcount logger seam', () => {
 
         expect(result.output).toBeNull();
         expect(result.errors.join('\n')).toContain('texcount exploded');
-        expect(error).toHaveBeenCalledWith(
-          'pinnedTexcount',
-          expect.stringContaining('Error getting tex count for'),
-        );
-        expect(error).toHaveBeenCalledWith(
-          'pinnedTexcount',
-          expect.stringContaining('Stderr: texcount exploded'),
-        );
-      }),
+        expect(
+          logs.has('ERROR', 'pinnedTexcount', 'Error getting tex count for'),
+        ).toBe(true);
+        expect(
+          logs.has('ERROR', 'pinnedTexcount', 'Stderr: texcount exploded'),
+        ).toBe(true);
+      }).pipe(withDiagnostics),
   );
 
-  // #10649: pins the sum-mode path's own log emission: getSummedCount's
-  // Chinese-package debug line reaches the spied namespace at debug level
-  // with its exact message, on both the threaded channel and the default
-  // LATEX_COMMANDS_CHANNEL. The spy is installed before the per-call
-  // createLog runs, so this test does not prove call-time loggerSelf
-  // delegation; that bind-time-vs-call-time seam is guarded by the
-  // import-time hasChinesePackages test above.
+  // #10649: pins the sum-mode path's own emission — getSummedCount's
+  // Chinese-package line reaches the caller's channel and the default one.
   it.effect(
     'emits the sum-mode Chinese-package debug line on the resolved channel',
     () =>
       Effect.gen(function* () {
         yield* withPlatform({
-          workspacePath: '/workspace',
-          files: { '/workspace/main.tex': '\\documentclass{ctexart}\n' },
+          '/workspace/main.tex': '\\documentclass{ctexart}\n',
         });
         mocks.runToolWithCheck.mockResolvedValue({
           success: true,
@@ -168,7 +181,7 @@ describe('texcount logger seam', () => {
           stderr: '',
           exitCode: 0,
         });
-        const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+        const logs = captureLogEntries();
 
         const pinned = yield* getTeXCount('main.tex', {
           mode: 'sum',
@@ -179,14 +192,10 @@ describe('texcount logger seam', () => {
         // The (sum) prefix proves the summed path, not the per-file path, ran.
         expect(pinned.output).toContain('Combined TeX Count Results (sum):');
         expect(defaulted).toEqual(pinned);
-        expect(debug).toHaveBeenCalledWith(
-          'pinnedTexcount',
-          'Chinese packages detected in main.tex, enabling Chinese character counting',
-        );
-        expect(debug).toHaveBeenCalledWith(
-          LATEX_COMMANDS_CHANNEL,
-          'Chinese packages detected in main.tex, enabling Chinese character counting',
-        );
-      }),
+        const line =
+          'Chinese packages detected in main.tex, enabling Chinese character counting';
+        expect(logs.has('DEBUG', 'pinnedTexcount', line)).toBe(true);
+        expect(logs.has('DEBUG', LATEX_COMMANDS_CHANNEL, line)).toBe(true);
+      }).pipe(withDiagnostics),
   );
 });

--- a/src/test-kernel/latex/Texcount.vitest.ts
+++ b/src/test-kernel/latex/Texcount.vitest.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
 import { LATEX_COMMANDS_CHANNEL } from '@latex/latexLogging';
 import { getTeXCount } from '@latex/texcount';
@@ -16,6 +18,12 @@ vi.mock('@utils/system/toolUtils', async (importOriginal) => {
   return { ...actual, runToolWithCheck: mocks.runToolWithCheck };
 });
 
+/** The memfs platform install, as a step inside an `it.effect` program. */
+const withPlatform = (
+  options: Parameters<typeof installPlatform>[0],
+): Effect.Effect<void> =>
+  Effect.promise(() => installPlatform(options)).pipe(Effect.asVoid);
+
 // #10635: texcount's helpers resolve their logger per function from the
 // threaded channel — a logger-namespace spy must observe the resolved channel.
 describe('texcount logger seam', () => {
@@ -27,101 +35,117 @@ describe('texcount logger seam', () => {
     vi.restoreAllMocks();
   });
 
-  it('warns on the resolved channel when no files are provided', async () => {
-    await installPlatform({ workspacePath: '/workspace' });
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  it.effect('warns on the resolved channel when no files are provided', () =>
+    Effect.gen(function* () {
+      yield* withPlatform({ workspacePath: '/workspace' });
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
-    const pinned = await getTeXCount('   ', { channel: 'pinnedTexcount' });
-    const defaulted = await getTeXCount('');
+      const pinned = yield* getTeXCount('   ', { channel: 'pinnedTexcount' });
+      const defaulted = yield* getTeXCount('');
 
-    expect(pinned).toEqual({
-      output: null,
-      errors: ['No LaTeX files provided for texcount.'],
-    });
-    expect(defaulted).toEqual(pinned);
-    expect(warn).toHaveBeenCalledWith(
-      'pinnedTexcount',
-      'No LaTeX files provided for texcount.',
-    );
-    expect(warn).toHaveBeenCalledWith(
-      LATEX_COMMANDS_CHANNEL,
-      'No LaTeX files provided for texcount.',
-    );
-  });
+      expect(pinned).toEqual({
+        output: null,
+        errors: ['No LaTeX files provided for texcount.'],
+      });
+      expect(defaulted).toEqual(pinned);
+      expect(warn).toHaveBeenCalledWith(
+        'pinnedTexcount',
+        'No LaTeX files provided for texcount.',
+      );
+      expect(warn).toHaveBeenCalledWith(
+        LATEX_COMMANDS_CHANNEL,
+        'No LaTeX files provided for texcount.',
+      );
+    }),
+  );
 
-  it('warns on the resolved channel when a file does not exist', async () => {
-    await installPlatform({ workspacePath: '/workspace' });
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  it.effect('warns on the resolved channel when a file does not exist', () =>
+    Effect.gen(function* () {
+      yield* withPlatform({ workspacePath: '/workspace' });
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
-    const result = await getTeXCount('missing.tex', {
-      channel: 'pinnedTexcount',
-    });
+      const result = yield* getTeXCount('missing.tex', {
+        channel: 'pinnedTexcount',
+      });
 
-    expect(result.output).toBeNull();
-    expect(result.errors).toHaveLength(1);
-    expect(warn).toHaveBeenCalledWith(
-      'pinnedTexcount',
-      expect.stringContaining('does not exist'),
-    );
-  });
+      expect(result.output).toBeNull();
+      expect(result.errors).toHaveLength(1);
+      expect(warn).toHaveBeenCalledWith(
+        'pinnedTexcount',
+        expect.stringContaining('does not exist'),
+      );
+    }),
+  );
 
   // The module-level `const log = createLog(CHANNEL)` in texcount.ts is bound
   // at import time, before this suite's spy exists — exactly the case
   // createLog's per-call loggerSelf lookup exists for. A read failure inside
   // hasChinesePackages must still reach the spied namespace.
-  it('emits through the import-time module binding when the Chinese-package check fails', async () => {
-    await installPlatform({
-      workspacePath: '/workspace',
-      files: { '/workspace/main.tex': '\\documentclass{article}\n' },
-    });
-    // The first (and only) AbsoluteFS.read in this flow is hasChinesePackages'.
-    vi.spyOn(platform().fs, 'readFile').mockRejectedValueOnce(
-      new Error('disk flutter'),
-    );
-    mocks.runToolWithCheck.mockResolvedValue({
-      success: true,
-      stdout: 'Words in text: 5',
-      stderr: '',
-      exitCode: 0,
-    });
-    const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+  it.effect(
+    'emits through the import-time module binding when the Chinese-package check fails',
+    () =>
+      Effect.gen(function* () {
+        yield* withPlatform({
+          workspacePath: '/workspace',
+          files: { '/workspace/main.tex': '\\documentclass{article}\n' },
+        });
+        // The first (and only) AbsoluteFS.read here is hasChinesePackages'.
+        vi.spyOn(platform().fs, 'readFile').mockRejectedValueOnce(
+          new Error('disk flutter'),
+        );
+        mocks.runToolWithCheck.mockResolvedValue({
+          success: true,
+          stdout: 'Words in text: 5',
+          stderr: '',
+          exitCode: 0,
+        });
+        const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
 
-    const result = await getTeXCount('main.tex');
+        const result = yield* getTeXCount('main.tex');
 
-    // The failed Chinese-package probe is best-effort: the count still runs.
-    expect(result.output).toContain('Words in text: 5');
-    expect(error).toHaveBeenCalledWith(
-      LATEX_COMMANDS_CHANNEL,
-      expect.stringContaining('Error checking Chinese packages: disk flutter'),
-    );
-  });
+        // The failed Chinese-package probe is best-effort: the count runs.
+        expect(result.output).toContain('Words in text: 5');
+        expect(error).toHaveBeenCalledWith(
+          LATEX_COMMANDS_CHANNEL,
+          expect.stringContaining(
+            'Error checking Chinese packages: disk flutter',
+          ),
+        );
+      }),
+  );
 
-  it('logs a failing texcount invocation at error level on the resolved channel', async () => {
-    await installPlatform({
-      workspacePath: '/workspace',
-      files: { '/workspace/main.tex': '\\documentclass{article}\n' },
-    });
-    mocks.runToolWithCheck.mockResolvedValue({
-      success: false,
-      stdout: 'partial output',
-      stderr: 'texcount exploded',
-      exitCode: 1,
-    });
-    const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+  it.effect(
+    'logs a failing texcount invocation at error level on the resolved channel',
+    () =>
+      Effect.gen(function* () {
+        yield* withPlatform({
+          workspacePath: '/workspace',
+          files: { '/workspace/main.tex': '\\documentclass{article}\n' },
+        });
+        mocks.runToolWithCheck.mockResolvedValue({
+          success: false,
+          stdout: 'partial output',
+          stderr: 'texcount exploded',
+          exitCode: 1,
+        });
+        const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
 
-    const result = await getTeXCount('main.tex', { channel: 'pinnedTexcount' });
+        const result = yield* getTeXCount('main.tex', {
+          channel: 'pinnedTexcount',
+        });
 
-    expect(result.output).toBeNull();
-    expect(result.errors.join('\n')).toContain('texcount exploded');
-    expect(error).toHaveBeenCalledWith(
-      'pinnedTexcount',
-      expect.stringContaining('Error getting tex count for'),
-    );
-    expect(error).toHaveBeenCalledWith(
-      'pinnedTexcount',
-      expect.stringContaining('Stderr: texcount exploded'),
-    );
-  });
+        expect(result.output).toBeNull();
+        expect(result.errors.join('\n')).toContain('texcount exploded');
+        expect(error).toHaveBeenCalledWith(
+          'pinnedTexcount',
+          expect.stringContaining('Error getting tex count for'),
+        );
+        expect(error).toHaveBeenCalledWith(
+          'pinnedTexcount',
+          expect.stringContaining('Stderr: texcount exploded'),
+        );
+      }),
+  );
 
   // #10649: pins the sum-mode path's own log emission: getSummedCount's
   // Chinese-package debug line reaches the spied namespace at debug level
@@ -130,35 +154,39 @@ describe('texcount logger seam', () => {
   // createLog runs, so this test does not prove call-time loggerSelf
   // delegation; that bind-time-vs-call-time seam is guarded by the
   // import-time hasChinesePackages test above.
-  it('emits the sum-mode Chinese-package debug line on the resolved channel', async () => {
-    await installPlatform({
-      workspacePath: '/workspace',
-      files: { '/workspace/main.tex': '\\documentclass{ctexart}\n' },
-    });
-    mocks.runToolWithCheck.mockResolvedValue({
-      success: true,
-      stdout: 'Words in text: 5',
-      stderr: '',
-      exitCode: 0,
-    });
-    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+  it.effect(
+    'emits the sum-mode Chinese-package debug line on the resolved channel',
+    () =>
+      Effect.gen(function* () {
+        yield* withPlatform({
+          workspacePath: '/workspace',
+          files: { '/workspace/main.tex': '\\documentclass{ctexart}\n' },
+        });
+        mocks.runToolWithCheck.mockResolvedValue({
+          success: true,
+          stdout: 'Words in text: 5',
+          stderr: '',
+          exitCode: 0,
+        });
+        const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
-    const pinned = await getTeXCount('main.tex', {
-      mode: 'sum',
-      channel: 'pinnedTexcount',
-    });
-    const defaulted = await getTeXCount('main.tex', { mode: 'sum' });
+        const pinned = yield* getTeXCount('main.tex', {
+          mode: 'sum',
+          channel: 'pinnedTexcount',
+        });
+        const defaulted = yield* getTeXCount('main.tex', { mode: 'sum' });
 
-    // The (sum) prefix proves the summed path, not the per-file path, ran.
-    expect(pinned.output).toContain('Combined TeX Count Results (sum):');
-    expect(defaulted).toEqual(pinned);
-    expect(debug).toHaveBeenCalledWith(
-      'pinnedTexcount',
-      'Chinese packages detected in main.tex, enabling Chinese character counting',
-    );
-    expect(debug).toHaveBeenCalledWith(
-      LATEX_COMMANDS_CHANNEL,
-      'Chinese packages detected in main.tex, enabling Chinese character counting',
-    );
-  });
+        // The (sum) prefix proves the summed path, not the per-file path, ran.
+        expect(pinned.output).toContain('Combined TeX Count Results (sum):');
+        expect(defaulted).toEqual(pinned);
+        expect(debug).toHaveBeenCalledWith(
+          'pinnedTexcount',
+          'Chinese packages detected in main.tex, enabling Chinese character counting',
+        );
+        expect(debug).toHaveBeenCalledWith(
+          LATEX_COMMANDS_CHANNEL,
+          'Chinese packages detected in main.tex, enabling Chinese character counting',
+        );
+      }),
+  );
 });

--- a/src/test-kernel/latex/extractBibliography.vitest.ts
+++ b/src/test-kernel/latex/extractBibliography.vitest.ts
@@ -1,7 +1,9 @@
 import * as assert from 'node:assert';
 import * as path from 'node:path';
 
-import { afterEach, describe, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { afterEach, describe, vi } from 'vitest';
 
 import {
   extractBibliographyContext,
@@ -23,11 +25,12 @@ describe('extractBibliography helpers', () => {
     vi.restoreAllMocks();
   });
 
-  it('collects bibliography paths and citation keys', async () => {
-    const texPath = path.join('chapters', 'main.tex');
-    const expectedBibPath = path.join('chapters', 'references.bib');
+  it.effect('collects bibliography paths and citation keys', () =>
+    Effect.gen(function* () {
+      const texPath = path.join('chapters', 'main.tex');
+      const expectedBibPath = path.join('chapters', 'references.bib');
 
-    vi.spyOn(WorkspaceFS, 'read').mockResolvedValue(`
+      vi.spyOn(WorkspaceFS, 'read').mockResolvedValue(`
       % comment
       \\documentclass{article}
       \\addbibresource[location=local]{references}
@@ -35,102 +38,115 @@ describe('extractBibliography helpers', () => {
       More citations \\nocite{gamma}
       % \\cite{ignored}
     `);
-    vi.spyOn(WorkspaceFS, 'exists').mockImplementation(
-      async (file) => file === expectedBibPath,
-    );
+      vi.spyOn(WorkspaceFS, 'exists').mockImplementation(
+        async (file) => file === expectedBibPath,
+      );
 
-    const result = await extractBibliographyContext(texPath);
+      const result = yield* extractBibliographyContext(texPath);
 
-    assert.deepStrictEqual(result.bibliographyFiles, [expectedBibPath]);
-    assert.deepStrictEqual(result.missingBibliographyFiles, []);
-    assert.deepStrictEqual(
-      new Set(result.citationKeys),
-      new Set(['alpha', 'beta', 'gamma']),
-    );
-  });
+      assert.deepStrictEqual(result.bibliographyFiles, [expectedBibPath]);
+      assert.deepStrictEqual(result.missingBibliographyFiles, []);
+      assert.deepStrictEqual(
+        new Set(result.citationKeys),
+        new Set(['alpha', 'beta', 'gamma']),
+      );
+    }),
+  );
 
-  it('handles wildcard nocite directives consistently across runs', async () => {
-    const texPath = 'paper.tex';
-    const expectedBibPath = 'refs.bib';
+  it.effect('handles wildcard nocite directives consistently across runs', () =>
+    Effect.gen(function* () {
+      const texPath = 'paper.tex';
+      const expectedBibPath = 'refs.bib';
 
-    vi.spyOn(WorkspaceFS, 'read').mockResolvedValue(`
+      vi.spyOn(WorkspaceFS, 'read').mockResolvedValue(`
       % bibliographies
       \\bibliography{refs}
       Intro text
       \\nocite{*}
     `);
-    vi.spyOn(WorkspaceFS, 'exists').mockResolvedValue(true);
+      vi.spyOn(WorkspaceFS, 'exists').mockResolvedValue(true);
 
-    const first = await extractBibliographyContext(texPath);
-    const second = await extractBibliographyContext(texPath);
+      const first = yield* extractBibliographyContext(texPath);
+      const second = yield* extractBibliographyContext(texPath);
 
-    const expectedKeys = new Set(['*']);
+      const expectedKeys = new Set(['*']);
 
-    assert.deepStrictEqual(first.bibliographyFiles, [expectedBibPath]);
-    assert.deepStrictEqual(second.bibliographyFiles, [expectedBibPath]);
-    assert.deepStrictEqual(new Set(first.citationKeys), expectedKeys);
-    assert.deepStrictEqual(new Set(second.citationKeys), expectedKeys);
-    assert.deepStrictEqual(second, first);
-  });
+      assert.deepStrictEqual(first.bibliographyFiles, [expectedBibPath]);
+      assert.deepStrictEqual(second.bibliographyFiles, [expectedBibPath]);
+      assert.deepStrictEqual(new Set(first.citationKeys), expectedKeys);
+      assert.deepStrictEqual(new Set(second.citationKeys), expectedKeys);
+      assert.deepStrictEqual(second, first);
+    }),
+  );
 
-  it('marks missing bibliography files and ignores empty citations', async () => {
-    const texPath = 'paper.tex';
+  it.effect(
+    'marks missing bibliography files and ignores empty citations',
+    () =>
+      Effect.gen(function* () {
+        const texPath = 'paper.tex';
 
-    vi.spyOn(WorkspaceFS, 'read').mockResolvedValue(`
+        vi.spyOn(WorkspaceFS, 'read').mockResolvedValue(`
       \\bibliography{bib/one, bib/two.bib, } % trailing comma
       \\cite{first} \\cite{second, third}
     `);
-    vi.spyOn(WorkspaceFS, 'exists').mockImplementation(
-      async (file) => file === path.join('bib', 'two.bib'),
-    );
+        vi.spyOn(WorkspaceFS, 'exists').mockImplementation(
+          async (file) => file === path.join('bib', 'two.bib'),
+        );
 
-    const result = await extractBibliographyContext(texPath);
+        const result = yield* extractBibliographyContext(texPath);
 
-    assert.deepStrictEqual(result.bibliographyFiles, [
-      path.join('bib', 'two.bib'),
-    ]);
-    assert.deepStrictEqual(result.missingBibliographyFiles, [
-      path.join('bib', 'one.bib'),
-    ]);
-    assert.deepStrictEqual(
-      new Set(result.citationKeys),
-      new Set(['first', 'second', 'third']),
-    );
-  });
+        assert.deepStrictEqual(result.bibliographyFiles, [
+          path.join('bib', 'two.bib'),
+        ]);
+        assert.deepStrictEqual(result.missingBibliographyFiles, [
+          path.join('bib', 'one.bib'),
+        ]);
+        assert.deepStrictEqual(
+          new Set(result.citationKeys),
+          new Set(['first', 'second', 'third']),
+        );
+      }),
+  );
 
-  it('loads requested bibliography entries and reports missing keys', async () => {
-    vi.spyOn(WorkspaceFS, 'read').mockResolvedValue(BIB_CONTENT);
+  it.effect(
+    'loads requested bibliography entries and reports missing keys',
+    () =>
+      Effect.gen(function* () {
+        vi.spyOn(WorkspaceFS, 'read').mockResolvedValue(BIB_CONTENT);
 
-    const { entries, missingKeys } = await loadBibliographyEntries(
-      ['references.bib'],
-      ['alpha', 'gamma'],
-    );
+        const { entries, missingKeys } = yield* loadBibliographyEntries(
+          ['references.bib'],
+          ['alpha', 'gamma'],
+        );
 
-    assert.strictEqual(entries.size, 1);
-    // formatBibEntry drops the trailing comma after the last field.
-    assert.strictEqual(
-      entries.get('alpha'),
-      '@article{alpha,\n  title = {Alpha Paper}\n}',
-    );
-    assert.deepStrictEqual(missingKeys, ['gamma']);
+        assert.strictEqual(entries.size, 1);
+        // formatBibEntry drops the trailing comma after the last field.
+        assert.strictEqual(
+          entries.get('alpha'),
+          '@article{alpha,\n  title = {Alpha Paper}\n}',
+        );
+        assert.deepStrictEqual(missingKeys, ['gamma']);
 
-    const formatted = summarizeBibliographyEntries(entries, 5);
-    assert.deepStrictEqual(formatted, [
-      '@article{alpha,\n  title = {Alpha Paper}\n}',
-    ]);
-  });
+        const formatted = summarizeBibliographyEntries(entries, 5);
+        assert.deepStrictEqual(formatted, [
+          '@article{alpha,\n  title = {Alpha Paper}\n}',
+        ]);
+      }),
+  );
 
-  it('loads all entries when nocite wildcard is present', async () => {
-    vi.spyOn(WorkspaceFS, 'read').mockResolvedValue(BIB_CONTENT);
+  it.effect('loads all entries when nocite wildcard is present', () =>
+    Effect.gen(function* () {
+      vi.spyOn(WorkspaceFS, 'read').mockResolvedValue(BIB_CONTENT);
 
-    const { entries, missingKeys } = await loadBibliographyEntries(
-      ['references.bib'],
-      ['*'],
-    );
+      const { entries, missingKeys } = yield* loadBibliographyEntries(
+        ['references.bib'],
+        ['*'],
+      );
 
-    assert.strictEqual(entries.size, 2);
-    assert.deepStrictEqual(missingKeys, []);
-    assert.ok(entries.has('alpha'));
-    assert.ok(entries.has('beta'));
-  });
+      assert.strictEqual(entries.size, 2);
+      assert.deepStrictEqual(missingKeys, []);
+      assert.ok(entries.has('alpha'));
+      assert.ok(entries.has('beta'));
+    }),
+  );
 });

--- a/src/test-kernel/support/logSinkCapture.ts
+++ b/src/test-kernel/support/logSinkCapture.ts
@@ -1,0 +1,55 @@
+/**
+ * Capture the diagnostic entries a subsystem writes.
+ *
+ * Both producers — `Effect.log*` through the logger layer and the
+ * channel-keyed writers in `@logger/logUtils` — end at the one host sink, so a
+ * suite asserts on the entries that reach it rather than on whichever producer
+ * the code under test happens to use. Install with `captureLogEntries()` and
+ * restore with `setLogSink(null)` in `afterEach`.
+ */
+import { entryChannel, entryMessage, setLogSink } from '@logger/logSink';
+import type { LogEntry } from '@logger/logSink';
+
+interface CapturedLog {
+  readonly level: string;
+  readonly channel: string | undefined;
+  readonly message: string;
+  readonly annotations: LogEntry['annotations'];
+}
+
+export interface LogCapture {
+  /** Every entry written since the capture was installed, in order. */
+  readonly entries: () => readonly CapturedLog[];
+  /** Entries at `level`, optionally narrowed to one channel. */
+  readonly at: (level: string, channel?: string) => readonly CapturedLog[];
+  /** Whether some entry at `level` on `channel` contains `text`. */
+  readonly has: (level: string, channel: string, text: string) => boolean;
+}
+
+/** Route diagnostics into an in-memory list for the current test. */
+export function captureLogEntries(): LogCapture {
+  const captured: CapturedLog[] = [];
+  setLogSink({
+    write: (entry) =>
+      captured.push({
+        level: entry.level,
+        channel: entryChannel(entry),
+        message: entryMessage(entry),
+        annotations: entry.annotations,
+      }),
+  });
+
+  const at = (level: string, channel?: string): readonly CapturedLog[] =>
+    captured.filter(
+      (entry) =>
+        entry.level === level &&
+        (channel === undefined || entry.channel === channel),
+    );
+
+  return {
+    entries: () => captured,
+    at,
+    has: (level, channel, text) =>
+      at(level, channel).some((entry) => entry.message.includes(text)),
+  };
+}

--- a/src/test-kernel/tools/TexcountTool.vitest.ts
+++ b/src/test-kernel/tools/TexcountTool.vitest.ts
@@ -2,6 +2,7 @@
 import * as assert from 'node:assert';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { describe, it, afterEach, vi } from 'vitest';
 
 // Local imports - tools
@@ -16,19 +17,18 @@ type TexcountCall = {
 };
 
 function stubTexcount(output: string | null, errors: string[] = []): void {
-  vi.spyOn(texcountModule, 'getTeXCount').mockImplementation(async () => ({
-    output,
-    errors,
-  }));
+  vi.spyOn(texcountModule, 'getTeXCount').mockImplementation(() =>
+    Effect.succeed({ output, errors }),
+  );
 }
 
 // Spies getTeXCount and records each call's files/options.
 function captureTexcountCalls(output: string): TexcountCall[] {
   const calls: TexcountCall[] = [];
   vi.spyOn(texcountModule, 'getTeXCount').mockImplementation(
-    async (files, options) => {
+    (files, options) => {
       calls.push({ files: Array.isArray(files) ? files : [files], options });
-      return { output, errors: [] };
+      return Effect.succeed({ output, errors: [] });
     },
   );
   return calls;

--- a/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
@@ -1,13 +1,15 @@
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as bibliographyModule from '@latex/extractBibliography';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 import { ExtractBibliographyTool } from '@tools/latex/ExtractBibliographyTool';
+import type { Success } from 'effect/Effect';
 
-type BibliographyContext = Awaited<
+type BibliographyContext = Success<
   ReturnType<typeof bibliographyModule.extractBibliographyContext>
 >;
-type BibliographyEntries = Awaited<
+type BibliographyEntries = Success<
   ReturnType<typeof bibliographyModule.loadBibliographyEntries>
 >;
 
@@ -21,17 +23,21 @@ function mockBibliography(options: {
   entries?: Partial<BibliographyEntries>;
   summary?: string[];
 }): void {
-  vi.spyOn(bibliographyModule, 'extractBibliographyContext').mockResolvedValue({
-    citationKeys: [],
-    bibliographyFiles: [],
-    missingBibliographyFiles: [],
-    ...options.context,
-  });
-  vi.spyOn(bibliographyModule, 'loadBibliographyEntries').mockResolvedValue({
-    entries: new Map(),
-    missingKeys: [],
-    ...options.entries,
-  });
+  vi.spyOn(bibliographyModule, 'extractBibliographyContext').mockReturnValue(
+    Effect.succeed({
+      citationKeys: [],
+      bibliographyFiles: [],
+      missingBibliographyFiles: [],
+      ...options.context,
+    }),
+  );
+  vi.spyOn(bibliographyModule, 'loadBibliographyEntries').mockReturnValue(
+    Effect.succeed({
+      entries: new Map(),
+      missingKeys: [],
+      ...options.entries,
+    }),
+  );
   vi.spyOn(bibliographyModule, 'summarizeBibliographyEntries').mockReturnValue(
     options.summary ?? [],
   );
@@ -119,10 +125,12 @@ describe('ExtractBibliographyTool', () => {
     });
     const loadEntries = vi
       .mocked(bibliographyModule.loadBibliographyEntries)
-      .mockResolvedValue({
-        entries: new Map([['alpha', '@article{alpha,...}']]),
-        missingKeys: [],
-      });
+      .mockReturnValue(
+        Effect.succeed({
+          entries: new Map([['alpha', '@article{alpha,...}']]),
+          missingKeys: [],
+        }),
+      );
 
     const result = await new ExtractBibliographyTool().call({
       texPath: 'thesis.tex',
@@ -142,7 +150,7 @@ describe('ExtractBibliographyTool', () => {
     mockBibliography({});
     const loadEntries = vi
       .mocked(bibliographyModule.loadBibliographyEntries)
-      .mockResolvedValue({ entries: new Map(), missingKeys: [] });
+      .mockReturnValue(Effect.succeed({ entries: new Map(), missingKeys: [] }));
 
     const result = await new ExtractBibliographyTool().call({
       texPath: 'standalone.tex',

--- a/src/test-kernel/tools/latex/ExtractFiguresTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractFiguresTool.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as figureModule from '@latex/extractFigure';
@@ -18,9 +19,9 @@ describe('ExtractLatexFiguresTool', () => {
       '/workspace/main.tex': '\\documentclass{article}',
       '/workspace/figures/plot.pdf': 'pdf',
     });
-    vi.spyOn(figureModule, 'extractFigurePathsFromLatex').mockResolvedValue([
-      'figures/plot.pdf',
-    ]);
+    vi.spyOn(figureModule, 'extractFigurePathsFromLatex').mockReturnValue(
+      Effect.succeed(['figures/plot.pdf']),
+    );
 
     const result = await new ExtractLatexFiguresTool().call({
       texPath: 'main.tex',
@@ -40,7 +41,9 @@ describe('ExtractLatexFiguresTool', () => {
     await installPlatform({
       '/workspace/report.tex': '\\documentclass{article}',
     });
-    vi.spyOn(figureModule, 'extractFigurePathsFromLatex').mockResolvedValue([]);
+    vi.spyOn(figureModule, 'extractFigurePathsFromLatex').mockReturnValue(
+      Effect.succeed([]),
+    );
 
     const result = await new ExtractLatexFiguresTool().call({
       texPath: 'report.tex',

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -12,6 +12,7 @@ import { isFileNotFoundError } from '@common/errors';
 import { TEMP_EXTENSIONS } from '@housekeeping/constants';
 import { LaTeXdiffService } from '@latex/latexdiff';
 import { debug, warn } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   LATEXDIFF_TEMP_FILE_LOCATIONS,
   type FileLocation,
@@ -265,15 +266,19 @@ export async function runLatexdiff(
       '_proposed',
     );
 
-    const result = await latexdiffService.runDiff(
-      tempPathToLocation(originalPath),
-      tempPathToLocation(proposedPath),
-      '_diff',
-      'coarse',
-      {
-        cwd: WorkspaceFS.getPath() ?? path.dirname(originalPath),
-        subtype: options.subtype,
-      },
+    // The one Promise seam left here: the diff service is Effect below this
+    // line and the approval preview's callback plumbing above it is not.
+    const result = await effectRuntime().runPromise(
+      latexdiffService.runDiff(
+        tempPathToLocation(originalPath),
+        tempPathToLocation(proposedPath),
+        '_diff',
+        'coarse',
+        {
+          cwd: WorkspaceFS.getPath() ?? path.dirname(originalPath),
+          subtype: options.subtype,
+        },
+      ),
     );
 
     if (!result.success || !result.diffPath) {

--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -121,7 +121,10 @@ export const createChildStream = Effect.fn('createChildStream')(function* (
   const setup = yield* Effect.exit(
     Effect.gen(function* () {
       // Attach the run's canonical event publication before activation.
-      detachSessionTrace = session.attachRunTrace(runTrace.trace, childStreamId);
+      detachSessionTrace = session.attachRunTrace(
+        runTrace.trace,
+        childStreamId,
+      );
       const disposeTrace = () => {
         detachSessionTrace?.();
         runTrace.dispose();

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -1,23 +1,27 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports - tools
+import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import {
   extractBibliographyContext,
   loadBibliographyEntries,
   summarizeBibliographyEntries,
 } from '@latex/extractBibliography';
+import { effectRuntime } from '@platform/processRuntime';
 import type { ToolResult } from '@shared/schemas';
 import { formatToolOutput } from '@tools/formatting';
 import { resolveAndFormat } from '@tools/pathResolution';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
+import { ensureError } from '@utils/errors/errorMessage';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { formatResultCount } from '@utils/text/stringUtils';
 import { getConfig } from '@utils/config/configUtils';
 import {
   emptyExtractionResult,
-  resolveLatexFileOrThrow,
+  resolveLatexFile,
   texPathField,
 } from './figureExtractionShared';
 
@@ -42,19 +46,14 @@ function formatPathList(filePaths: string[]): string {
     .join(', ');
 }
 
-export class ExtractBibliographyTool extends defineTool({
-  name: 'extract_bib_entries',
-  description:
-    'Collect BibTeX records for citations referenced in a LaTeX document.',
-  schema: ExtractBibliographyInputSchema,
-}) {
-  protected async execute({
+const extractBibliography = Effect.fn('ExtractBibliographyTool.execute')(
+  function* ({
     texPath,
     bibPath,
-  }: ExtractBibliographyInput): Promise<ToolResult> {
-    const { path, display } = await resolveLatexFileOrThrow(texPath);
+  }: ExtractBibliographyInput): Effect.fn.Return<ToolResult, Error> {
+    const { path, display } = yield* resolveLatexFile(texPath);
 
-    const context = await extractBibliographyContext(path.relative);
+    const context = yield* extractBibliographyContext(path.relative);
     const bibliographyFiles = [...context.bibliographyFiles];
     const missingBibliographyFiles = [...context.missingBibliographyFiles];
     let citationKeys = [...context.citationKeys];
@@ -65,7 +64,10 @@ export class ExtractBibliographyTool extends defineTool({
 
     if (effectiveBibPath) {
       const { path: resolved } = resolveAndFormat(effectiveBibPath);
-      const exists = await WorkspaceFS.exists(resolved.relative);
+      const exists = yield* Effect.tryPromise({
+        try: () => WorkspaceFS.exists(resolved.relative),
+        catch: ensureError,
+      });
       const target = exists ? bibliographyFiles : missingBibliographyFiles;
       if (!target.includes(resolved.relative)) {
         target.push(resolved.relative);
@@ -98,7 +100,7 @@ export class ExtractBibliographyTool extends defineTool({
       return { ...result, output: `${result.output}${missingNote}` };
     }
 
-    const { entries, missingKeys } = await loadBibliographyEntries(
+    const { entries, missingKeys } = yield* loadBibliographyEntries(
       bibliographyFiles,
       citationKeys,
     );
@@ -137,5 +139,20 @@ export class ExtractBibliographyTool extends defineTool({
       instructions.length > 0 ? `\n\nNote: ${instructions.join(' ')}` : '';
 
     return executed(`${output}${notes}`, summary);
+  },
+);
+
+export class ExtractBibliographyTool extends defineTool({
+  name: 'extract_bib_entries',
+  description:
+    'Collect BibTeX records for citations referenced in a LaTeX document.',
+  schema: ExtractBibliographyInputSchema,
+}) {
+  protected execute(input: ExtractBibliographyInput): Promise<ToolResult> {
+    // The owning run's cancellation enters the bibliography reads as
+    // interruption rather than waiting them out.
+    return effectRuntime().runPromise(extractBibliography(input), {
+      signal: getCurrentToolCallContext()?.signal,
+    });
   }
 }

--- a/src/tools/latex/ExtractFiguresTool.ts
+++ b/src/tools/latex/ExtractFiguresTool.ts
@@ -1,8 +1,11 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports - tools
+import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { extractFigurePathsFromLatex } from '@latex/extractFigure';
+import { effectRuntime } from '@platform/processRuntime';
 import type { ToolResult } from '@shared/schemas';
 import { formatToolOutput } from '@tools/formatting';
 import { resolveAndFormat } from '@tools/pathResolution';
@@ -13,7 +16,7 @@ import { formatResultCount } from '@utils/text/stringUtils';
 import {
   buildLimitedAttachments,
   emptyExtractionResult,
-  resolveLatexFileOrThrow,
+  resolveLatexFile,
   texPathField,
 } from './figureExtractionShared';
 
@@ -25,51 +28,56 @@ type ExtractFiguresInput = z.infer<typeof ExtractFiguresInputSchema>;
 
 const DEFAULT_MAX_FILES = 20;
 
+const extractFigures = Effect.fn('ExtractLatexFiguresTool.execute')(function* ({
+  texPath,
+}: ExtractFiguresInput): Effect.fn.Return<ToolResult, Error> {
+  const { path, display } = yield* resolveLatexFile(texPath);
+
+  const figurePaths = yield* extractFigurePathsFromLatex(
+    pathToLocation(path.absolute),
+  );
+  const uniqueFigures = unique(figurePaths);
+
+  if (uniqueFigures.length === 0) {
+    return emptyExtractionResult('Figures', `No figures found in ${display}.`);
+  }
+
+  const { attachments, limitedPaths, limitReached } =
+    yield* buildLimitedAttachments(uniqueFigures, {
+      limit: DEFAULT_MAX_FILES,
+      describe: () => `Figure referenced by ${display}`,
+    });
+
+  const formattedList = limitedPaths.map(
+    (figurePath) => `- ${resolveAndFormat(figurePath).display}`,
+  );
+  const header = `Figures referenced in ${display}`;
+  const output = formatToolOutput(header, formattedList);
+  const summary = `Found ${formatResultCount(uniqueFigures.length, 'figure file')} in ${display}.`;
+
+  const fullOutput = limitReached
+    ? `${output}\n\nNote: Limited attachments to ${attachments.length} of ${uniqueFigures.length} files.`
+    : output;
+
+  return {
+    status: 'executed',
+    summary,
+    output: fullOutput,
+    files: attachments,
+  };
+});
+
 export class ExtractLatexFiguresTool extends defineTool({
   name: 'extract_figures',
   description:
     'Resolve and list figure assets referenced by a LaTeX document, returning attachments when available.',
   schema: ExtractFiguresInputSchema,
 }) {
-  protected async execute({
-    texPath,
-  }: ExtractFiguresInput): Promise<ToolResult> {
-    const { path, display } = await resolveLatexFileOrThrow(texPath);
-
-    const figurePaths = await extractFigurePathsFromLatex(
-      pathToLocation(path.absolute),
-    );
-    const uniqueFigures = unique(figurePaths);
-
-    if (uniqueFigures.length === 0) {
-      return emptyExtractionResult(
-        'Figures',
-        `No figures found in ${display}.`,
-      );
-    }
-
-    const { attachments, limitedPaths, limitReached } =
-      await buildLimitedAttachments(uniqueFigures, {
-        limit: DEFAULT_MAX_FILES,
-        describe: () => `Figure referenced by ${display}`,
-      });
-
-    const formattedList = limitedPaths.map(
-      (figurePath) => `- ${resolveAndFormat(figurePath).display}`,
-    );
-    const header = `Figures referenced in ${display}`;
-    const output = formatToolOutput(header, formattedList);
-    const summary = `Found ${formatResultCount(uniqueFigures.length, 'figure file')} in ${display}.`;
-
-    const fullOutput = limitReached
-      ? `${output}\n\nNote: Limited attachments to ${attachments.length} of ${uniqueFigures.length} files.`
-      : output;
-
-    return {
-      status: 'executed',
-      summary,
-      output: fullOutput,
-      files: attachments,
-    };
+  protected execute(input: ExtractFiguresInput): Promise<ToolResult> {
+    // The owning run's cancellation enters the extraction as interruption, so
+    // the bounded probe fan-out is torn down instead of running to completion.
+    return effectRuntime().runPromise(extractFigures(input), {
+      signal: getCurrentToolCallContext()?.signal,
+    });
   }
 }

--- a/src/tools/latex/ExtractTikzFiguresTool.ts
+++ b/src/tools/latex/ExtractTikzFiguresTool.ts
@@ -1,17 +1,21 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports - tools
+import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { TikzPictureManager } from '@latex/TikzPictureManager';
+import { effectRuntime } from '@platform/processRuntime';
 import { type ToolFileAttachment, type ToolResult } from '@shared/schemas';
 import { formatToolOutput } from '@tools/formatting';
 import { defineTool } from '@tools/core/define';
+import { ensureError } from '@utils/errors/errorMessage';
 import { pathToLocation } from '@utils/files/fileLocation';
 import { formatResultCount } from '@utils/text/stringUtils';
 import {
   buildLimitedAttachments,
   emptyExtractionResult,
-  resolveLatexFileOrThrow,
+  resolveLatexFile,
   texPathField,
 } from './figureExtractionShared';
 
@@ -27,20 +31,18 @@ type ExtractTikzInput = z.infer<typeof ExtractTikzInputSchema>;
 
 const DEFAULT_TIKZ_MAX_FILES = 12;
 
-export class ExtractTikzFiguresTool extends defineTool({
-  name: 'extract_tikz_figures',
-  description:
-    'Discover TikZ figures inside a LaTeX document and optionally compile them into standalone PDFs.',
-  schema: ExtractTikzInputSchema,
-}) {
-  protected async execute({
+const extractTikzFigures = Effect.fn('ExtractTikzFiguresTool.execute')(
+  function* ({
     texPath,
     compile = true,
-  }: ExtractTikzInput): Promise<ToolResult> {
-    const { path, display } = await resolveLatexFileOrThrow(texPath);
+  }: ExtractTikzInput): Effect.fn.Return<ToolResult, Error> {
+    const { path, display } = yield* resolveLatexFile(texPath);
     const location = pathToLocation(path.absolute);
 
-    const tikzFigures = await TikzPictureManager.extract(location);
+    const tikzFigures = yield* Effect.tryPromise({
+      try: () => TikzPictureManager.extract(location),
+      catch: ensureError,
+    });
     if (tikzFigures.length === 0) {
       return emptyExtractionResult(
         'TikZ figures',
@@ -62,14 +64,17 @@ export class ExtractTikzFiguresTool extends defineTool({
 
     let attachments: ToolFileAttachment[] | undefined;
     if (compile) {
-      const compiledPaths = await TikzPictureManager.compile(location);
+      const compiledPaths = yield* Effect.tryPromise({
+        try: () => TikzPictureManager.compile(location),
+        catch: ensureError,
+      });
       if (compiledPaths.length > 0) {
         // Convert FileLocation[] to string[] for legacy attachment API
         const compiledPathStrings = compiledPaths.map(
           (loc) => loc.absolutePath,
         );
         const { attachments: compiledAttachments, limitReached } =
-          await buildLimitedAttachments(compiledPathStrings, {
+          yield* buildLimitedAttachments(compiledPathStrings, {
             limit: DEFAULT_TIKZ_MAX_FILES,
             describe: () => `Standalone TikZ figure derived from ${display}`,
             mimeType: 'application/pdf',
@@ -100,5 +105,20 @@ export class ExtractTikzFiguresTool extends defineTool({
       output: outputs.join('\n'),
       files: attachments,
     };
+  },
+);
+
+export class ExtractTikzFiguresTool extends defineTool({
+  name: 'extract_tikz_figures',
+  description:
+    'Discover TikZ figures inside a LaTeX document and optionally compile them into standalone PDFs.',
+  schema: ExtractTikzInputSchema,
+}) {
+  protected execute(input: ExtractTikzInput): Promise<ToolResult> {
+    // Compiling every picture is slow, so the run's cancellation has to reach
+    // it as interruption rather than waiting the compiles out.
+    return effectRuntime().runPromise(extractTikzFigures(input), {
+      signal: getCurrentToolCallContext()?.signal,
+    });
   }
 }

--- a/src/tools/latex/figureExtractionShared.ts
+++ b/src/tools/latex/figureExtractionShared.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 import {
@@ -12,6 +13,7 @@ import {
   type WorkspacePathResolution,
 } from '@tools/pathResolution';
 import { executed } from '@tools/core/result';
+import { ensureError } from '@utils/errors/errorMessage';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
 /** Shared `texPath` Zod field for LaTeX extraction tools, with a per-tool description. */
@@ -47,34 +49,50 @@ export function emptyExtractionResult(
   return executed(formatToolOutput(label, null), summary);
 }
 
-export async function resolveLatexFileOrThrow(
+/** Attachment builds read files, so bound the fan-out. */
+const ATTACHMENT_CONCURRENCY = 8;
+
+export const resolveLatexFile = Effect.fn('tools.resolveLatexFile')(function* (
   texPath: string,
-): Promise<LatexFileResolution> {
+): Effect.fn.Return<LatexFileResolution, ToolError | Error> {
   const { path, display } = resolveAndFormat(texPath);
-  if (!(await WorkspaceFS.exists(path.relative))) {
-    throw new ToolError(`LaTeX file not found: ${display}`);
+  const exists = yield* Effect.tryPromise({
+    try: () => WorkspaceFS.exists(path.relative),
+    catch: ensureError,
+  });
+  if (!exists) {
+    return yield* Effect.fail(
+      new ToolError(`LaTeX file not found: ${display}`),
+    );
   }
 
   return { path, display };
-}
+});
 
-export async function buildLimitedAttachments(
-  paths: string[],
+export const buildLimitedAttachments = Effect.fn(
+  'tools.buildLimitedAttachments',
+)(function* (
+  paths: readonly string[],
   { limit, describe, mimeType }: AttachmentLimitOptions,
-): Promise<AttachmentLimitResult> {
+): Effect.fn.Return<AttachmentLimitResult, Error> {
   if (paths.length === 0 || limit <= 0) {
     return { attachments: [], limitedPaths: [], limitReached: false };
   }
 
   const limitedPaths = paths.slice(0, limit);
-  const attachments = await Promise.all(
-    limitedPaths.map((filePath) =>
-      buildFileAttachment({
-        filePath,
-        description: describe(filePath),
-        mimeType,
+  const attachments = yield* Effect.forEach(
+    limitedPaths,
+    (filePath) =>
+      Effect.tryPromise({
+        try: () =>
+          buildFileAttachment({
+            filePath,
+            description: describe(filePath),
+            mimeType,
+          }),
+        catch: ensureError,
       }),
-    ),
+    { concurrency: ATTACHMENT_CONCURRENCY },
   );
 
   return {
@@ -82,4 +100,4 @@ export async function buildLimitedAttachments(
     limitedPaths,
     limitReached: paths.length > limit,
   };
-}
+});

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -1,9 +1,11 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports - latex utilities
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { getTeXCount } from '@latex/texcount';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { defineTool } from '@tools/core/define';
 import { nullishWithDefault } from '@tools/core/inputSchema';
@@ -27,6 +29,37 @@ const TexcountInputSchema = z.strictObject({
 
 type TexcountInput = z.infer<typeof TexcountInputSchema>;
 
+const texcount = Effect.fn('TexcountTool.execute')(function* (
+  input: TexcountInput,
+): Effect.fn.Return<ToolResult, ToolError> {
+  const files = ensureArray(input.files)
+    .map((file) => file.trim())
+    .filter((file) => file.length > 0);
+  if (files.length === 0) {
+    return yield* Effect.fail(
+      new ToolError('No LaTeX files provided for texcount.'),
+    );
+  }
+
+  const { output, errors } = yield* getTeXCount(files, { mode: input.mode });
+
+  if (!output) {
+    return yield* Effect.fail(
+      new ToolError(
+        errors.join('\n') ||
+          'texcount did not return any output. Ensure the files exist.',
+      ),
+    );
+  }
+
+  return executed(
+    input.format === 'stats'
+      ? `TeX Count Statistics:<texcount>\n${output}\n</texcount>\n\n`
+      : output,
+    `Analyzed: ${formatResultCount(files.length, 'file')}`,
+  );
+});
+
 export class TexcountTool extends defineTool({
   name: 'texcount',
   parallelSafe: true,
@@ -34,33 +67,11 @@ export class TexcountTool extends defineTool({
     'Run texcount on one or more LaTeX files. Use mode="separate" (default) for individual files, "include" to follow \\input/\\include, or "sum" to aggregate independent sources.',
   schema: TexcountInputSchema,
 }) {
-  protected async execute(input: TexcountInput): Promise<ToolResult> {
-    const files = ensureArray(input.files)
-      .map((file) => file.trim())
-      .filter((file) => file.length > 0);
-    if (files.length === 0) {
-      throw new ToolError('No LaTeX files provided for texcount.');
-    }
-
-    // Thread the tool call's abort signal to the texcount subprocess so a
-    // cancelled parallel batch terminates it instead of waiting it out.
-    const { output, errors } = await getTeXCount(files, {
-      mode: input.mode,
+  protected execute(input: TexcountInput): Promise<ToolResult> {
+    // Cancelling a parallel batch interrupts this fiber, and the texcount
+    // subprocesses abort with it — no signal is threaded through by hand.
+    return effectRuntime().runPromise(texcount(input), {
       signal: getCurrentToolCallContext()?.signal,
     });
-
-    if (!output) {
-      throw new ToolError(
-        errors.join('\n') ||
-          'texcount did not return any output. Ensure the files exist.',
-      );
-    }
-
-    return executed(
-      input.format === 'stats'
-        ? `TeX Count Statistics:<texcount>\n${output}\n</texcount>\n\n`
-        : output,
-      `Analyzed: ${formatResultCount(files.length, 'file')}`,
-    );
   }
 }


### PR DESCRIPTION
Move src/latex/ off Promises and onto Effect programs, converting each file
together with its callers up to a boundary (migration PRD, execution rule 1:
no Promise -> Effect -> Promise sandwich).

Converted, leaf-up:

- latexParsingUtils: resolveLatexDir, existingExternalPath and
  findExistingLatexPath. The ordered search stays sequential so a hit still
  stops the walk instead of racing every candidate.
- extractFigure, extractFileDependencies, extractBibliography: the per-path
  probes become one bounded Effect.forEach fan-out, retiring p-map from
  extractFileDependencies (a failure now interrupts its siblings instead of
  leaving them running behind a settled aggregate).
- texcount: getTeXCount and getTeXCountStats. The hand-threaded AbortSignal
  is gone - Effect.tryPromise hands the thunk the signal that aborts on fiber
  interruption, so cancelling a parallel tool batch tears the subprocess down
  with no plumbing.
- latexdiff: LaTeXdiffService, DiffCommandExecutor, DiffFileProcessor,
  diffOperations and runOutputFiles. runLatexdiff loses the two tryPromise
  wrappers it kept over its now-Effect callees, and the latexdiff subprocess
  gains the same interruption path as texcount.
- overleafClone: every port returns an Effect, so the workflow's try/catch
  becomes typed recovery and a cancelled clone interrupts the token prompt
  and the git subprocess.
- LatexMediaManager: p-map retired for Effect.forEach; both platform() reads
  replaced by resolveLatexDir, which also fixes a probe that used to skip
  every \usepackage sibling when realpath failed. Best-effort per-file
  recovery now catches typed failures only, so a defect or an interrupt is no
  longer swallowed as a skipped file.

Runs moved to the boundaries: the three LaTeX tools plus TexcountTool run at
execute(), and the VS Code, desktop and CLI commands run at their own entry.

Four consumers sit below the reflection flow, which is still Promise-shaped,
and each keeps exactly one runPromise against it: MediaExtractionNode,
TeXCountNode, LatexDiffManager and tools/approval/latexPreview. They are
recorded in the Effect.run* row with the lane that deletes them (PRD R4, the
agent-runtime rewrite) rather than left unnamed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L9T2AJUiYLse4uL5ytALGh