### PR TITLE
refactor: consolidate four independent stream-descendant walks into one

### DIFF
--- a/packages/agent/src/effect/sessions.ts
+++ b/packages/agent/src/effect/sessions.ts
@@ -65,10 +65,11 @@ import {
 import type { RequestError } from '@shared/session/requestErrors';
 import type { Outcome, RuntimeRequest } from '@shared/session/runtimeRequest';
 import type { SessionEventsShape } from '@shared/session/sessionEvents';
-import type {
-  SessionView as RuntimeSessionView,
-  StreamView as RuntimeStreamView,
-  TranscriptView as RuntimeTranscriptView,
+import {
+  descendantStreams,
+  type SessionView as RuntimeSessionView,
+  type StreamView as RuntimeStreamView,
+  type TranscriptView as RuntimeTranscriptView,
 } from '@shared/session/sessionView';
 import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -231,20 +232,6 @@ const log = createLog('agentPackage');
  * nothing here discards what it has yet to read.
  */
 const TRACE_HANDOVER_EVENTS = 512;
-
-/** The run's stream and every descendant the view holds. */
-function runStreamIds(view: SessionView, streamId: StreamTabId): StreamTabId[] {
-  const ids: StreamTabId[] = [];
-  for (const stream of view.streams.values()) {
-    if (
-      stream.id === streamId ||
-      stream.ancestors.some((ancestor) => ancestor.id === streamId)
-    ) {
-      ids.push(stream.id);
-    }
-  }
-  return ids;
-}
 
 /**
  * The refusal the package states from the caller's own input, before
@@ -466,7 +453,11 @@ function start(
         const drain = yield* Effect.forkDetach(
           Stream.runDrain(
             view.pipe(
-              Stream.tap((level) => interest(runStreamIds(level, streamId))),
+              Stream.tap((level) =>
+                interest(
+                  descendantStreams(level, streamId, { includeRoot: true }),
+                ),
+              ),
             ),
           ),
           { startImmediately: true },

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -14,6 +14,7 @@ import type {
   SubscriptionUsageSnapshot,
   UsageRoute,
 } from '@shared/schemas';
+import { descendantStreams } from '@shared/session/sessionView';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -30,7 +31,6 @@ import {
 import {
   ancestorPhaseLabel,
   cumulativeUsageOf,
-  descendantStreamIds,
   sessionView,
   streamPhaseOf,
   streamViewOf,
@@ -87,7 +87,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     status: streamPhaseOf(streamViewOf(view, rootRunStreamId)),
   };
   const ownedStreamIds = useMemo(
-    () => descendantStreamIds(view, rootStreamId),
+    () => descendantStreams(view, rootStreamId, { includeRoot: true }),
     [view, rootStreamId],
   );
   const target = statusBarStreamTarget({

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -53,6 +53,7 @@ import type {
 } from '@shared/schemas';
 import { AgentCategory, STREAM_PHASE } from '@shared/schemas';
 import { subscribeToSignalChanges } from '@shared/signals';
+import { descendantStreams } from '@shared/session/sessionView';
 import { getFirstRunDone } from '@shared/state/onboardingState';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { platformSettingsStores } from '@utils/config/platformSettings';
@@ -87,7 +88,6 @@ import {
 import {
   bindSessionView,
   currentView,
-  descendantStreamIds,
   sessionView,
   streamPhaseOf,
   streamViewOf,
@@ -439,9 +439,10 @@ export async function runChat(
     // Release this conversation's resident transcripts when their remaining
     // readers and writers leave. Clearing the terminal does not delete history.
     const store = runtimeSession.transcripts;
-    for (const streamId of descendantStreamIds(
+    for (const streamId of descendantStreams(
       currentView(),
       rootStreamIdSignal.get(),
+      { includeRoot: true },
     )) {
       store.requestEviction(streamId);
     }

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -9,13 +9,12 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 import { usageCostLabel } from '@shared/copy/modelAccess';
-import type { SessionView } from '@shared/session/sessionView';
-
 import {
-  cumulativeUsageOf,
-  descendantStreamIds,
-  streamViewOf,
-} from './sessionView';
+  descendantStreams,
+  type SessionView,
+} from '@shared/session/sessionView';
+
+import { cumulativeUsageOf, streamViewOf } from './sessionView';
 
 export interface ResumeTarget {
   readonly executionId: string;
@@ -72,7 +71,9 @@ export function collectResumeUsage(
   rootStreamId: StreamTabId | undefined,
 ): TokenUsageStats | undefined {
   const usages: TokenUsageStats[] = [];
-  for (const streamId of descendantStreamIds(view, rootStreamId)) {
+  for (const streamId of descendantStreams(view, rootStreamId, {
+    includeRoot: true,
+  })) {
     const usage = cumulativeUsageOf(streamViewOf(view, streamId));
     if (usage) usages.push(usage);
   }
@@ -112,8 +113,9 @@ export function collectResumeTargets({
     targets.push({ executionId: rootExecutionId, label: 'main', isRoot: true });
     seen.add(rootExecutionId);
   }
-  for (const streamId of descendantStreamIds(view, rootStreamId)) {
-    if (streamId === rootStreamId) continue;
+  for (const streamId of descendantStreams(view, rootStreamId, {
+    includeRoot: false,
+  })) {
     const stream = streamViewOf(view, streamId);
     if (!stream || seen.has(stream.executionId)) continue;
     if (!stream.resumeEligible) continue;

--- a/packages/cli/src/chat/tui/state/sessionView.ts
+++ b/packages/cli/src/chat/tui/state/sessionView.ts
@@ -24,7 +24,11 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 import { toSignal, type StreamSignal } from '@shared/signals';
-import type { SessionView, StreamView } from '@shared/session/sessionView';
+import {
+  descendantStreams,
+  type SessionView,
+  type StreamView,
+} from '@shared/session/sessionView';
 import { isInFlightPhase } from '@shared/streams/streamStatus';
 import { formatPhaseStageLabel } from '@shared/streams/streamStatusDisplay';
 
@@ -113,25 +117,6 @@ export function streamPhaseOf(
     : stream.status;
 }
 
-/** Every stream under `rootStreamId`, the root included, parents first. */
-export function descendantStreamIds(
-  view: SessionView,
-  rootStreamId: StreamTabId | undefined,
-): readonly StreamTabId[] {
-  const out: StreamTabId[] = [];
-  const pending = rootStreamId === undefined ? [] : [rootStreamId];
-  const seen = new Set<StreamTabId>();
-  while (pending.length > 0) {
-    const id = pending.shift()!;
-    const stream = view.streams.get(id);
-    if (!stream || seen.has(id)) continue;
-    seen.add(id);
-    out.push(id);
-    pending.push(...stream.childIds);
-  }
-  return out;
-}
-
 /**
  * The direct children in the RUNNING phase. The fold's `rollup.running`
  * counts in-flight streams (running or idle-waiting); the TUI's "active"
@@ -152,7 +137,7 @@ export function anyStreamRunning(
   view: SessionView,
   rootStreamId: StreamTabId | undefined,
 ): boolean {
-  return descendantStreamIds(view, rootStreamId).some(
+  return descendantStreams(view, rootStreamId, { includeRoot: true }).some(
     (id) => view.streams.get(id)?.status === STREAM_PHASE.RUNNING,
   );
 }

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -22,7 +22,11 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
-import type { SessionView, StreamView } from '@shared/session/sessionView';
+import {
+  descendantStreams,
+  type SessionView,
+  type StreamView,
+} from '@shared/session/sessionView';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
 import { formatCompactDuration, pluralize } from '@utils/text/stringUtils';
@@ -484,14 +488,17 @@ export function attachWorkflowPlainOutput(
     // summary; only the launched run's own subtree is this run's output.
     rootStreamId ??= claimRootStream(view, options.executionId, attachCursor);
     const root = rootStreamId;
-    const workflows =
+    const rootedIds =
       root === undefined
+        ? undefined
+        : new Set(descendantStreams(view, root, { includeRoot: true }));
+    const workflows =
+      rootedIds === undefined
         ? []
         : [...view.streams.values()].filter(
             (stream) =>
               stream.identity?.kind === 'multiAgentWorkflow' &&
-              (stream.id === root ||
-                stream.ancestors.some((ancestor) => ancestor.id === root)),
+              rootedIds.has(stream.id),
           );
     const key = workflows.map((stream) => stream.id).join('\0');
     if (key !== subscribed) {

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -30,7 +30,11 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 // Local imports
 import type { InquiryThreadUpdatedEvent, StreamTabId } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
-import type { SessionView, StreamView } from '@shared/session/sessionView';
+import {
+  descendantStreams,
+  type SessionView,
+  type StreamView,
+} from '@shared/session/sessionView';
 import type { Surface } from '@shared/session/surface';
 import { SessionUiEvents } from '@shared/session/uiEvents';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
@@ -253,10 +257,13 @@ export class BackgroundTasksPanel extends LitElement {
    *  since time read the same set: a direct child that finishes while a
    *  grandchild runs leaves the badge lit and the time standing. */
   private descendantsOf(streams: readonly StreamView[]): StreamView[] {
-    return streams.flatMap((child) => [
-      child,
-      ...this.descendantsOf(this.childrenOf(child)),
-    ]);
+    const view = this.view;
+    if (!view) return [];
+    return streams.flatMap((child) =>
+      descendantStreams(view, child.id, { includeRoot: true })
+        .map((id) => view.streams.get(id))
+        .filter((stream): stream is StreamView => stream !== undefined),
+    );
   }
 
   private inquiriesOf(stream: StreamView): InquiryThreadUpdatedEvent[] {

--- a/src/shared/session/sessionView.ts
+++ b/src/shared/session/sessionView.ts
@@ -290,10 +290,13 @@ export function descendantStreams(
 ): readonly StreamTabId[] {
   if (rootStreamId === undefined) return [];
   const out: StreamTabId[] = [];
+  // An index cursor over an append-only queue keeps this linear in the
+  // topology's size; `Array.shift()` would re-index the remainder on every
+  // pop and make a large fan-out's walk quadratic.
   const pending = [rootStreamId];
   const seen = new Set<StreamTabId>();
-  while (pending.length > 0) {
-    const id = pending.shift()!;
+  for (let cursor = 0; cursor < pending.length; cursor++) {
+    const id = pending[cursor]!;
     const stream = view.streams.get(id);
     if (!stream || seen.has(id)) continue;
     seen.add(id);

--- a/src/shared/session/sessionView.ts
+++ b/src/shared/session/sessionView.ts
@@ -39,6 +39,7 @@ import {
   TodoItemSchema,
   UserFollowUpSupportSchema,
   WorktreeInfoSchema,
+  type StreamTabId,
 } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 import { STREAM_STATUS_TONE } from '@shared/streams/streamStatusDisplay';
@@ -264,4 +265,40 @@ export function emptySessionView(key: string, cursor = 0): SessionView {
     local: { self: [], dead: [], unreadable: [] },
     queuedFollowUps: new Map(),
   };
+}
+
+/** The read shape `descendantStreams` needs: satisfied by `SessionView`
+ *  itself and by any deep-readonly projection of it (a `Map` structurally
+ *  satisfies `ReadonlyMap`), so a consumer holding a readonly view never
+ *  needs to re-derive the walk to keep its own copy. */
+type StreamTopology = {
+  readonly streams: ReadonlyMap<
+    StreamTabId,
+    { readonly childIds: readonly StreamTabId[] }
+  >;
+};
+
+/**
+ * Every stream under `rootStreamId`, parents first: the topology `childIds`
+ * (root to leaf) and `ancestors` (leaf to root) already state on every row,
+ * so a host walks the fold's own facts instead of re-deriving them.
+ */
+export function descendantStreams(
+  view: StreamTopology,
+  rootStreamId: StreamTabId | undefined,
+  { includeRoot }: { includeRoot: boolean },
+): readonly StreamTabId[] {
+  if (rootStreamId === undefined) return [];
+  const out: StreamTabId[] = [];
+  const pending = [rootStreamId];
+  const seen = new Set<StreamTabId>();
+  while (pending.length > 0) {
+    const id = pending.shift()!;
+    const stream = view.streams.get(id);
+    if (!stream || seen.has(id)) continue;
+    seen.add(id);
+    if (includeRoot || id !== rootStreamId) out.push(id);
+    pending.push(...stream.childIds);
+  }
+  return out;
 }

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -27,6 +27,7 @@ interface FakeStreamView {
   readonly id: string;
   readonly executionId: string;
   readonly ancestors: readonly { readonly id: string }[];
+  readonly childIds: readonly string[];
   readonly durableOutcome: 'completed' | null;
 }
 type FakeSessionView = Omit<RuntimeSessionView, 'streams'> & {
@@ -244,22 +245,34 @@ function sessionView(): SubscriptionRef.SubscriptionRef<FakeSessionView> {
   return mocks.sessionView as SubscriptionRef.SubscriptionRef<FakeSessionView>;
 }
 
-/** Fold one stream into the session view, as its `run.start` would. */
+/** Fold one stream into the session view, as its `run.start` would: the
+ *  fold keeps `childIds` and `ancestors` in sync, so entering a stream with
+ *  ancestors also links it onto its immediate parent's `childIds`. */
 function enterStream(
   id: string,
   stream: Partial<FakeStreamView> = {},
 ): Promise<void> {
+  const ancestors = stream.ancestors ?? [];
+  const parentId = ancestors.at(-1)?.id;
   return Effect.runPromise(
-    SubscriptionRef.update(sessionView(), (current) => ({
-      ...current,
-      streams: new Map(current.streams).set(id, {
+    SubscriptionRef.update(sessionView(), (current) => {
+      const streams = new Map(current.streams).set(id, {
         id,
         executionId: mocks.executionId,
         ancestors: [],
+        childIds: [],
         durableOutcome: null,
         ...stream,
-      }),
-    })),
+      });
+      const parent = parentId === undefined ? undefined : streams.get(parentId);
+      if (parentId !== undefined && parent) {
+        streams.set(parentId, {
+          ...parent,
+          childIds: [...parent.childIds, id],
+        });
+      }
+      return { ...current, streams };
+    }),
   );
 }
 

--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -121,7 +121,10 @@ export const createChildStream = Effect.fn('createChildStream')(function* (
   const setup = yield* Effect.exit(
     Effect.gen(function* () {
       // Attach the run's canonical event publication before activation.
-      detachSessionTrace = session.attachRunTrace(runTrace.trace, childStreamId);
+      detachSessionTrace = session.attachRunTrace(
+        runTrace.trace,
+        childStreamId,
+      );
       const disposeTrace = () => {
         detachSessionTrace?.();
         runTrace.dispose();


### PR DESCRIPTION
## Summary

Four hosts each independently re-derived a session's descendant-stream set
from facts `SessionView` already states on every row (`childIds`,
`ancestors`), instead of composing the walk once beside the fold that
computes those facts:

- `packages/cli/src/chat/tui/state/sessionView.ts` — `descendantStreamIds`,
  a BFS over `childIds`.
- `packages/agent/src/effect/sessions.ts` — `runStreamIds`, an
  `ancestors.some` scan over every stream in the view.
- `packages/cli/src/runtime/runProgressRenderer.ts` — an inline,
  unnamed `ancestors.some` filter.
- `packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts`
  — `descendantsOf`, a recursion over `childrenOf`.

Same conceptual walk, four independent authors, four different
implementations (and, for the root-included/root-excluded question, two
different answers depending on the caller) — exactly the kind of drift a
canonical module exists to prevent, and a second author changing the
topology shape would have had to find and update all four by hand.

## Issue acceptance gates

Addresses #12181 ("Four hosts each walk stream topology themselves, a fact
the fold already states on every row"):

- [x] One exported `descendantStreams(view, rootId, { includeRoot })` beside
  the fold in `src/shared/session/sessionView.ts`.
- [x] `descendantStreamIds`, `runStreamIds`, and the inline
  `ancestors.some` filter are deleted; their call sites point at the shared
  function.
- [x] `BackgroundTasksPanel`'s `descendantsOf` now composes from the shared
  walk instead of its own recursion. `childrenOf` (a direct-children
  accessor used independently for row rendering, not a topology walk) is
  unchanged.
- [x] The root-included-vs-excluded difference across call sites is the
  `includeRoot` flag, not a second function.

## Single source of truth

`descendantStreams` in `src/shared/session/sessionView.ts`, beside
`emptySessionView`, is now the one place the four **production hosts**
(CLI TUI state, CLI plain-output renderer, the `@texra-ai/agent` package,
and the extension's progress-view webview) walk `SessionView` topology.

Not covered: `packages/cli/scripts/tui-harness.tsx`'s own `descendantsOf`
(a `.shift()`-based BFS, same shape as the ones this PR removes) is a
manual dev harness excluded from the published CLI bin
(`!dist/bin/tui-harness.js` in `packages/cli/package.json`), out of
#12181's scope (its consumer-count grep excluded `scripts/`) and out of
this PR's. Flagging it rather than implying the consolidation reaches it.

## Duplication and abstraction budget

Removed: two duplicate walk implementations (`descendantStreamIds` BFS,
`runStreamIds` linear scan) plus one duplicate inline filter and one
duplicate recursion, all computing the same descendant-id set from the same
two fold-provided fields.

Added: one function plus a narrow structural parameter type
(`StreamTopology`) so a deep-readonly projection of `SessionView` (the
`@texra-ai/agent` package's own `ReadonlyDeep<SessionView>`) satisfies the
same signature without importing the agent package's type into `@shared` or
duplicating the function. No new pass-through layer — every call site now
calls straight through to the one implementation.

Side effect worth naming: `packages/agent/src/effect/sessions.ts`'s
`@shared/session/sessionView` import turns from type-only into a value
import (it now calls `descendantStreams`), so that module's runtime code —
not just its types — enters the published `@texra-ai/agent` bundle. The
package already value-imports `@shared/schemas` elsewhere, so this isn't a
new category of dependency, and `npm run typecheck:agent` (which builds
the package) shows no unexpected size jump, but it's a load-surface change
worth calling out explicitly rather than leaving implicit.

## Net elements (R6)

- Files changed: 9 for the consolidation itself (8 in the original commit,
  1 test fake fixed in the post-review round below), no new files. A 10th
  file on this branch, `src/tools/delegation/childStream.ts`, is an
  unrelated ported CI fix — see the standing-down comment on this PR — and
  is excluded from the counts below.
- Exported symbols: `^[+-]export` over the diff shows exactly one removed
  (`descendantStreamIds`) and one added (`descendantStreams`) — net 0, but
  consolidates four independent realizations (one exported function, one
  file-private function, one inline filter, one private-method recursion)
  into one.
- Class/interface/enum declarations: 0 net (one new `type` alias,
  `StreamTopology`, not in this bucket).
- Net LoC: +46 (`git diff --stat origin/main...HEAD` over the 9
  consolidation files, current head: 114 insertions, 68 deletions).

**Why net-positive LoC for a `refactor:`:** the prior audit (#12181)
estimated roughly −45 LoC assuming a leaner drop-in. Implementing it, two
things added lines the estimate didn't carry: (1) doc comments on the new
export and its structural parameter type, matching this file's existing
density (`emptySessionView` carries the same); (2) the `StreamTopology`
type needed so the `@texra-ai/agent` package's `ReadonlyDeep<SessionView>`
type-checks against the same function without a second implementation or a
new `@shared`→agent dependency. A post-review round (below) added a test
fixture fix and an index-cursor rewrite of the walk itself. The deletion is
real (four call sites lose their own walk logic) — the added lines buy one
documented, type-safe, linear-time owner instead of a leaner but
undocumented and quadratic one.

## Consumer counts (R8)

Grepped before this change (`rg` over `src` and `packages`, excluding
tests):

- `descendantStreamIds`: 4 external call sites
  (`panes/StatusBar.tsx:90`, `runChatTui.tsx:442`,
  `state/resumeHint.ts:75`, `state/resumeHint.ts:115`) plus 1 internal
  (`anyStreamRunning` in the same file) — all 5 migrated to
  `descendantStreams`.
- `runStreamIds`: 1 call site (`sessions.ts:469`) — migrated.
- The inline `ancestors.some` filter in `runProgressRenderer.ts`: 1 site —
  migrated to a `Set` built from `descendantStreams`.
- `descendantsOf`: 1 call site (`:280`, `renderChildren`'s `since` calc) —
  migrated. `childrenOf` keeps its 2 unrelated call sites (`:271`, `:369`)
  unchanged; it is a direct-children accessor, not a topology walk, so it
  is out of scope for this consolidation.

## Host impact

Extension: `BackgroundTasksPanel`'s dispatch-card rollup math (running
badge, "since" timestamp) is unchanged — same descendant set, sourced from
the shared walk instead of local recursion.

Desktop: none (no desktop-specific code touched).

CLI: `StatusBar`, `runChatTui`'s scrollback-clear eviction, and
`resumeHint`'s usage/target collection all read the same descendant set as
before; `runProgressRenderer`'s plain-output workflow filter is unchanged
in behavior (same membership test, now via a `Set` instead of a per-stream
`ancestors.some` scan) — see the coverage caveat under Validation below.

## Scheduled refactoring

None. This closes out #12181; no further follow-up needed for this
consolidation.

## Validation

- `npm run typecheck:workspace` — pass.
- `npm run typecheck:agent` — pass (package build + declaration validation).
- `npm run typecheck:cli` — pass.
- `npm run typecheck:test-kernel` — pass.
- `npx eslint <all changed files>` — pass.
- `npx prettier --check <all changed files>` — pass.
- `npm run check:dead-code-ratchet` — pass, no new findings.
- Targeted `vitest run`:
  `src/test-kernel/cli/StatusBar.vitest.ts`,
  `src/test-kernel/cli/ResumeHint.vitest.ts`,
  `src/test-kernel/cli/RunProgressRenderer.vitest.ts`,
  `src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts`,
  `src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts`,
  `src/test-kernel/agent/AgentPackage.vitest.ts` — 182 tests passed.

**Coverage caveat, called out by review rather than left implicit:**
`RunProgressRenderer.vitest.ts` exercises only the stderr status-line
renderer, not `attachWorkflowPlainOutput` (the function this PR's
`runProgressRenderer.ts` hunk actually changes); `RunExecution.vitest.ts`
mocks `attachWorkflowPlainOutput` rather than exercising its internals.
Behavior-equivalence for that one site rests on typecheck plus manual
reading (the `Set`-membership rewrite matching the old
`stream.id === root || stream.ancestors.some(...)` filter), not on the
listed suite. `BackgroundTasksPanel.ts` has no dedicated test file either;
same caveat applies there. Every other touched site (`sessions.ts`'s
subscription drain, `StatusBar`, `resumeHint`, `anyStreamRunning`) is
exercised by the suites above — `AgentPackage.vitest.ts` specifically
covers `sessions.ts`'s `descendantStreams` call via its "descendant joins
the run's subscription" case, added to the fake's coverage in the
post-review round below.

**Post-review round:** two findings from automated review, both verified
and fixed:
- `descendantStreams` used `Array.shift()` to pop its BFS queue, making a
  large fan-out's walk quadratic; switched to an index cursor over the
  append-only queue.
- `AgentPackage.vitest.ts`'s `FakeStreamView`/`enterStream` never carried
  `childIds`, so every faked stream crashed `descendantStreams`'
  `pending.push(...stream.childIds)` on `undefined` — this would have
  broken every run-lifecycle test in that file the moment the full suite
  ran it. Gave the fake a `childIds` field and had `enterStream` link a
  stream onto its immediate parent's `childIds` when `ancestors` are
  given, mirroring how the real fold keeps the two in sync.

Full repo-wide `vitest run` was not completed within this session's time
budget; the targeted suites above cover every host touched by this change,
with the one caveat noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aATDS8WgAbwbSyRqJ7kve