### PR TITLE
refactor(webview): consolidate three hand-rolled tick clocks into one shared ticker

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ToolTimer.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolTimer.ts
@@ -1,17 +1,11 @@
 /** Live elapsed-time timer for in-progress tool calls. */
 
 // Third-party imports
-import {
-  LitElement,
-  html,
-  css,
-  nothing,
-  type PropertyValues,
-  type TemplateResult,
-} from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 
 // Local imports
+import { TickerController } from '@shared/litControllers/TickerController';
 import { formatDuration } from '@utils/core';
 
 @customElement('tool-timer')
@@ -37,52 +31,23 @@ export class ToolTimer extends LitElement {
   /** Timeout limit in milliseconds. When set, displayed as "elapsed / limit". */
   @property({ attribute: false }) timeoutMs = 0;
 
-  @state() private _elapsed = '';
-
-  private _intervalId: ReturnType<typeof setInterval> | null = null;
-
-  override connectedCallback(): void {
-    super.connectedCallback();
-    this._update();
-    this._intervalId = setInterval(() => this._update(), 1000);
-  }
-
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    if (this._intervalId !== null) {
-      clearInterval(this._intervalId);
-      this._intervalId = null;
-    }
-  }
-
-  protected override willUpdate(changedProperties: PropertyValues<this>): void {
-    if (changedProperties.has('startTime')) this._update();
-  }
-
-  private _update(): void {
-    if (this.startTime <= 0) {
-      this._elapsed = '';
-      return;
-    }
-    // Lit's default `hasChanged` is `!==`, so an unchanged string schedules
-    // no update on its own.
-    this._elapsed = formatDuration(Date.now() - this.startTime);
-  }
+  private readonly _ticker = new TickerController(this, 1000);
 
   override render(): TemplateResult | typeof nothing {
-    if (!this._elapsed) return nothing;
+    if (this.startTime <= 0) return nothing;
+    const elapsed = formatDuration(this._ticker.now - this.startTime);
     if (this.timeoutMs > 0) {
       const limit = formatDuration(this.timeoutMs);
       // prettier-ignore
-      return html`<span class="timer" role="timer" aria-live="off" aria-label=${`Elapsed time: ${this._elapsed} of ${limit}`} dir="ltr">${this._elapsed}<span class="timer-limit"> / ${limit}</span></span>`;
+      return html`<span class="timer" role="timer" aria-live="off" aria-label=${`Elapsed time: ${elapsed} of ${limit}`} dir="ltr">${elapsed}<span class="timer-limit"> / ${limit}</span></span>`;
     }
     return html`<span
       class="timer"
       role="timer"
       aria-live="off"
-      aria-label=${`Elapsed time: ${this._elapsed}`}
+      aria-label=${`Elapsed time: ${elapsed}`}
       dir="ltr"
-      >${this._elapsed}</span
+      >${elapsed}</span
     >`;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/ToolTimer.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolTimer.ts
@@ -1,7 +1,14 @@
 /** Live elapsed-time timer for in-progress tool calls. */
 
 // Third-party imports
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports
@@ -32,6 +39,10 @@ export class ToolTimer extends LitElement {
   @property({ attribute: false }) timeoutMs = 0;
 
   private readonly _ticker = new TickerController(this, 1000);
+
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has('startTime')) this._ticker.refresh();
+  }
 
   override render(): TemplateResult | typeof nothing {
     if (this.startTime <= 0) return nothing;

--- a/packages/extension/src/progressView/frontend/progressWebview.ts
+++ b/packages/extension/src/progressView/frontend/progressWebview.ts
@@ -8,6 +8,7 @@
  * conversation.
  */
 import { resolveSelected } from '@shared/session/surface';
+import { createTicker } from '@utils/core';
 
 import { createSessionSurfaces } from './sessionSurfaces';
 import { webviewStorage } from './webviewStorage';
@@ -63,16 +64,16 @@ export function mountProgressWebview(app: ProgressApp): void {
     sessions.hostRequest(sessionKey, { kind: 'setActiveView', view: shown });
   };
   const unsubscribe = sessions.onChange(assign);
-  const clock = window.setInterval(() => {
+  const clock = createTicker(1000, () => {
     app.nowMs = Date.now();
-  }, 1000);
+  });
   assign();
 
   window.addEventListener(
     'pagehide',
     () => {
       window.removeEventListener('message', receive);
-      window.clearInterval(clock);
+      clock.dispose();
       unsubscribe();
       sessions.dispose();
     },

--- a/packages/extension/src/settingsView/frontend/tabs/SubscriptionsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/SubscriptionsTab.ts
@@ -8,7 +8,7 @@ import {
   type PropertyValues,
   type TemplateResult,
 } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles, schemas, and templates
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -23,6 +23,7 @@ import {
   type GrokAuthStatus,
   type SubscriptionUsageSnapshots,
 } from '@shared/schemas';
+import { TickerController } from '@shared/litControllers/TickerController';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderSettingsSectionHeading } from '@shared/wa/settingsSection';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
@@ -79,31 +80,18 @@ export class SubscriptionsTab extends LitElement {
   @property({ attribute: false }) usage: SubscriptionUsageSnapshots | null =
     null;
   @property({ attribute: false }) copilotModels: CopilotRouteInfo[] = [];
-  @state() private now = 0;
 
-  private clock: ReturnType<typeof setInterval> | undefined;
+  private readonly _ticker = new TickerController(this, 60_000);
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.refreshNow();
-    this.clock = setInterval(() => this.refreshNow(), 60_000);
     postMessage(SETTINGS_VIEW_COMMANDS.GET_SUBSCRIPTION_USAGE, {
       forceRefresh: false,
     });
   }
 
-  override disconnectedCallback(): void {
-    if (this.clock !== undefined) clearInterval(this.clock);
-    this.clock = undefined;
-    super.disconnectedCallback();
-  }
-
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
-    if (changedProperties.has('usage')) this.refreshNow();
-  }
-
-  private refreshNow(): void {
-    this.now = Date.now();
+    if (changedProperties.has('usage')) this._ticker.refresh();
   }
 
   override render(): TemplateResult {
@@ -138,12 +126,12 @@ export class SubscriptionsTab extends LitElement {
           .auth=${this.chatgptAuth}
           .contextWindow=${this.chatgptCodexContextWindow}
           .usage=${this.usage?.chatgpt ?? null}
-          .now=${this.now}
+          .now=${this._ticker.now}
         ></subscription-section>
         <subscription-section
           .provider=${GROK_SUBSCRIPTION_SECTION}
           .auth=${this.grokAuth}
-          .now=${this.now}
+          .now=${this._ticker.now}
         ></subscription-section>
         ${CODING_PLAN_SUBSCRIPTIONS.map((section) =>
           this.renderCodingPlanSection(section),
@@ -211,7 +199,7 @@ export class SubscriptionsTab extends LitElement {
           </div>
           <subscription-usage-row
             .snapshot=${this.usage?.[section.usageProvider] ?? null}
-            .now=${this.now}
+            .now=${this._ticker.now}
           ></subscription-usage-row>
         </div>
       </section>

--- a/src/shared/litControllers/TickerController.ts
+++ b/src/shared/litControllers/TickerController.ts
@@ -1,0 +1,53 @@
+import { createTicker, type Ticker } from '@utils/core';
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+/**
+ * Lit reactive controller that re-renders its host on a fixed interval,
+ * exposing the timestamp of the last tick for relative/elapsed-time
+ * rendering.
+ *
+ * ```typescript
+ * private readonly ticker = new TickerController(this, 1000);
+ *
+ * render() {
+ *   const elapsed = formatDuration(this.ticker.now - this.startTime);
+ *   ...
+ * }
+ * ```
+ */
+export class TickerController implements ReactiveController {
+  private _now = Date.now();
+  private _ticker: Ticker | undefined;
+
+  constructor(
+    private readonly host: ReactiveControllerHost,
+    private readonly intervalMs: number,
+  ) {
+    host.addController(this);
+  }
+
+  /** Timestamp (ms) as of the last tick or `refresh()` call. */
+  get now(): number {
+    return this._now;
+  }
+
+  hostConnected(): void {
+    this._tick();
+    this._ticker = createTicker(this.intervalMs, () => this._tick());
+  }
+
+  hostDisconnected(): void {
+    this._ticker?.dispose();
+    this._ticker = undefined;
+  }
+
+  /** Re-sync `now` immediately, outside the regular interval. */
+  refresh(): void {
+    this._tick();
+  }
+
+  private _tick(): void {
+    this._now = Date.now();
+    this.host.requestUpdate();
+  }
+}

--- a/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
+++ b/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
@@ -51,7 +51,7 @@ const snapshots: SubscriptionUsageSnapshots = {
 
 type SubscriptionsTabElement = HTMLElement & {
   usage: SubscriptionUsageSnapshots | null;
-  now: number;
+  _ticker: { now: number };
   updateComplete: Promise<boolean>;
 };
 
@@ -92,7 +92,7 @@ describe('subscription usage rendering', () => {
   afterEach(() => vi.useRealTimers());
 
   it('renders accessible meters and one refresh action', async () => {
-    const tab = await mountTab();
+    const tab = await mountTabWithFakeTimers();
 
     expect(mocks.postMessage).toHaveBeenCalledWith(
       SETTINGS_VIEW_COMMANDS.GET_SUBSCRIPTION_USAGE,
@@ -108,7 +108,6 @@ describe('subscription usage rendering', () => {
       { forceRefresh: true },
     );
 
-    tab.now = NOW;
     await tab.updateComplete;
     const kimiRow = getKimiUsageRow(tab);
     expect(kimiRow).not.toBeNull();
@@ -138,23 +137,23 @@ describe('subscription usage rendering', () => {
 
   it('advances one tab clock while connected and stops it after disconnect', async () => {
     const tab = await mountTabWithFakeTimers();
-    expect(tab.now).toBe(NOW);
+    expect(tab._ticker.now).toBe(NOW);
     expect(vi.getTimerCount()).toBe(1);
 
     vi.advanceTimersByTime(3 * 60_000);
     await tab.updateComplete;
-    expect(tab.now).toBe(NOW + 3 * 60_000);
+    expect(tab._ticker.now).toBe(NOW + 3 * 60_000);
     const kimiRow = getKimiUsageRow(tab);
     await kimiRow?.updateComplete;
-    expect(kimiRow?.now).toBe(tab.now);
+    expect(kimiRow?.now).toBe(tab._ticker.now);
     expect(kimiRow?.shadowRoot?.textContent).toContain(
       'stale · updated 3m ago',
     );
 
     tab.remove();
-    const disconnectedNow = tab.now;
+    const disconnectedNow = tab._ticker.now;
     vi.advanceTimersByTime(2 * 60_000);
-    expect(tab.now).toBe(disconnectedNow);
+    expect(tab._ticker.now).toBe(disconnectedNow);
     expect(vi.getTimerCount()).toBe(0);
   });
 
@@ -167,7 +166,7 @@ describe('subscription usage rendering', () => {
     document.body.append(tab);
     await tab.updateComplete;
 
-    expect(tab.now).toBe(NOW + 5 * 60_000);
+    expect(tab._ticker.now).toBe(NOW + 5 * 60_000);
     expect(vi.getTimerCount()).toBe(1);
 
     tab.remove();
@@ -176,7 +175,6 @@ describe('subscription usage rendering', () => {
 
   it('refreshes the tab clock when fresh usage arrives', async () => {
     const tab = await mountTabWithFakeTimers();
-    tab.now = NOW - 10 * 60_000;
     vi.setSystemTime(NOW + 30_000);
     tab.usage = {
       ...snapshots,
@@ -186,7 +184,7 @@ describe('subscription usage rendering', () => {
     const kimiRow = getKimiUsageRow(tab);
     await kimiRow?.updateComplete;
 
-    expect(tab.now).toBe(NOW + 30_000);
+    expect(tab._ticker.now).toBe(NOW + 30_000);
     expect(kimiRow?.shadowRoot?.textContent).toContain('updated just now');
   });
 });

--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -121,7 +121,10 @@ export const createChildStream = Effect.fn('createChildStream')(function* (
   const setup = yield* Effect.exit(
     Effect.gen(function* () {
       // Attach the run's canonical event publication before activation.
-      detachSessionTrace = session.attachRunTrace(runTrace.trace, childStreamId);
+      detachSessionTrace = session.attachRunTrace(
+        runTrace.trace,
+        childStreamId,
+      );
       const disposeTrace = () => {
         detachSessionTrace?.();
         runTrace.dispose();

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -295,6 +295,21 @@ export function createFlushableDebounce(
   };
 }
 
+/** A running interval. `dispose()` stops it; safe to call more than once. */
+export interface Ticker {
+  dispose(): void;
+}
+
+/** Thin `setInterval`/`clearInterval` wrapper exposing lifecycle as an object. */
+export function createTicker(intervalMs: number, onTick: () => void): Ticker {
+  const timer = setInterval(onTick, intervalMs);
+  return {
+    dispose() {
+      clearInterval(timer);
+    },
+  };
+}
+
 /**
  * Coalesce concurrent async requests for the same key: return a resolved
  * value from `resolved` if present, otherwise share one in-flight promise


### PR DESCRIPTION
## Summary

This is the result of a scheduled sweep for duplicate logic and hand-rolled reimplementations of native functionality. I surveyed `src/utils/`, `src/common/`, `src/agent/`, `src/tools/`, `packages/cli`, `packages/desktop`, `packages/extension` (host code), and the three webview frontend trees. The repo has already been through heavy consolidation (recent merges #12170–#12182, plus tracked items #12035/#12072/#12145) and came back clean everywhere except one spot: three independent hand-rolled interval clocks, all doing the same thing — running `setInterval`, restamping a "now" value, and tearing the timer down on disconnect — to drive relative/elapsed-time rendering:

- `progressWebview.ts` (`window.setInterval`, torn down on `pagehide`)
- `ToolTimer` (`setInterval` in `connectedCallback`/`disconnectedCallback`)
- `SubscriptionsTab` (`setInterval` in `connectedCallback`/`disconnectedCallback`)

This PR extracts one shared primitive and its Lit wrapper, and switches all three to it. No behavior change intended — same tick cadence per site (1s for the two timers, 60s for the subscriptions tab), same teardown-on-disconnect semantics, same forced re-sync when new usage data arrives.

## Issue acceptance gates

No tracked issue; this is a proactive scheduled sweep. Gate: each of the three call sites uses the shared primitive instead of its own `setInterval`/`clearInterval` pair, with identical observable behavior (verified by tests).

## Single source of truth

- `createTicker` (`src/utils/core/index.ts`) — the one `setInterval`/`clearInterval` wrapper, alongside the existing `createFlushableDebounce` it now sits next to.
- `TickerController` (`src/shared/litControllers/TickerController.ts`) — the one Lit `ReactiveController` for "re-render on an interval," following the existing `CopyButtonController`/`SortableController` pattern in the same directory (constructor takes `(host, ...)`, calls `host.addController(this)`, cleans up in `hostDisconnected`).

## Duplication and abstraction budget

Removed: three separate interval-lifecycle implementations (manual field + `connectedCallback`/`disconnectedCallback` wiring in two Lit components, a `window.setInterval`/`pagehide` pair in a third). `ToolTimer` additionally drops its `_elapsed` state field, `_update()`, and `willUpdate()` override — with `TickerController` driving re-renders, the elapsed string is just computed inline in `render()`.

Added: one non-Lit primitive (`createTicker`) and one Lit controller (`TickerController`) — the controller is a thin, documented wrapper with a real precedent (two sibling controllers in the same directory), not a novel abstraction shape.

## Net elements (R6)

- Files: 5 modified, 1 added (`src/shared/litControllers/TickerController.ts`)
- Exported symbols: +3 (`createTicker`, `Ticker`, `TickerController`), -0
- Classes/interfaces: +1 class (`TickerController`), +1 interface (`Ticker`)
- Net LoC: +20 (97 insertions, 77 deletions per `git diff --stat`)

## Consumer counts (R8)

Not deleting or re-routing an emit path or existing export — n/a. The three new exports each have exactly the 3 call sites this PR adds (`ToolTimer.ts`, `SubscriptionsTab.ts`, `progressWebview.ts`), replacing what were previously 3 independent inline implementations.

## Host impact

Extension: `packages/extension/src/progressView/frontend/{progressWebview.ts,components/ToolTimer.ts}` and `packages/extension/src/settingsView/frontend/tabs/SubscriptionsTab.ts` — all three now share one ticker implementation. No visible behavior change.

Desktop: none.

CLI: none.

## Scheduled refactoring

None — this is the full scope of the finding.

## Validation

- `npm run typecheck` — full workspace, clean
- `npm run lint` — clean (two import-order errors from the new imports were auto-fixed with `--fix`)
- `npx vitest run src/test-kernel/settings/` and `src/test-kernel/progressView/` — 27+28 files, 176+123 tests, all passing. Updated `SubscriptionUsageRendering.vitest.ts` to read the ticker's `now` through `tab._ticker.now` instead of the removed `tab.now` state field (same assertions, same fake-timer-driven behavior: clock advances while connected, stops on disconnect, restarts fresh on reconnect, force-refreshes when new usage data arrives).
- `npm run check:dead-code-ratchet` — no new findings
- `node scripts/check-browser-safe-utils.mjs` — unaffected (65 total, 5 reachable; `@utils/core` was already reachable)
- `npm run format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vi6MxdVEgXB9wH4MZpE7qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi6MxdVEgXB9wH4MZpE7qA)_