### PR TITLE
style: reformat childStream.ts with prettier

### DIFF
--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -121,7 +121,10 @@ export const createChildStream = Effect.fn('createChildStream')(function* (
   const setup = yield* Effect.exit(
     Effect.gen(function* () {
       // Attach the run's canonical event publication before activation.
-      detachSessionTrace = session.attachRunTrace(runTrace.trace, childStreamId);
+      detachSessionTrace = session.attachRunTrace(
+        runTrace.trace,
+        childStreamId,
+      );
       const disposeTrace = () => {
         detachSessionTrace?.();
         runTrace.dispose();


### PR DESCRIPTION
## Summary

`src/tools/delegation/childStream.ts` fails `prettier --check` on `main` as
of `cf88d2d` — unrelated to any behavior change, just an unwrapped call
that exceeds the project's line width:

```ts
detachSessionTrace = session.attachRunTrace(runTrace.trace, childStreamId);
```

wraps to:

```ts
detachSessionTrace = session.attachRunTrace(
  runTrace.trace,
  childStreamId,
);
```

Found while driving PR #12188 to green: its "static checks (linux)" CI job
fails on this same file, though #12188's diff never touches it — confirmed
by running `prettier --check` against the unmodified file at `cf88d2d`
directly.

## Validation

- `npx prettier --check src/tools/delegation/childStream.ts` — pass.
- `npx eslint src/tools/delegation/childStream.ts` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aATDS8WgAbwbSyRqJ7kve

---
_Generated by [Claude Code](https://claude.ai/code/session_015aATDS8WgAbwbSyRqJ7kve)_