### PR TITLE
Move run-lifecycle concurrency onto Effect primitives

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-10-execution-ownership-lane-and-lease.md
+++ b/.agents/docs/proposed/architecture/2026-09-10-execution-ownership-lane-and-lease.md
@@ -1,0 +1,176 @@
+---
+created: 2026-09-10
+status: proposed
+---
+
+# Execution ownership: the lane and the lease
+
+One execution is currently owned by three mechanisms at once. Two of them are
+durable and answer the same question with different storage; the third is
+local and is what silently makes the first two sound. The [1.0 implementation
+plan](2026-09-09-texra-1-0-implementation-plan.md) already rules that the file
+lease goes. It does not say what happens to the lane, and the lane is the half
+that carries the load-bearing invariant.
+
+This note maps the authorities, states the coupling that is currently
+unwritten, and proposes the shape ownership should take after the persistence
+cutover.
+
+## 1. The authorities today
+
+| #   | Mechanism                                                                                     | Scope                   | Keyed by                                 | Refusal                                                 | Where                                                                  |
+| --- | --------------------------------------------------------------------------------------------- | ----------------------- | ---------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 1   | Sequence-row `owner_id` claim, with liveness proof inside the write transaction               | cross-process, durable  | `AggregateId` (stream **and** execution) | `DatabaseClaimRefused`                                  | [`Database.ts`](../../../../src/controllers/session/Database.ts#L506)  |
+| 2   | Claim files `executionLeases/<id>/<token>.json`, pid liveness, lock-free token-order protocol | cross-process, durable  | `(storageRoot, executionId)`             | `ExecutionLeaseActiveError` / `ExecutionLeaseLostError` | [`executionLease.ts`](../../../../src/agent/storage/executionLease.ts) |
+| 3   | Per-execution lane: tail hand-off, `live` gate, `waiting` refusals                            | in-process, per session | `executionId`                            | `ExecutionBusy`                                         | [`executionLanes.ts`](../../../../src/agent/runtime/executionLanes.ts) |
+
+Around those three sit four more partial answers to "who owns this run right
+now": the registry's `handles` / `childActivations` maps (read as
+`hasRetainedOwner`, [`executionRegistry.ts`](../../../../src/agent/runtime/executionRegistry.ts#L275)),
+the handle's own `terminalState` / `suspension`
+([`ExecutionHandle.ts`](../../../../src/agent/runtime/ExecutionHandle.ts#L81)),
+the stream phase read as `isActiveOrResuming`, and the lease module's private
+`maintenanceExecutions` ALS set plus `unleasedWriteQueues`.
+
+This is PRD problem P13 — "status, settlement, and ownership are arbitrated,
+not owned" — in its most concentrated form.
+
+## 2. Findings
+
+### F1. The two durable mechanisms decide the same fact from the same evidence
+
+Both prove ownership with the _same_ primitive,
+[`proveOwnerLiveness`](../../../../src/agent/storage/leaseOwnerLiveness.ts):
+the lease reads it from a JSON file's `owner` field, the database reads it from
+a parsed `owner_id` column, inside the transaction. Neither adds information
+the other lacks. Fresh launch claims the aggregate by its first append ("first
+append claims the aggregate; later appends require that same claim",
+`Database.ts:196`); resume acquires explicitly with a liveness recheck. The
+lease repeats that decision in a second store with its own 653-line protocol
+(token ordering, `MAX_CLAIM_ROUNDS`, ABA avoidance, two reap policies).
+
+### F2. The lease's one remaining unique job is fencing files that are not in the database
+
+`runWithExecutionLeaseWriteFence` guards exactly one thing:
+[`ExecutionKVStore`](../../../../src/agent/storage/ExecutionKVStore.ts#L133)
+writes, which are `StorageFS` files under `executions/{executionId}/{key}.json`
+— the flow record, checkpoint, and turn state. That is why the lease cannot be
+deleted before the KV/checkpoint cutover, and why it _can_ be deleted with it:
+once those writes are transactions, the transaction's own claim check is the
+fence.
+
+### F3. The lease is generation-blind, and the lane is what makes it sound
+
+`ownedLeases` is a process-global `Map` keyed by `(storageRoot, executionId)`
+with no generation identity. `assertOwnedExecutionLease` says so outright:
+
+> Generations of one execution are serialized by the registry's per-execution
+> lane, so the owned record for an id is always the generation doing the
+> asking; no async-context capture is needed to tell generations apart.
+
+So the correctness of every in-run fence — `executeAgent.ts:410`,
+`childRunLoop.ts:838`, `childRunLoop.ts:914` — rests on an invariant owned by a
+different module, enforced by nothing, and checked by no type. If the lane ever
+admits two generations of one id concurrently, `ownsExecutionLease` answers for
+the wrong one and the fence passes silently. A regression of exactly this kind
+was introduced and caught by inspection, not by tests, while converting the
+lane to Effect primitives (a `holdLive` gate that opened on the shorter of two
+overlapping generations).
+
+The process-global map also contradicts the repo's own #7694 invariant. It is
+reached through ALS: nine call sites wrap a lease call in `runInSession` for no
+purpose other than telling it which storage root it is on.
+
+### F4. `holdLive` and `handle.suspend(teardown)` both compensate for a scope that ends before its generation does
+
+A run parked at WAITING returns from `runFlowWithLifecycle`, so the
+generation's scope closes — but the generation is not over: a later stop still
+has to run its teardown. The code recovers by stashing the teardown as an
+`Effect` field on the handle
+([`AgentRunLifecycle.ts:749`](../../../../src/agent/runtime/AgentRunLifecycle.ts#L749))
+and, when a stop finally runs it, re-opening a second gate on the lane through
+`holdLive` — whose only caller is
+[`waitingTermination.ts:104`](../../../../src/agent/runtime/waitingTermination.ts#L104).
+
+Everything expensive in the lane exists to serve that second gate: the `live`
+set, its ordering rules, and the "which generation may clear it" question that
+produced the regression above. Under structured concurrency a run parked at
+WAITING is a fiber suspended inside its scope, not a closed scope plus a
+detached teardown, and none of that machinery is needed.
+
+### F5. Admission is asked of queue occupancy, not of ownership
+
+`withInactiveStep` refuses when `hasRetainedOwner() || live.size > 0 ||
+fibers > 0`. Two of those three are properties of the queue's implementation,
+not facts about who owns the execution — which is why the predicate had to
+peek at `PQueue.size`/`pending` before, and at a fiber counter now. Admission
+policy and scheduling mechanism are fused in one object.
+
+## 3. What is already ruled, and what is not
+
+The 1.0 plan's retirement boundary already covers the lease:
+
+> File-based `executionLease` — replace ownership admission and write checks
+> with database transactions; delete lease files, polling, legacy readers, and
+> compatibility writes together.
+
+and its step B retires it together with the flow, checkpoint and KV
+dependencies. `leaseOwnerLiveness.ts` stays; `Database.ts` already uses it.
+
+Not covered anywhere: the lane, the three in-run `assertOwnedExecutionLease`
+fences that have no stated database successor, and F3's unwritten dependency.
+
+## 4. Proposed direction
+
+**D1 — one durable authority.** The sequence-row claim is it. Delete the lease
+with the KV cutover, per the 1.0 plan. Nothing new is designed here; the point
+is that the claim must also absorb the three in-run fences, either by an
+explicit "still mine" read or by the fact that every write becomes a
+transaction that checks the claim itself. Name which, in the cutover PR.
+
+**D2 — the lane stops being an ownership mechanism.** Split its two jobs:
+
+- _Admission_ ("may this generation start?") is one predicate over ownership —
+  the claim, plus the registry's live handles. It belongs beside the registry
+  that already answers `isActiveOrResuming`, and it must not read scheduling
+  counters.
+- _Ordering_ ("start after the previous generation has fully unwound") is one
+  permit per execution id, held for the generation's scope. `Effect.Semaphore`
+  with a scoped permit expresses it whole.
+
+**D3 — the generation's scope is the generation's lifetime.** Keep a run parked
+at WAITING inside its scope instead of returning and stashing a teardown. Then
+`holdLive`, the `live` set, and `AgentExecutionHandle.suspend`/
+`beginSuspendedTermination` all go, and a stop is an interrupt of a fiber
+rather than an invocation of a detached teardown that has to re-acquire a gate.
+This is the only item here with real design risk: parking a fiber across a
+process restart is not the same as parking a Promise, and the resume path
+(`resumeQueuedToolUse`) has to be re-read against it.
+
+**D4 — make the remaining ownership token generation-scoped.** Whatever
+survives D1–D3, the fix for F3 is that a run holds its ownership as a value in
+its own scope, not as an entry looked up by id in a process-global map. That
+removes the unwritten dependency rather than documenting it, and drops the nine
+ALS wrappers with it.
+
+## 5. What this deletes
+
+`executionLease.ts` (653 lines) and its claim protocol; `executionLanes.ts`'s
+`live` gate, `waiting` refusals and `holdLive`; `AgentExecutionHandle.suspend`
+/ `suspendedTerminationStarted` / `beginSuspendedTermination`; the lease's
+`maintenanceExecutions` ALS and `unleasedWriteQueues`; nine `runInSession`
+wrappers; and `SessionHandle.releaseExecutionLease`'s four-way failure
+aggregation, which exists because four independent things have to be released
+in order.
+
+## 6. For the owner to rule
+
+1. Does D3 (WAITING stays inside the generation's scope) belong in the 1.0
+   cutover, or after it? It is the item that makes D2 cheap, and the item most
+   likely to move the resume contract.
+2. Should admission keep refusing (`ExecutionBusy`) where it refuses today, or
+   should the queueing and refusing paths converge now that both would read
+   the same claim?
+3. F3 is a latent-correctness issue on today's code, not only after the
+   cutover. Worth a targeted regression test at the lane boundary before any
+   of this lands?

--- a/.agents/docs/proposed/architecture/2026-09-10-execution-ownership-lane-and-lease.md
+++ b/.agents/docs/proposed/architecture/2026-09-10-execution-ownership-lane-and-lease.md
@@ -13,7 +13,8 @@ lease goes. It does not say what happens to the lane, and the lane is the half
 that carries the load-bearing invariant.
 
 This note maps the authorities, states the coupling that is currently
-unwritten, and proposes the shape ownership should take after the persistence
+unwritten, asks which of the three survive contact with Effect's own
+primitives, and proposes the shape ownership should take after the persistence
 cutover.
 
 ## 1. The authorities today
@@ -120,7 +121,41 @@ dependencies. `leaseOwnerLiveness.ts` stays; `Database.ts` already uses it.
 Not covered anywhere: the lane, the three in-run `assertOwnedExecutionLease`
 fences that have no stated database successor, and F3's unwritten dependency.
 
-## 4. Proposed direction
+## 4. What Effect subsumes, and what it cannot
+
+Effect's primitives are all single-runtime: `Scope` for lifetime, fibers and
+interruption for cancellation, `Semaphore`/`Deferred`/`Queue` for coordination.
+That line runs straight through this subject, and it decides which of the three
+mechanisms survive.
+
+| Concern                                   | Still needed          | Why                                                                                                                                                                                                                 |
+| ----------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In-process ordering per execution id      | Yes, as one primitive | Generations arrive from independent callers — a host stop, a resume command, a delete. They are not nested fibers, so scope structure alone does not order them.                                                    |
+| `ExecutionLanes` as a class               | No                    | It is a second implementation of [`withPerKeyLane`](../../../../src/utils/core/perKeyQueue.ts#L108), plus a gate that exists only because a scope closes early, plus a hand-rolled interrupt.                       |
+| The `live` gate and `holdLive`            | No                    | Artifacts of F4: the WAITING branch returns from its scope while its generation continues.                                                                                                                          |
+| `disposeAll(error)` refusing queued steps | No                    | Scope interruption. Lanes held in the session's `Scope` interrupt their parked fibers when the session closes; the `waiting` set of refusal `Deferred`s is that written by hand.                                    |
+| Cross-process execution ownership         | Yes                   | Two TeXRA processes can open one workspace, and `proveOwnerLiveness` contemplates another _host_ sharing the storage directory (`unprovable`, hostname compare). No Effect primitive crosses a process boundary.    |
+| The file-lease protocol                   | No                    | Not because of Effect — because SQLite already carries the same fact with the same liveness proof, transactionally.                                                                                                 |
+| The release choreography                  | No                    | `SessionHandle.releaseExecutionLease` aggregates four independent releases by hand because four things were acquired without a scope. `Effect.acquireRelease` unwinds them in order and aggregates causes for free. |
+
+So Effect answers "is the lane needed" with: the _coordination_ is, the
+_object_ is not, and most of its surface area is compensation that disappears
+once the generation's scope matches the generation's lifetime. It answers "is
+the lease needed" with: not as a mechanism, but its removal is the database's
+work, not Effect's.
+
+Three things Effect does not touch, and that stay whatever the runtime is:
+durability, crash recovery, and the liveness verdict itself — including
+`unprovable`, which is a deliberate refusal to guess about another machine. Nor
+does it help the case the 1.0 plan already flags: a process dying mid-external
+side effect cannot be made exactly-once by a transaction.
+
+One honest limit on D3 below. Keeping a run parked at WAITING inside its own
+scope removes the _in-process_ compensation only. A process that exits while a
+run is parked takes its fibers with it; resume-after-exit still reads the
+durable record, exactly as it does today.
+
+## 5. Proposed direction
 
 **D1 — one durable authority.** The sequence-row claim is it. Delete the lease
 with the KV cutover, per the 1.0 plan. Nothing new is designed here; the point
@@ -153,7 +188,7 @@ its own scope, not as an entry looked up by id in a process-global map. That
 removes the unwritten dependency rather than documenting it, and drops the nine
 ALS wrappers with it.
 
-## 5. What this deletes
+## 6. What this deletes
 
 `executionLease.ts` (653 lines) and its claim protocol; `executionLanes.ts`'s
 `live` gate, `waiting` refusals and `holdLive`; `AgentExecutionHandle.suspend`
@@ -163,7 +198,7 @@ wrappers; and `SessionHandle.releaseExecutionLease`'s four-way failure
 aggregation, which exists because four independent things have to be released
 in order.
 
-## 6. For the owner to rule
+## 7. For the owner to rule
 
 1. Does D3 (WAITING stays inside the generation's scope) belong in the 1.0
    cutover, or after it? It is the item that makes D2 cheap, and the item most

--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -82,7 +82,6 @@
       "packages/desktop/src/main/index.ts": 1,
       "packages/extension/src/extension.ts": 1,
       "src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts": 1,
-      "src/agent/runtime/executionLanes.ts": 1,
       "src/agent/runtime/streamApprovalQueue.ts": 1,
       "src/agent/storage/executionLease.ts": 1,
       "src/agent/workflowScript/persistence.ts": 1,
@@ -103,10 +102,8 @@
     "import:p-defer": {
       "packages/cli/src/chat/chatSessionController.ts": 1,
       "src/agent/followUp/FollowUpQueue.ts": 1,
-      "src/agent/runtime/ExecutionHandle.ts": 1,
       "src/agent/runtime/ModelRetryGate.ts": 1,
       "src/agent/runtime/SessionHandle.ts": 1,
-      "src/agent/runtime/executionLanes.ts": 1,
       "src/agent/storage/executionLease.ts": 1
     },
     "import:async-mutex": {
@@ -117,7 +114,7 @@
       "src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts": 2,
       "src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts": 1,
       "src/agent/implementations/flows/reflection/output/LatexDiffManager.ts": 2,
-      "src/agent/runtime/SessionHandle.ts": 3,
+      "src/agent/runtime/SessionHandle.ts": 2,
       "src/controllers/session/SessionBridge.ts": 6,
       "src/controllers/session/sessionLayer.ts": 3,
       "src/platform/defaults/jsonStore.ts": 1,

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -638,9 +638,11 @@ HARNESS_DISPOSERS.push(bindSessionView(session().view));
     const key = ids.join('\0');
     if (key === subscribed) return;
     subscribed = key;
-    session().setTranscriptSubscriptions(
-      'tui-harness',
-      ids.map((id) => ({ id, fromSeq: 0 })),
+    effectRuntime().runFork(
+      session().setTranscriptSubscriptions(
+        'tui-harness',
+        ids.map((id) => ({ id, fromSeq: 0 })),
+      ),
     );
   };
   HARNESS_DISPOSERS.push(

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -338,9 +338,11 @@ export async function runChat(
     const key = ids.join('\0');
     if (key === subscribedStreams) return;
     subscribedStreams = key;
-    runtimeSession.setTranscriptSubscriptions(
-      'tui',
-      ids.map((id) => ({ id, fromSeq: 0 })),
+    effectRuntime().runFork(
+      runtimeSession.setTranscriptSubscriptions(
+        'tui',
+        ids.map((id) => ({ id, fromSeq: 0 })),
+      ),
     );
   };
   disposables.add(

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -496,9 +496,11 @@ export function attachWorkflowPlainOutput(
     const key = workflows.map((stream) => stream.id).join('\0');
     if (key !== subscribed) {
       subscribed = key;
-      session.setTranscriptSubscriptions(
-        'workflow-plain-output',
-        workflows.map((stream) => ({ id: stream.id, fromSeq: 0 })),
+      effectRuntime().runFork(
+        session.setTranscriptSubscriptions(
+          'workflow-plain-output',
+          workflows.map((stream) => ({ id: stream.id, fromSeq: 0 })),
+        ),
       );
     }
     for (const stream of workflows) printStream(stream);
@@ -506,6 +508,8 @@ export function attachWorkflowPlainOutput(
   return () => {
     detach();
     previous.clear();
-    session.setTranscriptSubscriptions('workflow-plain-output', []);
+    effectRuntime().runFork(
+      session.setTranscriptSubscriptions('workflow-plain-output', []),
+    );
   };
 }

--- a/packages/desktop/src/main/desktopProjects.ts
+++ b/packages/desktop/src/main/desktopProjects.ts
@@ -173,7 +173,7 @@ async function stopProjectExecutions(session: SessionHandle): Promise<void> {
     for (;;) {
       const active = executions.getActiveIds();
       if (active.length === 0) return;
-      await executions.waitForAnyChange(active);
+      await effectRuntime().runPromise(executions.waitForAnyChange(active));
     }
   });
 }

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -526,7 +526,8 @@ export const runFlowWithLifecycle = Effect.fn('runFlowWithLifecycle')(
     if (options?.onRun) {
       const onRun = options.onRun;
       // Start observation at the same time as invocation. The callback may
-      // await handle.result, so its observer must not hold up the flow.
+      // run handle.result to completion, so its observer must not hold up
+      // the flow that settles it.
       yield* Effect.tryPromise({
         try: async () => onRun(handle),
         catch: ensureError,

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -6,7 +6,7 @@
  * Termination policy lives with the owning registry.
  */
 
-import pDefer from 'p-defer';
+import { Deferred, Effect } from 'effect';
 
 import type { AgentTrace, ResultEvent } from '@agent/trace';
 import type { ToolUseFlowContext } from '@agent/implementations/flows/tooluse/runToolUseFlow';
@@ -18,7 +18,6 @@ import type {
   StreamTabId,
 } from '@shared/schemas';
 import { runIdentityName } from '@shared/schemas';
-import type { Effect } from 'effect';
 
 export interface ExecutionStatusInfo {
   status: StreamPhase | 'unknown';
@@ -146,12 +145,16 @@ export class AgentExecutionHandle<
   /**
    * The run's terminal outcome, settled exactly once (by the run lifecycle, or
    * by `finalizeChildStream` for non-lifecycle child streams) BEFORE the
-   * execution is untracked. Always resolves — never rejects — so a consumer-less
-   * failed run cannot produce an unhandled rejection. SDK consumers awaiting a
-   * specific run's outcome use this; the host-wide stream is `session.onResult`.
+   * execution is untracked. It always succeeds — it has no error channel — so
+   * a failed run reports through the `ResultEvent`'s own outcome rather than
+   * through a rejection nobody is required to observe, and a consumer that
+   * never awaits it costs nothing. Awaiting it is a fiber parked on the
+   * `Deferred`, so an interrupted consumer detaches with its fiber. SDK
+   * consumers awaiting a specific run's outcome use this; the host-wide
+   * stream is `session.onResult`.
    */
-  private readonly _deferred = pDefer<ResultEvent>();
-  readonly result = this._deferred.promise;
+  private readonly _terminal = Deferred.makeUnsafe<ResultEvent>();
+  readonly result: Effect.Effect<ResultEvent> = Deferred.await(this._terminal);
   private terminalState: TerminalState = 'open';
 
   constructor(
@@ -193,7 +196,7 @@ export class AgentExecutionHandle<
   /** Settle {@link result} with the terminal outcome (idempotent). */
   settleResult(event: ResultEvent): void {
     this.terminalState = 'settled';
-    this._deferred.resolve(event);
+    Deferred.doneUnsafe(this._terminal, Effect.succeed(event));
   }
 
   /**

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -192,8 +192,8 @@ export class SessionHandle {
    * transcript tier the view folds for that port, the view's set being the
    * union over every port. An Effect-native reader (the SDK's run drain,
    * the session bridge's ports) sets its own port here;
-   * {@link setTranscriptSubscriptions} is the same write for the callers
-   * that still speak Promises.
+   * {@link setTranscriptSubscriptions} is the same write with this session's
+   * qualification and disposal guard applied.
    */
   readonly subscriptions: SessionGraph['subscriptions'];
   /** Session-scoped status plane. */
@@ -759,20 +759,25 @@ export class SessionHandle {
    * logical stream ids whose transcript tier the view folds for that port.
    * Qualify them once when entering the event graph. An empty
    * set removes the port; the view's set is the union over every port.
+   *
+   * The write is returned, not run: the session owns no fiber for a set a
+   * surface asks for, so the host entry that asks runs it on its own runtime
+   * and a session disposed before it starts writes nothing.
    */
   setTranscriptSubscriptions(
     port: string,
     set: readonly (Omit<TranscriptSubscription, 'id'> & { id: StreamTabId })[],
-  ): void {
-    if (this.disposed) return;
-    effectRuntime().runFork(
-      this.subscriptions.set(
-        port,
-        set.map(({ id, fromSeq }) => ({
-          id: qualifyAggregateId('stream', id),
-          fromSeq,
-        })),
-      ),
+  ): Effect.Effect<void> {
+    return Effect.suspend(() =>
+      this.disposed
+        ? Effect.void
+        : this.subscriptions.set(
+            port,
+            set.map(({ id, fromSeq }) => ({
+              id: qualifyAggregateId('stream', id),
+              fromSeq,
+            })),
+          ),
     );
   }
 

--- a/src/agent/runtime/executionLanes.ts
+++ b/src/agent/runtime/executionLanes.ts
@@ -4,13 +4,19 @@
  * Owns the per-execution serial lanes that `ExecutionRegistry` runs lifecycle
  * steps through, so launch, resume, and delete of one execution id never
  * overlap while unrelated executions proceed in parallel.
+ *
+ * A lane is a `Deferred` hand-off chain, not a queue: each entrant swaps its
+ * own `Deferred` in as the lane's tail synchronously when its effect starts,
+ * waits for its predecessor's, and completes its own in `ensuring`. That gives
+ * FIFO admission for free and makes the whole wait interruptible — a caller
+ * whose fiber is interrupted while queued hands its successor the wait for
+ * whoever actually holds the lane, instead of leaving a task behind in a
+ * queue nobody can reach. It is the same shape as `withPerKeyLane`
+ * (`@utils/core/perKeyQueue`), with the two facts this scheduler adds on top:
+ * the generation gate (`live`) and refusal at session disposal.
  */
 
-import { Data, Effect } from 'effect';
-import pDefer from 'p-defer';
-import PQueue from 'p-queue';
-
-import { ensureError } from '@utils/errors/errorMessage';
+import { Data, Deferred, Effect } from 'effect';
 
 /** A local generation or its retained handle still owns the execution. */
 export class ExecutionBusy extends Data.TaggedError('ExecutionBusy')<{
@@ -19,30 +25,36 @@ export class ExecutionBusy extends Data.TaggedError('ExecutionBusy')<{
 
 /**
  * The serial lifecycle lane of one execution id. Launch, resume, delete and
- * any other lifecycle step run through `queue` one at a time, and each step
- * first waits for `live`, the generation the last launch started, to dispose.
- * Generations of one execution therefore never coexist: a resume cannot mint
- * a lease while the previous run still holds one, and a delete cannot run
- * under a live run. Stop is a signal to the live generation, not a step.
+ * any other lifecycle step run through the `tail` chain one at a time, and
+ * each step first waits for every generation in `live` — the ones the last
+ * launches started — to dispose. Generations of one execution therefore never
+ * coexist: a resume cannot mint a lease while the previous run still holds
+ * one, and a delete cannot run under a live run. Stop is a signal to the live
+ * generation, not a step.
  */
 interface ExecutionLane {
-  readonly queue: PQueue;
-  live: Promise<void> | undefined;
-  /** Steps admitted but not yet started; rejected if the session disposes. */
-  readonly waiting: Set<(error: Error) => void>;
-}
-
-/** Resolve when `promise` settles either way; a lane waits, it never fails. */
-function settled(promise: Promise<unknown>): Promise<void> {
-  return promise.then(
-    () => undefined,
-    () => undefined,
-  );
+  /**
+   * What the next entrant waits for: the `Deferred` the most recent one
+   * completes as it leaves. `undefined` on a lane no step has claimed yet.
+   */
+  tail: Deferred.Deferred<void> | undefined;
+  /** Fibers holding or waiting on the lane; at zero the lane can be forgotten. */
+  fibers: number;
+  /**
+   * The completion of every generation still unwinding — held as a set rather
+   * than one chained value because they end in no fixed order: a turn's
+   * teardown routinely ends while the child loop that outlives it is still
+   * live, and clearing the gate on the shorter one would let a resume claim
+   * the execution under the loop still holding it.
+   */
+  readonly live: Set<Deferred.Deferred<void>>;
+  /** Steps admitted but not yet started; failed if the session disposes. */
+  readonly waiting: Set<Deferred.Deferred<never, Error>>;
 }
 
 /**
  * The per-execution lanes of one session's registry. A lane is created on
- * first use and forgotten once it drains, so idle executions hold no queue.
+ * first use and forgotten once it drains, so idle executions hold no lane.
  */
 export class ExecutionLanes {
   private readonly lanes = new Map<string, ExecutionLane>();
@@ -53,36 +65,18 @@ export class ExecutionLanes {
     hasRetainedOwner: () => boolean,
     operation: Effect.Effect<A, E, R>,
   ): Effect.Effect<A, E | Error, R> {
-    return Effect.scoped(
-      Effect.gen({ self: this }, function* () {
-        const held = yield* Effect.acquireRelease(
-          Effect.sync(() => pDefer<void>()),
-          (held) => Effect.sync(() => held.resolve()),
-        );
-        yield* Effect.tryPromise({
-          try: () => {
-            // The ownership check and enqueue are synchronous. A launch either
-            // owns the slot already or queues after this operation's hold.
-            const lane = this.lanes.get(executionId);
-            if (
-              hasRetainedOwner() ||
-              (lane !== undefined &&
-                (lane.live !== undefined ||
-                  lane.queue.size > 0 ||
-                  lane.queue.pending > 0))
-            ) {
-              throw new ExecutionBusy({ executionId });
-            }
-            return this.enqueueLaneStep(executionId, () => ({
-              result: Promise.resolve(),
-              hold: held.promise,
-            }));
-          },
-          catch: ensureError,
-        });
-        return yield* operation;
-      }),
-    );
+    return Effect.suspend(() => {
+      // The ownership check and the claim are one synchronous step. A launch
+      // either owns the slot already or queues behind this operation's hold.
+      const lane = this.lanes.get(executionId);
+      if (
+        hasRetainedOwner() ||
+        (lane !== undefined && (lane.live.size > 0 || lane.fibers > 0))
+      ) {
+        return Effect.fail(new ExecutionBusy({ executionId }));
+      }
+      return this.onLane(executionId, operation);
+    });
   }
 
   /** Hold a generation's lane until its Effect and finalizers settle. */
@@ -90,49 +84,34 @@ export class ExecutionLanes {
     executionId: string,
     operation: Effect.Effect<A, E, R>,
   ): Effect.Effect<A, E | Error, R> {
-    return Effect.scoped(
-      Effect.gen({ self: this }, function* () {
-        const held = yield* Effect.acquireRelease(
-          Effect.sync(() => pDefer<void>()),
-          (held) => Effect.sync(() => held.resolve()),
-        );
-        yield* Effect.tryPromise({
-          try: () =>
-            this.enqueueLaneStep(executionId, () => ({
-              result: Promise.resolve(),
-              hold: held.promise,
-            })),
-          catch: ensureError,
-        });
-        return yield* operation;
-      }),
-    );
+    return this.onLane(executionId, operation);
   }
 
   /**
-   * Chain `termination` onto the lane's live generation.
+   * Add `termination` to the lane's live generations.
    *
    * The teardown releases the execution lease: it is the tail of the
    * suspended generation, so the lane waits for it before a resume can
    * claim the execution again.
-   * A child loop's generation stays the lane's live promise until the loop
-   * ends; the turn's teardown chains onto it rather than replacing it.
+   * A child loop's generation stays in the gate until the loop ends; a
+   * turn's teardown joins it rather than replacing it, and the gate opens
+   * only once every one of them has unwound.
    */
   holdLive(
     executionId: string,
     termination: Effect.Effect<void>,
   ): Effect.Effect<void> {
-    const completion = pDefer<void>();
+    const completion = Deferred.makeUnsafe<void>();
     const lane = this.laneFor(executionId);
-    const previous = lane.live;
-    lane.live = settled(
-      previous
-        ? Promise.all([previous, completion.promise])
-        : completion.promise,
-    );
-    this.forgetIdleLane(executionId, lane);
+    lane.live.add(completion);
     return termination.pipe(
-      Effect.ensuring(Effect.sync(() => completion.resolve())),
+      Effect.ensuring(
+        Effect.sync(() => {
+          Deferred.doneUnsafe(completion, Effect.void);
+          lane.live.delete(completion);
+          this.forgetIdleLane(executionId, lane);
+        }),
+      ),
       Effect.uninterruptible,
     );
   }
@@ -140,47 +119,98 @@ export class ExecutionLanes {
   /** Refuse every admitted-but-unstarted step and drop all lanes. */
   disposeAll(error: Error): void {
     for (const lane of this.lanes.values()) {
-      lane.queue.clear();
-      for (const reject of lane.waiting) reject(error);
+      for (const refusal of lane.waiting) {
+        Deferred.doneUnsafe(refusal, Effect.fail(error));
+      }
       lane.waiting.clear();
     }
     this.lanes.clear();
   }
 
-  private enqueueLaneStep<T>(
+  /**
+   * Run `operation` on `executionId`'s lane: claim the lane synchronously,
+   * wait for the predecessor and for the live generation, then hold the lane
+   * until `operation` and the finalizers it registered settle — which is why
+   * the hold is released by the scope rather than by `operation` returning.
+   */
+  private onLane<A, E, R>(
     executionId: string,
-    step: (lane: ExecutionLane) => {
-      readonly result: Promise<T>;
-      /** What the lane stays held for; `undefined` releases it at once. */
-      readonly hold: Promise<unknown> | undefined;
-    },
-  ): Promise<T> {
+    operation: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E | Error, R> {
+    return Effect.scoped(
+      Effect.gen({ self: this }, function* () {
+        const admitted = yield* Effect.acquireRelease(
+          Effect.sync(() => this.claim(executionId)),
+          (claim) => Effect.sync(claim.release),
+        );
+        yield* admitted.entry;
+        return yield* operation;
+      }),
+    );
+  }
+
+  /**
+   * Take this fiber's place in `executionId`'s lane. The swap is synchronous
+   * so that admission order is call order; `entry` is what the caller waits
+   * on, and `release` hands the lane to the successor however the caller
+   * left — returned, failed, or interrupted mid-wait.
+   */
+  private claim(executionId: string): {
+    readonly entry: Effect.Effect<void, Error>;
+    readonly release: () => void;
+  } {
+    const mine = Deferred.makeUnsafe<void>();
+    const refusal = Deferred.makeUnsafe<never, Error>();
     const lane = this.laneFor(executionId);
-    const handedOut = pDefer<Promise<T>>();
-    const settle: (result: Promise<T>) => void = handedOut.resolve;
-    const { reject: refuse } = handedOut;
-    lane.waiting.add(refuse);
-    void lane.queue
-      .add(async () => {
-        await lane.live;
-        // A disposal during the wait already refused this step.
-        if (!lane.waiting.delete(refuse)) return;
-        // The caller receives step failures through result; the queue only
-        // waits for settlement and remains available to later steps.
-        const run = Promise.resolve().then(() => step(lane));
-        settle(run.then(({ result }) => result));
-        await settled(run.then(({ hold }) => hold));
-      })
-      .finally(() => this.forgetIdleLane(executionId, lane));
-    return handedOut.promise.then((result) => result);
+    const previous = lane.tail;
+    lane.tail = mine;
+    lane.fibers += 1;
+    lane.waiting.add(refusal);
+    let entered = previous === undefined;
+
+    const entry = Effect.raceFirst(
+      Deferred.await(refusal),
+      Effect.gen(function* () {
+        if (previous !== undefined) {
+          yield* Deferred.await(previous);
+          entered = true;
+        }
+        // Read the gate after the predecessor left: a generation it started
+        // is exactly what this step must not overlap. One snapshot, as the
+        // predecessor's own wait took one — a generation opened after this
+        // read belongs to the step that opened it, not to this one.
+        yield* Effect.all(
+          [...lane.live].map((generation) => Deferred.await(generation)),
+          { concurrency: 'unbounded', discard: true },
+        );
+      }),
+    ).pipe(Effect.tap(() => Effect.sync(() => lane.waiting.delete(refusal))));
+
+    return {
+      entry,
+      release: () => {
+        // A fiber that never entered still owes its successor the wait it was
+        // itself doing, so the successor waits for whoever holds the lane.
+        Deferred.doneUnsafe(
+          mine,
+          entered || previous === undefined
+            ? Effect.void
+            : Deferred.await(previous),
+        );
+        lane.waiting.delete(refusal);
+        lane.fibers -= 1;
+        this.forgetIdleLane(executionId, lane);
+      },
+    };
   }
 
   private laneFor(executionId: string): ExecutionLane {
     let lane = this.lanes.get(executionId);
     if (!lane) {
       lane = {
-        queue: new PQueue({ concurrency: 1 }),
-        live: undefined,
+        tail: undefined,
+        fibers: 0,
+        live: new Set(),
         waiting: new Set(),
       };
       this.lanes.set(executionId, lane);
@@ -189,17 +219,8 @@ export class ExecutionLanes {
   }
 
   private forgetIdleLane(executionId: string, lane: ExecutionLane): void {
-    if (lane.queue.size !== 0 || lane.queue.pending !== 0) return;
+    if (lane.fibers !== 0 || lane.live.size !== 0) return;
     if (this.lanes.get(executionId) !== lane) return;
-    const live = lane.live;
-    if (live === undefined) {
-      this.lanes.delete(executionId);
-      return;
-    }
-    void live.then(() => {
-      if (lane.live !== live) return;
-      lane.live = undefined;
-      this.forgetIdleLane(executionId, lane);
-    });
+    this.lanes.delete(executionId);
   }
 }

--- a/src/agent/runtime/executionLanes.ts
+++ b/src/agent/runtime/executionLanes.ts
@@ -7,13 +7,14 @@
  *
  * A lane is a `Deferred` hand-off chain, not a queue: each entrant swaps its
  * own `Deferred` in as the lane's tail synchronously when its effect starts,
- * waits for its predecessor's, and completes its own in `ensuring`. That gives
- * FIFO admission for free and makes the whole wait interruptible — a caller
- * whose fiber is interrupted while queued hands its successor the wait for
- * whoever actually holds the lane, instead of leaving a task behind in a
- * queue nobody can reach. It is the same shape as `withPerKeyLane`
- * (`@utils/core/perKeyQueue`), with the two facts this scheduler adds on top:
- * the generation gate (`live`) and refusal at session disposal.
+ * waits for its predecessor's, and completes its own in its release
+ * finalizer. That gives FIFO admission for free and makes the whole wait
+ * interruptible — a caller whose fiber is interrupted while queued hands its
+ * successor the wait for whoever actually holds the lane, instead of leaving a
+ * task behind in a queue nobody can reach. It is the same shape as
+ * `withPerKeyLane` (`@utils/core/perKeyQueue`), with the two facts this
+ * scheduler adds on top: the generation gate (`live`) and refusal at session
+ * disposal.
  */
 
 import { Data, Deferred, Effect } from 'effect';
@@ -65,18 +66,7 @@ export class ExecutionLanes {
     hasRetainedOwner: () => boolean,
     operation: Effect.Effect<A, E, R>,
   ): Effect.Effect<A, E | Error, R> {
-    return Effect.suspend(() => {
-      // The ownership check and the claim are one synchronous step. A launch
-      // either owns the slot already or queues behind this operation's hold.
-      const lane = this.lanes.get(executionId);
-      if (
-        hasRetainedOwner() ||
-        (lane !== undefined && (lane.live.size > 0 || lane.fibers > 0))
-      ) {
-        return Effect.fail(new ExecutionBusy({ executionId }));
-      }
-      return this.onLane(executionId, operation);
-    });
+    return this.onLane(executionId, operation, hasRetainedOwner);
   }
 
   /** Hold a generation's lane until its Effect and finalizers settle. */
@@ -132,17 +122,27 @@ export class ExecutionLanes {
    * wait for the predecessor and for the live generation, then hold the lane
    * until `operation` and the finalizers it registered settle — which is why
    * the hold is released by the scope rather than by `operation` returning.
+   *
+   * `refuseWhenOwned` makes the claim conditional: `claim` reports the refusal
+   * instead of taking a place, so nothing was acquired and nothing is released.
    */
   private onLane<A, E, R>(
     executionId: string,
     operation: Effect.Effect<A, E, R>,
+    refuseWhenOwned?: () => boolean,
   ): Effect.Effect<A, E | Error, R> {
     return Effect.scoped(
       Effect.gen({ self: this }, function* () {
         const admitted = yield* Effect.acquireRelease(
-          Effect.sync(() => this.claim(executionId)),
-          (claim) => Effect.sync(claim.release),
+          Effect.sync(() => this.claim(executionId, refuseWhenOwned)),
+          (claim) =>
+            Effect.sync(() => {
+              if (!(claim instanceof ExecutionBusy)) claim.release();
+            }),
         );
+        if (admitted instanceof ExecutionBusy) {
+          return yield* Effect.fail(admitted);
+        }
         yield* admitted.entry;
         return yield* operation;
       }),
@@ -154,11 +154,32 @@ export class ExecutionLanes {
    * so that admission order is call order; `entry` is what the caller waits
    * on, and `release` hands the lane to the successor however the caller
    * left — returned, failed, or interrupted mid-wait.
+   *
+   * A caller that passes `refuseWhenOwned` refuses competing local ownership
+   * rather than queueing behind it: the ownership check reads the lane in the
+   * same synchronous step as the tail swap below, so no launch can claim the
+   * lane between the two. Refusing leaves the lane exactly as it was found —
+   * no entry, no tail link, no `fibers` count, not even a lane on an execution
+   * that had none — since it returns before any of them is touched.
    */
-  private claim(executionId: string): {
-    readonly entry: Effect.Effect<void, Error>;
-    readonly release: () => void;
-  } {
+  private claim(
+    executionId: string,
+    refuseWhenOwned: (() => boolean) | undefined,
+  ):
+    | ExecutionBusy
+    | {
+        readonly entry: Effect.Effect<void, Error>;
+        readonly release: () => void;
+      } {
+    const occupied = this.lanes.get(executionId);
+    if (
+      refuseWhenOwned !== undefined &&
+      (refuseWhenOwned() ||
+        (occupied !== undefined &&
+          (occupied.live.size > 0 || occupied.fibers > 0)))
+    ) {
+      return new ExecutionBusy({ executionId });
+    }
     const mine = Deferred.makeUnsafe<void>();
     const refusal = Deferred.makeUnsafe<never, Error>();
     const lane = this.laneFor(executionId);

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -26,7 +26,7 @@ import {
   isInFlightPhase,
   isTerminalOutcomePhase,
 } from '@shared/streams/streamStatus';
-import { formatDuration, onAbort } from '@utils/core';
+import { formatDuration } from '@utils/core';
 import { createListenerSet, type ListenerSet } from '@utils/core/listenerSet';
 import {
   type AgentExecutionHandle,
@@ -580,20 +580,20 @@ export class ExecutionRegistry {
 
   /**
    * Wait for any of the given executions to change — see {@link addListener}
-   * for the full wake set. Pass an AbortSignal for timeout cleanup.
-   * Resolves with the execution id that changed first (or '' on abort).
+   * for the full wake set — and succeed with the execution id that changed
+   * first.
+   *
+   * A caller that wants a bounded wait races or times out this effect instead
+   * of passing a deadline in: interrupting the waiting fiber is what detaches
+   * the listeners, so an abandoned wait leaves nothing registered and no
+   * caller has to read a sentinel to learn that its deadline, rather than an
+   * execution, ended the wait.
    */
-  waitForAnyChange(
-    executionIds: string[],
-    signal?: AbortSignal,
-  ): Promise<string> {
-    return new Promise<string>((resolve) => {
+  waitForAnyChange(executionIds: readonly string[]): Effect.Effect<string> {
+    return Effect.callback<string>((resume) => {
       let resolved = false;
-      let detachAbort: () => void = () => {};
       const detachListeners: Array<() => void> = [];
-
       const cleanup = (): void => {
-        detachAbort();
         for (const detach of detachListeners) detach();
       };
 
@@ -603,17 +603,12 @@ export class ExecutionRegistry {
             if (resolved) return;
             resolved = true;
             cleanup();
-            resolve(id);
+            resume(Effect.succeed(id));
           }),
         );
       }
 
-      detachAbort = onAbort(signal, () => {
-        if (resolved) return;
-        resolved = true;
-        cleanup();
-        resolve('');
-      });
+      return Effect.sync(cleanup);
     });
   }
 

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -593,18 +593,20 @@ const heldSession = (root: string) =>
       : { key, session: Context.get(held.value, Session) };
   });
 
-/** Resolve once every execution the registry holds has left it. Detaches
- *  on `signal`, so a bounded wait leaves no listener behind. */
-async function untilSettled(
-  executions: ExecutionRegistry,
-  signal: AbortSignal,
-): Promise<void> {
-  for (;;) {
-    const active = executions.getActiveIds();
-    if (active.length === 0 || signal.aborted) return;
-    await executions.waitForAnyChange(active, signal);
-  }
-}
+/**
+ * Resolve once every execution the registry holds has left it. Interrupting
+ * this fiber — which is what the close budget below does — detaches the
+ * registry listeners with it, so a bounded wait leaves none behind. The loop
+ * reads registry state only, so it needs no session scope of its own.
+ */
+const untilSettled = (executions: ExecutionRegistry): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    for (;;) {
+      const active = executions.getActiveIds();
+      if (active.length === 0) return;
+      yield* executions.waitForAnyChange(active);
+    }
+  });
 
 /** A root with nothing open: nothing to settle, nothing abandoned. */
 const NOTHING_TO_CLOSE: SessionCloseReport = { settled: true, abandoned: [] };
@@ -673,14 +675,7 @@ const closeSession = (root: string, signal?: AbortSignal) =>
     // The entry remains owned until waiting metadata finalization, not merely
     // handle removal, has completed as well as every live driver.
     const settled = Fiber.join(termination).pipe(
-      Effect.andThen(
-        Effect.promise(
-          (interrupt) =>
-            runInSession(session, () =>
-              untilSettled(executions, interrupt),
-            ) as Promise<void>,
-        ),
-      ),
+      Effect.andThen(untilSettled(executions)),
     );
     // One budget for the whole close: the caller's signal, else the phase
     // deadline, forked once so the flush below shares what settlement left.

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -596,15 +596,27 @@ const heldSession = (root: string) =>
 /**
  * Resolve once every execution the registry holds has left it. Interrupting
  * this fiber — which is what the close budget below does — detaches the
- * registry listeners with it, so a bounded wait leaves none behind. The loop
- * reads registry state only, so it needs no session scope of its own.
+ * registry listeners with it, so a bounded wait leaves none behind. The
+ * registry state is re-read once those listeners are attached, closing the
+ * window between the read below and a registration the fiber only reaches a
+ * scheduler step later: `raceAllFirst` starts its arms immediately and in
+ * order, so the wait registers first and the re-check then sees a last
+ * execution that left inside the window, instead of waiting out the whole
+ * close budget for a notification that can no longer come. The loop reads
+ * registry state only, so it needs no session scope of its own.
  */
 const untilSettled = (executions: ExecutionRegistry): Effect.Effect<void> =>
   Effect.gen(function* () {
     for (;;) {
       const active = executions.getActiveIds();
       if (active.length === 0) return;
-      yield* executions.waitForAnyChange(active);
+      const alreadySettled = Effect.suspend(() =>
+        executions.getActiveIds().length === 0 ? Effect.void : Effect.never,
+      );
+      yield* Effect.raceAllFirst([
+        executions.waitForAnyChange(active).pipe(Effect.asVoid),
+        alreadySettled,
+      ]);
     }
   });
 

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -616,7 +616,7 @@ describe('child stream progress events', () => {
             STREAM_PHASE.FAILED,
           );
           const failedHandle = handle;
-          const result = yield* Effect.promise(() => failedHandle.result);
+          const result = yield* failedHandle.result;
           expect(result).toMatchObject({
             type: 'result',
             outcome: 'failed',
@@ -670,7 +670,7 @@ describe('child stream progress events', () => {
       parentStreamId,
       items: [],
     });
-    await expect(handle?.result).resolves.toMatchObject({
+    await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
       type: 'result',
       outcome: 'failed',
       error: {
@@ -715,7 +715,7 @@ describe('child stream progress events', () => {
           qualifyAggregateId('stream', stoppedChildStreamId),
       ),
     ).toHaveLength(0);
-    await expect(handle?.result).resolves.toMatchObject({
+    await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
       type: 'result',
       outcome: 'cancelled',
       executionId: stoppedExecutionId,
@@ -737,7 +737,7 @@ describe('child stream progress events', () => {
       childStream.finalize({ outcome: RUN_OUTCOME.CANCELLED }),
     );
 
-    await expect(handle?.result).resolves.toMatchObject({
+    await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
       type: 'result',
       outcome: 'cancelled',
       executionId: cancelledExecutionId,
@@ -764,7 +764,7 @@ describe('child stream progress events', () => {
     expect(defaultSession().status.get(failedChildStreamId)).toBe(
       STREAM_PHASE.FAILED,
     );
-    await expect(handle?.result).resolves.toMatchObject({
+    await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
       type: 'result',
       outcome: 'failed',
       executionId: failedExecutionId,

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -252,7 +252,7 @@ describe('runFlowWithLifecycle', () => {
       );
 
       expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
-      await expect(terminalResult).resolves.toMatchObject({
+      await expect(Effect.runPromise(terminalResult!)).resolves.toMatchObject({
         category: 'workflow',
         agentName: 'polish',
       });
@@ -769,7 +769,7 @@ describe('runFlowWithLifecycle', () => {
           flowRecord: 'preserve',
         }),
       );
-      await expect(terminalResult).resolves.toMatchObject({
+      await expect(Effect.runPromise(terminalResult!)).resolves.toMatchObject({
         outcome: RUN_OUTCOME.CANCELLED,
         error: { kind: 'abort' },
       });
@@ -933,7 +933,7 @@ describe('runFlowWithLifecycle', () => {
       const stop = defaultSession().executions.kill(executionId);
       expect(stop.accepted).toBe(true);
       await Effect.runPromise(stop.settlement);
-      await waitingHandle.result;
+      await Effect.runPromise(waitingHandle.result);
 
       // The bypassed runFlowWithLifecycle can't emit the terminal result, so
       // terminateWaitingHandle must — trace subscribers would otherwise miss
@@ -1008,7 +1008,7 @@ describe('runFlowWithLifecycle', () => {
       expect(stop.accepted).toBe(true);
 
       await Effect.runPromise(stop.settlement);
-      await waitingHandle.result;
+      await Effect.runPromise(waitingHandle.result);
 
       expect(stopSessionsForRun).toHaveBeenCalledWith(executionId);
     } finally {
@@ -1398,7 +1398,9 @@ describe('finalizeRunTerminal', () => {
         ),
       ).toHaveLength(1);
       expect(untrack).toHaveBeenCalledTimes(1);
-      await expect(handle.result).resolves.toBe(event?.event);
+      await expect(Effect.runPromise(handle.result)).resolves.toBe(
+        event?.event,
+      );
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
     } finally {
       traceEmit.mockRestore();
@@ -1417,7 +1419,7 @@ describe('finalizeRunTerminal', () => {
         }),
     );
     let resultSettled = false;
-    void handle.result.then(() => {
+    void Effect.runPromise(handle.result).then(() => {
       resultSettled = true;
     });
 
@@ -1491,7 +1493,9 @@ describe('finalizeRunTerminal', () => {
           executionId,
         },
       });
-      await expect(handle.result).resolves.toBe(event?.event);
+      await expect(Effect.runPromise(handle.result)).resolves.toBe(
+        event?.event,
+      );
       expect(untrack).toHaveBeenCalledExactlyOnceWith(executionId);
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
       expect(channelTraceMocks.warn).toHaveBeenCalledExactlyOnceWith(
@@ -1548,7 +1552,9 @@ describe('finalizeRunTerminal', () => {
       // Error facts classified for a failure that the phase says never
       // happened must not ride the cancelled result.
       expect(finalized?.event.error).toBeUndefined();
-      await expect(handle.result).resolves.toBe(finalized?.event);
+      await expect(Effect.runPromise(handle.result)).resolves.toBe(
+        finalized?.event,
+      );
       expect(stage.end).toHaveBeenCalledExactlyOnceWith(RUN_OUTCOME.CANCELLED);
       expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
         defaultSession(),

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -938,7 +938,7 @@ describe('childRunLoop E2E fixtures', () => {
     await waitForLoopEnd(childStreamId);
 
     // Settled: handle.result resolves instead of hanging forever.
-    await expect(handle.result).resolves.toMatchObject({
+    await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
       outcome: 'cancelled',
       executionId,
     });
@@ -1108,7 +1108,7 @@ describe('childRunLoop E2E fixtures', () => {
     await resolveTurn(1, { kind: 'error-turn', value: 'oops' });
 
     await waitForLoopEnd(childStreamId);
-    await expect(handle.result).resolves.toMatchObject({
+    await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
       outcome: 'failed',
       executionId,
       error: expect.objectContaining({
@@ -1161,7 +1161,7 @@ describe('childRunLoop E2E fixtures', () => {
     await Promise.all(stopSettlements);
     expect(interruptAfterFailure).toHaveBeenCalledOnce();
     expect(session.status.get(childStreamId)).toBe(STREAM_PHASE.FAILED);
-    await expect(handle?.result).resolves.toMatchObject({
+    await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
       outcome: 'failed',
       executionId,
       error: expect.objectContaining({

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -461,7 +461,7 @@ describe('executionRegistry', () => {
       });
 
       expect(killRegistry(registry, executionId)).toBe(true);
-      await handle.result;
+      await Effect.runPromise(handle.result);
 
       expect(cleanup).toHaveBeenCalledOnce();
       expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
@@ -499,7 +499,7 @@ describe('executionRegistry', () => {
       });
 
       expect(killRegistry(registry, executionId)).toBe(true);
-      await handle.result;
+      await Effect.runPromise(handle.result);
 
       expect(publishResult).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
@@ -520,7 +520,7 @@ describe('executionRegistry', () => {
           outcome: RUN_OUTCOME.CANCELLED,
         }),
       );
-      await expect(handle.result).resolves.toMatchObject({
+      await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
         type: 'result',
         outcome: RUN_OUTCOME.CANCELLED,
         executionId,
@@ -559,7 +559,7 @@ describe('executionRegistry', () => {
       expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.WAITING);
 
       finishCleanup();
-      await expect(handle.result).resolves.toMatchObject({
+      await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
         type: 'result',
         outcome: RUN_OUTCOME.CANCELLED,
       });
@@ -602,7 +602,7 @@ describe('executionRegistry', () => {
 
       expect(successorInterrupt).toHaveBeenCalledOnce();
       finishCleanup();
-      await expect(previous.result).resolves.toMatchObject({
+      await expect(Effect.runPromise(previous.result)).resolves.toMatchObject({
         type: 'result',
         outcome: RUN_OUTCOME.CANCELLED,
       });
@@ -634,7 +634,7 @@ describe('executionRegistry', () => {
       });
 
       expect(killRegistry(registry, executionId)).toBe(true);
-      await expect(handle.result).resolves.toMatchObject({
+      await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
         type: 'result',
         outcome: RUN_OUTCOME.CANCELLED,
       });
@@ -670,7 +670,7 @@ describe('executionRegistry', () => {
 
       expect(killRegistry(registry, executionId)).toBe(true);
 
-      await expect(handle.result).resolves.toMatchObject({
+      await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
         type: 'result',
         outcome: RUN_OUTCOME.CANCELLED,
         executionId,
@@ -882,7 +882,7 @@ describe('executionRegistry', () => {
       releasePersist?.();
       await finalized;
       expect(teardown).not.toHaveBeenCalled();
-      await expect(handle.result).resolves.toMatchObject({
+      await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
         outcome: RUN_OUTCOME.COMPLETED,
       });
       expect(storageMocks.finalizeRun).toHaveBeenCalledExactlyOnceWith(
@@ -941,7 +941,7 @@ describe('executionRegistry', () => {
       });
 
       expect(killRegistry(registry, executionId)).toBe(true);
-      await handle.result;
+      await Effect.runPromise(handle.result);
 
       expect(cleanup).toHaveBeenCalledOnce();
       expect(registry.getHandle(executionId)).toBeUndefined();

--- a/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
@@ -140,7 +140,7 @@ describe('run lifecycle host-interaction cancel', () => {
     expect(Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)).toBe(true);
     await stopped.promise;
     expect(session.executions.getHandle(executionId)).toBeUndefined();
-    await expect(handle.result).resolves.toMatchObject({
+    await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
       outcome: RUN_OUTCOME.CANCELLED,
     });
     expect(ctx.disposeTrace).toHaveBeenCalledOnce();

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -145,7 +145,7 @@ describe('terminal result event', () => {
       // The handle carries the run's trace channel for run-scoped subscribers.
       expect(handle?.trace).toBe(logger);
       // `result` settles with the same terminal event (always resolves).
-      await expect(handle?.result).resolves.toMatchObject({
+      await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
         type: 'result',
         outcome: 'completed',
         executionId: ctx.runScope.executionId,
@@ -240,7 +240,7 @@ describe('terminal result event', () => {
           ),
         ),
       ).rejects.toThrow('boom');
-      await expect(handle?.result).resolves.toMatchObject({
+      await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
         type: 'result',
         outcome: 'failed',
       });

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -181,7 +181,7 @@ async function waitForChildren(session: SessionHandle): Promise<void> {
   while (true) {
     const active = session.executions.getActiveIds();
     if (active.length === 0) return;
-    await session.executions.waitForAnyChange(active);
+    await Effect.runPromise(session.executions.waitForAnyChange(active));
   }
 }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -152,7 +152,7 @@ const executionsRead = <A>(
  * pre-check and registration. The race settles on the first completion,
  * success or defect, so a throw inside the registry wait surfaces at once
  * instead of stalling until the deadline. Interrupting the winner-less
- * racers aborts the registry wait's signal and disposes the follow-up
+ * racers detaches the registry wait's listeners and disposes the follow-up
  * listener.
  */
 const awaitStatusChange = Effect.fn('ExecutionsTool.awaitStatusChange')(
@@ -173,11 +173,8 @@ const awaitStatusChange = Effect.fn('ExecutionsTool.awaitStatusChange')(
       ),
       (stop) => Effect.sync(stop),
     );
-    // Non-rejecting: `waitForAnyChange`'s executor resolves on a registry
-    // listener or on the abort and never rejects.
-    const statusChange = Effect.promise((signal) =>
-      context.session.executions.waitForAnyChange(executionIds, signal),
-    );
+    const statusChange =
+      context.session.executions.waitForAnyChange(executionIds);
     const alreadySettled = Effect.suspend(() =>
       settled() ? Effect.void : Effect.never,
     );


### PR DESCRIPTION
The live runtime's coordination was p-defer/p-queue reimplementations of
Deferred/Queue and hand-rolled AbortSignal waiters, even where every
consumer was already an Effect. Convert the pieces whose whole chain is
Effect, leaving the ones still gated by a PocketFlow or tool-layer
Promise consumer to the lanes that own them.

executionLanes: the per-execution serial lane is a Deferred hand-off
chain (the shape withPerKeyLane already uses) instead of a PQueue plus
three pDefers. Admission is now interruptible — a caller whose fiber dies
while queued hands its successor the wait for whoever actually holds the
lane, rather than stranding a task in a queue nobody can reach — and
session disposal refuses an unstarted step through a raced Deferred. The
generation gate is a Set of completions, not one chained value: a turn's
teardown routinely ends while the child loop that outlives it is still
live, and the gate opens only once every one of them has unwound.

ExecutionHandle: the terminal outcome is a Deferred, and `result` is an
Effect rather than a Promise, matching the SDK's own AgentRun.result. It
still has no error channel, so a consumer-less failed run costs nothing.

ExecutionRegistry.waitForAnyChange: an Effect.callback whose listeners
detach on interruption, replacing a new Promise + AbortSignal that
reported an aborted wait as an empty-string sentinel. ExecutionsTool
drops its Effect.promise wrapper, sessionLayer's settlement wait is an
Effect loop, and the desktop host runs it at its own boundary.

SessionHandle.setTranscriptSubscriptions returns its write instead of
forking it, so the session owns no fiber for a set a surface asked for
and the three CLI callers run it at the host entry.

Ratchet: import:p-queue 13 -> 12 files, import:p-defer 7 -> 5,
Effect.run* 22 -> 21 sites. Nothing widened.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TNmqqVMvFTcMndbqRZzoe1