### PR TITLE
refactor(tools): convert the src/tools remainder to Effect 4

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -201,7 +201,7 @@ export async function readCliHistoryDetails(
           store.readReport(),
           readCompletedRunConversation(id, session),
           store.readWorkspaceFiles(),
-          Effect.tryPromise(() => listRunGeneratedFiles(id)),
+          listRunGeneratedFiles(id, session),
           checkpointExists(id, session),
         ],
         { concurrency: 8 },

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -375,9 +375,11 @@ export async function initCliPlatform(
     // below), so upgrading users are not affected. Mirrors the
     // extension/desktop ordering — same seeding function, CLI's own version
     // key since the CLI tracks its bundled-agent version independently.
-    await seedDisabledToolDefaults(
-      stateStores.globalState,
-      GlobalStateKey.CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION,
+    await effectRuntime().runPromise(
+      seedDisabledToolDefaults(
+        stateStores.globalState,
+        GlobalStateKey.CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION,
+      ),
     );
 
     if (context.installSignalHandlers !== false) {

--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -1,4 +1,5 @@
 // Local imports
+import { effectRuntime } from '@platform/processRuntime';
 import {
   EXTERNAL_TOOL_DEFS,
   type ExternalToolDef,
@@ -54,7 +55,12 @@ function noteForTool(
 }
 
 export async function readCliToolStatuses(): Promise<CliToolStatusRecord[]> {
-  const checks = new Map((await runExternalToolChecks()).map((r) => [r.id, r]));
+  const checks = new Map(
+    (await effectRuntime().runPromise(runExternalToolChecks())).map((r) => [
+      r.id,
+      r,
+    ]),
+  );
   const disabledIds = getDisabledToolIds();
 
   return getCliToolDefs().map((def) => {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -345,14 +345,14 @@ export function createDesktopSettingsIpc(
     });
     await options.ui.showInfoMessage(GITHUB_TOKEN_SAVED_MESSAGE);
     await postGitHubTokenStatus();
-    await refreshToolAvailability();
+    await effectRuntime().runPromise(refreshToolAvailability());
   }
 
   async function removeGitHubToken(): Promise<void> {
     await options.secrets.delete(GITHUB_TOKEN_STORAGE_KEY);
     await options.ui.showInfoMessage(GITHUB_TOKEN_REMOVED_MESSAGE);
     await postGitHubTokenStatus();
-    await refreshToolAvailability();
+    await effectRuntime().runPromise(refreshToolAvailability());
   }
 
   async function postGitHubSubscriptions(): Promise<void> {

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -13,6 +13,7 @@ import type {
   ToolEditPreview,
   ToolEditPreviewContext,
 } from '@controllers/approval/ToolEditApprovalController';
+import { effectRuntime } from '@platform/processRuntime';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import { writeApprovalTempFiles } from '@tools/approval/tempFileManager';
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
@@ -47,12 +48,14 @@ export class DesktopToolEditApprovalHost implements ToolEditApprovalHost {
       'texra-tool-edit-',
       this.options.tempRoot,
     );
-    const { originalPath, proposedPath } = await writeApprovalTempFiles({
-      directory: tempDir,
-      targetPath: request.path,
-      originalContent: request.originalContent,
-      proposedContent: request.proposedContent,
-    });
+    const { originalPath, proposedPath } = await effectRuntime().runPromise(
+      writeApprovalTempFiles({
+        directory: tempDir,
+        targetPath: request.path,
+        originalContent: request.originalContent,
+        proposedContent: request.proposedContent,
+      }),
+    );
     return new DesktopToolEditPreview(this.options.ui, context, {
       tempDir,
       originalPath,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -852,7 +852,7 @@ function createWindow(options: {
       onboarding: requireOnboardingIpc(),
       openExternalUrl: requestPreviewHost.openExternal,
       recheckTools: async () => {
-        await refreshToolAvailability();
+        await effectRuntime().runPromise(refreshToolAvailability());
       },
       logger: console,
     });
@@ -1157,10 +1157,13 @@ function createWindow(options: {
           buildItems: async (cachedResults) => {
             const { buildToolDashboardItems } =
               await import('@controllers/settingsView/ToolDashboardData');
-            return buildToolDashboardItems('desktop', cachedResults);
+            return effectRuntime().runPromise(
+              buildToolDashboardItems('desktop', cachedResults),
+            );
           },
           getCachedCheckResults: async () => getLastCheckResults() ?? undefined,
-          refreshAvailability: refreshToolAvailability,
+          refreshAvailability: () =>
+            effectRuntime().runPromise(refreshToolAvailability()),
           planTerminalAction: async (toolId, kind) => {
             const { planToolTerminalAction } =
               await import('@controllers/settingsView/ToolDashboardData');

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -223,9 +223,11 @@ export async function initializeElectronPlatform(
   // Seed first-install defaults (e.g. disabled tools) before anything writes
   // LAST_KNOWN_VERSION, so upgrading users are not affected. Mirrors the
   // extension's ordering (extension.ts) — same key, same seeding function.
-  await seedDisabledToolDefaults(
-    globalStateStore,
-    GlobalStateKey.LAST_KNOWN_VERSION,
+  await effectRuntime().runPromise(
+    seedDisabledToolDefaults(
+      globalStateStore,
+      GlobalStateKey.LAST_KNOWN_VERSION,
+    ),
   );
 
   const resourcesPath = resolveResourcesPath(mainDirname);

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -567,9 +567,11 @@ async function activateExtension(context: vscode.ExtensionContext) {
 
   // Seed first-install defaults (e.g. disabled tools) before anything writes
   // LAST_KNOWN_VERSION, so upgrading users are not affected.
-  await seedDisabledToolDefaults(
-    context.globalState,
-    GlobalStateKey.LAST_KNOWN_VERSION,
+  await effectRuntime().runPromise(
+    seedDisabledToolDefaults(
+      context.globalState,
+      GlobalStateKey.LAST_KNOWN_VERSION,
+    ),
   );
 
   // Onboarding-funnel backfill (PRD: agent-native onboarding): upgraders who
@@ -729,22 +731,24 @@ async function activateExtension(context: vscode.ExtensionContext) {
       if (e.key !== SecretManager.GITHUB_TOKEN_KEY) return;
       // Re-probe so any subscribed UI (Tools tab) reflects the new token
       // presence; getGitHubToken() now reads SecretStorage live (no cache).
-      void refreshToolAvailability().catch(logRefreshFailure('secret change'));
+      void effectRuntime()
+        .runPromise(refreshToolAvailability())
+        .catch(logRefreshFailure('secret change'));
     }),
     // Lean/LaTeX extension installed or removed → re-probe so the Tools tab
     // reflects the new state without the user clicking Re-check.
     vscode.extensions.onDidChange(() => {
-      void refreshToolAvailability().catch(
-        logRefreshFailure('extension change'),
-      );
+      void effectRuntime()
+        .runPromise(refreshToolAvailability())
+        .catch(logRefreshFailure('extension change'));
     }),
     // Workspace folders opened/closed can flip `isGitRepository`, which
     // gates the GitHub PR subscription tool group. ProgressViewProvider owns
     // the ordered workspace-storage and native-config replacement.
     vscode.workspace.onDidChangeWorkspaceFolders(() => {
-      void refreshToolAvailability().catch(
-        logRefreshFailure('workspace folder change'),
-      );
+      void effectRuntime()
+        .runPromise(refreshToolAvailability())
+        .catch(logRefreshFailure('workspace folder change'));
     }),
   );
   const disposeGitHubAuthListener = appSignals.on(

--- a/packages/extension/src/frontend/approval/VscodeToolEditApprovalHost.ts
+++ b/packages/extension/src/frontend/approval/VscodeToolEditApprovalHost.ts
@@ -23,6 +23,7 @@ import {
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import type { DiffSession, DiffViewHost } from '@hosts/uiHosts';
+import { effectRuntime } from '@platform/processRuntime';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import type { ApprovalTempFiles } from '@tools/approval/tempFileManager';
 import { writeApprovalTempFiles } from '@tools/approval/tempFileManager';
@@ -48,12 +49,14 @@ export class VscodeToolEditApprovalHost implements ToolEditApprovalHost {
     context: ToolEditPreviewContext,
   ): Promise<ToolEditPreview> {
     await mkdir(this.storageDirectory, { recursive: true });
-    const staged = await writeApprovalTempFiles({
-      directory: this.storageDirectory,
-      targetPath: request.path,
-      originalContent: request.originalContent,
-      proposedContent: request.proposedContent,
-    });
+    const staged = await effectRuntime().runPromise(
+      writeApprovalTempFiles({
+        directory: this.storageDirectory,
+        targetPath: request.path,
+        originalContent: request.originalContent,
+        proposedContent: request.proposedContent,
+      }),
+    );
     return new VscodeToolEditPreview(
       this.diffViewHost,
       request,
@@ -133,7 +136,7 @@ class VscodeToolEditPreview implements ToolEditPreview {
     // Stop listening for tab closes before closing the diff ourselves.
     this.tabCloseListener?.dispose();
     await this.diffViewHost.closeDiff(this.diffSession);
-    await this.staged.cleanup();
+    await effectRuntime().runPromise(this.staged.cleanup);
   }
 
   private openDiff(): Promise<void> {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -347,7 +347,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       openToolInstallUrl: (message) => this.openExternalUrl(message.url),
       installToolExtension: (message) =>
         this.latexHandlers.installExtension(message.extensionId),
-      recheckToolStatus: () => refreshToolAvailability(),
+      recheckToolStatus: () =>
+        effectRuntime().runPromise(refreshToolAvailability()),
       toggleTool: async (message) => {
         await setToolEnabled(message.toolId, message.enabled);
         await this.withActiveWebview((w) =>
@@ -839,7 +840,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     const cachedResults = options?.skipChecks
       ? (getLastCheckResults() ?? undefined)
       : undefined;
-    const items = await buildToolDashboardItems('extension', cachedResults);
+    const items = await effectRuntime().runPromise(
+      buildToolDashboardItems('extension', cachedResults),
+    );
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
       items,

--- a/src/controllers/settingsView/ToolDashboardData.ts
+++ b/src/controllers/settingsView/ToolDashboardData.ts
@@ -6,6 +6,9 @@
  * keeps that tool-layer dependency out of shared settings-view code.
  */
 
+// Third-party imports
+import { Effect } from 'effect';
+
 // Local imports
 import type { ToolHost } from '@agent/core/tools/ToolTypes';
 import type { ToolCommandKind, ToolDashboardItem } from '@shared/schemas';
@@ -156,66 +159,65 @@ const BUILTIN_TOOLS: (Omit<
  *   these results (including their `statusDetail`). Used by the toggle
  *   handler for instant UI updates.
  */
-export async function buildToolDashboardItems(
-  host: ToolHost,
-  cachedResults?: ExternalToolCheckResult[],
-): Promise<ToolDashboardItem[]> {
-  const builtinItems: ToolDashboardItem[] = BUILTIN_TOOLS.filter(
-    ({ toolNames }) =>
-      !toolNames.every((name) => isDefaultToolUnavailableOnHost(name, host)),
-  ).map(({ toolNames, ...rest }) => ({
-    ...rest,
-    tools: toolNames.map((name) => ({ name })),
-    status: 'available' as const,
-    installActions: [],
-    requiresSetup: false,
-  }));
+export const buildToolDashboardItems = Effect.fn('buildToolDashboardItems')(
+  function* (host: ToolHost, cachedResults?: ExternalToolCheckResult[]) {
+    const builtinItems: ToolDashboardItem[] = BUILTIN_TOOLS.filter(
+      ({ toolNames }) =>
+        !toolNames.every((name) => isDefaultToolUnavailableOnHost(name, host)),
+    ).map(({ toolNames, ...rest }) => ({
+      ...rest,
+      tools: toolNames.map((name) => ({ name })),
+      status: 'available' as const,
+      installActions: [],
+      requiresSetup: false,
+    }));
 
-  const results = cachedResults ?? (await runExternalToolChecks());
+    const results = cachedResults ?? (yield* runExternalToolChecks());
 
-  const disabledIds = getDisabledToolIds();
-  const externalItems: ToolDashboardItem[] = [];
-  for (const { id, tools, status, statusLabel, statusDetail } of results) {
-    const def = findExternalToolDef(id);
-    if (!def || def.hideFromDashboard) continue;
-    externalItems.push({
-      id: def.id,
-      name: def.name,
-      category: def.category,
-      description: def.description,
-      tools: tools.map((name) => ({ name })),
-      status,
-      statusLabel,
-      requiresSetup: true,
-      installActions: [
-        ...(def.installGuide
-          ? [{ kind: 'guide' as const, text: def.installGuide }]
-          : []),
-        ...(def.installCommand
-          ? [{ kind: 'command' as const, command: def.installCommand }]
-          : []),
-        ...(def.authCommand
-          ? [{ kind: 'auth' as const, command: def.authCommand }]
-          : []),
-        ...(def.installExtensionId
-          ? [
-              {
-                kind: 'extension' as const,
-                extensionId: def.installExtensionId,
-              },
-            ]
-          : []),
-        ...(def.installUrl
-          ? [{ kind: 'url' as const, url: def.installUrl }]
-          : []),
-      ],
-      configNotes: def.configNotes,
-      statusDetail,
-      authNote: def.authNote,
-      toggleable: def.toggleable,
-      enabled: !disabledIds.has(def.id),
-    });
-  }
+    const disabledIds = getDisabledToolIds();
+    const externalItems: ToolDashboardItem[] = [];
+    for (const { id, tools, status, statusLabel, statusDetail } of results) {
+      const def = findExternalToolDef(id);
+      if (!def || def.hideFromDashboard) continue;
+      externalItems.push({
+        id: def.id,
+        name: def.name,
+        category: def.category,
+        description: def.description,
+        tools: tools.map((name) => ({ name })),
+        status,
+        statusLabel,
+        requiresSetup: true,
+        installActions: [
+          ...(def.installGuide
+            ? [{ kind: 'guide' as const, text: def.installGuide }]
+            : []),
+          ...(def.installCommand
+            ? [{ kind: 'command' as const, command: def.installCommand }]
+            : []),
+          ...(def.authCommand
+            ? [{ kind: 'auth' as const, command: def.authCommand }]
+            : []),
+          ...(def.installExtensionId
+            ? [
+                {
+                  kind: 'extension' as const,
+                  extensionId: def.installExtensionId,
+                },
+              ]
+            : []),
+          ...(def.installUrl
+            ? [{ kind: 'url' as const, url: def.installUrl }]
+            : []),
+        ],
+        configNotes: def.configNotes,
+        statusDetail,
+        authNote: def.authNote,
+        toggleable: def.toggleable,
+        enabled: !disabledIds.has(def.id),
+      });
+    }
 
-  return [...builtinItems, ...externalItems];
-}
+    return [...builtinItems, ...externalItems];
+  },
+);

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -258,7 +258,9 @@ describe('createWorkflowScriptAgentRunner', () => {
       category: 'workflow',
       path: `/agents/${name}.yml`,
     }));
-    mocks.selectAvailableDelegationModel.mockResolvedValue('child-model');
+    mocks.selectAvailableDelegationModel.mockReturnValue(
+      Effect.succeed('child-model'),
+    );
     mocks.workspaceExists.mockResolvedValue(true);
     mocks.rejectOversizedBibAttachments.mockResolvedValue(null);
     mocks.runStorageLocationFromAnyAbsolutePath.mockReturnValue(undefined);
@@ -424,6 +426,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     expect(mocks.workspaceExists).toHaveBeenCalledWith('/workspace/figure.pdf');
     expect(mocks.selectAvailableDelegationModel).toHaveBeenCalledWith({
       parentModel: 'parent-model',
+      withScope: expect.any(Function),
     });
     expect(mocks.executeStableSubagentInBand).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -503,16 +506,20 @@ describe('createWorkflowScriptAgentRunner', () => {
     expect(mocks.selectAvailableDelegationModel).toHaveBeenNthCalledWith(1, {
       requestedModel: 'economy-model',
       parentModel: 'parent-model',
+      withScope: expect.any(Function),
     });
     expect(mocks.selectAvailableDelegationModel).toHaveBeenNthCalledWith(2, {
       requestedModel: 'strong-model',
       parentModel: 'parent-model',
+      withScope: expect.any(Function),
     });
   });
 
   it('fails the workflow when a declared model is unavailable', async () => {
-    mocks.selectAvailableDelegationModel.mockRejectedValueOnce(
-      new Error('Model "missing-model" is not currently available.'),
+    mocks.selectAvailableDelegationModel.mockReturnValueOnce(
+      Effect.fail(
+        new Error('Model "missing-model" is not currently available.'),
+      ),
     );
     mocks.workspaceExists.mockResolvedValue(false);
     const runner = defaultRunner();
@@ -533,7 +540,9 @@ describe('createWorkflowScriptAgentRunner', () => {
 
   it('preserves delegation failures when no model is declared', async () => {
     const selectionError = new Error('No delegation models are available.');
-    mocks.selectAvailableDelegationModel.mockRejectedValueOnce(selectionError);
+    mocks.selectAvailableDelegationModel.mockReturnValueOnce(
+      Effect.fail(selectionError),
+    );
     const runner = defaultRunner();
 
     await expect(
@@ -937,6 +946,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     );
     expect(mocks.selectAvailableDelegationModel).toHaveBeenCalledWith({
       parentModel: 'parent-model',
+      withScope: expect.any(Function),
     });
     expect(mocks.preparedOptions[0]).toEqual(
       expect.objectContaining({

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -1,4 +1,4 @@
-import { Redacted } from 'effect';
+import { Effect, Redacted } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -19,9 +19,12 @@ import { UnsetApiKeyTool } from '@tools/setup/UnsetApiKeyTool';
 import { setSetupPlatform } from '@tools/setup/platform';
 
 const setupSecretsMocks = vi.hoisted(() => ({
-  deleteApiKey: vi.fn<(provider: ApiProvider) => Promise<void>>(),
-  hasUsableApiKey: vi.fn<(provider: ApiProvider) => Promise<boolean>>(),
-  storedApiKeyExists: vi.fn<(provider: ApiProvider) => Promise<boolean>>(),
+  deleteApiKey:
+    vi.fn<(provider: ApiProvider) => Effect.Effect<void, unknown>>(),
+  hasUsableApiKey:
+    vi.fn<(provider: ApiProvider) => Effect.Effect<boolean, unknown>>(),
+  storedApiKeyExists:
+    vi.fn<(provider: ApiProvider) => Effect.Effect<boolean, unknown>>(),
 }));
 
 vi.mock('@tools/setup/platform', async (importOriginal) => {
@@ -72,16 +75,20 @@ function setupApiKeyToolPlatform(
   store: Map<string, string>,
   envProviders: ReadonlySet<ApiProvider> = new Set(),
 ): void {
-  setupSecretsMocks.deleteApiKey.mockImplementation(async (provider) => {
-    store.delete(apiKeySecretName(provider));
-  });
-  setupSecretsMocks.hasUsableApiKey.mockImplementation(
-    async (provider) =>
-      (store.get(apiKeySecretName(provider))?.trim().length ?? 0) > 0 ||
-      envProviders.has(provider),
+  setupSecretsMocks.deleteApiKey.mockImplementation((provider) =>
+    Effect.sync(() => {
+      store.delete(apiKeySecretName(provider));
+    }),
   );
-  setupSecretsMocks.storedApiKeyExists.mockImplementation(async (provider) =>
-    store.has(apiKeySecretName(provider)),
+  setupSecretsMocks.hasUsableApiKey.mockImplementation((provider) =>
+    Effect.sync(
+      () =>
+        (store.get(apiKeySecretName(provider))?.trim().length ?? 0) > 0 ||
+        envProviders.has(provider),
+    ),
+  );
+  setupSecretsMocks.storedApiKeyExists.mockImplementation((provider) =>
+    Effect.sync(() => store.has(apiKeySecretName(provider))),
   );
   setSetupPlatform({
     host: 'cli',

--- a/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
+++ b/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
@@ -7,9 +7,10 @@ const gitignoreMock = vi.hoisted(() => ({
 }));
 
 vi.mock('@tools/gitignore', () => ({
-  getGitignoreMatcher: async () => ({
-    ignores: (path: string) => gitignoreMock.ignoredPaths.has(path),
-  }),
+  getGitignoreMatcher: () =>
+    Effect.succeed({
+      ignores: (path: string) => gitignoreMock.ignoredPaths.has(path),
+    }),
 }));
 
 // Local imports

--- a/src/test-kernel/tools/Attachments.vitest.ts
+++ b/src/test-kernel/tools/Attachments.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
 
 import { buildBytesAttachment } from '@tools/attachments';
@@ -17,11 +18,13 @@ function pngHeader(width: number, height: number): Buffer {
 }
 
 function buildImageAttachment(bytes: Buffer) {
-  return buildBytesAttachment({
-    path: 'figure.png',
-    mimeType: 'image/png',
-    bytes,
-  });
+  return Effect.runSync(
+    buildBytesAttachment({
+      path: 'figure.png',
+      mimeType: 'image/png',
+      bytes,
+    }),
+  );
 }
 
 describe('buildBytesAttachment oversized-image handling', () => {

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -2,6 +2,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - model
@@ -55,7 +56,7 @@ type BuildEnvOptions = Parameters<
 /** Reload the module under the current mocks and build the env in one step. */
 async function buildEnv(options?: BuildEnvOptions): Promise<NodeJS.ProcessEnv> {
   const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
-  return buildClaudeAgentEnv(options);
+  return Effect.runPromise(buildClaudeAgentEnv(options));
 }
 
 function seedManagedSecret(): void {

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -170,7 +170,7 @@ describe('claude_agent tool launch and resume fallback', () => {
     mocks.getCurrentToolContexts.mockReturnValue(fakeToolContexts());
     mocks.registerExecution.mockReturnValue(Effect.void);
     mocks.getExecutionStore.mockReturnValue({ write: async () => {} });
-    mocks.buildClaudeAgentEnv.mockResolvedValue({});
+    mocks.buildClaudeAgentEnv.mockReturnValue(Effect.succeed({}));
     mocks.findClaudeBinaryPath.mockResolvedValue(undefined);
     mocks.createChildStream.mockReturnValue(
       Effect.succeed(createFakeAgentCliChildStream(childStreamId)),
@@ -402,7 +402,7 @@ describe('claude_agent tool launch and resume fallback', () => {
     const captured = captureStrategy();
     mocks.buildClaudeAgentEnv.mockImplementation(() => {
       envStarted.resolve(undefined);
-      return envReady.promise;
+      return Effect.promise(() => envReady.promise);
     });
 
     const tool = new ClaudeAgentTool();
@@ -466,9 +466,12 @@ describe('claude_agent tool launch and resume fallback', () => {
     mocks.buildClaudeAgentEnv
       .mockImplementationOnce(() => {
         firstEnvStarted.resolve(undefined);
-        return firstEnv.promise;
+        // A rejected env read was a rejected Promise collaborator before the
+        // conversion; as an Effect with no failure channel it stays a defect,
+        // so the tool still surfaces it as an error result.
+        return Effect.promise(() => firstEnv.promise);
       })
-      .mockResolvedValueOnce({});
+      .mockReturnValueOnce(Effect.succeed({}));
 
     const tool = new ClaudeAgentTool();
     const first = tool.call({

--- a/src/test-kernel/tools/DelegationAvailability.vitest.ts
+++ b/src/test-kernel/tools/DelegationAvailability.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ModelOptionData, ToolDefinition } from '@shared/schemas';
@@ -363,10 +364,12 @@ describe('delegation model availability', () => {
     ]);
 
     await expect(
-      selectAvailableDelegationModel({
-        requestedModel: 'opus48T',
-        parentModel: 'sonnet46T',
-      }),
+      Effect.runPromise(
+        selectAvailableDelegationModel({
+          requestedModel: 'opus48T',
+          parentModel: 'sonnet46T',
+        }),
+      ),
     ).rejects.toThrow(
       'Model "opus48T" is not currently available for delegation with the currently configured model access. Available models: sonnet46T, deepseekT.',
     );
@@ -379,11 +382,15 @@ describe('delegation model availability', () => {
     ]);
 
     await expect(
-      selectAvailableDelegationModel({ parentModel: 'sonnet46T' }),
+      Effect.runPromise(
+        selectAvailableDelegationModel({ parentModel: 'sonnet46T' }),
+      ),
     ).resolves.toBe('sonnet46T');
 
     await expect(
-      selectAvailableDelegationModel({ parentModel: 'opus48T' }),
+      Effect.runPromise(
+        selectAvailableDelegationModel({ parentModel: 'opus48T' }),
+      ),
     ).resolves.toBe('deepseekT');
   });
 
@@ -391,7 +398,9 @@ describe('delegation model availability', () => {
     mocks.computeModelOptionsData.mockResolvedValue([]);
 
     await expect(
-      selectAvailableDelegationModel({ parentModel: 'opus48T' }),
+      Effect.runPromise(
+        selectAvailableDelegationModel({ parentModel: 'opus48T' }),
+      ),
     ).rejects.toThrow(
       'No models are currently available for delegation. Review or configure model access before delegating.',
     );

--- a/src/test-kernel/tools/EmlParser.vitest.ts
+++ b/src/test-kernel/tools/EmlParser.vitest.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
+import { Effect } from 'effect';
 import { describe, it } from 'vitest';
 
 // Local imports
@@ -21,7 +22,7 @@ Content-Type: text/html; charset=utf-8
 
 describe('parseEml', () => {
   it('converts an HTML-only body to Markdown without leaking style/script content', async () => {
-    const { text } = await parseEml(HTML_ONLY_EML);
+    const { text } = await Effect.runPromise(parseEml(HTML_ONLY_EML));
 
     assert.match(text, /Hello \*\*world\*\*,/);
     assert.match(text, /Item one/);

--- a/src/test-kernel/tools/GitignoreMatcher.vitest.ts
+++ b/src/test-kernel/tools/GitignoreMatcher.vitest.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { errnoError } from '@test/support/fsTestUtils';
@@ -88,7 +89,7 @@ vi.mock('@utils/system/platformPaths', () => ({
 async function loadMatcher() {
   vi.resetModules();
   const { getGitignoreMatcher } = await import('@tools/gitignore');
-  return getGitignoreMatcher();
+  return Effect.runPromise(getGitignoreMatcher());
 }
 
 async function loadWorkspaceMatcher(gitignore: string) {
@@ -162,8 +163,8 @@ describe('getGitignoreMatcher', () => {
     const { getGitignoreMatcher } = await import('@tools/gitignore');
 
     const failedCalls = await Promise.allSettled([
-      getGitignoreMatcher(),
-      getGitignoreMatcher(),
+      Effect.runPromise(getGitignoreMatcher()),
+      Effect.runPromise(getGitignoreMatcher()),
     ]);
 
     for (const result of failedCalls) {
@@ -176,8 +177,8 @@ describe('getGitignoreMatcher', () => {
 
     fsState.workspaceReadErrors.delete('.gitignore');
     const [matcher, concurrentMatcher] = await Promise.all([
-      getGitignoreMatcher(),
-      getGitignoreMatcher(),
+      Effect.runPromise(getGitignoreMatcher()),
+      Effect.runPromise(getGitignoreMatcher()),
     ]);
 
     expect(matcher).toBe(concurrentMatcher);

--- a/src/test-kernel/tools/RunGeneratedFiles.vitest.ts
+++ b/src/test-kernel/tools/RunGeneratedFiles.vitest.ts
@@ -1,9 +1,12 @@
 import * as path from 'node:path';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { platform } from '@platform/platform';
 import type { ExecutionId } from '@shared/schemas';
+import { createProcessSession } from '@test/support/sessionTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { listRunGeneratedFiles } from '@tools/executions/runGeneratedFiles';
 
@@ -38,6 +41,10 @@ describe('listRunGeneratedFiles', () => {
       [path.join(RUN_PATH, 'turn-state.json', 'buried.tex')]: 'buried',
     },
   });
+  let session: SessionHandle;
+  beforeEach(() => {
+    session = createProcessSession();
+  });
   afterEach(() => vi.restoreAllMocks());
 
   it('lists in path order, skipping KV-named subtrees and concurrent disappearance', async () => {
@@ -46,7 +53,9 @@ describe('listRunGeneratedFiles', () => {
       fsError('ENOENT', 'entry disappeared after readDir'),
     );
 
-    await expect(listRunGeneratedFiles(EXECUTION_ID)).resolves.toEqual([
+    await expect(
+      Effect.runPromise(listRunGeneratedFiles(EXECUTION_ID, session)),
+    ).resolves.toEqual([
       { path: 'blocked.tex', size: 7, isDirectory: false },
       { path: 'sub', size: 0, isDirectory: true },
       { path: 'sub/nested.tex', size: 6, isDirectory: false },
@@ -61,7 +70,9 @@ describe('listRunGeneratedFiles', () => {
       fsError('ENOTDIR', 'parent path is no longer a directory'),
     );
 
-    const files = await listRunGeneratedFiles(EXECUTION_ID);
+    const files = await Effect.runPromise(
+      listRunGeneratedFiles(EXECUTION_ID, session),
+    );
 
     expect(files.map((file) => file.path)).not.toContain('blocked.tex');
   });
@@ -70,6 +81,8 @@ describe('listRunGeneratedFiles', () => {
     const error = fsError('EACCES', 'generated file is unreadable');
     failStatFor(path.join(RUN_PATH, 'unreadable.tex'), error);
 
-    await expect(listRunGeneratedFiles(EXECUTION_ID)).rejects.toBe(error);
+    await expect(
+      Effect.runPromise(listRunGeneratedFiles(EXECUTION_ID, session)),
+    ).rejects.toBe(error);
   });
 });

--- a/src/test-kernel/tools/ToolAvailabilityAppSignals.vitest.ts
+++ b/src/test-kernel/tools/ToolAvailabilityAppSignals.vitest.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 afterEach(() => {
@@ -15,7 +16,7 @@ describe('tool availability app signals', () => {
           tools: [],
           name: 'Test tool',
           category: 'ai-agents',
-          check: vi.fn(async () => true),
+          check: vi.fn(() => Effect.succeed(true)),
         },
       ],
     }));
@@ -27,7 +28,7 @@ describe('tool availability app signals', () => {
     });
 
     try {
-      await refreshToolAvailability();
+      await Effect.runPromise(refreshToolAvailability());
 
       expect(events).toEqual([undefined]);
     } finally {
@@ -43,7 +44,7 @@ describe('tool availability app signals', () => {
           tools: ['present'],
           name: 'Present tool',
           category: 'ai-agents',
-          check: vi.fn(async () => true),
+          check: vi.fn(() => Effect.succeed(true)),
         },
         {
           id: 'missing-tool',
@@ -51,7 +52,7 @@ describe('tool availability app signals', () => {
           name: 'Missing tool',
           category: 'ai-agents',
           toggleable: true,
-          check: vi.fn(async () => false),
+          check: vi.fn(() => Effect.succeed(false)),
         },
       ],
     }));
@@ -60,7 +61,7 @@ describe('tool availability app signals', () => {
 
     expect([...getUnavailableToolNamesCached()]).toEqual([]);
 
-    await runExternalToolChecks();
+    await Effect.runPromise(runExternalToolChecks());
 
     // Toggling a tool on or off never changes this set — it reports missing
     // external dependencies only — so there is nothing to rebuild after a
@@ -76,27 +77,27 @@ describe('tool availability app signals', () => {
           tools: ['broken'],
           name: 'Broken probe',
           category: 'ai-agents',
-          probe: vi.fn(async () => {
-            throw new Error('invalid local configuration');
-          }),
-          check: vi.fn(async () => true),
-          statusLabel: vi.fn(async () => 'Needs setup'),
+          probe: vi.fn(() =>
+            Effect.fail(new Error('invalid local configuration')),
+          ),
+          check: vi.fn(() => Effect.succeed(true)),
+          statusLabel: vi.fn(() => Effect.succeed('Needs setup')),
         },
         {
           id: 'broken-detail',
           tools: ['present'],
           name: 'Broken detail',
           category: 'ai-agents',
-          check: vi.fn(async () => true),
-          detailCheck: vi.fn(async () => {
-            throw new Error('status command crashed');
-          }),
+          check: vi.fn(() => Effect.succeed(true)),
+          detailCheck: vi.fn(() =>
+            Effect.fail(new Error('status command crashed')),
+          ),
         },
       ],
     }));
     const { runExternalToolChecks } = await import('@tools/toolAvailability');
 
-    await expect(runExternalToolChecks()).resolves.toEqual([
+    await expect(Effect.runPromise(runExternalToolChecks())).resolves.toEqual([
       expect.objectContaining({
         id: 'broken-probe',
         status: 'unknown',

--- a/src/test-kernel/tools/ToolAvailabilitySeeding.vitest.ts
+++ b/src/test-kernel/tools/ToolAvailabilitySeeding.vitest.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports
@@ -20,7 +21,9 @@ describe('seedDisabledToolDefaults', () => {
   it('seeds every toggleable tool as disabled on a genuinely fresh install', async () => {
     await installPlatform({ globalState: {} });
 
-    await seedDisabledToolDefaults(platform().globalState, VERSION_KEY);
+    await Effect.runPromise(
+      seedDisabledToolDefaults(platform().globalState, VERSION_KEY),
+    );
 
     expect(platform().globalState.get(GlobalStateKey.DISABLED_TOOLS)).toEqual(
       EXPECTED_DEFAULTS,
@@ -39,7 +42,9 @@ describe('seedDisabledToolDefaults', () => {
   ])('does not seed for $name', async ({ globalState }) => {
     await installPlatform({ globalState });
 
-    await seedDisabledToolDefaults(platform().globalState, VERSION_KEY);
+    await Effect.runPromise(
+      seedDisabledToolDefaults(platform().globalState, VERSION_KEY),
+    );
 
     expect(platform().globalState.get(GlobalStateKey.DISABLED_TOOLS)).toEqual(
       globalState[GlobalStateKey.DISABLED_TOOLS],

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -265,7 +265,9 @@ beforeEach(async () => {
   await WorkspaceFS.write('references.bib', '@book{example}');
   await WorkspaceFS.write('figure.pdf', 'pdf');
   mocks.registerExecution.mockReturnValue(Effect.void);
-  mocks.selectAvailableDelegationModel.mockResolvedValue('parent-model');
+  mocks.selectAvailableDelegationModel.mockReturnValue(
+    Effect.succeed('parent-model'),
+  );
   mocks.requestDelegationProposal.mockResolvedValue({
     result: { action: 'approve' },
     autoApproved: false,
@@ -784,12 +786,15 @@ return null`;
   });
 
   it('gates the run model through delegation model availability', async () => {
-    mocks.selectAvailableDelegationModel.mockResolvedValueOnce('served-model');
+    mocks.selectAvailableDelegationModel.mockReturnValueOnce(
+      Effect.succeed('served-model'),
+    );
 
     await callTool();
 
     expect(mocks.selectAvailableDelegationModel).toHaveBeenCalledWith({
       parentModel: 'parent-model',
+      withScope: expect.any(Function),
     });
     expect(mocks.registerExecution).toHaveBeenCalledWith(
       currentSession(),
@@ -801,8 +806,10 @@ return null`;
   });
 
   it('rejects an unserveable run model before registering a detached run', async () => {
-    mocks.selectAvailableDelegationModel.mockRejectedValueOnce(
-      new Error('No models are currently available for delegation.'),
+    mocks.selectAvailableDelegationModel.mockReturnValueOnce(
+      Effect.fail(
+        new Error('No models are currently available for delegation.'),
+      ),
     );
 
     const result = await callTool();

--- a/src/test-kernel/tools/externalToolDefs.vitest.ts
+++ b/src/test-kernel/tools/externalToolDefs.vitest.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - platform/test support/tools
@@ -29,11 +30,11 @@ describe('external tool definitions', () => {
     await installToolAvailability(true);
 
     try {
-      const probeResult = await texraCli.probe?.();
+      const probeResult = await Effect.runPromise(texraCli.probe!());
 
       expect(probeResult).toBe(true);
-      expect(await texraCli.check(probeResult)).toBe(true);
-      expect(await texraCli.statusLabel?.(probeResult)).toBe(
+      expect(await Effect.runPromise(texraCli.check(probeResult))).toBe(true);
+      expect(await Effect.runPromise(texraCli.statusLabel!(probeResult))).toBe(
         'Detected; integration coming soon',
       );
     } finally {
@@ -50,23 +51,27 @@ describe('external tool definitions', () => {
     await installToolAvailability(false);
 
     try {
-      const probeResult = await lean.probe?.();
+      const probeResult = await Effect.runPromise(lean.probe!());
 
       expect(findPath).toHaveBeenCalledWith('lake');
       expect(probeResult).toEqual({
         extensionAvailable: false,
         lakeAvailable: true,
       });
-      await expect(lean.check(probeResult)).resolves.toBe(true);
+      await expect(Effect.runPromise(lean.check(probeResult))).resolves.toBe(
+        true,
+      );
 
       findPath.mockReturnValue(null);
-      const missingProbeResult = await lean.probe?.();
+      const missingProbeResult = await Effect.runPromise(lean.probe!());
 
       expect(missingProbeResult).toEqual({
         extensionAvailable: false,
         lakeAvailable: false,
       });
-      await expect(lean.check(missingProbeResult)).resolves.toBe(false);
+      await expect(
+        Effect.runPromise(lean.check(missingProbeResult)),
+      ).resolves.toBe(false);
     } finally {
       await installPlatform();
     }

--- a/src/test-kernel/tools/grep.vitest.ts
+++ b/src/test-kernel/tools/grep.vitest.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
@@ -44,10 +45,12 @@ describe('GrepTool execution', () => {
   });
 
   function mockWorkspaceGitignore(): void {
-    vi.spyOn(gitignoreUtils, 'getGitignoreMatcher').mockResolvedValue({
-      ignores: () => false,
-      ignoreFiles: ['/workspace/.gitignore'],
-    });
+    vi.spyOn(gitignoreUtils, 'getGitignoreMatcher').mockReturnValue(
+      Effect.succeed({
+        ignores: () => false,
+        ignoreFiles: ['/workspace/.gitignore'],
+      }),
+    );
   }
 
   it('preserves total-count and offset/head_limit pagination semantics', async () => {

--- a/src/test-kernel/tools/lean/LakeCommandsOutput.vitest.ts
+++ b/src/test-kernel/tools/lean/LakeCommandsOutput.vitest.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({ execa: vi.fn() }));
 vi.mock('execa', () => ({ execa: mocks.execa }));
 
 // Local imports
+import { effectRuntime } from '@platform/processRuntime';
 import { runLakeCommand } from '@tools/lean/direct/lakeCommands';
 
 describe('runLakeCommand output failures', () => {
@@ -37,7 +38,7 @@ describe('runLakeCommand output failures', () => {
       shortMessage: 'Command failed with exit code 7',
     });
 
-    const result = await runLakeCommand(LAKE_BUILD);
+    const result = await effectRuntime().runPromise(runLakeCommand(LAKE_BUILD));
 
     expect(result).toEqual({
       exitCode: 7,
@@ -56,7 +57,7 @@ describe('runLakeCommand output failures', () => {
       shortMessage: 'Command failed: stdout maxBuffer exceeded',
     });
 
-    const result = await runLakeCommand(LAKE_BUILD);
+    const result = await effectRuntime().runPromise(runLakeCommand(LAKE_BUILD));
 
     expect(result).toEqual({
       exitCode: -1,

--- a/src/test-kernel/tools/lean/LeanTools.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanTools.vitest.ts
@@ -124,7 +124,9 @@ describe('Lean external tool status', () => {
     });
 
     await expect(
-      lean!.statusLabel!({ extensionAvailable: false, lakeAvailable: true }),
+      effectRuntime().runPromise(
+        lean!.statusLabel!({ extensionAvailable: false, lakeAvailable: true }),
+      ),
     ).resolves.toBeUndefined();
 
     registerLeanServer({
@@ -134,12 +136,16 @@ describe('Lean external tool status', () => {
       status: 'starting',
     });
     await expect(
-      lean!.statusLabel!({ extensionAvailable: false, lakeAvailable: true }),
+      effectRuntime().runPromise(
+        lean!.statusLabel!({ extensionAvailable: false, lakeAvailable: true }),
+      ),
     ).resolves.toBe('1 server active');
 
     updateLeanServer('direct:/running', { status: 'running' });
     await expect(
-      lean!.statusLabel!({ extensionAvailable: false, lakeAvailable: true }),
+      effectRuntime().runPromise(
+        lean!.statusLabel!({ extensionAvailable: false, lakeAvailable: true }),
+      ),
     ).resolves.toBe('1 server active');
   });
 });

--- a/src/test-kernel/tools/lean/LeanTools.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanTools.vitest.ts
@@ -210,14 +210,16 @@ describe('runLakeCommand mutex', () => {
   });
 
   it('keeps the current 4,194,304-character tail cap and truncation marker', async () => {
-    const result = await runLakeCommand({
-      workspaceRoot: workspaceA,
-      lakeCommand: NODE,
-      args: [
-        '-e',
-        `process.stdout.write('HEAD_MARKER' + 'x'.repeat(${4 * 1024 * 1024 + 100}) + 'TAIL_MARKER')`,
-      ],
-    });
+    const result = await effectRuntime().runPromise(
+      runLakeCommand({
+        workspaceRoot: workspaceA,
+        lakeCommand: NODE,
+        args: [
+          '-e',
+          `process.stdout.write('HEAD_MARKER' + 'x'.repeat(${4 * 1024 * 1024 + 100}) + 'TAIL_MARKER')`,
+        ],
+      }),
+    );
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout.startsWith('…[output truncated]…\n')).toBe(true);
@@ -229,14 +231,16 @@ describe('runLakeCommand mutex', () => {
   });
 
   it('preserves non-zero exit diagnostics', async () => {
-    const result = await runLakeCommand({
-      workspaceRoot: workspaceA,
-      lakeCommand: NODE,
-      args: [
-        '-e',
-        `process.stdout.write('build context'); process.stderr.write('compile failed'); process.exit(7)`,
-      ],
-    });
+    const result = await effectRuntime().runPromise(
+      runLakeCommand({
+        workspaceRoot: workspaceA,
+        lakeCommand: NODE,
+        args: [
+          '-e',
+          `process.stdout.write('build context'); process.stderr.write('compile failed'); process.exit(7)`,
+        ],
+      }),
+    );
 
     expect(result).toEqual({
       exitCode: 7,
@@ -246,12 +250,14 @@ describe('runLakeCommand mutex', () => {
   });
 
   it('preserves timeout diagnostics', async () => {
-    const result = await runLakeCommand({
-      workspaceRoot: workspaceA,
-      lakeCommand: NODE,
-      args: ['-e', 'setTimeout(() => {}, 60_000)'],
-      timeoutMs: 20,
-    });
+    const result = await effectRuntime().runPromise(
+      runLakeCommand({
+        workspaceRoot: workspaceA,
+        lakeCommand: NODE,
+        args: ['-e', 'setTimeout(() => {}, 60_000)'],
+        timeoutMs: 20,
+      }),
+    );
 
     expect(result.exitCode).toBe(-1);
     expect(result.stderr).toContain('timed out after 20 milliseconds');
@@ -263,18 +269,22 @@ describe('runLakeCommand mutex', () => {
     const gateB = path.join(workspaceA, 'gate-b');
     const readyB = path.join(workspaceA, 'ready-b');
 
-    const first = runLakeCommand({
-      workspaceRoot: workspaceA,
-      lakeCommand: NODE,
-      args: nodeGateCommand(readyA, gateA),
-      serialize: true,
-    });
-    const second = runLakeCommand({
-      workspaceRoot: workspaceA,
-      lakeCommand: NODE,
-      args: nodeGateCommand(readyB, gateB),
-      serialize: true,
-    });
+    const first = effectRuntime().runPromise(
+      runLakeCommand({
+        workspaceRoot: workspaceA,
+        lakeCommand: NODE,
+        args: nodeGateCommand(readyA, gateA),
+        serialize: true,
+      }),
+    );
+    const second = effectRuntime().runPromise(
+      runLakeCommand({
+        workspaceRoot: workspaceA,
+        lakeCommand: NODE,
+        args: nodeGateCommand(readyB, gateB),
+        serialize: true,
+      }),
+    );
 
     // The first child holds the workspace mutex: it starts and blocks on its
     // gate. While that gate holds, the second call's child cannot have
@@ -314,18 +324,22 @@ describe('runLakeCommand mutex', () => {
     const readyB = path.join(secondWorkspace(), 'ready-b');
 
     const calls = Promise.all([
-      runLakeCommand({
-        workspaceRoot: workspaceA,
-        lakeCommand: NODE,
-        args: nodeGateCommand(readyA, gateA),
-        serialize,
-      }),
-      runLakeCommand({
-        workspaceRoot: secondWorkspace(),
-        lakeCommand: NODE,
-        args: nodeGateCommand(readyB, gateB),
-        serialize,
-      }),
+      effectRuntime().runPromise(
+        runLakeCommand({
+          workspaceRoot: workspaceA,
+          lakeCommand: NODE,
+          args: nodeGateCommand(readyA, gateA),
+          serialize,
+        }),
+      ),
+      effectRuntime().runPromise(
+        runLakeCommand({
+          workspaceRoot: secondWorkspace(),
+          lakeCommand: NODE,
+          args: nodeGateCommand(readyB, gateB),
+          serialize,
+        }),
+      ),
     ]);
 
     // Both children announce themselves while each is still blocked on its

--- a/src/test-kernel/tools/setup/ConfigTools.vitest.ts
+++ b/src/test-kernel/tools/setup/ConfigTools.vitest.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
+import { Effect } from 'effect';
 import { afterEach, describe, it, vi } from 'vitest';
 
 import { ReadConfigTool, UpdateConfigTool } from '@tools/setup/ConfigTools';
@@ -12,7 +13,7 @@ const mocks = vi.hoisted(() => ({
         key: string,
         value: unknown,
         target: 'user' | 'workspace',
-      ) => Promise<void>
+      ) => Effect.Effect<void, unknown>
     >(),
 }));
 
@@ -43,10 +44,12 @@ function createPlatform(initial: Record<string, unknown> = {}): {
   const store: Record<string, unknown> = { ...initial };
   const updates: UpdateRecord[] = [];
   mocks.get.mockImplementation((key) => store[key]);
-  mocks.update.mockImplementation(async (key, value, target) => {
-    updates.push({ key, value, target });
-    store[key] = value;
-  });
+  mocks.update.mockImplementation((key, value, target) =>
+    Effect.sync(() => {
+      updates.push({ key, value, target });
+      store[key] = value;
+    }),
+  );
   return { store, updates };
 }
 

--- a/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
+++ b/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
+import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, it, vi } from 'vitest';
 
 // Local imports
@@ -12,13 +13,19 @@ import { setSetupPlatform } from '@tools/setup/platform';
 import { createFakeSetupPlatform } from './fixtures';
 
 const mocks = vi.hoisted(() => ({
-  apiKeyOrigin: vi.fn<() => Promise<'secret' | 'env' | 'none' | 'unknown'>>(),
-  anyUsableCredentialExists: vi.fn<() => Promise<boolean>>(),
+  apiKeyOrigin:
+    vi.fn<
+      () => Effect.Effect<'secret' | 'env' | 'none' | 'unknown', unknown>
+    >(),
+  anyUsableCredentialExists: vi.fn<() => Effect.Effect<boolean, unknown>>(),
   locateTool:
     vi.fn<
       (
         name: string,
-      ) => Promise<{ name: string; installed: boolean; path?: string }>
+      ) => Effect.Effect<
+        { name: string; installed: boolean; path?: string },
+        unknown
+      >
     >(),
 }));
 
@@ -45,22 +52,25 @@ function outputOf(result: { output?: string }): string {
 }
 
 function installChatGptOnlySetupPlatform(): void {
-  mocks.anyUsableCredentialExists.mockResolvedValue(true);
-  vi.spyOn(
-    setupPlatformModule,
-    'getChatGptSubscriptionStatus',
-  ).mockResolvedValue({ signedIn: true, enabled: true });
+  mocks.anyUsableCredentialExists.mockReturnValue(Effect.succeed(true));
+  vi.spyOn(setupPlatformModule, 'getChatGptSubscriptionStatus').mockReturnValue(
+    Effect.succeed({ signedIn: true, enabled: true }),
+  );
 }
 
 beforeEach(() => {
   setSetupPlatform(createFakeSetupPlatform());
-  mocks.apiKeyOrigin.mockReset().mockResolvedValue('none');
-  mocks.anyUsableCredentialExists.mockReset().mockResolvedValue(false);
-  mocks.locateTool.mockReset().mockImplementation(async (name) => ({
-    name,
-    installed: true,
-    path: '/test/tool',
-  }));
+  mocks.apiKeyOrigin.mockReset().mockReturnValue(Effect.succeed('none'));
+  mocks.anyUsableCredentialExists
+    .mockReset()
+    .mockReturnValue(Effect.succeed(false));
+  mocks.locateTool.mockReset().mockImplementation((name) =>
+    Effect.succeed({
+      name,
+      installed: true,
+      path: '/test/tool',
+    }),
+  );
 });
 
 afterEach(() => {
@@ -69,7 +79,7 @@ afterEach(() => {
 
 describe('setup credential reporting', () => {
   it('reports the active host and provider-key origin without secret values', async () => {
-    mocks.apiKeyOrigin.mockResolvedValue('env');
+    mocks.apiKeyOrigin.mockReturnValue(Effect.succeed('env'));
 
     const result = await new ProbeEnvironmentTool().call({});
 
@@ -99,9 +109,11 @@ describe('setup credential reporting', () => {
   });
 
   it('keeps probing when one provider key origin is unavailable', async () => {
-    mocks.apiKeyOrigin.mockRejectedValue(new Error('Keychain unavailable'));
-    mocks.anyUsableCredentialExists.mockRejectedValue(
-      new Error('Credential scan unavailable'),
+    mocks.apiKeyOrigin.mockReturnValue(
+      Effect.fail(new Error('Keychain unavailable')),
+    );
+    mocks.anyUsableCredentialExists.mockReturnValue(
+      Effect.fail(new Error('Credential scan unavailable')),
     );
 
     const result = await new ProbeEnvironmentTool().call({});
@@ -114,8 +126,8 @@ describe('setup credential reporting', () => {
   });
 
   it('reports when aggregate credential readiness is unavailable', async () => {
-    mocks.anyUsableCredentialExists.mockRejectedValue(
-      new Error('Credential scan unavailable'),
+    mocks.anyUsableCredentialExists.mockReturnValue(
+      Effect.fail(new Error('Credential scan unavailable')),
     );
 
     const result = await new ProbeEnvironmentTool().call({});

--- a/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
+++ b/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
@@ -44,17 +45,25 @@ describe('shared setup capabilities', () => {
     expect(setup.commands).toBeUndefined();
     expect(setup.extensions).toBeUndefined();
     expect(setup.terminal).toBeUndefined();
-    await expect(setupSecrets.storedApiKeyExists('openai')).resolves.toBe(true);
-    await expect(setupSecrets.hasUsableApiKey('openai')).resolves.toBe(true);
-    await expect(setupSecrets.gitHubTokenExists()).resolves.toBe('env');
-    await expect(setupSecrets.listStoredKeys()).resolves.toContain(
-      'apiKey.openai',
-    );
+    await expect(
+      Effect.runPromise(setupSecrets.storedApiKeyExists('openai')),
+    ).resolves.toBe(true);
+    await expect(
+      Effect.runPromise(setupSecrets.hasUsableApiKey('openai')),
+    ).resolves.toBe(true);
+    await expect(
+      Effect.runPromise(setupSecrets.gitHubTokenExists()),
+    ).resolves.toBe('env');
+    await expect(
+      Effect.runPromise(setupSecrets.listStoredKeys()),
+    ).resolves.toContain('apiKey.openai');
 
     expect(texraScopedConfig.get('texra.bib.defaultPath')).toBe(
       'references.bib',
     );
-    await texraScopedConfig.update('texra.bib.defaultPath', 'main.bib', 'user');
+    await Effect.runPromise(
+      texraScopedConfig.update('texra.bib.defaultPath', 'main.bib', 'user'),
+    );
     expect(
       workspaceRoots().config.inspect('texra.bib.defaultPath')?.globalValue,
     ).toBe('main.bib');
@@ -72,22 +81,26 @@ describe('shared setup capabilities', () => {
       'apiKey.openai',
     ]);
 
-    await expect(setupSecrets.storedApiKeyExists('openai')).resolves.toBe(true);
+    await expect(
+      Effect.runPromise(setupSecrets.storedApiKeyExists('openai')),
+    ).resolves.toBe(true);
   });
 
   it('reports a signed-in account', async () => {
     vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(true);
     vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue(null);
 
-    await expect(getSetupAuthStatus()).resolves.toEqual({
+    await expect(Effect.runPromise(getSetupAuthStatus())).resolves.toEqual({
       authenticated: true,
       email: undefined,
     });
   });
 
   it('keeps API-key-only setup usable without reporting sign-in', async () => {
-    await expect(setupSecrets.anyUsableCredentialExists()).resolves.toBe(true);
-    await expect(getSetupAuthStatus()).resolves.toEqual({
+    await expect(
+      Effect.runPromise(setupSecrets.anyUsableCredentialExists()),
+    ).resolves.toBe(true);
+    await expect(Effect.runPromise(getSetupAuthStatus())).resolves.toEqual({
       authenticated: false,
     });
   });
@@ -99,7 +112,7 @@ describe('shared setup capabilities', () => {
       accountId: 'account-private-id',
     });
 
-    const status = await getChatGptSubscriptionStatus();
+    const status = await Effect.runPromise(getChatGptSubscriptionStatus());
 
     expect(status.signedIn).toBe(true);
     expect(status).not.toHaveProperty('account');
@@ -117,7 +130,9 @@ describe('shared setup capabilities', () => {
       'isCodexSubscriptionActive',
     ).mockResolvedValue(false);
 
-    await expect(getChatGptSubscriptionStatus()).resolves.toEqual({
+    await expect(
+      Effect.runPromise(getChatGptSubscriptionStatus()),
+    ).resolves.toEqual({
       signedIn: true,
       enabled: false,
     });

--- a/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
+++ b/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
@@ -2,6 +2,7 @@
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { beforeEach, describe, it, vi } from 'vitest';
 
 // Local imports
@@ -10,7 +11,7 @@ import { GITHUB_TOKEN_STORAGE_KEY } from '@tools/github/githubAuth';
 import { ListApiKeysTool } from '@tools/setup/ListApiKeysTool';
 
 const mocks = vi.hoisted(() => ({
-  listStoredKeys: vi.fn<() => Promise<readonly string[]>>(),
+  listStoredKeys: vi.fn<() => Effect.Effect<readonly string[], unknown>>(),
 }));
 
 vi.mock('@tools/setup/platform', async (importOriginal) => {
@@ -36,7 +37,7 @@ beforeEach(() => {
 async function callWithStoredKeys(
   keys: readonly string[],
 ): Promise<ToolCallResult> {
-  mocks.listStoredKeys.mockResolvedValue(keys);
+  mocks.listStoredKeys.mockReturnValue(Effect.succeed(keys));
   const result = await tool.call({});
   assert.equal(result.status, 'executed');
   return result;
@@ -54,8 +55,8 @@ describe('list_api_keys tool', () => {
   });
 
   it('reports unsupported enumeration instead of an empty store', async () => {
-    mocks.listStoredKeys.mockRejectedValue(
-      new Error('SecretStorage key enumeration is not supported'),
+    mocks.listStoredKeys.mockReturnValue(
+      Effect.fail(new Error('SecretStorage key enumeration is not supported')),
     );
 
     const result = await tool.call({});

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -1,9 +1,16 @@
+// Node imports
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
+import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import { currentSession } from '@agent/runtime/SessionHandle';
+import { hostPort } from '@common/hostPort';
 import { createLog } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import { type ToolResult, ToolError } from '@shared/schemas';
 import {
   currentToolRoot,
@@ -21,6 +28,30 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { defineTool } from './core/define';
 
 const log = createLog('DiagnosticsTool');
+
+/**
+ * The host capabilities and working directory this tool reads from the
+ * session, resolved in the caller's run context before the program runs.
+ */
+interface DiagnosticsPorts {
+  /**
+   * Reads the active working directory, bound to the calling turn. It stays a
+   * thunk so each command asks for it exactly where it did before: parsing
+   * rejects a relative working directory, and "add" reports that failure as
+   * its own.
+   */
+  readonly toolRoot: () => string | undefined;
+  readonly readDiagnostics: HostInteractions['readDiagnostics'];
+  readonly addCriticism: HostInteractions['addCriticism'];
+}
+
+/** Resolve an input path to an absolute path against the active working directory. */
+function resolveAbsolutePath(
+  filePath: string,
+  root: string | undefined,
+): string {
+  return resolveWorkspaceRelativePath(filePath, root).absolute;
+}
 
 const DiagnosticsPathSchema = z
   .string()
@@ -89,101 +120,125 @@ export class DiagnosticsTool extends defineTool({
     'Inspect or annotate diagnostics for a file. Use "list"/"count" to retrieve linter diagnostics; use "add" to push a critique annotation as a VS Code diagnostic (squiggle + Problems panel entry) instead of inserting a literal \\criticize{...}{...}{...} macro. The "add" command requires the experimental "texra.inlineCriticism.enabled" setting and reports "not accepted" if disabled; criticisms pushed this way are read back by "list".',
   schema: DiagnosticsInputSchema,
 }) {
-  protected async execute(input: DiagnosticsInput): Promise<ToolResult> {
-    if (input.command === 'add') {
-      return this.addCriticism(input);
-    }
-    return this.readDiagnostics(input);
+  protected execute(input: DiagnosticsInput): Promise<ToolResult> {
+    // The session and working directory belong to the calling turn, so they
+    // are read here and handed to the program rather than from a fiber.
+    const interactions = currentSession().interactions;
+    const ports: DiagnosticsPorts = {
+      toolRoot: AsyncLocalStorage.bind(currentToolRoot),
+      readDiagnostics: interactions.readDiagnostics,
+      addCriticism: interactions.addCriticism,
+    };
+    return effectRuntime().runPromise(
+      input.command === 'add'
+        ? this.addCriticism(ports, input)
+        : this.readDiagnostics(ports, input),
+    );
   }
 
-  /** Resolve an input path to an absolute path against the active working directory. */
-  private resolveAbsolutePath(filePath: string): string {
-    return resolveWorkspaceRelativePath(filePath, currentToolRoot()).absolute;
-  }
-
-  private async readDiagnostics(
+  private readonly readDiagnostics = Effect.fn(
+    'DiagnosticsTool.readDiagnostics',
+  )(function* (
+    ports: DiagnosticsPorts,
     input: Extract<DiagnosticsInput, { command: 'list' | 'count' }>,
-  ): Promise<ToolResult> {
+  ): Effect.fn.Return<ToolResult, ToolError> {
     const { command, path } = input;
-    const diagnosticsPath = this.resolveAbsolutePath(path);
-    const linter = currentSession().interactions.readDiagnostics;
+    const diagnosticsPath = resolveAbsolutePath(path, ports.toolRoot());
+    const linter = ports.readDiagnostics;
     if (!linter) {
-      throw new ToolError(
-        'Diagnostics capability unavailable: this session has no diagnostics provider.',
+      return yield* Effect.fail(
+        new ToolError(
+          'Diagnostics capability unavailable: this session has no diagnostics provider.',
+        ),
       );
     }
 
-    try {
-      const messages = await linter(diagnosticsPath);
-      const counts = countBySeverity(messages);
-      const header = `${diagnosticsPath}: ${formatCounts(counts)}`;
-      const summary = `Diagnostics ${command} for ${diagnosticsPath}`;
+    const messages = yield* hostPort(() => linter(diagnosticsPath)).pipe(
+      Effect.catch((error) => {
+        const detail = toErrorMessage(error);
+        log.error(
+          `Failed to collect diagnostics for ${diagnosticsPath}: ${detail}`,
+        );
+        return Effect.fail(
+          new ToolError(`Failed to collect diagnostics: ${detail}`),
+        );
+      }),
+    );
+    const counts = countBySeverity(messages);
+    const header = `${diagnosticsPath}: ${formatCounts(counts)}`;
+    const summary = `Diagnostics ${command} for ${diagnosticsPath}`;
 
-      const baseDiagnostics = {
-        path: diagnosticsPath,
-        command,
-        severity: counts,
-      };
+    const baseDiagnostics = {
+      path: diagnosticsPath,
+      command,
+      severity: counts,
+    };
 
-      if (command === 'count') {
-        return {
-          status: 'executed',
-          summary,
-          output: header,
-          diagnostics: baseDiagnostics,
-        };
-      }
-
-      const messageDetails =
-        messages.length > 0 ? `\n\n${formatMessageList(messages)}` : '';
+    if (command === 'count') {
       return {
         status: 'executed',
         summary,
-        output: `${header}${messageDetails}`,
-        diagnostics: { ...baseDiagnostics, messages },
+        output: header,
+        diagnostics: baseDiagnostics,
       };
-    } catch (error) {
-      const detail = toErrorMessage(error);
-      log.error(
-        `Failed to collect diagnostics for ${diagnosticsPath}: ${detail}`,
-      );
-      throw new ToolError(`Failed to collect diagnostics: ${detail}`);
-    }
-  }
-
-  private async addCriticism(
-    input: Extract<DiagnosticsInput, { command: 'add' }>,
-  ): Promise<ToolResult> {
-    const { path, line, message, severity, confidence } = input;
-    const addCriticismSink = currentSession().interactions.addCriticism;
-    if (!addCriticismSink) {
-      throw new ToolError(
-        'Diagnostics add capability unavailable: this session has no criticism sink.',
-      );
     }
 
-    try {
-      const absolutePath = this.resolveAbsolutePath(path);
-      const result = addCriticismSink({
-        absolutePath,
-        line,
-        message,
-        severity,
-        confidence,
+    const messageDetails =
+      messages.length > 0 ? `\n\n${formatMessageList(messages)}` : '';
+    return {
+      status: 'executed',
+      summary,
+      output: `${header}${messageDetails}`,
+      diagnostics: { ...baseDiagnostics, messages },
+    };
+  });
+
+  private readonly addCriticism = Effect.fn('DiagnosticsTool.addCriticism')(
+    function* (
+      ports: DiagnosticsPorts,
+      input: Extract<DiagnosticsInput, { command: 'add' }>,
+    ): Effect.fn.Return<ToolResult, ToolError> {
+      const { path, line, message, severity, confidence } = input;
+      const addCriticismSink = ports.addCriticism;
+      if (!addCriticismSink) {
+        return yield* Effect.fail(
+          new ToolError(
+            'Diagnostics add capability unavailable: this session has no criticism sink.',
+          ),
+        );
+      }
+
+      // Path resolution shares the sink's failure report: both are the "add"
+      // command failing before it could annotate anything.
+      const added = yield* Effect.try({
+        try: () => {
+          const absolutePath = resolveAbsolutePath(path, ports.toolRoot());
+          return {
+            absolutePath,
+            result: addCriticismSink({
+              absolutePath,
+              line,
+              message,
+              severity,
+              confidence,
+            }),
+          };
+        },
+        catch: (error) => {
+          const detail = toErrorMessage(error);
+          log.error(`Failed to add criticism: ${detail}`);
+          return new ToolError(`Failed to add criticism: ${detail}`);
+        },
       });
-      if (!result.accepted) {
+      if (!added.result.accepted) {
         return executed(
           'Inline criticism diagnostics are disabled. Enable "texra.inlineCriticism.enabled" in settings to surface critiques as diagnostics.',
           'Criticism not accepted',
         );
       }
-      const where = result.resolvedPath || absolutePath;
+      const where = added.result.resolvedPath || added.absolutePath;
       const summary = `Added criticism for ${where}:${line} (S${severity}/C${confidence})`;
       return executed(summary, summary);
-    } catch (error) {
-      const detail = toErrorMessage(error);
-      log.error(`Failed to add criticism: ${detail}`);
-      throw new ToolError(`Failed to add criticism: ${detail}`);
-    }
-  }
+    },
+  );
 }

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -1,12 +1,8 @@
-// Node imports
-import { AsyncLocalStorage } from 'node:async_hooks';
-
 // Third-party imports
 import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports - tools
-import { hostPort } from '@common/hostPort';
 import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import {
@@ -39,33 +35,20 @@ const EditInputSchema = z.strictObject({
 
 export type EditInput = z.infer<typeof EditInputSchema>;
 
-/**
- * The edit flow, bound to the calling turn: both steps read the working
- * directory, the read-before-edit tracker, and the approval host from the
- * run context the tool was called in, not from the fiber that runs them.
- */
-interface FileEditPorts {
-  readonly resolveWritableTarget: typeof resolveWritableTarget;
-  readonly applyApprovedFileEdit: typeof applyApprovedFileEdit;
-}
-
 const edit = Effect.fn('EditFileTool.execute')(function* (
-  ports: FileEditPorts,
   input: EditInput,
 ): Effect.fn.Return<ToolResult, unknown> {
   const { old_str, new_str, replace_all } = input;
-  const prepared = yield* hostPort(() =>
-    ports.resolveWritableTarget(input.path, {
-      validate: ({ displayPath }) => {
-        if (old_str.length === 0) {
-          throw new ToolError(
-            `old_str must not be empty for ${displayPath}. ` +
-              `Provide the exact text to replace, copied from read_file output (excluding the line-number prefix).`,
-          );
-        }
-      },
-    }),
-  );
+  const prepared = yield* resolveWritableTarget(input.path, {
+    validate: ({ displayPath }) => {
+      if (old_str.length === 0) {
+        throw new ToolError(
+          `old_str must not be empty for ${displayPath}. ` +
+            `Provide the exact text to replace, copied from read_file output (excluding the line-number prefix).`,
+        );
+      }
+    },
+  });
   if ('blocked' in prepared) {
     return prepared.blocked;
   }
@@ -95,20 +78,18 @@ const edit = Effect.fn('EditFileTool.execute')(function* (
   });
 
   const occurrenceWord = pluralize(replacement.count, 'occurrence');
-  return yield* hostPort(() =>
-    ports.applyApprovedFileEdit({
-      path,
-      displayPath,
-      originalContent,
-      proposedContent: replacement.content,
-      sourceTool: 'edit_file',
-      startLine: 'approval',
-      present: () => ({
-        summary: `Edited ${displayPath}: replaced ${replacement.count} ${occurrenceWord}`,
-        output: `Replaced ${replacement.count} ${occurrenceWord}.`,
-      }),
+  return yield* applyApprovedFileEdit({
+    path,
+    displayPath,
+    originalContent,
+    proposedContent: replacement.content,
+    sourceTool: 'edit_file',
+    startLine: 'approval',
+    present: () => ({
+      summary: `Edited ${displayPath}: replaced ${replacement.count} ${occurrenceWord}`,
+      output: `Replaced ${replacement.count} ${occurrenceWord}.`,
     }),
-  );
+  });
 });
 
 export class EditFileTool extends defineTool({
@@ -119,14 +100,6 @@ export class EditFileTool extends defineTool({
   schema: EditInputSchema,
 }) {
   protected execute(input: EditInput): Promise<ToolResult> {
-    return effectRuntime().runPromise(
-      edit(
-        {
-          resolveWritableTarget: AsyncLocalStorage.bind(resolveWritableTarget),
-          applyApprovedFileEdit: AsyncLocalStorage.bind(applyApprovedFileEdit),
-        },
-        input,
-      ),
-    );
+    return effectRuntime().runPromise(edit(input));
   }
 }

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -1,7 +1,13 @@
+// Node imports
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports - tools
+import { hostPort } from '@common/hostPort';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import {
   applyApprovedFileEdit,
@@ -33,16 +39,23 @@ const EditInputSchema = z.strictObject({
 
 export type EditInput = z.infer<typeof EditInputSchema>;
 
-export class EditFileTool extends defineTool({
-  name: 'edit_file',
-  requiresApproval: true,
-  description:
-    'Performs exact string replacements in workspace files using literal matching. Copy text exactly as it appears in read_file output after the line-number prefix.',
-  schema: EditInputSchema,
-}) {
-  protected async execute(input: EditInput): Promise<ToolResult> {
-    const { old_str, new_str, replace_all } = input;
-    const prepared = await resolveWritableTarget(input.path, {
+/**
+ * The edit flow, bound to the calling turn: both steps read the working
+ * directory, the read-before-edit tracker, and the approval host from the
+ * run context the tool was called in, not from the fiber that runs them.
+ */
+interface FileEditPorts {
+  readonly resolveWritableTarget: typeof resolveWritableTarget;
+  readonly applyApprovedFileEdit: typeof applyApprovedFileEdit;
+}
+
+const edit = Effect.fn('EditFileTool.execute')(function* (
+  ports: FileEditPorts,
+  input: EditInput,
+): Effect.fn.Return<ToolResult, unknown> {
+  const { old_str, new_str, replace_all } = input;
+  const prepared = yield* hostPort(() =>
+    ports.resolveWritableTarget(input.path, {
       validate: ({ displayPath }) => {
         if (old_str.length === 0) {
           throw new ToolError(
@@ -51,31 +64,39 @@ export class EditFileTool extends defineTool({
           );
         }
       },
-    });
-    if ('blocked' in prepared) {
-      return prepared.blocked;
-    }
-    const { path, displayPath, originalContent } = prepared.target;
+    }),
+  );
+  if ('blocked' in prepared) {
+    return prepared.blocked;
+  }
+  const { path, displayPath, originalContent } = prepared.target;
 
-    const replacement = replaceLiteralMatches({
-      content: originalContent,
-      search: old_str,
-      replacement: new_str,
-      mode: replace_all ? 'all' : 'unique',
-      notFoundError: () =>
-        `old_str not found in ${displayPath}.\n` +
-        `To fix:\n` +
-        `- Re-read the file: content may have changed since last read\n` +
-        `- Copy text exactly from read_file output, excluding the line-number prefix (e.g. "  42\t"); whitespace must match`,
-      multipleMatchesError: ({ count }) =>
-        `old_str matches ${count} locations in ${displayPath}.\n` +
-        `To fix, either:\n` +
-        `- Include more surrounding context to make old_str unique\n` +
-        `- Set replace_all to true to replace every occurrence: { "replace_all": true }`,
-    });
+  // A missing or ambiguous match is the model's error to correct, so it stays
+  // a failure the tool runner reports rather than a defect.
+  const replacement = yield* Effect.try({
+    try: () =>
+      replaceLiteralMatches({
+        content: originalContent,
+        search: old_str,
+        replacement: new_str,
+        mode: replace_all ? 'all' : 'unique',
+        notFoundError: () =>
+          `old_str not found in ${displayPath}.\n` +
+          `To fix:\n` +
+          `- Re-read the file: content may have changed since last read\n` +
+          `- Copy text exactly from read_file output, excluding the line-number prefix (e.g. "  42\t"); whitespace must match`,
+        multipleMatchesError: ({ count }) =>
+          `old_str matches ${count} locations in ${displayPath}.\n` +
+          `To fix, either:\n` +
+          `- Include more surrounding context to make old_str unique\n` +
+          `- Set replace_all to true to replace every occurrence: { "replace_all": true }`,
+      }),
+    catch: (error) => error,
+  });
 
-    const occurrenceWord = pluralize(replacement.count, 'occurrence');
-    return applyApprovedFileEdit({
+  const occurrenceWord = pluralize(replacement.count, 'occurrence');
+  return yield* hostPort(() =>
+    ports.applyApprovedFileEdit({
       path,
       displayPath,
       originalContent,
@@ -86,6 +107,26 @@ export class EditFileTool extends defineTool({
         summary: `Edited ${displayPath}: replaced ${replacement.count} ${occurrenceWord}`,
         output: `Replaced ${replacement.count} ${occurrenceWord}.`,
       }),
-    });
+    }),
+  );
+});
+
+export class EditFileTool extends defineTool({
+  name: 'edit_file',
+  requiresApproval: true,
+  description:
+    'Performs exact string replacements in workspace files using literal matching. Copy text exactly as it appears in read_file output after the line-number prefix.',
+  schema: EditInputSchema,
+}) {
+  protected execute(input: EditInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(
+      edit(
+        {
+          resolveWritableTarget: AsyncLocalStorage.bind(resolveWritableTarget),
+          applyApprovedFileEdit: AsyncLocalStorage.bind(applyApprovedFileEdit),
+        },
+        input,
+      ),
+    );
   }
 }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -1044,9 +1044,10 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     context: ExecutionToolContext,
     executionId: ExecutionId,
   ) {
-    const files = yield* executionsRead(context, () =>
-      listRunGeneratedFiles(executionId),
-    );
+    const files = yield* listRunGeneratedFiles(
+      executionId,
+      context.session,
+    ).pipe(Effect.mapError((cause) => new ExecutionsReadFailed({ cause })));
     if (files.length === 0) {
       return executed('No files generated for this execution.');
     }

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -17,8 +17,8 @@ import { effectRuntime } from '@platform/processRuntime';
 import {
   fileLocationDisplayPath,
   ToolError,
-  type ExecutionId,
   type FileLocation,
+  type RunStorageFileLocation,
   type ToolResult,
 } from '@shared/schemas';
 import {
@@ -56,7 +56,14 @@ interface OpenPdfPorts {
    * absolute run-storage path must resolve without ever asking for one.
    */
   readonly toolRoot: () => string | undefined;
-  readonly executionId: ExecutionId | undefined;
+  /**
+   * The requested path's run-storage identity, resolved in the caller's turn:
+   * the run-storage root is `workspaceRoots().storage`, which is per-session
+   * ambient state, so recognising the path must not depend on whichever roots
+   * the program's fiber carries. Undefined when this run has no storage of its
+   * own or the path lies outside it.
+   */
+  readonly runStorageLocation: RunStorageFileLocation | undefined;
 }
 
 const openPdfProgram = Effect.fn('OpenPdfTool.execute')(function* (
@@ -106,10 +113,15 @@ export class OpenPdfTool extends defineTool({
   protected execute(input: OpenPdfInput): Promise<ToolResult> {
     // The session and the run it belongs to are the calling turn's, so they
     // are read here and handed to the program rather than from a fiber.
+    const executionId = getRunContextExecutionId(tryUseRunContext());
+    const trimmedPath = input.path.trim();
     const ports: OpenPdfPorts = {
       openPdf: currentSession().interactions.openPdf,
       toolRoot: AsyncLocalStorage.bind(currentToolRoot),
-      executionId: getRunContextExecutionId(tryUseRunContext()),
+      runStorageLocation:
+        executionId && trimmedPath
+          ? runStorageLocationFromAbsolutePath(trimmedPath, executionId)
+          : undefined,
     };
     return effectRuntime().runPromise(openPdfProgram(ports, input));
   }
@@ -125,11 +137,8 @@ const resolvePdfLocation = Effect.fn('OpenPdfTool.resolvePdfLocation')(
       return yield* Effect.fail(new ToolError('path is required.'));
     }
 
-    const runStorageLocation = ports.executionId
-      ? runStorageLocationFromAbsolutePath(trimmed, ports.executionId)
-      : undefined;
-    if (runStorageLocation) {
-      return runStorageLocation;
+    if (ports.runStorageLocation) {
+      return ports.runStorageLocation;
     }
 
     const resolved = resolveWorkspaceRelativePath(trimmed, ports.toolRoot());

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -1,15 +1,23 @@
+// Node imports
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
+import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import {
   getRunContextExecutionId,
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { currentSession } from '@agent/runtime/SessionHandle';
+import { hostPort } from '@common/hostPort';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   fileLocationDisplayPath,
   ToolError,
+  type ExecutionId,
   type FileLocation,
   type ToolResult,
 } from '@shared/schemas';
@@ -36,54 +44,95 @@ const OpenPdfInputSchema = z.strictObject({
 
 export type OpenPdfInput = z.infer<typeof OpenPdfInputSchema>;
 
+/**
+ * The host viewer and the run coordinates path resolution needs, read from
+ * the session in the caller's run context before the program runs.
+ */
+interface OpenPdfPorts {
+  readonly openPdf: HostInteractions['openPdf'];
+  /**
+   * Reads the active working directory, bound to the calling turn. It stays a
+   * thunk because parsing rejects a relative working directory, and an
+   * absolute run-storage path must resolve without ever asking for one.
+   */
+  readonly toolRoot: () => string | undefined;
+  readonly executionId: ExecutionId | undefined;
+}
+
+const openPdfProgram = Effect.fn('OpenPdfTool.execute')(function* (
+  ports: OpenPdfPorts,
+  input: OpenPdfInput,
+) {
+  const openPdf = ports.openPdf;
+  if (!openPdf) {
+    return yield* Effect.fail(
+      new ToolError(
+        'open_pdf is not available in this host. Open the PDF manually, or use a host that registers a PDF opener.',
+      ),
+    );
+  }
+
+  const location = yield* resolvePdfLocation(input.path, ports);
+  const displayPath = fileLocationDisplayPath(location);
+
+  if (!hasExtension(location.absolutePath, '.pdf')) {
+    return yield* Effect.fail(
+      new ToolError(`open_pdf only opens PDF files: ${displayPath}`),
+    );
+  }
+  if (!(yield* hostPort(() => AbsoluteFS.isFile(location.absolutePath)))) {
+    return yield* Effect.fail(
+      new ToolError(`PDF file not found: ${displayPath}`),
+    );
+  }
+
+  yield* hostPort(() =>
+    openPdf({
+      location,
+      preserveFocus: input.preserve_focus ?? false,
+    }),
+  );
+
+  const message = `Opened PDF: ${displayPath}`;
+  return executed(message, message);
+});
+
 export class OpenPdfTool extends defineTool({
   name: 'open_pdf',
   description:
     'Open a PDF file in the host PDF viewer. The tool accepts workspace-relative paths, working-directory-relative paths, and absolute run-storage paths.',
   schema: OpenPdfInputSchema,
 }) {
-  protected async execute(input: OpenPdfInput): Promise<ToolResult> {
-    const openPdf = currentSession().interactions.openPdf;
-    if (!openPdf) {
-      throw new ToolError(
-        'open_pdf is not available in this host. Open the PDF manually, or use a host that registers a PDF opener.',
-      );
-    }
-
-    const location = resolvePdfLocation(input.path);
-    const displayPath = fileLocationDisplayPath(location);
-
-    if (!hasExtension(location.absolutePath, '.pdf')) {
-      throw new ToolError(`open_pdf only opens PDF files: ${displayPath}`);
-    }
-    if (!(await AbsoluteFS.isFile(location.absolutePath))) {
-      throw new ToolError(`PDF file not found: ${displayPath}`);
-    }
-
-    await openPdf({
-      location,
-      preserveFocus: input.preserve_focus ?? false,
-    });
-
-    const message = `Opened PDF: ${displayPath}`;
-    return executed(message, message);
+  protected execute(input: OpenPdfInput): Promise<ToolResult> {
+    // The session and the run it belongs to are the calling turn's, so they
+    // are read here and handed to the program rather than from a fiber.
+    const ports: OpenPdfPorts = {
+      openPdf: currentSession().interactions.openPdf,
+      toolRoot: AsyncLocalStorage.bind(currentToolRoot),
+      executionId: getRunContextExecutionId(tryUseRunContext()),
+    };
+    return effectRuntime().runPromise(openPdfProgram(ports, input));
   }
 }
 
-function resolvePdfLocation(rawPath: string): FileLocation {
-  const trimmed = rawPath.trim();
-  if (!trimmed) {
-    throw new ToolError('path is required.');
-  }
+const resolvePdfLocation = Effect.fn('OpenPdfTool.resolvePdfLocation')(
+  function* (
+    rawPath: string,
+    ports: OpenPdfPorts,
+  ): Effect.fn.Return<FileLocation, ToolError> {
+    const trimmed = rawPath.trim();
+    if (!trimmed) {
+      return yield* Effect.fail(new ToolError('path is required.'));
+    }
 
-  const executionId = getRunContextExecutionId(tryUseRunContext());
-  const runStorageLocation = executionId
-    ? runStorageLocationFromAbsolutePath(trimmed, executionId)
-    : undefined;
-  if (runStorageLocation) {
-    return runStorageLocation;
-  }
+    const runStorageLocation = ports.executionId
+      ? runStorageLocationFromAbsolutePath(trimmed, ports.executionId)
+      : undefined;
+    if (runStorageLocation) {
+      return runStorageLocation;
+    }
 
-  const resolved = resolveWorkspaceRelativePath(trimmed, currentToolRoot());
-  return pathToLocation(resolved.absolute);
-}
+    const resolved = resolveWorkspaceRelativePath(trimmed, ports.toolRoot());
+    return pathToLocation(resolved.absolute);
+  },
+);

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -227,7 +227,7 @@ export class ReadFileTool extends defineTool({
     });
 
     if (emlImages.length > 0) {
-      result.files = emlImages.map((img) =>
+      result.files = yield* Effect.forEach(emlImages, (img) =>
         buildBytesAttachment({
           path: img.filename,
           mimeType: img.mimeType,
@@ -275,13 +275,11 @@ export class ReadFileTool extends defineTool({
     resolved: WorkspacePathResolution,
   ): Effect.fn.Return<ToolResult, unknown> {
     const copy = ATTACHMENT_COPY[kind];
-    const attachment = yield* hostPort(() =>
-      buildFileAttachment({
-        filePath: resolved.fsPath,
-        description: `${copy.label} returned by read_file tool.`,
-        resolved,
-      }),
-    );
+    const attachment = yield* buildFileAttachment({
+      filePath: resolved.fsPath,
+      description: `${copy.label} returned by read_file tool.`,
+      resolved,
+    });
 
     const baseSummary = `Attached ${copy.label} ${attachment.path}.`;
     const summary = input.range

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -128,7 +128,10 @@ const ATTACHMENT_COPY: Record<
  */
 interface ReadPorts {
   readonly signal: AbortSignal | undefined;
-  readonly toolRoot: () => string | undefined;
+  readonly resolve: (targetPath: string) => {
+    path: WorkspacePathResolution;
+    display: string;
+  };
   readonly recordRead: (path: string) => void;
 }
 
@@ -140,13 +143,18 @@ export class ReadFileTool extends defineTool({
   schema: ReadInputSchema,
 }) {
   protected execute(input: ReadInput): Promise<ToolResult> {
-    // The read tracker and the working directory belong to the calling turn,
-    // so they are bound here and handed to the program rather than read from
-    // a fiber. `toolRoot` stays a thunk so the abort check still comes first.
+    // The read tracker and path resolution belong to the calling turn: the
+    // working directory comes from its RunContext and the fallback root from
+    // its workspace, both async-local. Binding the whole resolve step — not
+    // just the working-directory lookup — keeps the workspace fallback on the
+    // caller's context too. They stay thunks so the abort check still comes
+    // first.
     const context = getCurrentToolCallContext();
     const ports: ReadPorts = {
       signal: context?.signal,
-      toolRoot: AsyncLocalStorage.bind(currentToolRoot),
+      resolve: AsyncLocalStorage.bind((targetPath: string) =>
+        resolveAndFormat(targetPath, currentToolRoot()),
+      ),
       recordRead: AsyncLocalStorage.bind(recordToolFileRead),
     };
     return effectRuntime().runPromise(this.read(ports, input));
@@ -162,11 +170,7 @@ export class ReadFileTool extends defineTool({
     if (ports.signal?.aborted) {
       return yield* Effect.fail(new ToolError('Cancelled before execution.'));
     }
-    const root = ports.toolRoot();
-    const { path: resolved, display: displayPath } = resolveAndFormat(
-      input.path,
-      root,
-    );
+    const { path: resolved, display: displayPath } = ports.resolve(input.path);
     const filePath = resolved.fsPath;
 
     const attachmentKind = this.getAttachmentConfig(resolved.absolute);

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -1,8 +1,14 @@
+// Node imports
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
+import { hostPort } from '@common/hostPort';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { buildBytesAttachment, buildFileAttachment } from '@tools/attachments';
 import { formatFileView } from '@tools/formatting';
@@ -115,6 +121,17 @@ const ATTACHMENT_COPY: Record<
   },
 };
 
+/**
+ * The per-call context this tool reads from the caller's turn: the batch's
+ * abort signal, the working directory, and the read tracker that gates
+ * later edits.
+ */
+interface ReadPorts {
+  readonly signal: AbortSignal | undefined;
+  readonly toolRoot: () => string | undefined;
+  readonly recordRead: (path: string) => void;
+}
+
 export class ReadFileTool extends defineTool({
   name: 'read_file',
   parallelSafe: true,
@@ -122,13 +139,30 @@ export class ReadFileTool extends defineTool({
     'Read and return workspace files. For text files you can supply an optional line range. PDFs (.pdf) and common image formats are returned as attachments so vision-capable models can inspect their pages or visual content.',
   schema: ReadInputSchema,
 }) {
-  protected async execute(input: ReadInput): Promise<ToolResult> {
+  protected execute(input: ReadInput): Promise<ToolResult> {
+    // The read tracker and the working directory belong to the calling turn,
+    // so they are bound here and handed to the program rather than read from
+    // a fiber. `toolRoot` stays a thunk so the abort check still comes first.
+    const context = getCurrentToolCallContext();
+    const ports: ReadPorts = {
+      signal: context?.signal,
+      toolRoot: AsyncLocalStorage.bind(currentToolRoot),
+      recordRead: AsyncLocalStorage.bind(recordToolFileRead),
+    };
+    return effectRuntime().runPromise(this.read(ports, input));
+  }
+
+  private readonly read = Effect.fn('ReadFileTool.execute')(function* (
+    this: ReadFileTool,
+    ports: ReadPorts,
+    input: ReadInput,
+  ): Effect.fn.Return<ToolResult, unknown> {
     // Local reads finish in milliseconds, so no mid-read cancellation is
     // needed — but a queued call must not start after the batch aborted.
-    if (getCurrentToolCallContext()?.signal?.aborted) {
-      throw new ToolError('Cancelled before execution.');
+    if (ports.signal?.aborted) {
+      return yield* Effect.fail(new ToolError('Cancelled before execution.'));
     }
-    const root = currentToolRoot();
+    const root = ports.toolRoot();
     const { path: resolved, display: displayPath } = resolveAndFormat(
       input.path,
       root,
@@ -137,12 +171,12 @@ export class ReadFileTool extends defineTool({
 
     const attachmentKind = this.getAttachmentConfig(resolved.absolute);
     if (attachmentKind) {
-      const result = await this.returnBinaryAttachment(
+      const result = yield* this.returnBinaryAttachment(
         input,
         attachmentKind,
         resolved,
       );
-      recordToolFileRead(filePath);
+      ports.recordRead(filePath);
       return result;
     }
 
@@ -152,21 +186,25 @@ export class ReadFileTool extends defineTool({
     let lines: string[];
 
     if (hasExtension(input.path, '.eml')) {
-      const stats = await WorkspaceFS.stat(filePath);
+      const stats = yield* hostPort(() => WorkspaceFS.stat(filePath));
       if (stats.size > MAX_EML_BYTES) {
-        throw new ToolError(
-          `EML file exceeds maximum size of ${formatBytes(MAX_EML_BYTES)}.`,
+        return yield* Effect.fail(
+          new ToolError(
+            `EML file exceeds maximum size of ${formatBytes(MAX_EML_BYTES)}.`,
+          ),
         );
       }
-      const raw = await WorkspaceFS.read(filePath);
-      const { text, images } = await parseEml(raw);
+      const raw = yield* hostPort(() => WorkspaceFS.read(filePath));
+      const { text, images } = yield* parseEml(raw);
       lines = splitContentLines(text);
       emlImages = images;
     } else {
-      lines = splitContentLines(await WorkspaceFS.read(filePath));
+      lines = splitContentLines(
+        yield* hostPort(() => WorkspaceFS.read(filePath)),
+      );
     }
 
-    recordToolFileRead(filePath);
+    ports.recordRead(filePath);
 
     const range = input.range;
     const totalLines = lines.length;
@@ -200,7 +238,7 @@ export class ReadFileTool extends defineTool({
     }
 
     return result;
-  }
+  });
 
   private getAttachmentConfig(filePath: string): AttachmentKind | null {
     const mimeType = getMimeType(filePath)?.toLowerCase();
@@ -229,17 +267,21 @@ export class ReadFileTool extends defineTool({
     return null;
   }
 
-  private async returnBinaryAttachment(
+  private readonly returnBinaryAttachment = Effect.fn(
+    'ReadFileTool.returnBinaryAttachment',
+  )(function* (
     input: ReadInput,
     kind: AttachmentKind,
     resolved: WorkspacePathResolution,
-  ): Promise<ToolResult> {
+  ): Effect.fn.Return<ToolResult, unknown> {
     const copy = ATTACHMENT_COPY[kind];
-    const attachment = await buildFileAttachment({
-      filePath: resolved.fsPath,
-      description: `${copy.label} returned by read_file tool.`,
-      resolved,
-    });
+    const attachment = yield* hostPort(() =>
+      buildFileAttachment({
+        filePath: resolved.fsPath,
+        description: `${copy.label} returned by read_file tool.`,
+        resolved,
+      }),
+    );
 
     const baseSummary = `Attached ${copy.label} ${attachment.path}.`;
     const summary = input.range
@@ -250,5 +292,5 @@ export class ReadFileTool extends defineTool({
       : copy.coreOutput;
 
     return { status: 'executed', summary, output, files: [attachment] };
-  }
+  });
 }

--- a/src/tools/ReportReviewIssueTool.ts
+++ b/src/tools/ReportReviewIssueTool.ts
@@ -1,10 +1,15 @@
+// Third-party imports
+import { Effect } from 'effect';
+
 // Internal imports
 import {
   ReportReviewIssueInputSchema,
   type ReviewIssueReport,
 } from '@agent/review/reviewIssues';
+import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { createLog } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import { type ToolResult, ToolError } from '@shared/schemas';
 import { executed } from '@tools/core/result';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -19,35 +24,49 @@ const NormalizedReportReviewIssueSchema = normalizeStructuredOutputSchema(
   ReportReviewIssueInputSchema,
 );
 
+/** The review sink a host attaches, as the session exposes it. */
+type ReviewIssueSink = NonNullable<HostInteractions['reportReviewIssue']>;
+
+const report = Effect.fn('ReportReviewIssueTool.execute')(function* (
+  sink: ReviewIssueSink | undefined,
+  input: ReviewIssueReport,
+) {
+  if (!sink) {
+    return executed(
+      'Agent review is not available in this host.',
+      'Review issue not accepted',
+    );
+  }
+
+  const result = yield* Effect.try({
+    try: () => sink(input),
+    catch: (error) => {
+      const detail = toErrorMessage(error);
+      log.error(`Failed to report review issue: ${detail}`);
+      return new ToolError(`Failed to report review issue: ${detail}`);
+    },
+  });
+  if (!result.accepted) {
+    return executed(
+      result.reason ?? 'The review issue was not accepted.',
+      'Review issue not accepted',
+    );
+  }
+  const summary = `Reported review issue ${input.file}:${input.startLine} [${input.severity}] ${input.title}`;
+  return executed(summary, summary);
+});
+
 export class ReportReviewIssueTool extends defineTool({
   name: 'report_review_issue',
   description:
     'Report one finding from an agent review of the current change set. The issue appears in the Agent Review panel and as an editor diagnostic with quick fixes. Only accepted while an agent review session is collecting issues.',
   schema: NormalizedReportReviewIssueSchema.zodSchema,
 }) {
-  protected async execute(input: ReviewIssueReport): Promise<ToolResult> {
-    const sink = currentSession().interactions.reportReviewIssue;
-    if (!sink) {
-      return executed(
-        'Agent review is not available in this host.',
-        'Review issue not accepted',
-      );
-    }
-
-    try {
-      const result = sink(input);
-      if (!result.accepted) {
-        return executed(
-          result.reason ?? 'The review issue was not accepted.',
-          'Review issue not accepted',
-        );
-      }
-      const summary = `Reported review issue ${input.file}:${input.startLine} [${input.severity}] ${input.title}`;
-      return executed(summary, summary);
-    } catch (error) {
-      const detail = toErrorMessage(error);
-      log.error(`Failed to report review issue: ${detail}`);
-      throw new ToolError(`Failed to report review issue: ${detail}`);
-    }
+  protected execute(input: ReviewIssueReport): Promise<ToolResult> {
+    // The sink is read here, in the caller's run context, and handed to the
+    // program: the session is scoped to the calling turn, not to the fiber.
+    return effectRuntime().runPromise(
+      report(currentSession().interactions.reportReviewIssue, input),
+    );
   }
 }

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -1,8 +1,14 @@
+// Node imports
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports - tools
+import { hostPort } from '@common/hostPort';
 import { isTexFile } from '@common/files/fileTypeUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import replacementEngine from '@replacement/engine';
 import type { ToolResult } from '@shared/schemas';
 import {
@@ -23,26 +29,33 @@ const WriteInputSchema = z.strictObject({
 
 export type WriteInput = z.infer<typeof WriteInputSchema>;
 
-export class WriteFileTool extends defineTool({
-  name: 'write_file',
-  requiresApproval: true,
-  description:
-    'Overwrite a workspace file with the provided content. Creates the file if it does not exist.',
-  schema: WriteInputSchema,
-}) {
-  protected async execute(input: WriteInput): Promise<ToolResult> {
-    const prepared = await resolveWritableTarget(input.path, {
-      missing: 'allow',
-    });
-    if ('blocked' in prepared) {
-      return prepared.blocked;
-    }
-    const { path, displayPath, exists, originalContent } = prepared.target;
-    const proposedContent = isTexFile(path)
-      ? replacementEngine.applyFor(input.content, 'tex-write')
-      : input.content;
+/**
+ * The edit flow, bound to the calling turn: both steps read the working
+ * directory, the read-before-edit tracker, and the approval host from the
+ * run context the tool was called in, not from the fiber that runs them.
+ */
+interface FileEditPorts {
+  readonly resolveWritableTarget: typeof resolveWritableTarget;
+  readonly applyApprovedFileEdit: typeof applyApprovedFileEdit;
+}
 
-    return applyApprovedFileEdit({
+const write = Effect.fn('WriteFileTool.execute')(function* (
+  ports: FileEditPorts,
+  input: WriteInput,
+): Effect.fn.Return<ToolResult, unknown> {
+  const prepared = yield* hostPort(() =>
+    ports.resolveWritableTarget(input.path, { missing: 'allow' }),
+  );
+  if ('blocked' in prepared) {
+    return prepared.blocked;
+  }
+  const { path, displayPath, exists, originalContent } = prepared.target;
+  const proposedContent = isTexFile(path)
+    ? replacementEngine.applyFor(input.content, 'tex-write')
+    : input.content;
+
+  return yield* hostPort(() =>
+    ports.applyApprovedFileEdit({
       path,
       displayPath,
       originalContent,
@@ -62,6 +75,26 @@ export class WriteFileTool extends defineTool({
           output: replacementNote ? `written\n\n${replacementNote}` : 'written',
         };
       },
-    });
+    }),
+  );
+});
+
+export class WriteFileTool extends defineTool({
+  name: 'write_file',
+  requiresApproval: true,
+  description:
+    'Overwrite a workspace file with the provided content. Creates the file if it does not exist.',
+  schema: WriteInputSchema,
+}) {
+  protected execute(input: WriteInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(
+      write(
+        {
+          resolveWritableTarget: AsyncLocalStorage.bind(resolveWritableTarget),
+          applyApprovedFileEdit: AsyncLocalStorage.bind(applyApprovedFileEdit),
+        },
+        input,
+      ),
+    );
   }
 }

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -1,12 +1,8 @@
-// Node imports
-import { AsyncLocalStorage } from 'node:async_hooks';
-
 // Third-party imports
 import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports - tools
-import { hostPort } from '@common/hostPort';
 import { isTexFile } from '@common/files/fileTypeUtils';
 import { effectRuntime } from '@platform/processRuntime';
 import replacementEngine from '@replacement/engine';
@@ -29,23 +25,12 @@ const WriteInputSchema = z.strictObject({
 
 export type WriteInput = z.infer<typeof WriteInputSchema>;
 
-/**
- * The edit flow, bound to the calling turn: both steps read the working
- * directory, the read-before-edit tracker, and the approval host from the
- * run context the tool was called in, not from the fiber that runs them.
- */
-interface FileEditPorts {
-  readonly resolveWritableTarget: typeof resolveWritableTarget;
-  readonly applyApprovedFileEdit: typeof applyApprovedFileEdit;
-}
-
 const write = Effect.fn('WriteFileTool.execute')(function* (
-  ports: FileEditPorts,
   input: WriteInput,
 ): Effect.fn.Return<ToolResult, unknown> {
-  const prepared = yield* hostPort(() =>
-    ports.resolveWritableTarget(input.path, { missing: 'allow' }),
-  );
+  const prepared = yield* resolveWritableTarget(input.path, {
+    missing: 'allow',
+  });
   if ('blocked' in prepared) {
     return prepared.blocked;
   }
@@ -54,29 +39,27 @@ const write = Effect.fn('WriteFileTool.execute')(function* (
     ? replacementEngine.applyFor(input.content, 'tex-write')
     : input.content;
 
-  return yield* hostPort(() =>
-    ports.applyApprovedFileEdit({
-      path,
-      displayPath,
-      originalContent,
-      proposedContent,
-      sourceTool: 'write_file',
-      startLine: 'approval',
-      present: ({ appliedContent }) => {
-        const originalLineCount = countLines(originalContent);
-        const newLineCount = countLines(appliedContent);
-        const action = exists ? 'Overwrote' : 'Created';
-        const replacementNote =
-          exists && originalLineCount > 0
-            ? `Replaced ${originalLineCount} lines with ${newLineCount} lines.`
-            : undefined;
-        return {
-          summary: `${action} ${displayPath} (${newLineCount} lines)`,
-          output: replacementNote ? `written\n\n${replacementNote}` : 'written',
-        };
-      },
-    }),
-  );
+  return yield* applyApprovedFileEdit({
+    path,
+    displayPath,
+    originalContent,
+    proposedContent,
+    sourceTool: 'write_file',
+    startLine: 'approval',
+    present: ({ appliedContent }) => {
+      const originalLineCount = countLines(originalContent);
+      const newLineCount = countLines(appliedContent);
+      const action = exists ? 'Overwrote' : 'Created';
+      const replacementNote =
+        exists && originalLineCount > 0
+          ? `Replaced ${originalLineCount} lines with ${newLineCount} lines.`
+          : undefined;
+      return {
+        summary: `${action} ${displayPath} (${newLineCount} lines)`,
+        output: replacementNote ? `written\n\n${replacementNote}` : 'written',
+      };
+    },
+  });
 });
 
 export class WriteFileTool extends defineTool({
@@ -87,14 +70,6 @@ export class WriteFileTool extends defineTool({
   schema: WriteInputSchema,
 }) {
   protected execute(input: WriteInput): Promise<ToolResult> {
-    return effectRuntime().runPromise(
-      write(
-        {
-          resolveWritableTarget: AsyncLocalStorage.bind(resolveWritableTarget),
-          applyApprovedFileEdit: AsyncLocalStorage.bind(applyApprovedFileEdit),
-        },
-        input,
-      ),
-    );
+    return effectRuntime().runPromise(write(input));
   }
 }

--- a/src/tools/approval/tempFileManager.ts
+++ b/src/tools/approval/tempFileManager.ts
@@ -23,6 +23,8 @@
 import { unlink, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { Effect } from 'effect';
+
 import { debug } from '@logger/logUtils';
 import { generateShortId } from '@utils/core';
 
@@ -34,7 +36,7 @@ export interface ApprovalTempFiles {
    * callers that manage an enclosing directory (e.g. Desktop's mkdtemp)
    * can still rm-rf the dir afterwards without seeing errors here.
    */
-  readonly cleanup: () => Promise<void>;
+  readonly cleanup: Effect.Effect<void>;
 }
 
 interface WriteApprovalTempFilesInput {
@@ -45,43 +47,64 @@ interface WriteApprovalTempFilesInput {
   readonly proposedContent: string;
 }
 
+/** Best-effort temp cleanup; ENOENT/already-removed is expected and benign. */
+const removeTempFile = (target: string): Effect.Effect<void> =>
+  Effect.tryPromise({
+    try: () => unlink(target),
+    catch: (error) => error,
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.sync(() => {
+        debug('approval.tempFiles', `Failed to unlink temp file ${target}`, {
+          data: error,
+        });
+      }),
+    ),
+  );
+
 /**
  * File names use a per-side random ID so reusing a shared directory across
  * concurrent requests cannot collide.
  */
-export async function writeApprovalTempFiles(
-  input: WriteApprovalTempFilesInput,
-): Promise<ApprovalTempFiles> {
-  const { directory, targetPath, originalContent, proposedContent } = input;
-  const ext = path.extname(targetPath) || '.txt';
-  const originalPath = path.join(
-    directory,
-    `${generateShortId()}-original${ext}`,
-  );
-  const proposedPath = path.join(
-    directory,
-    `${generateShortId()}-proposed${ext}`,
-  );
+export const writeApprovalTempFiles = Effect.fn('writeApprovalTempFiles')(
+  function* (
+    input: WriteApprovalTempFilesInput,
+  ): Effect.fn.Return<ApprovalTempFiles, unknown> {
+    const { directory, targetPath, originalContent, proposedContent } = input;
+    const ext = path.extname(targetPath) || '.txt';
+    const originalPath = path.join(
+      directory,
+      `${generateShortId()}-original${ext}`,
+    );
+    const proposedPath = path.join(
+      directory,
+      `${generateShortId()}-proposed${ext}`,
+    );
 
-  await Promise.all([
-    writeFile(originalPath, originalContent, 'utf8'),
-    writeFile(proposedPath, proposedContent, 'utf8'),
-  ]);
+    // Both sides start together and the first failure fails the stage, as the
+    // `Promise.all` here did; a staged pair nobody can read is not a partial
+    // success to salvage.
+    yield* Effect.all(
+      [
+        Effect.tryPromise({
+          try: () => writeFile(originalPath, originalContent, 'utf8'),
+          catch: (error) => error,
+        }),
+        Effect.tryPromise({
+          try: () => writeFile(proposedPath, proposedContent, 'utf8'),
+          catch: (error) => error,
+        }),
+      ],
+      { concurrency: 'unbounded' },
+    );
 
-  return {
-    originalPath,
-    proposedPath,
-    cleanup: async () => {
-      const swallowUnlink = (target: string) => (error: unknown) => {
-        // Best-effort cleanup; ENOENT/already-removed is expected and benign.
-        debug('approval.tempFiles', `Failed to unlink temp file ${target}`, {
-          data: error,
-        });
-      };
-      await Promise.all([
-        unlink(originalPath).catch(swallowUnlink(originalPath)),
-        unlink(proposedPath).catch(swallowUnlink(proposedPath)),
-      ]);
-    },
-  };
-}
+    return {
+      originalPath,
+      proposedPath,
+      cleanup: Effect.all(
+        [removeTempFile(originalPath), removeTempFile(proposedPath)],
+        { concurrency: 'unbounded', discard: true },
+      ),
+    };
+  },
+);

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
+import { hostPort } from '@common/hostPort';
 import { ArxivProcessor, type ArxivSourceError } from '@latex/arxivProcessor';
 import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
@@ -27,10 +28,12 @@ function formatDirEntry(name: string, type: number): string {
 }
 
 /** List the freshly-extracted source directory, skipping VCS noise. */
-async function listExtractedEntries(dirFsPath: string): Promise<string> {
-  const entries = await WorkspaceFS.readDir(dirFsPath);
+const listExtractedEntries = Effect.fn('listExtractedEntries')(function* (
+  dirFsPath: string,
+): Effect.fn.Return<string, unknown> {
+  const entries = yield* hostPort(() => WorkspaceFS.readDir(dirFsPath));
   const dirRelative = toPosixPath(WorkspaceFS.relativePath(dirFsPath) || '.');
-  const gitignore = await getGitignoreMatcher();
+  const gitignore = yield* getGitignoreMatcher();
   const formatted = entries
     .filter(([name]) => {
       if (DEFAULT_HIDDEN_NAMES.has(name)) return false;
@@ -41,7 +44,7 @@ async function listExtractedEntries(dirFsPath: string): Promise<string> {
     .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([name, type]) => formatDirEntry(name, type));
   return formatted.length > 0 ? formatted.join('\n') : NO_ENTRIES_MESSAGE;
-}
+});
 
 const ArxivDownloadInputSchema = z.strictObject({
   id: z.string().describe('arXiv identifier or URL for the source archive.'),
@@ -87,10 +90,7 @@ const download = Effect.fn('ArxivDownloadTool.execute')(function* (
 
   // A listing failure degrades to a note in the output, not a tool error:
   // the download itself already succeeded.
-  const listingOutput = yield* Effect.tryPromise({
-    try: () => listExtractedEntries(downloadResult.path),
-    catch: (err) => err,
-  }).pipe(
+  const listingOutput = yield* listExtractedEntries(downloadResult.path).pipe(
     Effect.catch((err) =>
       Effect.succeed(`Failed to list directory: ${toErrorMessage(err)}`),
     ),

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -1,14 +1,16 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { imageSize } from 'image-size';
 
 // Local imports
+import { hostPort } from '@common/hostPort';
 import { ToolError, type ToolFileAttachment } from '@shared/schemas';
 import {
   resolveAndFormat,
   type WorkspacePathResolution,
 } from '@tools/pathResolution';
-import { wrapApiCall } from '@tools/utils';
 import { isNonEmptyString } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getMimeType, isImageMimeType } from '@utils/files/mimeUtils';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toPosixPath } from '@utils/core/pathCore';
@@ -39,17 +41,29 @@ const ATTACHMENT_MAX_BYTES = 15 * 1024 * 1024; // 15 MiB
 const MANY_IMAGE_MAX_DIMENSION = 2000;
 
 /** Returns true if buffer is an image exceeding the many-image dimension limit. */
-function isOversizedImage(buffer: Buffer | Uint8Array): boolean {
-  try {
-    const { width, height } = imageSize(buffer);
-    return (
-      width > MANY_IMAGE_MAX_DIMENSION || height > MANY_IMAGE_MAX_DIMENSION
-    );
-  } catch {
+function isOversizedImage(buffer: Buffer | Uint8Array): Effect.Effect<boolean> {
+  return Effect.try(() => imageSize(buffer)).pipe(
+    Effect.map(
+      ({ width, height }) =>
+        width > MANY_IMAGE_MAX_DIMENSION || height > MANY_IMAGE_MAX_DIMENSION,
+    ),
     // Unrecognized or truncated image data — nothing to measure.
-    return false;
-  }
+    Effect.catch(() => Effect.succeed(false)),
+  );
 }
+
+/**
+ * Preserve a nested ToolError so its message and cause chain survive; wrap
+ * anything else in one prefixed with the operation that failed.
+ */
+const attachmentFailure =
+  (errorPrefix: string) =>
+  (error: unknown): ToolError =>
+    error instanceof ToolError
+      ? error
+      : new ToolError(`${errorPrefix}: ${toErrorMessage(error)}`, {
+          cause: error,
+        });
 
 export interface BuildBytesAttachmentOptions {
   /** Display path surfaced to the model. */
@@ -68,70 +82,85 @@ export interface BuildBytesAttachmentOptions {
  * read_file hint. The returned attachment owns a copy of `bytes`, so callers
  * may zero their own buffer afterwards.
  */
-export function buildBytesAttachment({
-  path,
-  mimeType,
-  bytes,
-  description,
-}: BuildBytesAttachmentOptions): ToolFileAttachment {
-  if (isImageMimeType(mimeType) && isOversizedImage(bytes)) {
+export const buildBytesAttachment = Effect.fn('buildBytesAttachment')(
+  function* ({
+    path,
+    mimeType,
+    bytes,
+    description,
+  }: BuildBytesAttachmentOptions): Effect.fn.Return<ToolFileAttachment, never> {
+    const oversized =
+      isImageMimeType(mimeType) && (yield* isOversizedImage(bytes));
+    if (oversized) {
+      return {
+        path,
+        mimeType,
+        description:
+          (description ? `${description}: ` : '') +
+          `Image exceeds ${MANY_IMAGE_MAX_DIMENSION}px dimension limit; binary data stripped`,
+      };
+    }
+
     return {
       path,
       mimeType,
-      description:
-        (description ? `${description}: ` : '') +
-        `Image exceeds ${MANY_IMAGE_MAX_DIMENSION}px dimension limit; binary data stripped`,
+      bytes: Uint8Array.from(bytes),
+      ...(description && { description }),
     };
-  }
-
-  return {
-    path,
-    mimeType,
-    bytes: Uint8Array.from(bytes),
-    ...(description && { description }),
-  };
-}
+  },
+);
 
 /**
  * Build a tool attachment by reading a workspace file and packaging metadata.
  */
-export async function buildFileAttachment({
+export const buildFileAttachment = Effect.fn('buildFileAttachment')(function* ({
   filePath,
   description,
   mimeType,
   resolved,
-}: BuildFileAttachmentOptions): Promise<ToolFileAttachment> {
+}: BuildFileAttachmentOptions): Effect.fn.Return<ToolFileAttachment, unknown> {
   if (!isNonEmptyString(filePath)) {
-    throw new ToolError('Attachment path must be provided.');
-  }
-
-  const { path, display } = resolved
-    ? { path: resolved, display: toPosixPath(resolved.relative) }
-    : resolveAndFormat(filePath);
-  if (!(await WorkspaceFS.exists(path.fsPath))) {
-    throw new ToolError(`Attachment not found: ${display}`);
-  }
-
-  const stats = await wrapApiCall(
-    () => WorkspaceFS.stat(path.fsPath),
-    `Failed to inspect attachment ${display}`,
-  );
-
-  if (stats.size > ATTACHMENT_MAX_BYTES) {
-    throw new ToolError(
-      `Attachment ${display} exceeds maximum size of ${formatBytes(ATTACHMENT_MAX_BYTES)}.`,
+    return yield* Effect.fail(
+      new ToolError('Attachment path must be provided.'),
     );
   }
 
-  const buffer = await wrapApiCall(
-    () => WorkspaceFS.readBytes(path.fsPath),
-    `Failed to read attachment ${display}`,
-  );
+  // An unresolvable path rejects with a ToolError the tool runner reports to
+  // the model, so it stays a failure rather than becoming a defect.
+  const { path, display } = resolved
+    ? { path: resolved, display: toPosixPath(resolved.relative) }
+    : yield* Effect.try({
+        try: () => resolveAndFormat(filePath),
+        catch: (error) => error,
+      });
+  if (!(yield* hostPort(() => WorkspaceFS.exists(path.fsPath)))) {
+    return yield* Effect.fail(
+      new ToolError(`Attachment not found: ${display}`),
+    );
+  }
+
+  const stats = yield* Effect.tryPromise({
+    try: () => WorkspaceFS.stat(path.fsPath),
+    catch: attachmentFailure(`Failed to inspect attachment ${display}`),
+  });
+
+  if (stats.size > ATTACHMENT_MAX_BYTES) {
+    return yield* Effect.fail(
+      new ToolError(
+        `Attachment ${display} exceeds maximum size of ${formatBytes(ATTACHMENT_MAX_BYTES)}.`,
+      ),
+    );
+  }
+
+  const buffer = yield* Effect.tryPromise({
+    try: () => WorkspaceFS.readBytes(path.fsPath),
+    catch: attachmentFailure(`Failed to read attachment ${display}`),
+  });
 
   const inferredMime =
     mimeType ?? getMimeType(path.fsPath) ?? 'application/octet-stream';
 
-  const attachment = buildBytesAttachment({
+  const attachment = yield* buildBytesAttachment({
     path: display,
     mimeType: inferredMime,
     bytes: buffer,
@@ -140,4 +169,4 @@ export async function buildFileAttachment({
   buffer.fill(0);
 
   return attachment;
-}
+});

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -3,7 +3,6 @@ import { Effect } from 'effect';
 import { imageSize } from 'image-size';
 
 // Local imports
-import { hostPort } from '@common/hostPort';
 import { ToolError, type ToolFileAttachment } from '@shared/schemas';
 import {
   resolveAndFormat,
@@ -118,7 +117,10 @@ export const buildFileAttachment = Effect.fn('buildFileAttachment')(function* ({
   description,
   mimeType,
   resolved,
-}: BuildFileAttachmentOptions): Effect.fn.Return<ToolFileAttachment, unknown> {
+}: BuildFileAttachmentOptions): Effect.fn.Return<
+  ToolFileAttachment,
+  ToolError
+> {
   if (!isNonEmptyString(filePath)) {
     return yield* Effect.fail(
       new ToolError('Attachment path must be provided.'),
@@ -131,9 +133,13 @@ export const buildFileAttachment = Effect.fn('buildFileAttachment')(function* ({
     ? { path: resolved, display: toPosixPath(resolved.relative) }
     : yield* Effect.try({
         try: () => resolveAndFormat(filePath),
-        catch: (error) => error,
+        catch: attachmentFailure(`Failed to resolve attachment ${filePath}`),
       });
-  if (!(yield* hostPort(() => WorkspaceFS.exists(path.fsPath)))) {
+  const present = yield* Effect.tryPromise({
+    try: () => WorkspaceFS.exists(path.fsPath),
+    catch: attachmentFailure(`Failed to inspect attachment ${display}`),
+  });
+  if (!present) {
     return yield* Effect.fail(
       new ToolError(`Attachment not found: ${display}`),
     );

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -626,9 +626,10 @@ const launchClaudeAgentSession = Effect.fn(
   // `additionalDirectories`, unlike codex's `workingDirectory`.
   const { workingDirectory, additionalDirectories } =
     buildAgentWorkspaceOptions(workingDir);
-  const env = yield* agentCliCall(() =>
-    runInSession(session, () => config.buildClaudeAgentEnv()),
-  );
+  // No session frame here, unlike the module read above: the env block reads
+  // only the process environment and `platform().secrets`, neither of which is
+  // workspace-scoped, so it needs no `runInSession` scope of its own.
+  const env = yield* config.buildClaudeAgentEnv();
   const pathToClaudeCodeExecutable = yield* agentCliCall(() =>
     findClaudeBinaryPath(),
   );

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -4,6 +4,7 @@ import { access } from 'node:fs/promises';
 import * as path from 'node:path';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { execa } from 'execa';
 
 // Local imports
@@ -11,6 +12,7 @@ import {
   AgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
+import { hostPort } from '@common/hostPort';
 import { createLog } from '@logger/logUtils';
 import { exposeApiKey, lookupApiKey, apiKeyEnvName } from '@model/apiProviders';
 import { platform } from '@platform/platform';
@@ -100,43 +102,52 @@ export function hasClaudeCodeOauthToken(
  * `env` and `currentPlatform` are injectable for testability; home-directory
  * resolution goes through `safeHomedir()` (mockable via `node:os`).
  */
-async function hasClaudeOauthCredential(
-  env: NodeJS.ProcessEnv = process.env,
-  currentPlatform: NodeJS.Platform = process.platform,
-): Promise<boolean> {
-  if (hasClaudeCodeOauthToken(env)) return true;
+const hasClaudeOauthCredential = Effect.fn('hasClaudeOauthCredential')(
+  function* (
+    env: NodeJS.ProcessEnv = process.env,
+    currentPlatform: NodeJS.Platform = process.platform,
+  ): Effect.fn.Return<boolean, never> {
+    if (hasClaudeCodeOauthToken(env)) return true;
 
-  const configDir = resolveClaudeConfigDir(env.CLAUDE_CONFIG_DIR);
-  try {
+    const configDir = resolveClaudeConfigDir(env.CLAUDE_CONFIG_DIR);
     // Raw node:fs/promises, not platform().fs: FileSystemProvider
     // (@platform/interfaces) exposes no access/existence-check primitive, only
-    // `stat`, which would need this same try/catch for a not-found error — so
-    // routing through it buys nothing for this single boolean check.
-    await access(path.join(configDir, '.credentials.json'));
-    return true;
-  } catch {
-    // access(F_OK) succeeds when the file exists regardless of its read
-    // permissions, so an error means the file is absent or the path is not
-    // traversable. Neither case is a usable credential.
-  }
+    // `stat`, which would need this same failure branch for a not-found error
+    // — so routing through it buys nothing for this single boolean check.
+    const credentialFileExists = yield* Effect.tryPromise({
+      try: () => access(path.join(configDir, '.credentials.json')),
+      catch: (error) => error,
+    }).pipe(
+      Effect.as(true),
+      // access(F_OK) succeeds when the file exists regardless of its read
+      // permissions, so an error means the file is absent or the path is not
+      // traversable. Neither case is a usable credential.
+      Effect.catch(() => Effect.succeed(false)),
+    );
+    if (credentialFileExists) return true;
 
-  if (currentPlatform === 'darwin') {
-    for (const probe of claudeKeychainCredentialProbes(configDir)) {
-      try {
-        const result = await execa('security', probe, {
-          stdio: 'ignore',
-          timeout: 1000,
-          reject: false,
-        });
-        if (result.exitCode === 0) return true;
-      } catch {
-        // Not found / `security` unavailable — try the next known service name.
+    if (currentPlatform === 'darwin') {
+      for (const probe of claudeKeychainCredentialProbes(configDir)) {
+        const exitCode = yield* Effect.tryPromise({
+          try: () =>
+            execa('security', probe, {
+              stdio: 'ignore',
+              timeout: 1000,
+              reject: false,
+            }),
+          catch: (error) => error,
+        }).pipe(
+          Effect.map((result) => result.exitCode),
+          // Not found / `security` unavailable — try the next known service name.
+          Effect.catch(() => Effect.succeed(undefined)),
+        );
+        if (exitCode === 0) return true;
       }
     }
-  }
 
-  return false;
-}
+    return false;
+  },
+);
 
 function resolveClaudeConfigDir(configDirInput: string | undefined): string {
   const homeDir = safeHomedir() ?? '/nonexistent';
@@ -199,9 +210,9 @@ function claudeKeychainCredentialProbes(configDir: string): string[][] {
  *
  * The SDK identifies itself in the User-Agent via CLAUDE_AGENT_SDK_CLIENT_APP.
  */
-export async function buildClaudeAgentEnv(
+export const buildClaudeAgentEnv = Effect.fn('buildClaudeAgentEnv')(function* (
   options: { platform?: NodeJS.Platform } = {},
-): Promise<NodeJS.ProcessEnv> {
+): Effect.fn.Return<NodeJS.ProcessEnv, never> {
   const env: NodeJS.ProcessEnv = { ...process.env };
   env.CLAUDE_AGENT_SDK_CLIENT_APP = 'texra';
   env.CLAUDE_CODE_ENABLE_TODO_TOOLS = '1';
@@ -217,7 +228,7 @@ export async function buildClaudeAgentEnv(
   // 1. OAuth wins: drop any inherited API key so it can't out-prioritize the
   //    OAuth credential, and skip injecting the managed secret entirely.
   if (
-    await hasClaudeOauthCredential(env, options.platform ?? process.platform)
+    yield* hasClaudeOauthCredential(env, options.platform ?? process.platform)
   ) {
     delete env[apiKeyVar];
     return env;
@@ -229,20 +240,22 @@ export async function buildClaudeAgentEnv(
   // 3. Fall back to the Settings-managed secret. An unreadable secret store
   //    leaves the subprocess with no credential at all, so say so rather than
   //    letting it surface as an opaque "Invalid API key" from Claude Code.
-  const managed = await lookupApiKey(platform().secrets, 'anthropic').catch(
-    (error: unknown) => {
+  const managed = yield* hostPort(() =>
+    lookupApiKey(platform().secrets, 'anthropic'),
+  ).pipe(
+    Effect.catch((error: unknown) => {
       log.warn(
         `Failed to read the managed Anthropic API key: ${toErrorMessage(error)}`,
       );
-      return undefined;
-    },
+      return Effect.succeed(undefined);
+    }),
   );
   if (managed) {
     env[apiKeyVar] = exposeApiKey(managed);
   }
 
   return env;
-}
+});
 
 // ============================================================================
 // Synthetic execution metadata for child streams

--- a/src/tools/comment/InlineCommentTool.ts
+++ b/src/tools/comment/InlineCommentTool.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Internal imports
@@ -7,6 +8,7 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { createLog } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
 import { executed } from '@tools/core/result';
@@ -66,19 +68,20 @@ export function setInlineCommentProvider(next: InlineCommentProvider): void {
 }
 
 /**
- * Resolve the host-injected provider, throwing when none was wired. The throw
+ * Resolve the host-injected provider, failing when none was wired. The failure
  * is intentional: `unavailableHosts` already keeps `inline_comment` out of the
  * CLI and desktop rosters, so reaching the tool with no provider means a host
  * skipped the registration — a startup bug that must name itself rather than
  * report a plausible no-op back to the agent.
  */
-function requireProvider(): InlineCommentProvider {
-  if (!provider) {
-    throw new ToolError(
-      'Inline comments are unavailable: no host called setInlineCommentProvider() during startup. Only the VS Code extension host wires this tool.',
-    );
-  }
-  return provider;
+function requireProvider(): Effect.Effect<InlineCommentProvider, ToolError> {
+  return provider
+    ? Effect.succeed(provider)
+    : Effect.fail(
+        new ToolError(
+          'Inline comments are unavailable: no host called setInlineCommentProvider() during startup. Only the VS Code extension host wires this tool.',
+        ),
+      );
 }
 
 const THREAD_ID_DESCRIPTION = 'The thread id returned by "add" or "list".';
@@ -171,6 +174,124 @@ function formatThread(thread: InlineCommentThreadView): string {
   return comments ? `${header}\n${comments}` : header;
 }
 
+/**
+ * Wrap an unexpected failure from path resolution or the provider. A
+ * `ToolError` already names itself and passes through unchanged.
+ */
+function addCommentFailure(error: unknown): ToolError {
+  if (error instanceof ToolError) return error;
+  const detail = toErrorMessage(error);
+  log.error(`Failed to add inline comment: ${detail}`);
+  return new ToolError(`Failed to add inline comment: ${detail}`);
+}
+
+function threadNotFound(threadId: string): ToolResult {
+  return executed(
+    `No comment thread with id "${threadId}". Use the "list" command to see open threads.`,
+    'Thread not found',
+  );
+}
+
+const addThread = Effect.fn('InlineCommentTool.addThread')(function* (
+  input: AddCommentInput,
+) {
+  const { path, line, endLine, body } = input;
+  const resolved = yield* Effect.try({
+    try: () =>
+      resolveWorkspaceRelativePath(
+        path,
+        getRunContextWorkingDirectory(tryUseRunContext()),
+      ),
+    catch: addCommentFailure,
+  });
+  const provider = yield* requireProvider();
+  const result = yield* Effect.try({
+    try: () =>
+      provider.add({
+        absolutePath: resolved.absolute,
+        line,
+        endLine: endLine ?? line,
+        body,
+      }),
+    catch: addCommentFailure,
+  });
+  if (!result) {
+    return yield* Effect.fail(
+      new ToolError('Failed to create the comment thread.'),
+    );
+  }
+  const where = result.resolvedPath || resolved.absolute;
+  const summary = `Opened comment thread ${result.threadId} at ${where}:${line}`;
+  return executed(
+    `${summary}\nThe user can reply or resolve it in the editor; read replies with the "list" command.`,
+    summary,
+  );
+});
+
+const replyToThread = Effect.fn('InlineCommentTool.reply')(function* (
+  input: ReplyCommentInput,
+) {
+  const { threadId, body } = input;
+  if (!(yield* requireProvider()).reply({ threadId, body })) {
+    return threadNotFound(threadId);
+  }
+  const summary = `Replied to comment thread ${threadId}`;
+  return executed(summary, summary);
+});
+
+const setThreadResolved = Effect.fn('InlineCommentTool.setResolved')(function* (
+  input: SetResolvedInput,
+  resolved: boolean,
+) {
+  const { threadId } = input;
+  if (!(yield* requireProvider()).setResolved({ threadId, resolved })) {
+    return threadNotFound(threadId);
+  }
+  const summary = `${resolved ? 'Resolved' : 'Reopened'} comment thread ${threadId}`;
+  return executed(summary, summary);
+});
+
+const listThreads = Effect.fn('InlineCommentTool.list')(function* (
+  input: ListCommentInput,
+) {
+  let absolutePath: string | undefined;
+  if (input.path != null) {
+    const workingDirectory = getRunContextWorkingDirectory(tryUseRunContext());
+    absolutePath = resolveWorkspaceRelativePath(
+      input.path,
+      workingDirectory,
+    ).absolute;
+  }
+  const threads = (yield* requireProvider()).list({ absolutePath });
+  if (threads.length === 0) {
+    return executed(
+      input.path
+        ? `No comment threads in ${input.path}.`
+        : 'No comment threads are open.',
+      'No comment threads',
+    );
+  }
+  const summary = formatResultCount(threads.length, 'comment thread');
+  return executed(threads.map(formatThread).join('\n\n'), summary);
+});
+
+function inlineComment(
+  input: InlineCommentInput,
+): Effect.Effect<ToolResult, ToolError> {
+  switch (input.command) {
+    case 'add':
+      return addThread(input);
+    case 'reply':
+      return replyToThread(input);
+    case 'resolve':
+      return setThreadResolved(input, true);
+    case 'unresolve':
+      return setThreadResolved(input, false);
+    case 'list':
+      return listThreads(input);
+  }
+}
+
 export class InlineCommentTool extends defineTool({
   name: 'inline_comment',
   // Requires the VS Code Comments UI.
@@ -179,95 +300,7 @@ export class InlineCommentTool extends defineTool({
     'Leave inline comment threads in the editor via VS Code\'s native Comments UI (gutter bubbles + Comments panel) that the user can reply to and resolve. Commands: "add" opens a thread on a file range, "reply" appends to a thread, "resolve"/"unresolve" toggle a thread\'s state, "list" reads open threads including the user\'s replies. Use this for conversational, resolvable review notes; use the diagnostics tool\'s "add" command for one-off lint-style critique squiggles. Not available outside the VS Code extension host.',
   schema: InlineCommentInputSchema,
 }) {
-  protected async execute(input: InlineCommentInput): Promise<ToolResult> {
-    switch (input.command) {
-      case 'add':
-        return this.addThread(input);
-      case 'reply':
-        return this.reply(input);
-      case 'resolve':
-        return this.setResolved(input, true);
-      case 'unresolve':
-        return this.setResolved(input, false);
-      case 'list':
-        return this.list(input);
-    }
-  }
-
-  private addThread(input: AddCommentInput): ToolResult {
-    const { path, line, endLine, body } = input;
-    try {
-      const workingDirectory =
-        getRunContextWorkingDirectory(tryUseRunContext());
-      const resolved = resolveWorkspaceRelativePath(path, workingDirectory);
-      const result = requireProvider().add({
-        absolutePath: resolved.absolute,
-        line,
-        endLine: endLine ?? line,
-        body,
-      });
-      if (!result) {
-        throw new ToolError('Failed to create the comment thread.');
-      }
-      const where = result.resolvedPath || resolved.absolute;
-      const summary = `Opened comment thread ${result.threadId} at ${where}:${line}`;
-      return executed(
-        `${summary}\nThe user can reply or resolve it in the editor; read replies with the "list" command.`,
-        summary,
-      );
-    } catch (error) {
-      if (error instanceof ToolError) throw error;
-      const detail = toErrorMessage(error);
-      log.error(`Failed to add inline comment: ${detail}`);
-      throw new ToolError(`Failed to add inline comment: ${detail}`);
-    }
-  }
-
-  private reply(input: ReplyCommentInput): ToolResult {
-    const { threadId, body } = input;
-    if (!requireProvider().reply({ threadId, body })) {
-      return this.threadNotFound(threadId);
-    }
-    const summary = `Replied to comment thread ${threadId}`;
-    return executed(summary, summary);
-  }
-
-  private setResolved(input: SetResolvedInput, resolved: boolean): ToolResult {
-    const { threadId } = input;
-    if (!requireProvider().setResolved({ threadId, resolved })) {
-      return this.threadNotFound(threadId);
-    }
-    const summary = `${resolved ? 'Resolved' : 'Reopened'} comment thread ${threadId}`;
-    return executed(summary, summary);
-  }
-
-  private list(input: ListCommentInput): ToolResult {
-    let absolutePath: string | undefined;
-    if (input.path != null) {
-      const workingDirectory =
-        getRunContextWorkingDirectory(tryUseRunContext());
-      absolutePath = resolveWorkspaceRelativePath(
-        input.path,
-        workingDirectory,
-      ).absolute;
-    }
-    const threads = requireProvider().list({ absolutePath });
-    if (threads.length === 0) {
-      return executed(
-        input.path
-          ? `No comment threads in ${input.path}.`
-          : 'No comment threads are open.',
-        'No comment threads',
-      );
-    }
-    const summary = formatResultCount(threads.length, 'comment thread');
-    return executed(threads.map(formatThread).join('\n\n'), summary);
-  }
-
-  private threadNotFound(threadId: string): ToolResult {
-    return executed(
-      `No comment thread with id "${threadId}". Use the "list" command to see open threads.`,
-      'Thread not found',
-    );
+  protected execute(input: InlineCommentInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(inlineComment(input));
   }
 }

--- a/src/tools/delegation/DelegationTools.ts
+++ b/src/tools/delegation/DelegationTools.ts
@@ -130,10 +130,12 @@ Optional auto-attach from the input LaTeX:
     const agentName = agent.name;
     const { streamId, context } = requireRunStream('delegate_workflow');
 
-    const model = await selectAvailableDelegationModel({
-      requestedModel: input.model,
-      parentModel: context.model,
-    });
+    const model = await effectRuntime().runPromise(
+      selectAvailableDelegationModel({
+        requestedModel: input.model,
+        parentModel: context.model,
+      }),
+    );
 
     await assertWorkflowFilesExist([
       { label: 'Input file', files: input.inputFiles },
@@ -267,10 +269,12 @@ Git worktree support: resolved from the active workspace at runtime.`,
 
     const { streamId, context } = requireRunStream('delegate_agent');
 
-    const model = await selectAvailableDelegationModel({
-      requestedModel: input.model,
-      parentModel: context.model,
-    });
+    const model = await effectRuntime().runPromise(
+      selectAvailableDelegationModel({
+        requestedModel: input.model,
+        parentModel: context.model,
+      }),
+    );
     const rootUserInstruction = getCurrentToolCallContext()?.userInstruction;
 
     // Construct tool-use proposal (no file fields)

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -373,10 +373,14 @@ Durability: the journal is keyed by meta.name and the agent field within this se
         // Same availability gate as delegate_agent/delegate_workflow: a run model
         // the active credentials cannot serve fails here, with the available list,
         // instead of mid-run on the first provider call.
-        const runModel = yield* runPhase(() =>
-          selectAvailableDelegationModel({
-            parentModel: parent.model,
-          }),
+        const runModel = yield* selectAvailableDelegationModel({
+          parentModel: parent.model,
+          withScope: <T>(read: () => T) => withRunContext(parent, read),
+        }).pipe(
+          // Same annotation `runPhase` puts on every other phase failure.
+          Effect.mapError((error) =>
+            workflowScriptToolError(error, scriptPath),
+          ),
         );
 
         const runConfigPayload: AgentConfigPayload = {

--- a/src/tools/delegation/delegationAvailability.ts
+++ b/src/tools/delegation/delegationAvailability.ts
@@ -23,6 +23,9 @@
  * the block instead.
  */
 
+// Third-party imports
+import { Effect } from 'effect';
+
 // Local imports
 import {
   findAgentByIdentifier,
@@ -41,6 +44,7 @@ import type {
 import { isModelOptionAvailable } from '@shared/schemas';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { unique } from '@utils/core';
+import { ensureError } from '@utils/errors/errorMessage';
 import { isWorktreeSupportEnabled } from '@utils/config/worktreeConfig';
 
 /**
@@ -211,17 +215,35 @@ function formatAvailableModelsLine(
  * against the live availability list so an unavailable choice fails here rather
  * than after launch.
  */
-export async function selectAvailableDelegationModel(input: {
+export const selectAvailableDelegationModel = Effect.fn(
+  'selectAvailableDelegationModel',
+)(function* (input: {
   readonly requestedModel?: string | null;
   readonly parentModel?: string | null;
-}): Promise<string> {
+  /**
+   * Context frame the availability read runs inside. Callers that reach this
+   * from outside their run's own frame — an approved proposal, a workflow
+   * script's per-call model routing — pass their `withRunContext` /
+   * `runInSession` wrapper here. Only the read needs it; the decision below
+   * is pure.
+   */
+  readonly withScope?: <T>(read: () => T) => T;
+}) {
+  const { withScope } = input;
+  const models = yield* Effect.tryPromise({
+    try: () =>
+      withScope
+        ? withScope(() => computeModelOptionsData())
+        : computeModelOptionsData(),
+    catch: ensureError,
+  });
   const availableModels = unique(
-    availableModelNamesFromOptions(await computeModelOptionsData())
+    availableModelNamesFromOptions(models)
       .map((model) => model.trim())
       .filter(Boolean),
   );
   if (availableModels.length === 0) {
-    throw new Error(NO_DELEGATION_MODELS_MESSAGE);
+    return yield* Effect.fail(new Error(NO_DELEGATION_MODELS_MESSAGE));
   }
 
   const decision = decideRunModel(
@@ -237,16 +259,18 @@ export async function selectAvailableDelegationModel(input: {
     (model) => availableModels.includes(model),
   );
   if (!decision) {
-    throw new Error(NO_DELEGATION_MODELS_MESSAGE);
+    return yield* Effect.fail(new Error(NO_DELEGATION_MODELS_MESSAGE));
   }
   if (decision.unavailable) {
     const requestedModel = input.requestedModel?.trim() || null;
-    throw new Error(
-      `Model "${requestedModel}" is not currently available for delegation with the currently configured model access. Available models: ${availableModels.join(', ')}.`,
+    return yield* Effect.fail(
+      new Error(
+        `Model "${requestedModel}" is not currently available for delegation with the currently configured model access. Available models: ${availableModels.join(', ')}.`,
+      ),
     );
   }
   return decision.model;
-}
+});
 
 /* -------------------------------------------------------------------------
  * Worktree support

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -250,15 +250,10 @@ export const proposeAndExecute = Effect.fn('proposeAndExecute')(function* (
   let modelOverride: string | undefined;
   if (result.model && result.model !== proposal.model) {
     const modelExit = yield* Effect.exit(
-      Effect.tryPromise({
-        try: () =>
-          withRunContext(parentContext, () =>
-            selectAvailableDelegationModel({
-              requestedModel: result.model,
-              parentModel: proposal.model,
-            }),
-          ),
-        catch: ensureError,
+      selectAvailableDelegationModel({
+        requestedModel: result.model,
+        parentModel: proposal.model,
+        withScope: <T>(read: () => T) => withRunContext(parentContext, read),
       }),
     );
     if (Exit.isFailure(modelExit)) {

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -37,15 +37,13 @@ function workflowScriptModelSelection(
   parent: LaunchRunContext,
 ): Effect.Effect<string, Error> {
   const requestedModel = invocation.options.model;
-  return Effect.tryPromise({
-    try: () =>
-      runInSession(parent.runScope.session, () =>
-        selectAvailableDelegationModel({
-          ...(requestedModel !== undefined && { requestedModel }),
-          parentModel: parent.model,
-        }),
-      ),
-    catch: (error) => {
+  return selectAvailableDelegationModel({
+    ...(requestedModel !== undefined && { requestedModel }),
+    parentModel: parent.model,
+    withScope: <T>(read: () => T) =>
+      runInSession(parent.runScope.session, read),
+  }).pipe(
+    Effect.mapError((error) => {
       // A declared model is workflow configuration, so its rejection must not
       // disappear as a nullable call inside parallel(). When the
       // script omits the field, preserve the established delegation failure
@@ -55,8 +53,8 @@ function workflowScriptModelSelection(
         formatError('Workflow model could not be selected', error),
         { cause: error },
       );
-    },
-  });
+    }),
+  );
 }
 
 /**

--- a/src/tools/emlParser.ts
+++ b/src/tools/emlParser.ts
@@ -1,7 +1,9 @@
 // Third-party imports
+import { Effect } from 'effect';
 import PostalMime from 'postal-mime';
 
 // Local imports
+import { hostPort } from '@common/hostPort';
 import { createHtmlToMarkdown } from '@utils/text/htmlToMarkdown';
 
 import type { Address, Attachment, Email } from 'postal-mime';
@@ -40,12 +42,14 @@ const turndownService = createHtmlToMarkdown();
  * When no plain-text part exists, falls back to a Markdown conversion of the HTML body.
  * Non-image attachment filenames are listed at the end of the text.
  */
-export async function parseEml(rawEml: string): Promise<EmlParseResult> {
-  const email = await PostalMime.parse(rawEml);
+export const parseEml = Effect.fn('parseEml')(function* (
+  rawEml: string,
+): Effect.fn.Return<EmlParseResult, unknown> {
+  const email = yield* hostPort(() => PostalMime.parse(rawEml));
   const partition = partitionAttachments(email.attachments);
   const text = formatEmail(email, partition);
   return { text, images: partition.images };
-}
+});
 
 // ---------------------------------------------------------------------------
 // Formatting helpers

--- a/src/tools/executions/runGeneratedFiles.ts
+++ b/src/tools/executions/runGeneratedFiles.ts
@@ -17,7 +17,12 @@
 
 import * as path from 'node:path';
 
+import { Effect } from 'effect';
+
+import { runInSession } from '@agent/runtime/RunContext';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+import { hostPort } from '@common/hostPort';
 import { createLog } from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 import { byStringProp } from '@utils/core';
@@ -46,72 +51,106 @@ export interface RunGeneratedFile {
 /**
  * List the generated (non-KV) files under a run's storage directory, sorted by
  * path. Returns `[]` when the run has no storage directory at all.
+ *
+ * Every storage read runs in `session`'s scope: `StorageFS` resolves its root
+ * from the ambient session, and a fiber's continuation carries no caller's
+ * scope, so a host holding one session per open paper would otherwise walk the
+ * wrong root.
  */
-export async function listRunGeneratedFiles(
-  executionId: ExecutionId,
-): Promise<RunGeneratedFile[]> {
-  const runDir = await findExistingRunStoragePath(executionId);
-  if (!runDir) return [];
-  const files = await walkRunStorage(runDir, '', RUN_FILE_SCAN_DEPTH);
-  return files.sort(byStringProp((file) => file.path));
-}
+export const listRunGeneratedFiles = Effect.fn('listRunGeneratedFiles')(
+  function* (
+    executionId: ExecutionId,
+    session: SessionHandle,
+  ): Effect.fn.Return<RunGeneratedFile[], unknown> {
+    const runDir = yield* hostPort(() =>
+      runInSession(session, () => findExistingRunStoragePath(executionId)),
+    );
+    if (!runDir) return [];
+    const files = yield* walkRunStorage(
+      session,
+      runDir,
+      '',
+      RUN_FILE_SCAN_DEPTH,
+    );
+    return files.sort(byStringProp((file) => file.path));
+  },
+);
 
-async function walkRunStorage(
+function walkRunStorage(
+  session: SessionHandle,
   basePath: string,
   relativePath: string,
   maxDepth: number,
-): Promise<RunGeneratedFile[]> {
-  const fullPath = relativePath ? path.join(basePath, relativePath) : basePath;
+): Effect.Effect<RunGeneratedFile[], unknown> {
+  return Effect.gen(function* () {
+    const fullPath = relativePath
+      ? path.join(basePath, relativePath)
+      : basePath;
 
-  let entries: readonly (readonly [string, number])[];
-  try {
-    entries = await StorageFS.readDir(fullPath);
-  } catch (error) {
-    // Deliberately warn-and-continue rather than rethrow: an unreadable
-    // subdirectory must not blank out the rest of the listing. A missing
-    // directory is the expected "nothing persisted here" case; any other read
-    // failure (permissions, corrupt storage) still degrades to empty, but
-    // loudly — the warn is the surfacing mechanism, matching the
-    // outputDiscovery/externalInquiryStorage fallback precedent (#10630).
-    if (!isFileNotFoundError(error)) {
-      log.warn(`Unreadable run directory '${fullPath}'; listing it as empty`, {
-        data: error,
-      });
-    }
-    return [];
-  }
+    const entries = yield* hostPort(() =>
+      runInSession(session, () => StorageFS.readDir(fullPath)),
+    ).pipe(
+      // Deliberately warn-and-continue rather than rethrow: an unreadable
+      // subdirectory must not blank out the rest of the listing. A missing
+      // directory is the expected "nothing persisted here" case; any other read
+      // failure (permissions, corrupt storage) still degrades to empty, but
+      // loudly — the warn is the surfacing mechanism, matching the
+      // outputDiscovery/externalInquiryStorage fallback precedent (#10630).
+      Effect.catch((error) =>
+        Effect.sync((): [string, number][] => {
+          if (!isFileNotFoundError(error)) {
+            log.warn(
+              `Unreadable run directory '${fullPath}'; listing it as empty`,
+              { data: error },
+            );
+          }
+          return [];
+        }),
+      ),
+    );
 
-  const files: RunGeneratedFile[] = [];
-  for (const [name, type] of entries) {
-    // Skip before stat and before recursion: a KV-named *directory* is
-    // internal metadata all the way down, so its children are not generated
-    // output either.
-    if (isKVFile(name)) continue;
+    const files: RunGeneratedFile[] = [];
+    for (const [name, type] of entries) {
+      // Skip before stat and before recursion: a KV-named *directory* is
+      // internal metadata all the way down, so its children are not generated
+      // output either.
+      if (isKVFile(name)) continue;
 
-    const rawRelative = relativePath ? path.join(relativePath, name) : name;
-    const childPath = path.join(basePath, rawRelative);
-    const entryIsDirectory = isDirectory(type);
+      const rawRelative = relativePath ? path.join(relativePath, name) : name;
+      const childPath = path.join(basePath, rawRelative);
+      const entryIsDirectory = isDirectory(type);
 
-    try {
-      const stat = await StorageFS.stat(childPath);
+      const stat = yield* hostPort(() =>
+        runInSession(session, () => StorageFS.stat(childPath)),
+      ).pipe(
+        // An entry that vanished (or whose parent stopped being a directory)
+        // between readDir and stat is a benign race; anything else is a real
+        // fault and propagates.
+        Effect.catch((error) =>
+          isFileNotFoundError(error) || isNotADirectoryError(error)
+            ? Effect.succeed(undefined)
+            : Effect.fail(error),
+        ),
+      );
+      if (!stat) continue;
+
       files.push({
         path: toPosixPath(rawRelative),
         size: stat.size,
         isDirectory: entryIsDirectory,
       });
-    } catch (error) {
-      // An entry that vanished (or whose parent stopped being a directory)
-      // between readDir and stat is a benign race; anything else is a real
-      // fault and propagates.
-      if (isFileNotFoundError(error) || isNotADirectoryError(error)) continue;
-      throw error;
-    }
 
-    if (entryIsDirectory && maxDepth > 1) {
-      files.push(
-        ...(await walkRunStorage(basePath, rawRelative, maxDepth - 1)),
-      );
+      if (entryIsDirectory && maxDepth > 1) {
+        files.push(
+          ...(yield* walkRunStorage(
+            session,
+            basePath,
+            rawRelative,
+            maxDepth - 1,
+          )),
+        );
+      }
     }
-  }
-  return files;
+    return files;
+  });
 }

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -11,7 +11,11 @@
  *   - {@link @controllers/settingsView/ToolDashboardData} — reads everything for the UI
  */
 
+// Third-party imports
+import { Effect } from 'effect';
+
 // Local imports
+import { hostPort } from '@common/hostPort';
 import { apiKeyEnvName, lookupApiKeyOrigin } from '@model/apiProviders';
 import { platform } from '@platform/platform';
 import type { ToolCategory } from '@shared/schemas';
@@ -73,13 +77,17 @@ export interface ExternalToolDef {
   /** Tool names belonging to this group — must match registry keys. */
   readonly tools: readonly RegisteredToolName[];
   /** Optional shared probe result passed to check/status/detail callbacks. */
-  readonly probe?: () => Promise<unknown>;
+  readonly probe?: () => Effect.Effect<unknown, unknown>;
   /** Returns true if the external dependency is available. */
-  readonly check: (probeResult?: unknown) => Promise<boolean>;
+  readonly check: (probeResult?: unknown) => Effect.Effect<boolean, unknown>;
   /** Optional detailed status string resolved at check time (shown below description). */
-  readonly detailCheck?: (probeResult?: unknown) => Promise<string | undefined>;
+  readonly detailCheck?: (
+    probeResult?: unknown,
+  ) => Effect.Effect<string | undefined, unknown>;
   /** Optional short status label for the dashboard badge. */
-  readonly statusLabel?: (probeResult?: unknown) => Promise<string | undefined>;
+  readonly statusLabel?: (
+    probeResult?: unknown,
+  ) => Effect.Effect<string | undefined, unknown>;
   // Dashboard UI metadata
   readonly name: string;
   readonly category: ToolCategory;
@@ -109,39 +117,33 @@ export interface ExternalToolDef {
 // Zotero probe helpers
 // ============================================================
 
-async function fetchLocalhost(
+function fetchLocalhost(
   url: string,
   timeoutMs = ZOTERO_PROBE_TIMEOUT_MS,
-): Promise<Pick<Response, 'ok' | 'status'>> {
-  let response: Response | undefined;
-  try {
-    response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
-    return { ok: response.ok, status: response.status };
-  } finally {
-    await response?.body?.cancel().catch(() => undefined);
-  }
+): Effect.Effect<Pick<Response, 'ok' | 'status'>, unknown> {
+  return Effect.acquireUseRelease(
+    hostPort(() => fetch(url, { signal: AbortSignal.timeout(timeoutMs) })),
+    (response) => Effect.succeed({ ok: response.ok, status: response.status }),
+    // The probe never reads the body; releasing it frees the socket, and a
+    // cancel that itself fails says nothing about availability.
+    (response) => Effect.ignore(hostPort(() => response.body?.cancel())),
+  );
 }
 
 /** Probe the Zotero connector endpoint (responds if Zotero is running). */
-async function probeZoteroConnector(port: number): Promise<boolean> {
-  try {
-    await fetchLocalhost(`http://127.0.0.1:${port}/connector/ping`);
-    return true;
-  } catch {
-    return false;
-  }
+function probeZoteroConnector(port: number): Effect.Effect<boolean> {
+  return fetchLocalhost(`http://127.0.0.1:${port}/connector/ping`).pipe(
+    Effect.as(true),
+    Effect.catch(() => Effect.succeed(false)),
+  );
 }
 
 /** Probe the Better BibTeX JSON-RPC endpoint. */
-async function probeZoteroBbt(port: number): Promise<boolean> {
-  try {
-    const response = await fetchLocalhost(
-      `http://127.0.0.1:${port}/better-bibtex/json-rpc`,
-    );
-    return response.ok || response.status === 405;
-  } catch {
-    return false;
-  }
+function probeZoteroBbt(port: number): Effect.Effect<boolean> {
+  return fetchLocalhost(`http://127.0.0.1:${port}/better-bibtex/json-rpc`).pipe(
+    Effect.map((response) => response.ok || response.status === 405),
+    Effect.catch(() => Effect.succeed(false)),
+  );
 }
 
 interface GitHubPRPrerequisites {
@@ -149,28 +151,30 @@ interface GitHubPRPrerequisites {
   inGitRepo: boolean;
 }
 
-async function getGitHubPRPrerequisites(): Promise<GitHubPRPrerequisites> {
-  const tokenPresent = (await getGitHubToken()) !== undefined;
-  const inGitRepo = await isGitRepository();
-  return { tokenPresent, inGitRepo };
-}
+const getGitHubPRPrerequisites = Effect.fn('getGitHubPRPrerequisites')(
+  function* () {
+    const tokenPresent = (yield* hostPort(getGitHubToken)) !== undefined;
+    const inGitRepo = yield* hostPort(isGitRepository);
+    return { tokenPresent, inGitRepo };
+  },
+);
 
 function resolveGitHubPRPrerequisites(
   probeResult: unknown,
-): GitHubPRPrerequisites | Promise<GitHubPRPrerequisites> {
+): Effect.Effect<GitHubPRPrerequisites, unknown> {
   // The probe runs in-process and its result is handed straight back here, so
-  // the shape is structurally guaranteed; only a thrown probe (probeResult
+  // the shape is structurally guaranteed; only a failed probe (probeResult
   // undefined) needs the re-probe fallback.
   return probeResult === undefined
     ? getGitHubPRPrerequisites()
-    : (probeResult as GitHubPRPrerequisites);
+    : Effect.succeed(probeResult as GitHubPRPrerequisites);
 }
 
-async function probeTexraCli(): Promise<boolean> {
+const probeTexraCli = Effect.fn('probeTexraCli')(function* () {
   if (platform().toolAvailability.isTexraCliEntrypoint()) return true;
-  if (await checkToolInstalled('texra', false)) return true;
-  return checkToolInstalled('texra-local', false);
-}
+  if (yield* hostPort(() => checkToolInstalled('texra', false))) return true;
+  return yield* hostPort(() => checkToolInstalled('texra-local', false));
+});
 
 interface Lean4Prerequisites {
   extensionAvailable: boolean;
@@ -204,16 +208,14 @@ function wslInstallHint(): string {
  * Code): the dependency is present when its SDK imports and the native binary
  * resolves. Any import or resolution failure counts as unavailable.
  */
-async function probeSdkBinaryAvailable(
+function probeSdkBinaryAvailable(
   importSdk: () => Promise<unknown>,
   findBinary: () => Promise<string | undefined>,
-): Promise<boolean> {
-  try {
-    await importSdk();
-    return (await findBinary()) != null;
-  } catch {
-    return false;
-  }
+): Effect.Effect<boolean> {
+  return Effect.gen(function* () {
+    yield* hostPort(importSdk);
+    return (yield* hostPort(findBinary)) != null;
+  }).pipe(Effect.catch(() => Effect.succeed(false)));
 }
 
 /** Resolved status of an SDK-backed CLI integration for the dashboard. */
@@ -227,34 +229,43 @@ type SdkBinaryStatus =
  * absent). Callers own only the final "ready" line, so the import/binary
  * narrative lives in one place instead of once per entry.
  */
-async function probeSdkBinaryStatus(config: {
+function probeSdkBinaryStatus(config: {
   importSdk: () => Promise<unknown>;
   findBinary: () => Promise<string | undefined>;
   missingPackageMessage: string;
   importFailedLabel: string;
   binaryNotFoundMessage: string;
   classifyImportError?: (msg: string) => string | undefined;
-}): Promise<SdkBinaryStatus> {
-  try {
-    await config.importSdk();
-  } catch (err: unknown) {
-    const msg = toErrorMessage(err);
-    if (isMissingPackageError(msg)) {
-      return { ok: false, message: config.missingPackageMessage };
+}): Effect.Effect<SdkBinaryStatus, unknown> {
+  return Effect.gen(function* () {
+    // Only the import is classified into a message; a binary-resolution
+    // failure stays on the error channel, as it did when it threw past the
+    // import's try/catch.
+    const importFailure = yield* hostPort(config.importSdk).pipe(
+      Effect.as(undefined),
+      Effect.catch((err: unknown) => {
+        const msg = toErrorMessage(err);
+        if (isMissingPackageError(msg)) {
+          return Effect.succeed(config.missingPackageMessage);
+        }
+        const classified = config.classifyImportError?.(msg);
+        if (classified != null) return Effect.succeed(classified);
+        return Effect.succeed(`${config.importFailedLabel}: ${msg}`);
+      }),
+    );
+    if (importFailure !== undefined) {
+      return { ok: false as const, message: importFailure };
     }
-    const classified = config.classifyImportError?.(msg);
-    if (classified != null) return { ok: false, message: classified };
-    return { ok: false, message: `${config.importFailedLabel}: ${msg}` };
-  }
 
-  const binaryPath = await config.findBinary();
-  if (!binaryPath) {
-    return {
-      ok: false,
-      message: config.binaryNotFoundMessage + wslInstallHint(),
-    };
-  }
-  return { ok: true, binaryPath };
+    const binaryPath = yield* hostPort(config.findBinary);
+    if (!binaryPath) {
+      return {
+        ok: false as const,
+        message: config.binaryNotFoundMessage + wslInstallHint(),
+      };
+    }
+    return { ok: true as const, binaryPath };
+  });
 }
 
 /**
@@ -267,8 +278,8 @@ async function probeSdkBinaryStatus(config: {
  * callbacks, and those callbacks stay pure functions of the resolved value.
  */
 function prerequisitesChecks<T>(config: {
-  probe: () => Promise<T>;
-  resolve: (probeResult: unknown) => T | Promise<T>;
+  probe: () => Effect.Effect<T, unknown>;
+  resolve: (probeResult: unknown) => Effect.Effect<T, unknown>;
   check: (prereqs: T) => boolean;
   statusLabel: (prereqs: T) => string | undefined;
   detailCheck: (prereqs: T) => string | undefined;
@@ -276,9 +287,9 @@ function prerequisitesChecks<T>(config: {
   const { probe, resolve, check, statusLabel, detailCheck } = config;
   return {
     probe,
-    check: async (probeResult) => check(await resolve(probeResult)),
-    statusLabel: async (probeResult) => statusLabel(await resolve(probeResult)),
-    detailCheck: async (probeResult) => detailCheck(await resolve(probeResult)),
+    check: (probeResult) => Effect.map(resolve(probeResult), check),
+    statusLabel: (probeResult) => Effect.map(resolve(probeResult), statusLabel),
+    detailCheck: (probeResult) => Effect.map(resolve(probeResult), detailCheck),
   };
 }
 
@@ -336,7 +347,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     installUrl: 'https://app.uio.no/ifi/texcount/',
     configNotes: 'Part of most TeX Live distributions.',
     hideFromDashboard: true, // Shown in LaTeX settings tab instead
-    check: () => checkToolInstalled('texcount', false),
+    check: () => hostPort(() => checkToolInstalled('texcount', false)),
   },
   {
     id: 'wolfram',
@@ -356,7 +367,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'it automatically. Free licenses are available for development use.',
     installUrl: 'https://www.wolfram.com/engine/',
     configNotes: 'Requires the free Wolfram Engine (provides wolframscript).',
-    check: () => checkToolInstalled('wolframscript', false),
+    check: () => hostPort(() => checkToolInstalled('wolframscript', false)),
   },
   {
     id: 'zotero',
@@ -384,11 +395,11 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     configNotes:
       'Zotero must be running with Better BibTeX installed. Port configurable via texra.bib.zoteroPort.',
     toggleable: true,
-    check: async () => probeZoteroBbt(getZoteroPort()),
-    detailCheck: async () => {
+    check: () => probeZoteroBbt(getZoteroPort()),
+    detailCheck: Effect.fn('externalToolDefs.zoteroDetail')(function* () {
       const port = getZoteroPort();
-      const zoteroOk = await probeZoteroConnector(port);
-      const bbtOk = await probeZoteroBbt(port);
+      const zoteroOk = yield* probeZoteroConnector(port);
+      const bbtOk = yield* probeZoteroBbt(port);
       if (zoteroOk && bbtOk) {
         return `Zotero running on port ${port}, Better BibTeX responding.`;
       }
@@ -396,7 +407,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
         return `Zotero detected on port ${port}, but Better BibTeX is not responding. Install the Better BibTeX plugin.`;
       }
       return `Zotero not detected on port ${port}. Make sure Zotero is running.`;
-    },
+    }),
   },
   {
     id: 'lean4',
@@ -435,15 +446,17 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'VS Code build: requires the leanprover.lean4 extension. ' +
       'CLI / desktop builds: requires `lake` on PATH; each Lake project can have its own language server, and idle ones stop after thirty minutes, surfaced below.',
     ...prerequisitesChecks({
-      probe: async () => {
-        const extensionAvailable =
-          platform().toolAvailability.isVscodeExtensionInstalled(
-            LEAN4_EXTENSION_ID,
-          );
-        const lakeAvailable = BinaryResolver.findPath('lake') !== null;
-        return { extensionAvailable, lakeAvailable };
-      },
-      resolve: resolveLean4Prerequisites,
+      probe: () =>
+        Effect.sync(() => {
+          const extensionAvailable =
+            platform().toolAvailability.isVscodeExtensionInstalled(
+              LEAN4_EXTENSION_ID,
+            );
+          const lakeAvailable = BinaryResolver.findPath('lake') !== null;
+          return { extensionAvailable, lakeAvailable };
+        }),
+      resolve: (probeResult) =>
+        Effect.succeed(resolveLean4Prerequisites(probeResult)),
       check: ({ extensionAvailable, lakeAvailable }) =>
         extensionAvailable || lakeAvailable,
       statusLabel: ({ extensionAvailable, lakeAvailable }) => {
@@ -482,7 +495,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     configNotes:
       'No local install required. Turning this off removes delegate_multi_agents from every agent tool list, even agents whose configuration names it explicitly.',
     toggleable: true,
-    check: async () => true,
+    check: () => Effect.succeed(true),
   },
 
   {
@@ -541,7 +554,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'No local install required. Uses your own external chat subscription through a human-in-the-loop copy/paste flow.',
     authNote: 'Uses your premium chat subscription',
     toggleable: true,
-    check: async () => true,
+    check: () => Effect.succeed(true),
   },
 
   {
@@ -567,7 +580,9 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     ...prerequisitesChecks<boolean | undefined>({
       probe: probeTexraCli,
       resolve: (probeResult) =>
-        typeof probeResult === 'boolean' ? probeResult : undefined,
+        Effect.succeed(
+          typeof probeResult === 'boolean' ? probeResult : undefined,
+        ),
       check: (detected) => detected ?? false,
       statusLabel: (detected) =>
         detected ? 'Detected; integration coming soon' : undefined,
@@ -609,8 +624,8 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     authNote: 'Uses ChatGPT subscription (free with Plus/Pro)',
     toggleable: true,
     check: () => probeSdkBinaryAvailable(importCodexClass, findCodexBinaryPath),
-    detailCheck: async () => {
-      const status = await probeSdkBinaryStatus({
+    detailCheck: Effect.fn('externalToolDefs.codexDetail')(function* () {
+      const status = yield* probeSdkBinaryStatus({
         importSdk: importCodexClass,
         findBinary: findCodexBinaryPath,
         missingPackageMessage:
@@ -626,7 +641,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       });
       if (!status.ok) return status.message;
       return `Codex CLI ready. Binary: ${status.binaryPath}`;
-    },
+    }),
   },
 
   {
@@ -667,8 +682,8 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     toggleable: true,
     check: () =>
       probeSdkBinaryAvailable(importClaudeAgentSdk, findClaudeBinaryPath),
-    detailCheck: async () => {
-      const status = await probeSdkBinaryStatus({
+    detailCheck: Effect.fn('externalToolDefs.claudeAgentDetail')(function* () {
+      const status = yield* probeSdkBinaryStatus({
         importSdk: importClaudeAgentSdk,
         findBinary: findClaudeBinaryPath,
         missingPackageMessage:
@@ -682,10 +697,13 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       const claudePath = status.binaryPath;
 
       const anthropicApiKeyEnv = apiKeyEnvName('anthropic');
-      const keyOrigin = await lookupApiKeyOrigin(
-        platform().secrets,
-        'anthropic',
-      ).catch(() => (process.env[anthropicApiKeyEnv] ? 'env' : 'none'));
+      const keyOrigin = yield* hostPort(() =>
+        lookupApiKeyOrigin(platform().secrets, 'anthropic'),
+      ).pipe(
+        Effect.catch(() =>
+          Effect.succeed(process.env[anthropicApiKeyEnv] ? 'env' : 'none'),
+        ),
+      );
       const hasOauthToken = hasClaudeCodeOauthToken();
       const authBits: string[] = [];
       if (keyOrigin === 'secret') {
@@ -701,7 +719,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
           : 'No ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN detected: the CLI will use whatever `claude login` session you have.';
 
       return `Claude CLI ready. Binary: ${claudePath}. ${authNote}`;
-    },
+    }),
   },
 
   // System dependencies (latexindent, image processing) have moved to the

--- a/src/tools/fileEditFlow.ts
+++ b/src/tools/fileEditFlow.ts
@@ -1,3 +1,9 @@
+// Third-party imports
+import { Effect } from 'effect';
+
+// Local imports - common
+import { hostPort } from '@common/hostPort';
+
 // Local imports - shared schemas
 import { ToolError, type ToolResult } from '@shared/schemas';
 
@@ -104,38 +110,51 @@ interface ResolveWritableTargetOptions {
 }
 
 /** Resolve, authorize, read-gate, and load a workspace file for editing. */
-export async function resolveWritableTarget(
-  inputPath: string,
-  options: ResolveWritableTargetOptions = {},
-): Promise<WritableTargetPreparation> {
-  const { path: resolved, display: displayPath } = resolveAndFormat(
-    inputPath,
-    currentToolRoot(),
-  );
-  assertWritable(resolved, displayPath);
+export const resolveWritableTarget = Effect.fn('resolveWritableTarget')(
+  function* (
+    inputPath: string,
+    options: ResolveWritableTargetOptions = {},
+  ): Effect.fn.Return<WritableTargetPreparation, unknown> {
+    // Resolution, the read-only-root check and the caller's own validation all
+    // reject with a ToolError the tool runner reports to the model, so they
+    // stay a failure rather than becoming a defect.
+    const { path, displayPath } = yield* Effect.try({
+      try: () => {
+        const { path: resolved, display } = resolveAndFormat(
+          inputPath,
+          currentToolRoot(),
+        );
+        assertWritable(resolved, display);
 
-  const path = resolved.fsPath;
-  options.validate?.({ path, displayPath });
+        const fsPath = resolved.fsPath;
+        options.validate?.({ path: fsPath, displayPath: display });
+        return { path: fsPath, displayPath: display };
+      },
+      catch: (error) => error,
+    });
 
-  // Shared read-before-edit gate, then the current content.
-  const exists = await WorkspaceFS.exists(path);
-  const blocked = requireFileReadForEdit(path, exists);
-  if (blocked) {
-    return { blocked };
-  }
+    // Shared read-before-edit gate, then the current content.
+    const exists = yield* hostPort(() => WorkspaceFS.exists(path));
+    const blocked = requireFileReadForEdit(path, exists);
+    if (blocked) {
+      return { blocked };
+    }
 
-  return {
-    target: {
-      path,
-      displayPath,
-      exists,
-      originalContent:
-        exists || (options.missing ?? 'require') === 'require'
-          ? await WorkspaceFS.read(path)
-          : '',
-    },
-  };
-}
+    const originalContent =
+      exists || (options.missing ?? 'require') === 'require'
+        ? yield* hostPort(() => WorkspaceFS.read(path))
+        : '';
+
+    return {
+      target: {
+        path,
+        displayPath,
+        exists,
+        originalContent,
+      },
+    };
+  },
+);
 
 interface LiteralMatchContext {
   count: number;
@@ -222,54 +241,58 @@ interface ApprovedFileEditRequest {
  * tool-specific; approval, writing, rejection, diff notes, and edit metadata
  * remain one invariant pipeline.
  */
-export async function applyApprovedFileEdit({
-  path,
-  displayPath,
-  originalContent,
-  proposedContent,
-  sourceTool,
-  present,
-  beforeWrite,
-  afterWrite,
-  startLine = 'omit',
-  diffSeparator,
-}: ApprovedFileEditRequest): Promise<ToolResult> {
-  const outcome = await requestAndWriteApprovedEdit({
+export const applyApprovedFileEdit = Effect.fn('applyApprovedFileEdit')(
+  function* ({
     path,
     displayPath,
     originalContent,
     proposedContent,
     sourceTool,
+    present,
     beforeWrite,
-  });
-  if ('rejected' in outcome) {
-    return outcome.rejected;
-  }
-
-  const edit: AppliedFileEdit = outcome;
-  await afterWrite?.(edit);
-  const presentation = present(edit);
-  const output = appendApprovalDiffNote(
-    presentation.output,
-    displayPath,
-    proposedContent,
-    edit.appliedContent,
+    afterWrite,
+    startLine = 'omit',
     diffSeparator,
-  );
+  }: ApprovedFileEditRequest): Effect.fn.Return<ToolResult, unknown> {
+    const outcome = yield* hostPort(() =>
+      requestAndWriteApprovedEdit({
+        path,
+        displayPath,
+        originalContent,
+        proposedContent,
+        sourceTool,
+        beforeWrite,
+      }),
+    );
+    if ('rejected' in outcome) {
+      return outcome.rejected;
+    }
 
-  return {
-    status: 'executed',
-    summary: presentation.summary,
-    output,
-    userPatch: edit.approval.userPatch,
-    edits: [
-      {
-        path: displayPath,
-        lineChanges: edit.approval.lineChanges,
-        ...(startLine === 'approval' && {
-          startLine: edit.approval.startLine,
-        }),
-      },
-    ],
-  };
-}
+    const edit: AppliedFileEdit = outcome;
+    yield* hostPort(() => afterWrite?.(edit));
+    const presentation = present(edit);
+    const output = appendApprovalDiffNote(
+      presentation.output,
+      displayPath,
+      proposedContent,
+      edit.appliedContent,
+      diffSeparator,
+    );
+
+    return {
+      status: 'executed',
+      summary: presentation.summary,
+      output,
+      userPatch: edit.approval.userPatch,
+      edits: [
+        {
+          path: displayPath,
+          lineChanges: edit.approval.lineChanges,
+          ...(startLine === 'approval' && {
+            startLine: edit.approval.startLine,
+          }),
+        },
+      ],
+    };
+  },
+);

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -2,10 +2,12 @@
 import * as path from 'node:path';
 
 // Third-party imports
+import { Deferred, Effect, Exit } from 'effect';
 import ignore from 'ignore';
 
 // Local imports - common
 import { isFileNotFoundError } from '@common/errors';
+import { hostPort } from '@common/hostPort';
 
 // Local imports - utils
 import { filterNotNull } from '@utils/core';
@@ -29,58 +31,73 @@ const EMPTY_GITIGNORE_MATCHER: GitignoreMatcher = {
   ignoreFiles: [],
 };
 
-let gitignoreMatcherPromise: Promise<GitignoreMatcher> | undefined;
+/**
+ * The shared load, or nothing when no load has succeeded yet. Callers that
+ * arrive while a load is in flight await its outcome instead of starting a
+ * second one; a failed load clears this so the next caller retries.
+ */
+let sharedLoad: Deferred.Deferred<GitignoreMatcher, unknown> | undefined;
 
-async function readGitignoreFile(
+const readGitignoreFile = (
   absolutePath: string,
-  readContent: () => Promise<string>,
-): Promise<GitignoreSource | null> {
-  try {
-    const content = await readContent();
-    return { absolutePath, content };
-  } catch (error) {
-    if (isFileNotFoundError(error)) {
-      return null;
-    }
-    throw error;
-  }
-}
+  readContent: Effect.Effect<string, unknown>,
+): Effect.Effect<GitignoreSource | null, unknown> =>
+  readContent.pipe(
+    Effect.map((content): GitignoreSource | null => ({
+      absolutePath,
+      content,
+    })),
+    // An absent policy file is the normal case; any other read failure is the
+    // caller's to see.
+    Effect.catch((error) =>
+      isFileNotFoundError(error) ? Effect.succeed(null) : Effect.fail(error),
+    ),
+  );
 
-async function readWorkspaceGitignore(
+const readWorkspaceGitignore = (
   relativePath: string,
-): Promise<GitignoreSource | null> {
+): Effect.Effect<GitignoreSource | null, unknown> => {
   const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
-    return null;
+    return Effect.succeed(null);
   }
   const normalized = relativePath.replace(/^\/+/, '');
-  return readGitignoreFile(path.join(workspacePath, normalized), () =>
-    WorkspaceFS.read(normalized),
+  return readGitignoreFile(
+    path.join(workspacePath, normalized),
+    hostPort(() => WorkspaceFS.read(normalized)),
   );
-}
+};
 
-async function readGlobalGitignore(): Promise<GitignoreSource | null> {
+const readGlobalGitignore = (): Effect.Effect<
+  GitignoreSource | null,
+  unknown
+> => {
   const homeDirectory = safeHomedir();
   if (!homeDirectory) {
-    return null;
+    return Effect.succeed(null);
   }
   const absolutePath = path.join(homeDirectory, '.gitignore_global');
-  return readGitignoreFile(absolutePath, () => AbsoluteFS.read(absolutePath));
-}
+  return readGitignoreFile(
+    absolutePath,
+    hostPort(() => AbsoluteFS.read(absolutePath)),
+  );
+};
 
-async function loadGitignoreMatcher(): Promise<GitignoreMatcher> {
+const loadGitignoreMatcher = Effect.fn('loadGitignoreMatcher')(function* () {
   const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
     return EMPTY_GITIGNORE_MATCHER;
   }
 
-  const sources = (
-    await Promise.all([
+  const sources = (yield* Effect.all(
+    [
       readGlobalGitignore(),
       readWorkspaceGitignore('.gitignore_global'),
       readWorkspaceGitignore('.gitignore'),
-    ])
-  ).filter(filterNotNull);
+    ],
+    // The three policies were read together and fail fast, as Promise.all did.
+    { concurrency: 'unbounded' },
+  )).filter(filterNotNull);
 
   if (sources.length === 0) {
     return EMPTY_GITIGNORE_MATCHER;
@@ -108,19 +125,30 @@ async function loadGitignoreMatcher(): Promise<GitignoreMatcher> {
     },
     ignoreFiles: sources.map((source) => source.absolutePath),
   };
-}
+});
 
-export async function getGitignoreMatcher(): Promise<GitignoreMatcher> {
-  if (!gitignoreMatcherPromise) {
-    gitignoreMatcherPromise = loadGitignoreMatcher();
-  }
-  const matcherPromise = gitignoreMatcherPromise;
-  try {
-    return await matcherPromise;
-  } catch (error) {
-    if (gitignoreMatcherPromise === matcherPromise) {
-      gitignoreMatcherPromise = undefined;
+export const getGitignoreMatcher = Effect.fn('getGitignoreMatcher')(
+  function* (): Effect.fn.Return<GitignoreMatcher, unknown> {
+    const inFlight = sharedLoad;
+    if (inFlight) {
+      return yield* Deferred.await(inFlight);
     }
-    throw error;
-  }
-}
+    const deferred = Deferred.makeUnsafe<GitignoreMatcher, unknown>();
+    sharedLoad = deferred;
+    // The load completes even if the caller that started it is interrupted:
+    // every other caller is waiting on this Deferred, and an interrupted
+    // shared load would strand them.
+    return yield* Effect.uninterruptible(
+      loadGitignoreMatcher().pipe(
+        Effect.onExit((exit) =>
+          Effect.sync(() => {
+            if (Exit.isFailure(exit) && sharedLoad === deferred) {
+              sharedLoad = undefined;
+            }
+            Deferred.doneUnsafe(deferred, exit);
+          }),
+        ),
+      ),
+    );
+  },
+);

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -1,13 +1,17 @@
 // Node imports
+import { AsyncLocalStorage } from 'node:async_hooks';
 import * as nodePath from 'node:path';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { glob } from 'glob';
 import { z } from 'zod';
 
 // Local imports
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+import { hostPort } from '@common/hostPort';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, ToolResult } from '@shared/schemas';
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { formatToolOutput } from '@tools/formatting';
@@ -15,7 +19,6 @@ import {
   joinWorkspaceRelativePath,
   resolveAndFormat,
   currentToolRoot,
-  type WorkspacePathResolution,
 } from '@tools/pathResolution';
 import { executed } from '@tools/core/result';
 import { filterNotNull } from '@utils/core';
@@ -45,22 +48,27 @@ interface GlobMatchInfo {
   mtime: number;
 }
 
-export class GlobTool extends defineTool({
-  name: 'glob',
-  parallelSafe: true,
-  description:
-    'Find files matching glob patterns (e.g., "**/*.tex", "src/**/*.ts"). Returns paths sorted by modification time.',
-  schema: GlobInputSchema,
-}) {
-  protected async execute(input: GlobInput): Promise<ToolResult> {
-    const root = currentToolRoot();
-    const { path, display } = resolveAndFormat(input.path ?? undefined, root);
-    const gitignore = await getGitignoreMatcher();
+/**
+ * The per-call context this tool reads from the caller's turn: the batch's
+ * abort signal and the working directory.
+ */
+interface GlobPorts {
+  readonly signal: AbortSignal | undefined;
+  readonly toolRoot: () => string | undefined;
+}
 
-    const cancelSignal = getCurrentToolCallContext()?.signal;
-    let matches: string[];
-    try {
-      matches = await glob(input.pattern, {
+const runGlob = Effect.fn('GlobTool.execute')(function* (
+  ports: GlobPorts,
+  input: GlobInput,
+): Effect.fn.Return<ToolResult, unknown> {
+  const root = ports.toolRoot();
+  const { path, display } = resolveAndFormat(input.path ?? undefined, root);
+  const gitignore = yield* getGitignoreMatcher();
+
+  const cancelSignal = ports.signal;
+  const matches = yield* Effect.tryPromise({
+    try: () =>
+      glob(input.pattern, {
         cwd: path.absolute,
         dot: true,
         nodir: false,
@@ -68,69 +76,92 @@ export class GlobTool extends defineTool({
         // Large-tree walks stop promptly when the batch is aborted.
         signal: cancelSignal,
         follow: false,
-      });
-    } catch (err) {
-      throw new ToolError(
+      }),
+    catch: (err) =>
+      new ToolError(
         `Glob pattern error: ${toErrorMessage(err)}. ` +
           `Check syntax: use ** for recursive, * for single level. Example: "**/*.tex"`,
-      );
+      ),
+  });
+
+  // The walk is done, but stat-ing every match on a large tree is itself
+  // slow — bail before it so a cancelled batch doesn't wait out the
+  // post-walk stat/sort phase across several concurrent glob calls.
+  if (cancelSignal?.aborted) {
+    return yield* Effect.fail(
+      new ToolError('Cancelled before stat-ing glob matches.'),
+    );
+  }
+
+  const statMatch = Effect.fn('GlobTool.statMatch')(function* (
+    match: string,
+  ): Effect.fn.Return<GlobMatchInfo | null, unknown> {
+    const resolved = yield* Effect.try({
+      try: () => joinWorkspaceRelativePath(path.relative, match, root),
+      catch: (err) =>
+        new ToolError(
+          `Match resolved outside the working directory: ${match} (${toErrorMessage(err)})`,
+        ),
+    });
+
+    const relativePath = resolved.relative;
+    if (
+      relativePath === '.' ||
+      (!nodePath.isAbsolute(relativePath) && gitignore.ignores(relativePath))
+    ) {
+      return null;
     }
 
-    // The walk is done, but stat-ing every match on a large tree is itself
-    // slow — bail before it so a cancelled batch doesn't wait out the
-    // post-walk stat/sort phase across several concurrent glob calls.
-    if (cancelSignal?.aborted) {
-      throw new ToolError('Cancelled before stat-ing glob matches.');
-    }
-
-    // Process matches in parallel for better performance
-    const statPromises = matches.map(
-      async (match): Promise<GlobMatchInfo | null> => {
-        let resolved: WorkspacePathResolution;
-        try {
-          resolved = joinWorkspaceRelativePath(path.relative, match, root);
-        } catch (err) {
-          throw new ToolError(
-            `Match resolved outside the working directory: ${match} (${toErrorMessage(err)})`,
-          );
-        }
-
-        const relativePath = resolved.relative;
-        if (
-          relativePath === '.' ||
-          (!nodePath.isAbsolute(relativePath) &&
-            gitignore.ignores(relativePath))
-        ) {
-          return null;
-        }
-
-        try {
-          const stat = await WorkspaceFS.stat(resolved.fsPath);
-          return { relativePath, mtime: stat.mtime };
-        } catch (error) {
-          if (isFileNotFoundError(error) || isNotADirectoryError(error)) {
-            return null;
-          }
-          throw error;
-        }
-      },
+    return yield* hostPort(() => WorkspaceFS.stat(resolved.fsPath)).pipe(
+      Effect.map((stat): GlobMatchInfo | null => ({
+        relativePath,
+        mtime: stat.mtime,
+      })),
+      // A match that vanished (or turned out not to be a directory) between
+      // the walk and the stat is dropped; any other stat failure is real.
+      Effect.catch((error) =>
+        isFileNotFoundError(error) || isNotADirectoryError(error)
+          ? Effect.succeed(null)
+          : Effect.fail(error),
+      ),
     );
+  });
 
-    const results = await Promise.all(statPromises);
-    const lines = results
-      .filter(filterNotNull)
-      .toSorted((a, b) => {
-        if (b.mtime !== a.mtime) {
-          return b.mtime - a.mtime;
-        }
-        return a.relativePath.localeCompare(b.relativePath);
-      })
-      .map((item) => toPosixPath(item.relativePath));
-    const count = lines.length;
-    const header = `Found ${count} ${pluralize(count, 'file')} matching "${input.pattern}" under ${display}`;
-    return executed(
-      formatToolOutput(header, lines, '(no matches)'),
-      `Found ${count} ${pluralize(count, 'file')} for "${input.pattern}" in ${display}`,
-    );
+  // Process matches in parallel for better performance
+  const results = yield* Effect.forEach(matches, statMatch, {
+    concurrency: 'unbounded',
+  });
+  const lines = results
+    .filter(filterNotNull)
+    .toSorted((a, b) => {
+      if (b.mtime !== a.mtime) {
+        return b.mtime - a.mtime;
+      }
+      return a.relativePath.localeCompare(b.relativePath);
+    })
+    .map((item) => toPosixPath(item.relativePath));
+  const count = lines.length;
+  const header = `Found ${count} ${pluralize(count, 'file')} matching "${input.pattern}" under ${display}`;
+  return executed(
+    formatToolOutput(header, lines, '(no matches)'),
+    `Found ${count} ${pluralize(count, 'file')} for "${input.pattern}" in ${display}`,
+  );
+});
+
+export class GlobTool extends defineTool({
+  name: 'glob',
+  parallelSafe: true,
+  description:
+    'Find files matching glob patterns (e.g., "**/*.tex", "src/**/*.ts"). Returns paths sorted by modification time.',
+  schema: GlobInputSchema,
+}) {
+  protected execute(input: GlobInput): Promise<ToolResult> {
+    // The working directory belongs to the calling turn, so it is bound here
+    // and handed to the program rather than read from a fiber.
+    const ports: GlobPorts = {
+      signal: getCurrentToolCallContext()?.signal,
+      toolRoot: AsyncLocalStorage.bind(currentToolRoot),
+    };
+    return effectRuntime().runPromise(runGlob(ports, input));
   }
 }

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,11 +1,15 @@
 // Node imports
+import { AsyncLocalStorage } from 'node:async_hooks';
 import * as nodePath from 'node:path';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports - tools
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
+import { hostPort } from '@common/hostPort';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { resolveAndFormat, currentToolRoot } from '@tools/pathResolution';
@@ -109,6 +113,109 @@ export function buildArguments(
   return args;
 }
 
+/**
+ * The per-call context this tool reads from the caller's turn: the batch's
+ * abort signal and the working directory.
+ */
+interface GrepPorts {
+  readonly signal: AbortSignal | undefined;
+  readonly toolRoot: () => string | undefined;
+}
+
+const runGrep = Effect.fn('GrepTool.execute')(function* (
+  ports: GrepPorts,
+  input: GrepInput,
+): Effect.fn.Return<ToolResult, unknown> {
+  const { output_mode: outputMode } = input;
+  const root = ports.toolRoot();
+  const { path, display } = resolveAndFormat(input.path ?? undefined, root);
+  const gitignore = yield* getGitignoreMatcher();
+  const args = buildArguments(input, outputMode);
+  const applyWorkspaceIgnores = !nodePath.isAbsolute(path.relative);
+  const ignoreArgs = applyWorkspaceIgnores
+    ? gitignore.ignoreFiles.flatMap((ignoreFile) => [
+        '--ignore-file',
+        ignoreFile,
+      ])
+    : [];
+
+  // `--` ends rg option parsing so the LLM-controlled pattern can't be read as
+  // a flag — e.g. `--pre=<cmd>` would run <cmd> as a preprocessor on every
+  // searched file (code execution via this non-approval-gated tool). Our own
+  // flags in args/ignoreArgs precede it and are unaffected; a leading-dash
+  // literal pattern (e.g. "-foo") now searches correctly instead of erroring.
+  const command = [
+    'rg',
+    ...args,
+    ...ignoreArgs,
+    '--',
+    input.pattern,
+    path.fsPath,
+  ];
+
+  const result = yield* hostPort(() =>
+    executeCommand(command, {
+      cwd: root,
+      channel: CHANNEL,
+      truncate: false,
+      maxBuffer: GREP_MAX_BUFFER_CHARS,
+      // Cancellation for the owning agent run — parallel batches must be
+      // able to terminate large-repo rg subprocesses on interrupt.
+      signal: ports.signal,
+    }),
+  );
+
+  if (result.outputLimitExceeded) {
+    return yield* Effect.fail(
+      new ToolError(
+        `Search output exceeded the ${GREP_MAX_BUFFER_CHARS.toLocaleString()}-character retained-output ceiling.\n` +
+          `Narrow the search path or pattern, or use glob/type filters. ` +
+          `Pagination with offset/head_limit does not avoid draining the total ripgrep output.`,
+      ),
+    );
+  }
+
+  // ripgrep exit codes: 0 = matches found, 1 = no matches, 2+ = error
+  const exitCode = result.exitCode;
+  if (exitCode >= 2) {
+    return yield* Effect.fail(
+      new ToolError(
+        `Regex error: ${result.stderr || `exit code ${exitCode}`}.\n` +
+          `To fix, either:\n` +
+          `- Escape special regex characters in the pattern (e.g. \\., \\(, \\{)\n` +
+          `- Set literal: true for exact string matching: { "literal": true }`,
+      ),
+    );
+  }
+
+  // Filter empty lines consistently for counting and pagination
+  const allLines = splitOutputLines(result.stdout);
+  const totalCount = allLines.length;
+
+  if (totalCount === 0) {
+    return executed(
+      `No matches found for "${input.pattern}" in ${display}. ` +
+        `Try a broader pattern, { "-i": true } for case-insensitive, or search a wider directory.`,
+      `No matches for "${input.pattern}" in ${display}`,
+    );
+  }
+
+  // Apply pagination to filtered lines for consistent offset calculation
+  const offset = input.offset ?? 0;
+  const limit = input.head_limit;
+  const end = limit ? offset + limit : undefined;
+  const paginatedLines = allLines.slice(offset, end);
+  const returnedCount = paginatedLines.length;
+
+  const summary = `Found ${returnedCount} of ${totalCount} matches for "${input.pattern}" in ${display}`;
+  const hasMore = offset + returnedCount < totalCount;
+  const output = hasMore
+    ? `${paginatedLines.join('\n')}\n\n[Showing ${returnedCount} of ${totalCount} results. Use offset=${offset + returnedCount} to see more.]`
+    : paginatedLines.join('\n');
+
+  return executed(output, summary);
+});
+
 export class GrepTool extends defineTool({
   name: 'grep',
   parallelSafe: true,
@@ -116,88 +223,13 @@ export class GrepTool extends defineTool({
     'Search file contents using regex patterns. For surrounding lines use -C with output_mode "content".',
   schema: GrepInputSchema,
 }) {
-  protected async execute(input: GrepInput): Promise<ToolResult> {
-    const { output_mode: outputMode } = input;
-    const root = currentToolRoot();
-    const { path, display } = resolveAndFormat(input.path ?? undefined, root);
-    const gitignore = await getGitignoreMatcher();
-    const args = buildArguments(input, outputMode);
-    const applyWorkspaceIgnores = !nodePath.isAbsolute(path.relative);
-    const ignoreArgs = applyWorkspaceIgnores
-      ? gitignore.ignoreFiles.flatMap((ignoreFile) => [
-          '--ignore-file',
-          ignoreFile,
-        ])
-      : [];
-
-    // `--` ends rg option parsing so the LLM-controlled pattern can't be read as
-    // a flag — e.g. `--pre=<cmd>` would run <cmd> as a preprocessor on every
-    // searched file (code execution via this non-approval-gated tool). Our own
-    // flags in args/ignoreArgs precede it and are unaffected; a leading-dash
-    // literal pattern (e.g. "-foo") now searches correctly instead of erroring.
-    const command = [
-      'rg',
-      ...args,
-      ...ignoreArgs,
-      '--',
-      input.pattern,
-      path.fsPath,
-    ];
-
-    const result = await executeCommand(command, {
-      cwd: root,
-      channel: CHANNEL,
-      truncate: false,
-      maxBuffer: GREP_MAX_BUFFER_CHARS,
-      // Cancellation for the owning agent run — parallel batches must be
-      // able to terminate large-repo rg subprocesses on interrupt.
+  protected execute(input: GrepInput): Promise<ToolResult> {
+    // The working directory belongs to the calling turn, so it is bound here
+    // and handed to the program rather than read from a fiber.
+    const ports: GrepPorts = {
       signal: getCurrentToolCallContext()?.signal,
-    });
-
-    if (result.outputLimitExceeded) {
-      throw new ToolError(
-        `Search output exceeded the ${GREP_MAX_BUFFER_CHARS.toLocaleString()}-character retained-output ceiling.\n` +
-          `Narrow the search path or pattern, or use glob/type filters. ` +
-          `Pagination with offset/head_limit does not avoid draining the total ripgrep output.`,
-      );
-    }
-
-    // ripgrep exit codes: 0 = matches found, 1 = no matches, 2+ = error
-    const exitCode = result.exitCode;
-    if (exitCode >= 2) {
-      throw new ToolError(
-        `Regex error: ${result.stderr || `exit code ${exitCode}`}.\n` +
-          `To fix, either:\n` +
-          `- Escape special regex characters in the pattern (e.g. \\., \\(, \\{)\n` +
-          `- Set literal: true for exact string matching: { "literal": true }`,
-      );
-    }
-
-    // Filter empty lines consistently for counting and pagination
-    const allLines = splitOutputLines(result.stdout);
-    const totalCount = allLines.length;
-
-    if (totalCount === 0) {
-      return executed(
-        `No matches found for "${input.pattern}" in ${display}. ` +
-          `Try a broader pattern, { "-i": true } for case-insensitive, or search a wider directory.`,
-        `No matches for "${input.pattern}" in ${display}`,
-      );
-    }
-
-    // Apply pagination to filtered lines for consistent offset calculation
-    const offset = input.offset ?? 0;
-    const limit = input.head_limit;
-    const end = limit ? offset + limit : undefined;
-    const paginatedLines = allLines.slice(offset, end);
-    const returnedCount = paginatedLines.length;
-
-    const summary = `Found ${returnedCount} of ${totalCount} matches for "${input.pattern}" in ${display}`;
-    const hasMore = offset + returnedCount < totalCount;
-    const output = hasMore
-      ? `${paginatedLines.join('\n')}\n\n[Showing ${returnedCount} of ${totalCount} results. Use offset=${offset + returnedCount} to see more.]`
-      : paginatedLines.join('\n');
-
-    return executed(output, summary);
+      toolRoot: AsyncLocalStorage.bind(currentToolRoot),
+    };
+    return effectRuntime().runPromise(runGrep(ports, input));
   }
 }

--- a/src/tools/latex/figureExtractionShared.ts
+++ b/src/tools/latex/figureExtractionShared.ts
@@ -74,7 +74,7 @@ export const buildLimitedAttachments = Effect.fn(
 )(function* (
   paths: readonly string[],
   { limit, describe, mimeType }: AttachmentLimitOptions,
-): Effect.fn.Return<AttachmentLimitResult, Error> {
+): Effect.fn.Return<AttachmentLimitResult, unknown> {
   if (paths.length === 0 || limit <= 0) {
     return { attachments: [], limitedPaths: [], limitReached: false };
   }
@@ -83,14 +83,10 @@ export const buildLimitedAttachments = Effect.fn(
   const attachments = yield* Effect.forEach(
     limitedPaths,
     (filePath) =>
-      Effect.tryPromise({
-        try: () =>
-          buildFileAttachment({
-            filePath,
-            description: describe(filePath),
-            mimeType,
-          }),
-        catch: ensureError,
+      buildFileAttachment({
+        filePath,
+        description: describe(filePath),
+        mimeType,
       }),
     { concurrency: ATTACHMENT_CONCURRENCY },
   );

--- a/src/tools/latex/figureExtractionShared.ts
+++ b/src/tools/latex/figureExtractionShared.ts
@@ -74,7 +74,7 @@ export const buildLimitedAttachments = Effect.fn(
 )(function* (
   paths: readonly string[],
   { limit, describe, mimeType }: AttachmentLimitOptions,
-): Effect.fn.Return<AttachmentLimitResult, unknown> {
+): Effect.fn.Return<AttachmentLimitResult, ToolError> {
   if (paths.length === 0 || limit <= 0) {
     return { attachments: [], limitedPaths: [], limitReached: false };
   }

--- a/src/tools/lean/direct/lakeCommands.ts
+++ b/src/tools/lean/direct/lakeCommands.ts
@@ -3,15 +3,15 @@
  *
  * The VS Code Lean extension exposes these as command IDs; the direct adapter
  * has to run the real `lake` binary itself. We serialize per-workspace via an
- * in-process mutex so two agents in the same TeXRA instance can't fire two
+ * in-process semaphore so two agents in the same TeXRA instance can't fire two
  * concurrent `lake build` invocations against the same `.lake/build`.
  */
 
 import * as path from 'node:path';
 
+import { Effect, Semaphore } from 'effect';
 import { execa } from 'execa';
 
-import { KeyedMutex } from '@utils/core';
 import { deriveCommandStderr } from '@utils/system/execUtils';
 
 const LAKE_RUN_TIMEOUT_MS = 10 * 60 * 1000;
@@ -22,7 +22,15 @@ const LAKE_MAX_OUTPUT_CHARS = 4 * 1024 * 1024;
 // changing when a command is terminated for excessive output.
 const LAKE_PROCESS_MAX_BUFFER_CHARS = 100_000_000;
 
-const workspaceMutex = new KeyedMutex<string>();
+/**
+ * One single-permit semaphore per workspace root. `users` counts the
+ * invocations holding or waiting on it so the entry can be dropped once the
+ * workspace goes idle, keeping the map from growing with every root visited.
+ */
+const workspaceLocks = new Map<
+  string,
+  { readonly semaphore: Semaphore.Semaphore; users: number }
+>();
 
 function capOutput(output: string): string {
   if (output.length <= LAKE_MAX_OUTPUT_CHARS) return output;
@@ -50,49 +58,80 @@ interface LakeCommandOptions {
 
 /**
  * Run a `lake` subcommand against a workspace root. Returns a result instead of
- * throwing on non-zero exit so callers can decide how to format failures.
+ * failing on non-zero exit so callers can decide how to format failures.
  */
-export async function runLakeCommand(
+export const runLakeCommand = (
   options: LakeCommandOptions,
-): Promise<LakeCommandResult> {
-  if (!options.serialize) {
-    return executeLake(options);
-  }
-  const workspaceKey = path.resolve(options.workspaceRoot);
-  return workspaceMutex.runExclusive(workspaceKey, () => executeLake(options));
+): Effect.Effect<LakeCommandResult> =>
+  options.serialize
+    ? serializeOnWorkspace(options.workspaceRoot, executeLake(options))
+    : executeLake(options);
+
+function serializeOnWorkspace(
+  workspaceRoot: string,
+  work: Effect.Effect<LakeCommandResult>,
+): Effect.Effect<LakeCommandResult> {
+  return Effect.suspend(() => {
+    const workspaceKey = path.resolve(workspaceRoot);
+    const lock = workspaceLocks.get(workspaceKey) ?? {
+      semaphore: Semaphore.makeUnsafe(1),
+      users: 0,
+    };
+    workspaceLocks.set(workspaceKey, lock);
+    lock.users += 1;
+    return lock.semaphore.withPermit(work).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          lock.users -= 1;
+          if (lock.users === 0 && workspaceLocks.get(workspaceKey) === lock) {
+            workspaceLocks.delete(workspaceKey);
+          }
+        }),
+      ),
+    );
+  });
 }
 
-async function executeLake(
+function executeLake(
   options: LakeCommandOptions,
-): Promise<LakeCommandResult> {
+): Effect.Effect<LakeCommandResult> {
   // Lake remains buffer-then-cap deliberately: preserving the current tail
   // result and complete exit diagnostics is simpler than duplicating bash's
   // head/tail streaming policy for this serialized, lower-risk path.
-  const result = await execa(options.lakeCommand, [...options.args], {
-    cwd: options.workspaceRoot,
-    timeout: options.timeoutMs ?? LAKE_RUN_TIMEOUT_MS,
-    reject: false,
-    maxBuffer: LAKE_PROCESS_MAX_BUFFER_CHARS,
-    windowsHide: true,
-    stdin: 'ignore',
-  });
-  const { stdout, stderr } = result;
-  const shouldUseShortMessage =
-    result.isMaxBuffer ||
-    result.exitCode === undefined ||
-    result.timedOut ||
-    !stdout;
-  const stderrOrMessage = deriveCommandStderr(
-    stderr,
-    result.shortMessage,
-    shouldUseShortMessage,
+  //
+  // `reject: false` means execa settles on a failed command rather than
+  // rejecting, so `Effect.promise` keeps the failure channel empty here — as
+  // the Promise contract this replaces did.
+  return Effect.promise(() =>
+    execa(options.lakeCommand, [...options.args], {
+      cwd: options.workspaceRoot,
+      timeout: options.timeoutMs ?? LAKE_RUN_TIMEOUT_MS,
+      reject: false,
+      maxBuffer: LAKE_PROCESS_MAX_BUFFER_CHARS,
+      windowsHide: true,
+      stdin: 'ignore',
+    }),
+  ).pipe(
+    Effect.map((result) => {
+      const { stdout, stderr } = result;
+      const shouldUseShortMessage =
+        result.isMaxBuffer ||
+        result.exitCode === undefined ||
+        result.timedOut ||
+        !stdout;
+      const stderrOrMessage = deriveCommandStderr(
+        stderr,
+        result.shortMessage,
+        shouldUseShortMessage,
+      );
+      return {
+        exitCode:
+          result.failed && (!result.exitCode || result.isMaxBuffer)
+            ? -1
+            : (result.exitCode ?? -1),
+        stdout: capOutput(stdout),
+        stderr: capOutput(stderrOrMessage),
+      };
+    }),
   );
-  return {
-    exitCode:
-      result.failed && (!result.exitCode || result.isMaxBuffer)
-        ? -1
-        : (result.exitCode ?? -1),
-    stdout: capOutput(stdout),
-    stderr: capOutput(stderrOrMessage),
-  };
 }

--- a/src/tools/lean/direct/lakeCommands.ts
+++ b/src/tools/lean/direct/lakeCommands.ts
@@ -92,6 +92,21 @@ function serializeOnWorkspace(
   });
 }
 
+/** The raw `lake` spawn, split out so its exact execa result type stays
+ *  inferred rather than widened by the generic `Result`. */
+function spawnLake(options: LakeCommandOptions) {
+  return execa(options.lakeCommand, [...options.args], {
+    cwd: options.workspaceRoot,
+    timeout: options.timeoutMs ?? LAKE_RUN_TIMEOUT_MS,
+    reject: false,
+    maxBuffer: LAKE_PROCESS_MAX_BUFFER_CHARS,
+    windowsHide: true,
+    stdin: 'ignore',
+  });
+}
+
+type LakeExecaResult = Awaited<ReturnType<typeof spawnLake>>;
+
 function executeLake(
   options: LakeCommandOptions,
 ): Effect.Effect<LakeCommandResult> {
@@ -100,18 +115,37 @@ function executeLake(
   // head/tail streaming policy for this serialized, lower-risk path.
   //
   // `reject: false` means execa settles on a failed command rather than
-  // rejecting, so `Effect.promise` keeps the failure channel empty here — as
-  // the Promise contract this replaces did.
-  return Effect.promise(() =>
-    execa(options.lakeCommand, [...options.args], {
-      cwd: options.workspaceRoot,
-      timeout: options.timeoutMs ?? LAKE_RUN_TIMEOUT_MS,
-      reject: false,
-      maxBuffer: LAKE_PROCESS_MAX_BUFFER_CHARS,
-      windowsHide: true,
-      stdin: 'ignore',
-    }),
-  ).pipe(
+  // rejecting, so the failure channel stays empty here — as the Promise
+  // contract this replaces did; a genuine spawn error is still a defect.
+  //
+  // The child is owned across interruption rather than abandoned. An
+  // interrupt (a sibling root's `lease` failing under the unbounded
+  // `Effect.forEach` in `leanServerPool.runLake`, or runtime disposal) must
+  // not release this workspace's permit while `lake` is still writing
+  // `.lake/build`: the next `build`/`clean` would then run concurrently with
+  // an orphan, which is exactly what this module's lock exists to prevent.
+  // The returned canceller terminates the child and awaits its exit, and the
+  // interrupt only propagates once that finishes — so `withPermit` and the
+  // `users` bookkeeping in `serializeOnWorkspace` release after the process
+  // is gone. A bare abort signal is not enough: Effect aborts the controller
+  // but does not wait for the abortee.
+  return Effect.callback<LakeExecaResult>((resume) => {
+    const child = spawnLake(options);
+    child.then(
+      (result) => resume(Effect.succeed(result)),
+      (error: unknown) => resume(Effect.die(error)),
+    );
+    // `Effect.exit` absorbs however the child settles — including a spawn
+    // rejection — without a raw catch clause, which this file may not carry.
+    return Effect.asVoid(
+      Effect.exit(
+        Effect.promise(() => {
+          child.kill();
+          return child;
+        }),
+      ),
+    );
+  }).pipe(
     Effect.map((result) => {
       const { stdout, stderr } = result;
       const shouldUseShortMessage =

--- a/src/tools/lean/direct/leanServerPool.ts
+++ b/src/tools/lean/direct/leanServerPool.ts
@@ -381,7 +381,7 @@ const make = Effect.fn('LeanServerPool.make')(function* ({
     }
     // Leased for the command's duration: a build is server activity. The
     // lake commands serialize per workspace inside `runLakeCommand`, which
-    // resolves with the exit code and never rejects on it.
+    // succeeds with the exit code and never fails on it.
     const results = yield* Effect.forEach(
       roots,
       (root) =>
@@ -389,16 +389,14 @@ const make = Effect.fn('LeanServerPool.make')(function* ({
           lease(root, runId).pipe(
             Effect.andThen(
               // `runLakeCommand` reports a non-zero exit in its result and
-              // runs execa with `reject: false`, so it settles rather than
-              // rejecting — including when `lake` is missing.
-              Effect.promise(() =>
-                runLakeCommand({
-                  workspaceRoot: root,
-                  lakeCommand,
-                  args,
-                  serialize: true,
-                }),
-              ),
+              // runs execa with `reject: false`, so it succeeds rather than
+              // failing — including when `lake` is missing.
+              runLakeCommand({
+                workspaceRoot: root,
+                lakeCommand,
+                args,
+                serialize: true,
+              }),
             ),
           ),
         ),

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -13,6 +13,9 @@
  * they return plain guidance for ordinary turn-by-turn chat.
  */
 
+// Node imports
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 // Third-party imports
 import { Effect } from 'effect';
 import { z } from 'zod';
@@ -27,7 +30,10 @@ import {
   getRunContextInteractions,
   getRunContextStreamId,
 } from '@agent/runtime/RunContext';
-import { currentSession } from '@agent/runtime/SessionHandle';
+import {
+  currentSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import {
   getCurrentToolContexts,
   type CurrentToolContexts,
@@ -111,17 +117,41 @@ function buildApprovedResult(): ToolResult {
 }
 
 /**
+ * Everything this tool's program needs from ambient storage, taken in the
+ * caller's turn rather than read from the program's fiber.
+ *
+ * `GoalStore` and the goal feature flag both resolve `workspaceRoots()` —
+ * per-session state whose fallback is the process (no-workspace) roots — so
+ * they are re-entered in the calling turn's context instead of whichever one
+ * the fiber carries.
+ */
+interface PlanPorts {
+  /** The tool-call and run contexts of the calling turn. */
+  readonly contexts: CurrentToolContexts | undefined;
+  /** The session that owns this turn; it holds the approval surface. */
+  readonly session: SessionHandle;
+  /** Runs `operation` in the calling turn's async context. */
+  readonly inRunScope: <A>(operation: () => A) => A;
+}
+
+/**
  * Engage or clear the goal's selected auto-approval scope when the run
  * context can reach the host. Best-effort: without a runtime host (e.g.
  * tests or headless edge paths) approvals simply keep prompting.
  */
 const setGoalAutoApproval = Effect.fn('PlanTool.setGoalAutoApproval')(
-  function* (streamId: string, scope: GoalAutoApprovalScope | false) {
-    const interactions = getRunContextInteractions(
-      getCurrentToolContexts()?.runContext,
-    );
+  function* (
+    ports: PlanPorts,
+    streamId: string,
+    scope: GoalAutoApprovalScope | false,
+  ) {
+    const interactions = getRunContextInteractions(ports.contexts?.runContext);
     if (interactions) {
-      yield* hostPort(() => setGoalSessionAutoApproval(streamId, scope));
+      yield* hostPort(() =>
+        setGoalSessionAutoApproval(streamId, scope, {
+          session: ports.session,
+        }),
+      );
     }
   },
 );
@@ -133,11 +163,12 @@ const setGoalAutoApproval = Effect.fn('PlanTool.setGoalAutoApproval')(
  * continuations follow the current user decision.
  */
 const startGoalForPlan = Effect.fn('PlanTool.startGoalForPlan')(function* (
+  ports: PlanPorts,
   plan: Plan,
   streamId: string,
   autoApprovalScope: GoalAutoApprovalScope,
 ) {
-  if (!isGoalEnabled()) {
+  if (!ports.inRunScope(isGoalEnabled)) {
     logger.warn(
       'Run as Goal requested but goal feature flag is off; ' +
         'continuing without an autonomous goal.',
@@ -157,18 +188,19 @@ const startGoalForPlan = Effect.fn('PlanTool.startGoalForPlan')(function* (
   // If a goal is already in flight on this stream, retarget it at the
   // newly approved objective instead of silently leaving the loop driving
   // the stale one.
-  const existing = GoalStore.getForStream(streamId);
+  const existing = ports.inRunScope(() => GoalStore.getForStream(streamId));
   if (isGoalInFlight(existing)) {
     return yield* Effect.gen(function* () {
       const retargeted = yield* hostPort(() =>
-        GoalStore.editObjective(streamId, objective),
+        ports.inRunScope(() => GoalStore.editObjective(streamId, objective)),
       );
       const active =
         retargeted.status === 'paused'
-          ? ((yield* hostPort(() => GoalStore.setStatus(streamId, 'active'))) ??
-            retargeted)
+          ? ((yield* hostPort(() =>
+              ports.inRunScope(() => GoalStore.setStatus(streamId, 'active')),
+            )) ?? retargeted)
           : retargeted;
-      yield* setGoalAutoApproval(streamId, autoApprovalScope);
+      yield* setGoalAutoApproval(ports, streamId, autoApprovalScope);
       return executed(
         `The user approved a new plan while goal ${active.goalId} ` +
           `was already in flight. The goal has been retargeted to the ` +
@@ -207,8 +239,10 @@ const startGoalForPlan = Effect.fn('PlanTool.startGoalForPlan')(function* (
   }
 
   return yield* Effect.gen(function* () {
-    const goal = yield* hostPort(() => GoalStore.start(streamId, objective));
-    yield* setGoalAutoApproval(streamId, autoApprovalScope);
+    const goal = yield* hostPort(() =>
+      ports.inRunScope(() => GoalStore.start(streamId, objective)),
+    );
+    yield* setGoalAutoApproval(ports, streamId, autoApprovalScope);
     return executed(
       `The user approved this plan and started an autonomous goal ` +
         `(${goal.goalId}) toward its stopping condition.\n\n` +
@@ -244,19 +278,20 @@ const startGoalForPlan = Effect.fn('PlanTool.startGoalForPlan')(function* (
  * Request user approval for a new plan. Pauses execution until approved/rejected.
  */
 const requestApproval = Effect.fn('PlanTool.requestApproval')(function* (
+  ports: PlanPorts,
   plan: Plan,
   streamId: string,
   workPlanState: WorkPlanState,
 ) {
   const requestId = `plan-${generateShortId()}`;
-  const goalEnabled = isGoalEnabled();
+  const goalEnabled = ports.inRunScope(isGoalEnabled);
 
   logger.info('Requesting approval for plan objective');
 
   // Dispatching inside the port keeps a host that throws on the request
   // itself on the same failure channel as one that rejects the interaction.
   const result: PlanApprovalResult = yield* hostPort(() => {
-    const interaction = currentSession().interactions.requestPlanApproval({
+    const interaction = ports.session.interactions.requestPlanApproval({
       requestId,
       streamId,
       plan,
@@ -276,6 +311,7 @@ const requestApproval = Effect.fn('PlanTool.requestApproval')(function* (
   if (result.action === 'approve_and_goal') {
     logger.info('Plan approved by user with goal mode');
     return yield* startGoalForPlan(
+      ports,
       plan,
       streamId,
       result.autoApproveAll ? 'allAgentWork' : 'commands',
@@ -333,11 +369,11 @@ const requestApproval = Effect.fn('PlanTool.requestApproval')(function* (
 });
 
 const executeUpdate = Effect.fn('PlanTool.executeUpdate')(function* (
+  ports: PlanPorts,
   plan: Plan,
-  contexts: CurrentToolContexts | undefined,
 ) {
-  const callContext = contexts?.callContext;
-  const runContext = contexts?.runContext;
+  const callContext = ports.contexts?.callContext;
+  const runContext = ports.contexts?.runContext;
 
   if (!callContext?.workPlanState) {
     return yield* Effect.fail(
@@ -357,14 +393,20 @@ const executeUpdate = Effect.fn('PlanTool.executeUpdate')(function* (
     logger.warn('Plan created without streamId: skipping approval gate');
     return buildApprovedResult();
   }
-  return yield* requestApproval(plan, streamId, callContext.workPlanState);
+  return yield* requestApproval(
+    ports,
+    plan,
+    streamId,
+    callContext.workPlanState,
+  );
 });
 
 const executePause = Effect.fn('PlanTool.executePause')(function* (
+  ports: PlanPorts,
   streamId: string,
   reason: string,
 ) {
-  const goal = GoalStore.getForStream(streamId);
+  const goal = ports.inRunScope(() => GoalStore.getForStream(streamId));
   if (!goal) {
     return executed(
       'No autonomous goal is currently running on this stream, so there is nothing to pause. ' +
@@ -379,8 +421,10 @@ const executePause = Effect.fn('PlanTool.executePause')(function* (
     );
   }
   const updated =
-    (yield* hostPort(() => GoalStore.setStatus(streamId, 'paused'))) ?? goal;
-  yield* setGoalAutoApproval(streamId, false);
+    (yield* hostPort(() =>
+      ports.inRunScope(() => GoalStore.setStatus(streamId, 'paused')),
+    )) ?? goal;
+  yield* setGoalAutoApproval(ports, streamId, false);
   return executed(
     `Goal paused: ${reason}\n\n${formatGoalView(updated)}`,
     'Goal paused.',
@@ -388,10 +432,11 @@ const executePause = Effect.fn('PlanTool.executePause')(function* (
 });
 
 const executeComplete = Effect.fn('PlanTool.executeComplete')(function* (
+  ports: PlanPorts,
   streamId: string,
   reason: string,
 ) {
-  const goal = GoalStore.getForStream(streamId);
+  const goal = ports.inRunScope(() => GoalStore.getForStream(streamId));
   if (!goal) {
     return executed(
       'No autonomous goal is currently running on this stream, so there is nothing to mark complete. ' +
@@ -402,8 +447,8 @@ const executeComplete = Effect.fn('PlanTool.executeComplete')(function* (
   // Completing forgets the record — a goal is a live pursuit, not an
   // archived one. The autonomous loop stops because no `active` record
   // remains for the next wait-node continuation check.
-  yield* hostPort(() => GoalStore.forget(streamId));
-  yield* setGoalAutoApproval(streamId, false);
+  yield* hostPort(() => ports.inRunScope(() => GoalStore.forget(streamId)));
+  yield* setGoalAutoApproval(ports, streamId, false);
   return executed(
     `Goal ${goal.goalId} marked complete.\n\n` +
       `Reason: ${reason}\n\n` +
@@ -418,20 +463,23 @@ const executeComplete = Effect.fn('PlanTool.executeComplete')(function* (
  * `execute`, so `requireStreamId` / `requireNonEmptyString` still reject a
  * malformed call in the caller's own turn, before any fiber starts.
  */
-function planCommand(input: PlanToolInput): Effect.Effect<ToolResult, unknown> {
-  const contexts = getCurrentToolContexts();
-
+function planCommand(
+  ports: PlanPorts,
+  input: PlanToolInput,
+): Effect.Effect<ToolResult, unknown> {
   switch (input.command) {
     case 'update':
-      return executeUpdate({ objective: input.objective }, contexts);
+      return executeUpdate(ports, { objective: input.objective });
     case 'pause':
       return executePause(
-        requireStreamId('plan(pause)', contexts?.runContext),
+        ports,
+        requireStreamId('plan(pause)', ports.contexts?.runContext),
         requireNonEmptyString(input.reason, 'reason'),
       );
     case 'complete':
       return executeComplete(
-        requireStreamId('plan(complete)', contexts?.runContext),
+        ports,
+        requireStreamId('plan(complete)', ports.contexts?.runContext),
         requireNonEmptyString(input.reason, 'reason'),
       );
   }
@@ -451,6 +499,13 @@ pause/complete only affect autonomous goals; with no goal running they return gu
   schema: PlanToolInputSchema,
 }) {
   protected execute(input: PlanToolInput): Promise<ToolResult> {
-    return effectRuntime().runPromise(planCommand(input));
+    const ports: PlanPorts = {
+      contexts: getCurrentToolContexts(),
+      session: currentSession(),
+      inRunScope: AsyncLocalStorage.bind(<A>(operation: () => A): A =>
+        operation(),
+      ),
+    };
+    return effectRuntime().runPromise(planCommand(ports, input));
   }
 }

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -14,6 +14,7 @@
  */
 
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
@@ -31,7 +32,9 @@ import {
   getCurrentToolContexts,
   type CurrentToolContexts,
 } from '@agent/followUp/ToolFileInteractionContext';
+import { hostPort } from '@common/hostPort';
 import { createLog } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import type { Goal, Plan, ToolResult } from '@shared/schemas';
 import { goalElapsedMs, isGoalInFlight, ToolError } from '@shared/schemas';
 import { requireStreamId } from '@tools/contextHelpers';
@@ -100,6 +103,340 @@ const PlanToolInputSchema = z.discriminatedUnion('command', [
 
 type PlanToolInput = z.infer<typeof PlanToolInputSchema>;
 
+function buildApprovedResult(): ToolResult {
+  return executed(
+    'Plan approved by the user. Work toward the objective, tracking concrete steps with the todo tool.',
+    'Plan approved: proceed with implementation',
+  );
+}
+
+/**
+ * Engage or clear the goal's selected auto-approval scope when the run
+ * context can reach the host. Best-effort: without a runtime host (e.g.
+ * tests or headless edge paths) approvals simply keep prompting.
+ */
+const setGoalAutoApproval = Effect.fn('PlanTool.setGoalAutoApproval')(
+  function* (streamId: string, scope: GoalAutoApprovalScope | false) {
+    const interactions = getRunContextInteractions(
+      getCurrentToolContexts()?.runContext,
+    );
+    if (interactions) {
+      yield* hostPort(() => setGoalSessionAutoApproval(streamId, scope));
+    }
+  },
+);
+
+/**
+ * Start an autonomous goal whose objective is the just-approved plan
+ * document, verbatim. Falls back explicitly if goal is disabled. If one
+ * is already in flight for the stream, retarget it so future
+ * continuations follow the current user decision.
+ */
+const startGoalForPlan = Effect.fn('PlanTool.startGoalForPlan')(function* (
+  plan: Plan,
+  streamId: string,
+  autoApprovalScope: GoalAutoApprovalScope,
+) {
+  if (!isGoalEnabled()) {
+    logger.warn(
+      'Run as Goal requested but goal feature flag is off; ' +
+        'continuing without an autonomous goal.',
+    );
+    return executed(
+      `The user selected Run as Goal, but the goal feature flag is ` +
+        `currently disabled. The plan is approved, but no autonomous ` +
+        `goal was started.\n\n` +
+        `Work toward the objective as a normal turn-by-turn workflow, ` +
+        `tracking concrete steps with the todo tool.`,
+      'Plan approved: autonomous run unavailable',
+    );
+  }
+
+  const objective = plan.objective;
+
+  // If a goal is already in flight on this stream, retarget it at the
+  // newly approved objective instead of silently leaving the loop driving
+  // the stale one.
+  const existing = GoalStore.getForStream(streamId);
+  if (isGoalInFlight(existing)) {
+    return yield* Effect.gen(function* () {
+      const retargeted = yield* hostPort(() =>
+        GoalStore.editObjective(streamId, objective),
+      );
+      const active =
+        retargeted.status === 'paused'
+          ? ((yield* hostPort(() => GoalStore.setStatus(streamId, 'active'))) ??
+            retargeted)
+          : retargeted;
+      yield* setGoalAutoApproval(streamId, autoApprovalScope);
+      return executed(
+        `The user approved a new plan while goal ${active.goalId} ` +
+          `was already in flight. The goal has been retargeted to the ` +
+          `new objective.\n\n` +
+          `${formatGoalView(active)}\n\n` +
+          `Discipline:\n` +
+          `- Drop work that only served the previous objective.\n` +
+          `- Track concrete steps with the todo tool as you work.\n` +
+          `- Do not call plan(command="complete") until the stopping condition is verifiably true.\n` +
+          `- If you genuinely need user input, call plan(command="pause") with a reason.\n\n` +
+          `Objective:\n${objective}`,
+        `Plan approved: goal ${active.goalId} retargeted`,
+      );
+    }).pipe(
+      Effect.catch((err) => {
+        const reason = toErrorMessage(err);
+        logger.warn(
+          'Failed to retarget in-flight goal for approved plan; returning an explicit error result.',
+          { data: err },
+        );
+        return Effect.succeed(
+          errorResult(
+            `The user approved this plan and requested autonomous execution, ` +
+              `but the in-flight goal could not be retargeted: ${reason}\n\n` +
+              `Work toward the new objective turn-by-turn. The pre-existing ` +
+              `goal is still active and will keep injecting continuations ` +
+              `against its previous objective until the user pauses or abandons it.`,
+            {
+              summary:
+                'Plan approved: goal could not be retargeted, proceeding without it',
+            },
+          ),
+        );
+      }),
+    );
+  }
+
+  return yield* Effect.gen(function* () {
+    const goal = yield* hostPort(() => GoalStore.start(streamId, objective));
+    yield* setGoalAutoApproval(streamId, autoApprovalScope);
+    return executed(
+      `The user approved this plan and started an autonomous goal ` +
+        `(${goal.goalId}) toward its stopping condition.\n\n` +
+        `Discipline:\n` +
+        `- Track concrete steps with the todo tool as you work.\n` +
+        `- Do not call plan(command="complete") until the stopping condition is verified against current external state (file contents, command output, test results).\n` +
+        `- If you genuinely need user input, call plan(command="pause") with a reason describing what you need.\n` +
+        `- Otherwise, keep working until the objective is done.\n\n` +
+        `Objective:\n${objective}`,
+      `Plan approved: goal ${goal.goalId} started`,
+    );
+  }).pipe(
+    Effect.catch((err) => {
+      const reason = toErrorMessage(err);
+      logger.warn(
+        'Failed to start goal for approved plan; falling back to plain approval.',
+        { data: err },
+      );
+      return Effect.succeed(
+        executed(
+          `The user approved this plan and requested autonomous execution, but ` +
+            `the goal could not be started: ${reason}\n\n` +
+            `Work toward the objective as a normal turn-by-turn workflow, ` +
+            `tracking concrete steps with the todo tool.`,
+          'Plan approved: goal could not be started, proceeding without it',
+        ),
+      );
+    }),
+  );
+});
+
+/**
+ * Request user approval for a new plan. Pauses execution until approved/rejected.
+ */
+const requestApproval = Effect.fn('PlanTool.requestApproval')(function* (
+  plan: Plan,
+  streamId: string,
+  workPlanState: WorkPlanState,
+) {
+  const requestId = `plan-${generateShortId()}`;
+  const goalEnabled = isGoalEnabled();
+
+  logger.info('Requesting approval for plan objective');
+
+  // Dispatching inside the port keeps a host that throws on the request
+  // itself on the same failure channel as one that rejects the interaction.
+  const result: PlanApprovalResult = yield* hostPort(() => {
+    const interaction = currentSession().interactions.requestPlanApproval({
+      requestId,
+      streamId,
+      plan,
+      goalEnabled,
+    });
+    if (!interaction) {
+      throw new Error('HostInteractions.requestPlanApproval is required');
+    }
+    return interaction;
+  });
+
+  if (result.action === 'approve') {
+    logger.info('Plan approved by user');
+    return buildApprovedResult();
+  }
+
+  if (result.action === 'approve_and_goal') {
+    logger.info('Plan approved by user with goal mode');
+    return yield* startGoalForPlan(
+      plan,
+      streamId,
+      result.autoApproveAll ? 'allAgentWork' : 'commands',
+    );
+  }
+
+  // Rejected — clear the plan from UI
+  workPlanState.updatePlan(null);
+
+  const classification = classifyRejection(result);
+
+  // 'cancelled' and 'policy' differ only in wording: a host cancel with an
+  // optional cause vs a policy denial with its reason.
+  const denialResult = (outcome: string, detail?: string): ToolResult => {
+    const trimmed = detail?.trim();
+    logger.info(
+      `Plan approval ${outcome}`,
+      trimmed ? { data: trimmed } : undefined,
+    );
+    return errorResult(
+      trimmed
+        ? `Plan approval was ${outcome}.\n\n${trimmed}`
+        : `Plan approval was ${outcome}.`,
+      { summary: `Plan approval ${outcome}` },
+    );
+  };
+
+  switch (classification.kind) {
+    case 'cancelled':
+      return denialResult('cancelled', classification.cause);
+    case 'policy':
+      return denialResult('denied', classification.reason);
+    case 'feedback': {
+      const feedback = classification.feedback?.trim();
+      const feedbackNote = feedback
+        ? `\nUser feedback: ${feedback}`
+        : '\nNo specific feedback was provided.';
+
+      logger.info(
+        'Plan rejected by user',
+        feedback ? { data: feedback } : undefined,
+      );
+
+      return errorResult(
+        `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
+        {
+          summary: 'Plan rejected: revise approach',
+          ...(feedback ? { userInstruction: feedback } : {}),
+        },
+      );
+    }
+    default:
+      return assertNever(classification, 'Unhandled rejection classification');
+  }
+});
+
+const executeUpdate = Effect.fn('PlanTool.executeUpdate')(function* (
+  plan: Plan,
+  contexts: CurrentToolContexts | undefined,
+) {
+  const callContext = contexts?.callContext;
+  const runContext = contexts?.runContext;
+
+  if (!callContext?.workPlanState) {
+    return yield* Effect.fail(
+      new ToolError(
+        'plan(update) requires an active agent tool-use turn: there is no work plan to update.',
+      ),
+    );
+  }
+
+  callContext.workPlanState.updatePlan(plan);
+
+  // Every update is a (re-)proposal: with no step statuses to record,
+  // the only reason to call update is a new or changed objective, and
+  // that decision belongs to the user.
+  const streamId = getRunContextStreamId(runContext);
+  if (!streamId) {
+    logger.warn('Plan created without streamId: skipping approval gate');
+    return buildApprovedResult();
+  }
+  return yield* requestApproval(plan, streamId, callContext.workPlanState);
+});
+
+const executePause = Effect.fn('PlanTool.executePause')(function* (
+  streamId: string,
+  reason: string,
+) {
+  const goal = GoalStore.getForStream(streamId);
+  if (!goal) {
+    return executed(
+      'No autonomous goal is currently running on this stream, so there is nothing to pause. ' +
+        'If you need user input, ask the user directly in your next message; do not call plan(command="pause") again.',
+      'No autonomous goal to pause.',
+    );
+  }
+  if (goal.status !== 'active') {
+    return executed(
+      `Goal is ${goal.status}; pause is a no-op.\n\n${formatGoalView(goal)}`,
+      `Goal already ${goal.status}: pause is a no-op.`,
+    );
+  }
+  const updated =
+    (yield* hostPort(() => GoalStore.setStatus(streamId, 'paused'))) ?? goal;
+  yield* setGoalAutoApproval(streamId, false);
+  return executed(
+    `Goal paused: ${reason}\n\n${formatGoalView(updated)}`,
+    'Goal paused.',
+  );
+});
+
+const executeComplete = Effect.fn('PlanTool.executeComplete')(function* (
+  streamId: string,
+  reason: string,
+) {
+  const goal = GoalStore.getForStream(streamId);
+  if (!goal) {
+    return executed(
+      'No autonomous goal is currently running on this stream, so there is nothing to mark complete. ' +
+        'The plan work is otherwise finished; return the final answer to the user and do not call plan(command="complete") again.',
+      'Plan-only work complete: summarize the result.',
+    );
+  }
+  // Completing forgets the record — a goal is a live pursuit, not an
+  // archived one. The autonomous loop stops because no `active` record
+  // remains for the next wait-node continuation check.
+  yield* hostPort(() => GoalStore.forget(streamId));
+  yield* setGoalAutoApproval(streamId, false);
+  return executed(
+    `Goal ${goal.goalId} marked complete.\n\n` +
+      `Reason: ${reason}\n\n` +
+      `The autonomous continuation loop has stopped. ` +
+      `Returning control to the user.`,
+    'Goal complete.',
+  );
+});
+
+/**
+ * Build the program for one plan command. Called synchronously from
+ * `execute`, so `requireStreamId` / `requireNonEmptyString` still reject a
+ * malformed call in the caller's own turn, before any fiber starts.
+ */
+function planCommand(input: PlanToolInput): Effect.Effect<ToolResult, unknown> {
+  const contexts = getCurrentToolContexts();
+
+  switch (input.command) {
+    case 'update':
+      return executeUpdate({ objective: input.objective }, contexts);
+    case 'pause':
+      return executePause(
+        requireStreamId('plan(pause)', contexts?.runContext),
+        requireNonEmptyString(input.reason, 'reason'),
+      );
+    case 'complete':
+      return executeComplete(
+        requireStreamId('plan(complete)', contexts?.runContext),
+        requireNonEmptyString(input.reason, 'reason'),
+      );
+  }
+}
+
 export class PlanTool extends defineTool({
   name: 'plan',
   requiresApproval: true,
@@ -113,318 +450,7 @@ Commands:
 pause/complete only affect autonomous goals; with no goal running they return guidance for ordinary chat.`,
   schema: PlanToolInputSchema,
 }) {
-  protected async execute(input: PlanToolInput): Promise<ToolResult> {
-    const contexts = getCurrentToolContexts();
-
-    switch (input.command) {
-      case 'update':
-        return this.executeUpdate({ objective: input.objective }, contexts);
-      case 'pause':
-        return this.executePause(
-          requireStreamId('plan(pause)', contexts?.runContext),
-          requireNonEmptyString(input.reason, 'reason'),
-        );
-      case 'complete':
-        return this.executeComplete(
-          requireStreamId('plan(complete)', contexts?.runContext),
-          requireNonEmptyString(input.reason, 'reason'),
-        );
-    }
-  }
-
-  private async executeUpdate(
-    plan: Plan,
-    contexts: CurrentToolContexts | undefined,
-  ): Promise<ToolResult> {
-    const callContext = contexts?.callContext;
-    const runContext = contexts?.runContext;
-
-    if (!callContext?.workPlanState) {
-      throw new ToolError(
-        'plan(update) requires an active agent tool-use turn: there is no work plan to update.',
-      );
-    }
-
-    callContext.workPlanState.updatePlan(plan);
-
-    // Every update is a (re-)proposal: with no step statuses to record,
-    // the only reason to call update is a new or changed objective, and
-    // that decision belongs to the user.
-    const streamId = getRunContextStreamId(runContext);
-    if (!streamId) {
-      logger.warn('Plan created without streamId: skipping approval gate');
-      return this.buildApprovedResult();
-    }
-    return this.requestApproval(plan, streamId, callContext.workPlanState);
-  }
-
-  private async executePause(
-    streamId: string,
-    reason: string,
-  ): Promise<ToolResult> {
-    const goal = GoalStore.getForStream(streamId);
-    if (!goal) {
-      return executed(
-        'No autonomous goal is currently running on this stream, so there is nothing to pause. ' +
-          'If you need user input, ask the user directly in your next message; do not call plan(command="pause") again.',
-        'No autonomous goal to pause.',
-      );
-    }
-    if (goal.status !== 'active') {
-      return executed(
-        `Goal is ${goal.status}; pause is a no-op.\n\n${formatGoalView(goal)}`,
-        `Goal already ${goal.status}: pause is a no-op.`,
-      );
-    }
-    const updated = (await GoalStore.setStatus(streamId, 'paused')) ?? goal;
-    await this.setGoalAutoApproval(streamId, false);
-    return executed(
-      `Goal paused: ${reason}\n\n${formatGoalView(updated)}`,
-      'Goal paused.',
-    );
-  }
-
-  /**
-   * Engage or clear the goal's selected auto-approval scope when the run
-   * context can reach the host. Best-effort: without a runtime host (e.g.
-   * tests or headless edge paths) approvals simply keep prompting.
-   */
-  private async setGoalAutoApproval(
-    streamId: string,
-    scope: GoalAutoApprovalScope | false,
-  ): Promise<void> {
-    const interactions = getRunContextInteractions(
-      getCurrentToolContexts()?.runContext,
-    );
-    if (interactions) {
-      await setGoalSessionAutoApproval(streamId, scope);
-    }
-  }
-
-  private async executeComplete(
-    streamId: string,
-    reason: string,
-  ): Promise<ToolResult> {
-    const goal = GoalStore.getForStream(streamId);
-    if (!goal) {
-      return executed(
-        'No autonomous goal is currently running on this stream, so there is nothing to mark complete. ' +
-          'The plan work is otherwise finished; return the final answer to the user and do not call plan(command="complete") again.',
-        'Plan-only work complete: summarize the result.',
-      );
-    }
-    // Completing forgets the record — a goal is a live pursuit, not an
-    // archived one. The autonomous loop stops because no `active` record
-    // remains for the next wait-node continuation check.
-    await GoalStore.forget(streamId);
-    await this.setGoalAutoApproval(streamId, false);
-    return executed(
-      `Goal ${goal.goalId} marked complete.\n\n` +
-        `Reason: ${reason}\n\n` +
-        `The autonomous continuation loop has stopped. ` +
-        `Returning control to the user.`,
-      'Goal complete.',
-    );
-  }
-
-  /**
-   * Request user approval for a new plan. Pauses execution until approved/rejected.
-   */
-  private async requestApproval(
-    plan: Plan,
-    streamId: string,
-    workPlanState: WorkPlanState,
-  ): Promise<ToolResult> {
-    const requestId = `plan-${generateShortId()}`;
-    const goalEnabled = isGoalEnabled();
-
-    logger.info('Requesting approval for plan objective');
-
-    const interaction = currentSession().interactions.requestPlanApproval({
-      requestId,
-      streamId,
-      plan,
-      goalEnabled,
-    });
-    if (!interaction) {
-      throw new Error('HostInteractions.requestPlanApproval is required');
-    }
-    const result: PlanApprovalResult = await interaction;
-
-    if (result.action === 'approve') {
-      logger.info('Plan approved by user');
-      return this.buildApprovedResult();
-    }
-
-    if (result.action === 'approve_and_goal') {
-      logger.info('Plan approved by user with goal mode');
-      return this.startGoalForPlan(
-        plan,
-        streamId,
-        result.autoApproveAll ? 'allAgentWork' : 'commands',
-      );
-    }
-
-    // Rejected — clear the plan from UI
-    workPlanState.updatePlan(null);
-
-    const classification = classifyRejection(result);
-
-    // 'cancelled' and 'policy' differ only in wording: a host cancel with an
-    // optional cause vs a policy denial with its reason.
-    const denialResult = (outcome: string, detail?: string): ToolResult => {
-      const trimmed = detail?.trim();
-      logger.info(
-        `Plan approval ${outcome}`,
-        trimmed ? { data: trimmed } : undefined,
-      );
-      return errorResult(
-        trimmed
-          ? `Plan approval was ${outcome}.\n\n${trimmed}`
-          : `Plan approval was ${outcome}.`,
-        { summary: `Plan approval ${outcome}` },
-      );
-    };
-
-    switch (classification.kind) {
-      case 'cancelled':
-        return denialResult('cancelled', classification.cause);
-      case 'policy':
-        return denialResult('denied', classification.reason);
-      case 'feedback': {
-        const feedback = classification.feedback?.trim();
-        const feedbackNote = feedback
-          ? `\nUser feedback: ${feedback}`
-          : '\nNo specific feedback was provided.';
-
-        logger.info(
-          'Plan rejected by user',
-          feedback ? { data: feedback } : undefined,
-        );
-
-        return errorResult(
-          `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
-          {
-            summary: 'Plan rejected: revise approach',
-            ...(feedback ? { userInstruction: feedback } : {}),
-          },
-        );
-      }
-      default:
-        return assertNever(
-          classification,
-          'Unhandled rejection classification',
-        );
-    }
-  }
-
-  /**
-   * Start an autonomous goal whose objective is the just-approved plan
-   * document, verbatim. Falls back explicitly if goal is disabled. If one
-   * is already in flight for the stream, retarget it so future
-   * continuations follow the current user decision.
-   */
-  private async startGoalForPlan(
-    plan: Plan,
-    streamId: string,
-    autoApprovalScope: GoalAutoApprovalScope,
-  ): Promise<ToolResult> {
-    if (!isGoalEnabled()) {
-      logger.warn(
-        'Run as Goal requested but goal feature flag is off; ' +
-          'continuing without an autonomous goal.',
-      );
-      return executed(
-        `The user selected Run as Goal, but the goal feature flag is ` +
-          `currently disabled. The plan is approved, but no autonomous ` +
-          `goal was started.\n\n` +
-          `Work toward the objective as a normal turn-by-turn workflow, ` +
-          `tracking concrete steps with the todo tool.`,
-        'Plan approved: autonomous run unavailable',
-      );
-    }
-
-    const objective = plan.objective;
-
-    // If a goal is already in flight on this stream, retarget it at the
-    // newly approved objective instead of silently leaving the loop driving
-    // the stale one.
-    const existing = GoalStore.getForStream(streamId);
-    if (isGoalInFlight(existing)) {
-      try {
-        const retargeted = await GoalStore.editObjective(streamId, objective);
-        const active =
-          retargeted.status === 'paused'
-            ? ((await GoalStore.setStatus(streamId, 'active')) ?? retargeted)
-            : retargeted;
-        await this.setGoalAutoApproval(streamId, autoApprovalScope);
-        return executed(
-          `The user approved a new plan while goal ${active.goalId} ` +
-            `was already in flight. The goal has been retargeted to the ` +
-            `new objective.\n\n` +
-            `${formatGoalView(active)}\n\n` +
-            `Discipline:\n` +
-            `- Drop work that only served the previous objective.\n` +
-            `- Track concrete steps with the todo tool as you work.\n` +
-            `- Do not call plan(command="complete") until the stopping condition is verifiably true.\n` +
-            `- If you genuinely need user input, call plan(command="pause") with a reason.\n\n` +
-            `Objective:\n${objective}`,
-          `Plan approved: goal ${active.goalId} retargeted`,
-        );
-      } catch (err) {
-        const reason = toErrorMessage(err);
-        logger.warn(
-          'Failed to retarget in-flight goal for approved plan; returning an explicit error result.',
-          { data: err },
-        );
-        return errorResult(
-          `The user approved this plan and requested autonomous execution, ` +
-            `but the in-flight goal could not be retargeted: ${reason}\n\n` +
-            `Work toward the new objective turn-by-turn. The pre-existing ` +
-            `goal is still active and will keep injecting continuations ` +
-            `against its previous objective until the user pauses or abandons it.`,
-          {
-            summary:
-              'Plan approved: goal could not be retargeted, proceeding without it',
-          },
-        );
-      }
-    }
-
-    try {
-      const goal = await GoalStore.start(streamId, objective);
-      await this.setGoalAutoApproval(streamId, autoApprovalScope);
-      return executed(
-        `The user approved this plan and started an autonomous goal ` +
-          `(${goal.goalId}) toward its stopping condition.\n\n` +
-          `Discipline:\n` +
-          `- Track concrete steps with the todo tool as you work.\n` +
-          `- Do not call plan(command="complete") until the stopping condition is verified against current external state (file contents, command output, test results).\n` +
-          `- If you genuinely need user input, call plan(command="pause") with a reason describing what you need.\n` +
-          `- Otherwise, keep working until the objective is done.\n\n` +
-          `Objective:\n${objective}`,
-        `Plan approved: goal ${goal.goalId} started`,
-      );
-    } catch (err) {
-      const reason = toErrorMessage(err);
-      logger.warn(
-        'Failed to start goal for approved plan; falling back to plain approval.',
-        { data: err },
-      );
-      return executed(
-        `The user approved this plan and requested autonomous execution, but ` +
-          `the goal could not be started: ${reason}\n\n` +
-          `Work toward the objective as a normal turn-by-turn workflow, ` +
-          `tracking concrete steps with the todo tool.`,
-        'Plan approved: goal could not be started, proceeding without it',
-      );
-    }
-  }
-
-  private buildApprovedResult(): ToolResult {
-    return executed(
-      'Plan approved by the user. Work toward the objective, tracking concrete steps with the todo tool.',
-      'Plan approved: proceed with implementation',
-    );
+  protected execute(input: PlanToolInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(planCommand(input));
   }
 }

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -13,6 +13,7 @@
  * silently dropped.
  */
 
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 import {
@@ -72,6 +73,131 @@ const ApplyTeamInputSchema = z.strictObject({
 
 type ApplyTeamInput = z.infer<typeof ApplyTeamInputSchema>;
 
+const applyTeam = Effect.fn('ApplyTeamTool.execute')(function* (
+  input: ApplyTeamInput,
+) {
+  const state = { getAgents: getAgentsByCategory };
+  const roster = createWorkspaceAgentRosterController();
+  const { signIn } = getSetupPlatform();
+  const authStatus = yield* getSetupAuthStatus();
+
+  // Applying the roster and recording it as the default team both go
+  // through this tool's adapter — the Settings "apply team" action commits
+  // only the roster, since it has no notion of a fresh-workspace default.
+  const catalog: TeamRosterCatalog = {
+    resolvePreset: (presetId) => {
+      const preset =
+        presetId === STARTER_AGENT_MODE_PRESET.id
+          ? STARTER_AGENT_MODE_PRESET
+          : AGENT_MODE_PRESETS_BY_ID.get(presetId);
+      if (!preset) return { ok: false, reason: 'unknownPreset' };
+      return {
+        ok: true,
+        preset,
+        resolution: resolveTeamRoster(state, preset),
+      };
+    },
+    commitPreset: async (preset) => {
+      await roster.setTeam(preset.id);
+      await roster.setDefaultTeam(preset.id);
+      // The setup agent runs this mid-conversation, so an open settings
+      // view is showing a roster this call just replaced.
+      appSignals.emit('agentRosterChanged', undefined);
+    },
+  };
+
+  const result = yield* applyTeamRosterWithPreflight(input.teamId, {
+    catalog,
+    loadLocalCatalog: () => loadAgents({ includeRemote: false }),
+    canAccessRemoteCatalog: async () => authStatus.authenticated,
+    providedChoice: input.unavailableAction ?? undefined,
+    choose: async () => undefined,
+    signIn,
+    forceRefreshRemoteCatalog: () => refresh({ includeRemote: true }),
+  });
+
+  if (result.status === 'unknown') {
+    // The schema gates ids, so this only fires if the enum and the preset
+    // list ever disagree — fail loudly rather than half-apply.
+    return yield* Effect.fail(
+      new ToolError(
+        `Unknown team id "${input.teamId}". Valid ids: ${TEAM_IDS.join(', ')}.`,
+      ),
+    );
+  }
+
+  if (result.status === 'choice-required') {
+    const names = result.unavailableNames.join(', ');
+    return executed(
+      `The ${result.preset.name} team has unavailable TeXRA-hosted members: ${names}. Ask the user to choose one action: Sign in to TeXRA, Continue with available members, or Cancel. Then call apply_team again with unavailableAction set to "sign-in", "continue", or "cancel". No roster or default-team state was written.`,
+      `Team not applied; TeXRA-hosted members are unavailable: ${names}.`,
+    );
+  }
+
+  if (result.status === 'cancelled') {
+    return executed(
+      'Cancelled. No roster or default-team state was written.',
+      `Cancelled ${result.preset.name} team application.`,
+    );
+  }
+  if (result.status === 'unavailable') {
+    return yield* Effect.fail(
+      new ToolError(
+        `The ${result.preset.name} team is still unavailable after refreshing the TeXRA agent catalog: ${result.unavailableNames.join(', ')}.`,
+      ),
+    );
+  }
+
+  const { preset } = result;
+  const { keys, unresolvedNames } = result.resolution;
+  const texraHostedNames = teamHostedNamesForPreflight(preset, unresolvedNames);
+
+  // `keys` holds only the agent keys that resolved in the registry. Names
+  // that didn't resolve are not dropped: the roster stores the team
+  // reference and re-resolves `preset.agents` on every read, so a member
+  // activates the moment it appears. `unresolvedNames` is preflight
+  // evidence, not stored state. Account-served leads are absent until
+  // sign-in — say so instead of letting it read as a silent failure; check
+  // registry resolution, never auth.
+  const activeWorkflow = keys.workflow;
+  const activeToolUse = keys.toolUse;
+  const pendingRemoteLeads = unresolvedNames.filter((name) =>
+    texraHostedNames.has(name),
+  );
+  const pendingOther = unresolvedNames.filter(
+    (name) => !texraHostedNames.has(name),
+  );
+
+  const signInNote =
+    pendingRemoteLeads.length > 0
+      ? `The ${pendingRemoteLeads.join(' and ')} lead is TeXRA-hosted. It joins the roster automatically after sign-in.`
+      : undefined;
+
+  const lines = [
+    `Applied the ${preset.name} roster to this workspace.`,
+    `Workflow agents (${activeWorkflow.length}): ${
+      activeWorkflow.map((key) => agentName(key)).join(', ') || '(none)'
+    }`,
+    `Assistants (${activeToolUse.length}): ${
+      activeToolUse.map((key) => agentName(key)).join(', ') || '(none)'
+    }`,
+    `Saved "${preset.id}" as the default team: fresh workspaces start with this roster.`,
+  ];
+  if (signInNote) lines.push(signInNote);
+  if (pendingOther.length > 0) {
+    lines.push(
+      `Not installed yet (kept in the roster, activates when available): ${pendingOther.join(', ')}.`,
+    );
+  }
+
+  const summary = [
+    `Applied the ${preset.name} roster: ${activeWorkflow.length} workflows, ${activeToolUse.length} assistants.`,
+    ...(signInNote ? [signInNote] : []),
+  ].join(' ');
+
+  return executed(lines.join('\n'), summary);
+});
+
 export class ApplyTeamTool extends defineTool({
   name: 'apply_team',
   description: `Apply an agent team (a discipline roster) to this workspace and record it as the user's default team.
@@ -82,127 +208,7 @@ Teams:
 ${describeTeams()}`,
   schema: ApplyTeamInputSchema,
 }) {
-  protected async execute(input: ApplyTeamInput): Promise<ToolResult> {
-    const state = { getAgents: getAgentsByCategory };
-    const roster = createWorkspaceAgentRosterController();
-    const { signIn } = getSetupPlatform();
-    const authStatus = await getSetupAuthStatus();
-
-    // Applying the roster and recording it as the default team both go
-    // through this tool's adapter — the Settings "apply team" action commits
-    // only the roster, since it has no notion of a fresh-workspace default.
-    const catalog: TeamRosterCatalog = {
-      resolvePreset: (presetId) => {
-        const preset =
-          presetId === STARTER_AGENT_MODE_PRESET.id
-            ? STARTER_AGENT_MODE_PRESET
-            : AGENT_MODE_PRESETS_BY_ID.get(presetId);
-        if (!preset) return { ok: false, reason: 'unknownPreset' };
-        return {
-          ok: true,
-          preset,
-          resolution: resolveTeamRoster(state, preset),
-        };
-      },
-      commitPreset: async (preset) => {
-        await roster.setTeam(preset.id);
-        await roster.setDefaultTeam(preset.id);
-        // The setup agent runs this mid-conversation, so an open settings
-        // view is showing a roster this call just replaced.
-        appSignals.emit('agentRosterChanged', undefined);
-      },
-    };
-
-    const result = await effectRuntime().runPromise(
-      applyTeamRosterWithPreflight(input.teamId, {
-        catalog,
-        loadLocalCatalog: () => loadAgents({ includeRemote: false }),
-        canAccessRemoteCatalog: async () => authStatus.authenticated,
-        providedChoice: input.unavailableAction ?? undefined,
-        choose: async () => undefined,
-        signIn,
-        forceRefreshRemoteCatalog: () => refresh({ includeRemote: true }),
-      }),
-    );
-
-    if (result.status === 'unknown') {
-      // The schema gates ids, so this only fires if the enum and the preset
-      // list ever disagree — fail loudly rather than half-apply.
-      throw new ToolError(
-        `Unknown team id "${input.teamId}". Valid ids: ${TEAM_IDS.join(', ')}.`,
-      );
-    }
-
-    if (result.status === 'choice-required') {
-      const names = result.unavailableNames.join(', ');
-      return executed(
-        `The ${result.preset.name} team has unavailable TeXRA-hosted members: ${names}. Ask the user to choose one action: Sign in to TeXRA, Continue with available members, or Cancel. Then call apply_team again with unavailableAction set to "sign-in", "continue", or "cancel". No roster or default-team state was written.`,
-        `Team not applied; TeXRA-hosted members are unavailable: ${names}.`,
-      );
-    }
-
-    if (result.status === 'cancelled') {
-      return executed(
-        'Cancelled. No roster or default-team state was written.',
-        `Cancelled ${result.preset.name} team application.`,
-      );
-    }
-    if (result.status === 'unavailable') {
-      throw new ToolError(
-        `The ${result.preset.name} team is still unavailable after refreshing the TeXRA agent catalog: ${result.unavailableNames.join(', ')}.`,
-      );
-    }
-
-    const { preset } = result;
-    const { keys, unresolvedNames } = result.resolution;
-    const texraHostedNames = teamHostedNamesForPreflight(
-      preset,
-      unresolvedNames,
-    );
-
-    // `keys` holds only the agent keys that resolved in the registry. Names
-    // that didn't resolve are not dropped: the roster stores the team
-    // reference and re-resolves `preset.agents` on every read, so a member
-    // activates the moment it appears. `unresolvedNames` is preflight
-    // evidence, not stored state. Account-served leads are absent until
-    // sign-in — say so instead of letting it read as a silent failure; check
-    // registry resolution, never auth.
-    const activeWorkflow = keys.workflow;
-    const activeToolUse = keys.toolUse;
-    const pendingRemoteLeads = unresolvedNames.filter((name) =>
-      texraHostedNames.has(name),
-    );
-    const pendingOther = unresolvedNames.filter(
-      (name) => !texraHostedNames.has(name),
-    );
-
-    const signInNote =
-      pendingRemoteLeads.length > 0
-        ? `The ${pendingRemoteLeads.join(' and ')} lead is TeXRA-hosted. It joins the roster automatically after sign-in.`
-        : undefined;
-
-    const lines = [
-      `Applied the ${preset.name} roster to this workspace.`,
-      `Workflow agents (${activeWorkflow.length}): ${
-        activeWorkflow.map((key) => agentName(key)).join(', ') || '(none)'
-      }`,
-      `Assistants (${activeToolUse.length}): ${
-        activeToolUse.map((key) => agentName(key)).join(', ') || '(none)'
-      }`,
-      `Saved "${preset.id}" as the default team: fresh workspaces start with this roster.`,
-    ];
-    if (signInNote) lines.push(signInNote);
-    if (pendingOther.length > 0) {
-      lines.push(
-        `Not installed yet (kept in the roster, activates when available): ${pendingOther.join(', ')}.`,
-      );
-    }
-
-    const summary = [
-      `Applied the ${preset.name} roster: ${activeWorkflow.length} workflows, ${activeToolUse.length} assistants.`,
-      ...(signInNote ? [signInNote] : []),
-    ].join(' ');
-
-    return executed(lines.join('\n'), summary);
+  protected execute(input: ApplyTeamInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(applyTeam(input));
   }
 }

--- a/src/tools/setup/ConfigTools.ts
+++ b/src/tools/setup/ConfigTools.ts
@@ -9,8 +9,10 @@
  * edited through the regular host settings surface.
  */
 
+import { Effect } from 'effect';
 import { z } from 'zod';
 
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 
 import { executed } from '@tools/core/result';
@@ -106,6 +108,7 @@ export class ReadConfigTool extends defineTool({
 Accepts any key starting with \`texra.\`. Returns the current resolved value (workspace value if set, else user, else default). Use this when teaching the user what a setting controls: read first, explain, then propose a change with \`update_config\`.`,
   schema: ReadConfigInputSchema,
 }) {
+  // Reading configuration is synchronous; there is no program to run.
   protected async execute(input: ReadConfigInput): Promise<ToolResult> {
     const value = texraScopedConfig.get(input.key);
     const json = JSON.stringify(value, null, 2) ?? 'undefined';
@@ -134,6 +137,30 @@ const UpdateConfigInputSchema = z.strictObject({
 
 type UpdateConfigInput = z.infer<typeof UpdateConfigInputSchema>;
 
+const updateConfig = Effect.fn('UpdateConfigTool.execute')(function* (
+  input: UpdateConfigInput,
+) {
+  const entry = UPDATABLE_KEYS[input.key];
+  const parsed = entry.schema.safeParse(input.value);
+  if (!parsed.success) {
+    return yield* Effect.fail(
+      new ToolError(
+        `Value rejected for ${input.key}: ${z.prettifyError(parsed.error)}. ${entry.summary}`,
+      ),
+    );
+  }
+
+  const previous = texraScopedConfig.get(input.key);
+  yield* texraScopedConfig.update(input.key, parsed.data, input.target);
+
+  const before = JSON.stringify(previous);
+  const after = JSON.stringify(parsed.data);
+  return executed(
+    `Updated ${input.key} (${input.target} scope): ${before ?? 'undefined'} → ${after}.`,
+    `Updated ${input.key} (${input.target})`,
+  );
+});
+
 export class UpdateConfigTool extends defineTool({
   name: 'update_config',
   requiresApproval: true,
@@ -147,23 +174,7 @@ ${describeAllowlist()}
 Anything outside this list must be changed through the host's regular configuration surface.`,
   schema: UpdateConfigInputSchema,
 }) {
-  protected async execute(input: UpdateConfigInput): Promise<ToolResult> {
-    const entry = UPDATABLE_KEYS[input.key];
-    const parsed = entry.schema.safeParse(input.value);
-    if (!parsed.success) {
-      throw new ToolError(
-        `Value rejected for ${input.key}: ${z.prettifyError(parsed.error)}. ${entry.summary}`,
-      );
-    }
-
-    const previous = texraScopedConfig.get(input.key);
-    await texraScopedConfig.update(input.key, parsed.data, input.target);
-
-    const before = JSON.stringify(previous);
-    const after = JSON.stringify(parsed.data);
-    return executed(
-      `Updated ${input.key} (${input.target} scope): ${before ?? 'undefined'} → ${after}.`,
-      `Updated ${input.key} (${input.target})`,
-    );
+  protected execute(input: UpdateConfigInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(updateConfig(input));
   }
 }

--- a/src/tools/setup/InstallVscodeExtensionTool.ts
+++ b/src/tools/setup/InstallVscodeExtensionTool.ts
@@ -1,10 +1,10 @@
-// Node imports
-import { setTimeout as delay } from 'node:timers/promises';
-
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
+import { hostPort } from '@common/hostPort';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latexToolchain';
 import { LEAN4_EXTENSION_ID } from '@tools/lean/leanTypes';
@@ -23,6 +23,9 @@ const ALLOWED_EXTENSIONS: ReadonlySet<string> = new Set([
   LEAN4_EXTENSION_ID,
 ]);
 
+/** Grace period before re-reading the extension registry after an install. */
+const REGISTRATION_GRACE_MS = 250;
+
 const InstallVscodeExtensionInputSchema = z.strictObject({
   extensionId: z
     .string()
@@ -36,41 +39,37 @@ type InstallVscodeExtensionInput = z.infer<
   typeof InstallVscodeExtensionInputSchema
 >;
 
-export class InstallVscodeExtensionTool extends defineTool({
-  name: 'install_vscode_extension',
-  // Requires VS Code extensions.
-  unavailableHosts: ['cli', 'desktop'],
-  requiresApproval: true,
-  description: `Install a VS Code extension from the Marketplace. Allowlisted: James-Yu.latex-workshop, leanprover.lean4. Blocks other extension IDs. Use this (rather than \`invoke_command workbench.extensions.installExtension\`) so the caller gets a clean success/failure status.`,
-  schema: InstallVscodeExtensionInputSchema,
-}) {
-  protected async execute(
-    input: InstallVscodeExtensionInput,
-  ): Promise<ToolResult> {
+const installExtension = Effect.fn('InstallVscodeExtensionTool.execute')(
+  function* (input: InstallVscodeExtensionInput) {
     const platform = getSetupPlatform();
     const id = input.extensionId.trim();
 
     if (!ALLOWED_EXTENSIONS.has(id)) {
-      throw new ToolError(
-        `Extension "${id}" is not in the setup allowlist. Allowed: ${[...ALLOWED_EXTENSIONS].sort().join(', ')}.`,
+      return yield* Effect.fail(
+        new ToolError(
+          `Extension "${id}" is not in the setup allowlist. Allowed: ${[...ALLOWED_EXTENSIONS].sort().join(', ')}.`,
+        ),
       );
     }
 
-    if (!platform.extensions) {
-      throw new ToolError('This host cannot install VS Code extensions.');
+    const extensions = platform.extensions;
+    if (!extensions) {
+      return yield* Effect.fail(
+        new ToolError('This host cannot install VS Code extensions.'),
+      );
     }
-    if (platform.extensions.isInstalled(id)) {
+    if (extensions.isInstalled(id)) {
       return executed(
         `The "${id}" extension is already installed. No action taken.`,
         `Extension ${id} already installed`,
       );
     }
 
-    await platform.extensions.install(id);
+    yield* hostPort(() => extensions.install(id));
 
     // Give VS Code a brief moment to register the new extension.
-    await delay(250);
-    const installed = platform.extensions.isInstalled(id);
+    yield* Effect.sleep(REGISTRATION_GRACE_MS);
+    const installed = extensions.isInstalled(id);
 
     return executed(
       installed
@@ -80,5 +79,18 @@ export class InstallVscodeExtensionTool extends defineTool({
         ? `Installed extension ${id}`
         : `Install issued for ${id} (verify manually)`,
     );
+  },
+);
+
+export class InstallVscodeExtensionTool extends defineTool({
+  name: 'install_vscode_extension',
+  // Requires VS Code extensions.
+  unavailableHosts: ['cli', 'desktop'],
+  requiresApproval: true,
+  description: `Install a VS Code extension from the Marketplace. Allowlisted: James-Yu.latex-workshop, leanprover.lean4. Blocks other extension IDs. Use this (rather than \`invoke_command workbench.extensions.installExtension\`) so the caller gets a clean success/failure status.`,
+  schema: InstallVscodeExtensionInputSchema,
+}) {
+  protected execute(input: InstallVscodeExtensionInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(installExtension(input));
   }
 }

--- a/src/tools/setup/InvokeCommandTool.ts
+++ b/src/tools/setup/InvokeCommandTool.ts
@@ -1,8 +1,11 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
 import { AUTH_COMMANDS } from '@auth/constants';
+import { hostPort } from '@common/hostPort';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import type { CommandId } from '@shared/commands/catalog';
 
@@ -55,6 +58,34 @@ const InvokeCommandInputSchema = z.strictObject({
 
 type InvokeCommandInput = z.infer<typeof InvokeCommandInputSchema>;
 
+const invokeCommand = Effect.fn('InvokeCommandTool.execute')(function* (
+  input: InvokeCommandInput,
+) {
+  const platform = getSetupPlatform();
+  const commandId = input.command.trim();
+
+  if (!ALLOWED_COMMANDS.has(commandId)) {
+    return yield* Effect.fail(
+      new ToolError(
+        `Command "${commandId}" is not in the setup allowlist. Allowed: ${[...ALLOWED_COMMANDS].sort().join(', ')}.`,
+      ),
+    );
+  }
+
+  const commands = platform.commands;
+  if (!commands) {
+    return yield* Effect.fail(
+      new ToolError('VS Code command invocation is unavailable in this host.'),
+    );
+  }
+  yield* hostPort(() => commands.invoke(commandId));
+
+  return executed(
+    `Invoked VS Code command "${commandId}". If this opens a UI prompt, wait for the user's response before continuing.`,
+    `Invoked ${commandId}`,
+  );
+});
+
 export class InvokeCommandTool extends defineTool({
   name: 'invoke_command',
   // Requires VS Code commands.
@@ -63,26 +94,7 @@ export class InvokeCommandTool extends defineTool({
   description: `Invoke an allowlisted VS Code command. Use this to hand off to TeXRA's existing UX: the API-key quick-pick (texra.setApiKey), the TeXRA account sign-in (texra.auth.signIn), the settings-dashboard tab openers (texra.showDashboard / texra.showModels / texra.showAgents / texra.showMemory / texra.showMultiAgent / texra.showTools / texra.showGitSettings), the sample-project creator (texra.createSampleProject), the Overleaf clone wizard (texra.cloneOverleafProject), and the arXiv source downloader (texra.downloadArXivSource). Non-allowlisted commands are rejected. To install a VS Code extension (LaTeX Workshop, Lean 4), use \`install_vscode_extension\` instead: it enforces a stricter per-extension allowlist.`,
   schema: InvokeCommandInputSchema,
 }) {
-  protected async execute(input: InvokeCommandInput): Promise<ToolResult> {
-    const platform = getSetupPlatform();
-    const commandId = input.command.trim();
-
-    if (!ALLOWED_COMMANDS.has(commandId)) {
-      throw new ToolError(
-        `Command "${commandId}" is not in the setup allowlist. Allowed: ${[...ALLOWED_COMMANDS].sort().join(', ')}.`,
-      );
-    }
-
-    if (!platform.commands) {
-      throw new ToolError(
-        'VS Code command invocation is unavailable in this host.',
-      );
-    }
-    await platform.commands.invoke(commandId);
-
-    return executed(
-      `Invoked VS Code command "${commandId}". If this opens a UI prompt, wait for the user's response before continuing.`,
-      `Invoked ${commandId}`,
-    );
+  protected execute(input: InvokeCommandInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(invokeCommand(input));
   }
 }

--- a/src/tools/setup/ListApiKeysTool.ts
+++ b/src/tools/setup/ListApiKeysTool.ts
@@ -1,8 +1,10 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
 import { apiKeySecretName } from '@model/apiProviders';
+import { effectRuntime } from '@platform/processRuntime';
 import { type ToolResult } from '@shared/schemas';
 import { GITHUB_TOKEN_STORAGE_KEY } from '@tools/github/githubAuth';
 import { executed } from '@tools/core/result';
@@ -20,6 +22,88 @@ const ListApiKeysInputSchema = z
 
 type ListApiKeysInput = z.infer<typeof ListApiKeysInputSchema>;
 
+const listApiKeys = Effect.fn('ListApiKeysTool.execute')(function* () {
+  const storedKeys = yield* setupSecrets.listStoredKeys();
+
+  if (storedKeys.length === 0) {
+    return executed(
+      'The credential store is empty: no API keys or tokens are persisted.',
+      'No secrets stored',
+    );
+  }
+
+  const { providers } = setupSecrets;
+  const knownProviderKeyMap = new Map(
+    providers.map((p) => [apiKeySecretName(p), p] as const),
+  );
+
+  const providerKeys: string[] = [];
+  const unknownApiKeys: string[] = [];
+  let hasGithubToken = false;
+  const otherKeys: string[] = [];
+
+  for (const key of storedKeys) {
+    const provider = knownProviderKeyMap.get(key);
+    if (provider !== undefined) {
+      providerKeys.push(provider);
+    } else if (key === GITHUB_TOKEN_STORAGE_KEY) {
+      hasGithubToken = true;
+    } else if (key.startsWith('apiKey.')) {
+      unknownApiKeys.push(key);
+    } else {
+      otherKeys.push(key);
+    }
+  }
+
+  const missingProviders = providers.filter((p) => !providerKeys.includes(p));
+
+  const lines: string[] = [`Stored secrets (${storedKeys.length} total):`];
+
+  if (providerKeys.length > 0) {
+    lines.push('', 'Provider API keys stored:');
+    for (const p of providerKeys) lines.push(`  ${p}`);
+  } else {
+    lines.push('', 'No provider API keys persisted in TeXRA secrets.');
+  }
+
+  if (missingProviders.length > 0) {
+    lines.push(
+      '',
+      'Providers without a key in TeXRA secrets (environment not checked here):',
+    );
+    for (const p of missingProviders) lines.push(`  ${p}`);
+  }
+
+  if (unknownApiKeys.length > 0) {
+    lines.push(
+      '',
+      'Unrecognised apiKey.* entries (diagnostic only, not unset_api_key providers):',
+    );
+    for (const k of unknownApiKeys) lines.push(`  ${k}`);
+  }
+
+  if (hasGithubToken) {
+    lines.push('', 'GitHub token: stored');
+  }
+
+  if (otherKeys.length > 0) {
+    lines.push(
+      '',
+      `Other stored secrets: ${formatResultCount(otherKeys.length, 'redacted key name')}`,
+    );
+  }
+
+  const providerSummary =
+    providerKeys.length === 0
+      ? 'no persisted provider API keys'
+      : `${providerKeys.length}/${providers.length} persisted provider API keys`;
+
+  return executed(
+    lines.join('\n'),
+    `${formatResultCount(storedKeys.length, 'stored secret')}: ${providerSummary}`,
+  );
+});
+
 /**
  * Audit persisted secret key *names* without reading their values.
  *
@@ -31,85 +115,7 @@ export class ListApiKeysTool extends defineTool({
   description: `Audit only TeXRA's persisted credential store without reading secret values. Environment-backed provider keys are deliberately excluded and are reported by probe_environment instead. Known persisted provider keys are shown by provider name (e.g. \`anthropic\`); unrecognised \`apiKey.*\` entries are shown by raw key name to help identify stale secrets; other secret key names are counted but redacted because they may contain user-derived identifiers. Use this to detect persisted provider keys and stale API-key entries. Recognised providers can be removed with unset_api_key; other entries must be removed through the current host's credential-management surface.`,
   schema: ListApiKeysInputSchema,
 }) {
-  protected async execute(_input: ListApiKeysInput): Promise<ToolResult> {
-    const storedKeys = await setupSecrets.listStoredKeys();
-
-    if (storedKeys.length === 0) {
-      return executed(
-        'The credential store is empty: no API keys or tokens are persisted.',
-        'No secrets stored',
-      );
-    }
-
-    const { providers } = setupSecrets;
-    const knownProviderKeyMap = new Map(
-      providers.map((p) => [apiKeySecretName(p), p] as const),
-    );
-
-    const providerKeys: string[] = [];
-    const unknownApiKeys: string[] = [];
-    let hasGithubToken = false;
-    const otherKeys: string[] = [];
-
-    for (const key of storedKeys) {
-      const provider = knownProviderKeyMap.get(key);
-      if (provider !== undefined) {
-        providerKeys.push(provider);
-      } else if (key === GITHUB_TOKEN_STORAGE_KEY) {
-        hasGithubToken = true;
-      } else if (key.startsWith('apiKey.')) {
-        unknownApiKeys.push(key);
-      } else {
-        otherKeys.push(key);
-      }
-    }
-
-    const missingProviders = providers.filter((p) => !providerKeys.includes(p));
-
-    const lines: string[] = [`Stored secrets (${storedKeys.length} total):`];
-
-    if (providerKeys.length > 0) {
-      lines.push('', 'Provider API keys stored:');
-      for (const p of providerKeys) lines.push(`  ${p}`);
-    } else {
-      lines.push('', 'No provider API keys persisted in TeXRA secrets.');
-    }
-
-    if (missingProviders.length > 0) {
-      lines.push(
-        '',
-        'Providers without a key in TeXRA secrets (environment not checked here):',
-      );
-      for (const p of missingProviders) lines.push(`  ${p}`);
-    }
-
-    if (unknownApiKeys.length > 0) {
-      lines.push(
-        '',
-        'Unrecognised apiKey.* entries (diagnostic only, not unset_api_key providers):',
-      );
-      for (const k of unknownApiKeys) lines.push(`  ${k}`);
-    }
-
-    if (hasGithubToken) {
-      lines.push('', 'GitHub token: stored');
-    }
-
-    if (otherKeys.length > 0) {
-      lines.push(
-        '',
-        `Other stored secrets: ${formatResultCount(otherKeys.length, 'redacted key name')}`,
-      );
-    }
-
-    const providerSummary =
-      providerKeys.length === 0
-        ? 'no persisted provider API keys'
-        : `${providerKeys.length}/${providers.length} persisted provider API keys`;
-
-    return executed(
-      lines.join('\n'),
-      `${formatResultCount(storedKeys.length, 'stored secret')}: ${providerSummary}`,
-    );
+  protected execute(_input: ListApiKeysInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(listApiKeys());
   }
 }

--- a/src/tools/setup/ProbeEnvironmentTool.ts
+++ b/src/tools/setup/ProbeEnvironmentTool.ts
@@ -2,10 +2,12 @@
 import * as path from 'node:path';
 
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
 import { tryPlatform } from '@platform/platform';
+import { effectRuntime } from '@platform/processRuntime';
 import { nodeHostEnvironment } from '@platform/defaults/nodeHostEnvironment';
 import { type ToolResult } from '@shared/schemas';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latexToolchain';
@@ -32,6 +34,153 @@ type ProbeInput = z.infer<typeof ProbeEnvironmentInputSchema>;
 
 const OPTIONAL_TOOLS = ['git', 'node', 'python3'] as const;
 
+const probe = Effect.fn('ProbeEnvironmentTool.execute')(function* () {
+  const platform = getSetupPlatform();
+
+  // `os.homedir()` can throw UV_ENOENT in container/remote environments
+  // where the home directory is not resolvable; fall back to a string
+  // sentinel so the probe still produces a useful environment report.
+  const homedir = safeHomedir() ?? '<unresolved>';
+  const extendedPath = extendEnvPath();
+  const pm = detectPackageManager();
+  // tryPlatform() picks up an installed Platform's hostEnvironment (a test
+  // fake, in suites that override it); nodeHostEnvironment is the fallback
+  // for the rare caller running before initPlatform(). Neither call grows
+  // the frozen platform() ratchet — see effect-migration-ratchet.mjs.
+  const hostInfo = (
+    tryPlatform()?.hostEnvironment ?? nodeHostEnvironment
+  ).hostInfo();
+  const [
+    core,
+    optionalTools,
+    apiKeys,
+    credentialReadiness,
+    githubToken,
+    chatGptStatus,
+  ] = yield* Effect.all(
+    [
+      collectCoreSetupStatus(platform),
+      Effect.all(
+        OPTIONAL_TOOLS.map((name) => locateTool(name)),
+        { concurrency: 'unbounded' },
+      ),
+      Effect.all(
+        setupSecrets.providers.map((provider) =>
+          setupSecrets.apiKeyOrigin(provider).pipe(
+            Effect.catch(() => Effect.succeed('unknown' as const)),
+            Effect.map((origin) => ({ provider, origin })),
+          ),
+        ),
+        { concurrency: 'unbounded' },
+      ),
+      setupSecrets.anyUsableCredentialExists().pipe(
+        Effect.map((available) => ({ available, status: 'known' as const })),
+        Effect.catch(() =>
+          Effect.succeed({ available: false, status: 'unknown' as const }),
+        ),
+      ),
+      setupSecrets
+        .gitHubTokenExists()
+        .pipe(Effect.catch(() => Effect.succeed('none' as const))),
+      getChatGptSubscriptionStatus().pipe(
+        Effect.catch(() => Effect.succeed({ signedIn: false, enabled: false })),
+      ),
+    ],
+    { concurrency: 'unbounded' },
+  );
+
+  const { auth, coreTools, missingCore, latexWorkshopInstalled } = core;
+
+  const summary = {
+    host: platform.host,
+    os: {
+      platform: hostInfo.platform,
+      arch: hostInfo.arch,
+      release: hostInfo.osRelease,
+    },
+    shell: hostInfo.shell,
+    home: homedir,
+    path: extendedPath.split(path.delimiter).filter(Boolean),
+    packageManager: pm,
+    coreTools,
+    optionalTools,
+    missingCore,
+    latexWorkshop: {
+      extensionId: LATEX_WORKSHOP_EXT_ID,
+      supported: latexWorkshopInstalled !== undefined,
+      installed: latexWorkshopInstalled ?? false,
+    },
+    credentials: {
+      // `anyApiKeySet` is literal — only true if at least one
+      // per-provider API key is present (matches the `apiKeys`
+      // array below). A TeXRA-account-only user would have
+      // had this come out true under the previous adapter-backed
+      // check, which contradicted the per-provider detail and
+      // misled credential planning.
+      anyApiKeySet: apiKeys.some(
+        (key) => key.origin === 'secret' || key.origin === 'env',
+      ),
+      // `hasAnyUsableCredential` is the broader "can setup launch a
+      // model right now" signal — direct key, ChatGPT subscription,
+      // or server-side TeXRA account. Kept as a separate field
+      // so the agent can reason about API keys separately.
+      hasAnyUsableCredential: credentialReadiness.available,
+      usableCredentialStatus: credentialReadiness.status,
+      apiKeys,
+      researcherAccess: {
+        authenticated: auth.authenticated,
+        email: auth.authenticated ? auth.email : undefined,
+      },
+      chatGptSubscription: chatGptStatus,
+      githubToken,
+    },
+  };
+
+  const parts: string[] = [
+    `OS: ${summary.os.platform}`,
+    `package manager: ${summary.packageManager ?? 'none detected'}`,
+    summary.missingCore.length === 0
+      ? 'all core LaTeX tools installed'
+      : `missing: ${summary.missingCore.join(', ')}`,
+    summary.latexWorkshop.supported
+      ? `LaTeX Workshop: ${summary.latexWorkshop.installed ? 'installed' : 'not installed'}`
+      : 'LaTeX Workshop: not applicable',
+  ];
+  const creds: string[] = [];
+  const origins = new Set(summary.credentials.apiKeys.map((key) => key.origin));
+  if (origins.has('secret')) creds.push('provider API key saved');
+  if (origins.has('env')) creds.push('provider API key in environment');
+  if (origins.has('unknown')) {
+    creds.push('provider API key status unavailable');
+  }
+  if (summary.credentials.usableCredentialStatus === 'unknown') {
+    creds.push('overall credential status unavailable');
+  }
+  if (summary.credentials.chatGptSubscription.enabled) {
+    creds.push('ChatGPT subscription enabled');
+  }
+  if (summary.credentials.researcherAccess.authenticated)
+    creds.push('signed in');
+  if (
+    summary.credentials.hasAnyUsableCredential &&
+    !summary.credentials.anyApiKeySet &&
+    !summary.credentials.researcherAccess.authenticated &&
+    !summary.credentials.chatGptSubscription.enabled
+  ) {
+    creds.push('usable credential');
+  }
+  parts.push(`credentials: ${creds.length > 0 ? creds.join(' + ') : 'none'}`);
+  const headline = parts.join('; ');
+
+  return executed(
+    headline +
+      '\n\n<probe-json>\n' +
+      JSON.stringify(summary, null, 2) +
+      '\n</probe-json>',
+    headline,
+  );
+});
+
 /**
  * Read-only probe of the host environment.
  *
@@ -45,142 +194,7 @@ export class ProbeEnvironmentTool extends defineTool({
   description: `Probe the active host and environment and return a structured JSON summary covering host kind, OS, shell, PATH, detected package manager (brew/apt/scoop), installation status of TeXRA's core LaTeX dependencies (pdflatex, latexmk, latexindent, perl, gs, gm/magick, texcount, latexdiff), the LaTeX Workshop VS Code extension, each provider API key's origin (TeXRA secrets, environment, or absent; values are never returned), ChatGPT subscription state, broader usable credential status, and TeXRA account sign-in status. Read-only, no approval required. Call this first in any setup session to decide what to do next.`,
   schema: ProbeEnvironmentInputSchema,
 }) {
-  protected async execute(_input: ProbeInput): Promise<ToolResult> {
-    const platform = getSetupPlatform();
-
-    // `os.homedir()` can throw UV_ENOENT in container/remote environments
-    // where the home directory is not resolvable; fall back to a string
-    // sentinel so the probe still produces a useful environment report.
-    const homedir = safeHomedir() ?? '<unresolved>';
-    const extendedPath = extendEnvPath();
-    const pm = detectPackageManager();
-    // tryPlatform() picks up an installed Platform's hostEnvironment (a test
-    // fake, in suites that override it); nodeHostEnvironment is the fallback
-    // for the rare caller running before initPlatform(). Neither call grows
-    // the frozen platform() ratchet — see effect-migration-ratchet.mjs.
-    const hostInfo = (
-      tryPlatform()?.hostEnvironment ?? nodeHostEnvironment
-    ).hostInfo();
-    const [
-      core,
-      optionalTools,
-      apiKeys,
-      credentialReadiness,
-      githubToken,
-      chatGptStatus,
-    ] = await Promise.all([
-      collectCoreSetupStatus(platform),
-      Promise.all(OPTIONAL_TOOLS.map((name) => locateTool(name))),
-      Promise.all(
-        setupSecrets.providers.map(async (provider) => {
-          const origin = await setupSecrets
-            .apiKeyOrigin(provider)
-            .catch(() => 'unknown' as const);
-          return { provider, origin };
-        }),
-      ),
-      setupSecrets
-        .anyUsableCredentialExists()
-        .then((available) => ({ available, status: 'known' as const }))
-        .catch(() => ({ available: false, status: 'unknown' as const })),
-      setupSecrets.gitHubTokenExists().catch(() => 'none' as const),
-      getChatGptSubscriptionStatus().catch(() => ({
-        signedIn: false,
-        enabled: false,
-      })),
-    ]);
-
-    const { auth, coreTools, missingCore, latexWorkshopInstalled } = core;
-
-    const summary = {
-      host: platform.host,
-      os: {
-        platform: hostInfo.platform,
-        arch: hostInfo.arch,
-        release: hostInfo.osRelease,
-      },
-      shell: hostInfo.shell,
-      home: homedir,
-      path: extendedPath.split(path.delimiter).filter(Boolean),
-      packageManager: pm,
-      coreTools,
-      optionalTools,
-      missingCore,
-      latexWorkshop: {
-        extensionId: LATEX_WORKSHOP_EXT_ID,
-        supported: latexWorkshopInstalled !== undefined,
-        installed: latexWorkshopInstalled ?? false,
-      },
-      credentials: {
-        // `anyApiKeySet` is literal — only true if at least one
-        // per-provider API key is present (matches the `apiKeys`
-        // array below). A TeXRA-account-only user would have
-        // had this come out true under the previous adapter-backed
-        // check, which contradicted the per-provider detail and
-        // misled credential planning.
-        anyApiKeySet: apiKeys.some(
-          (key) => key.origin === 'secret' || key.origin === 'env',
-        ),
-        // `hasAnyUsableCredential` is the broader "can setup launch a
-        // model right now" signal — direct key, ChatGPT subscription,
-        // or server-side TeXRA account. Kept as a separate field
-        // so the agent can reason about API keys separately.
-        hasAnyUsableCredential: credentialReadiness.available,
-        usableCredentialStatus: credentialReadiness.status,
-        apiKeys,
-        researcherAccess: {
-          authenticated: auth.authenticated,
-          email: auth.authenticated ? auth.email : undefined,
-        },
-        chatGptSubscription: chatGptStatus,
-        githubToken,
-      },
-    };
-
-    const parts: string[] = [
-      `OS: ${summary.os.platform}`,
-      `package manager: ${summary.packageManager ?? 'none detected'}`,
-      summary.missingCore.length === 0
-        ? 'all core LaTeX tools installed'
-        : `missing: ${summary.missingCore.join(', ')}`,
-      summary.latexWorkshop.supported
-        ? `LaTeX Workshop: ${summary.latexWorkshop.installed ? 'installed' : 'not installed'}`
-        : 'LaTeX Workshop: not applicable',
-    ];
-    const creds: string[] = [];
-    const origins = new Set(
-      summary.credentials.apiKeys.map((key) => key.origin),
-    );
-    if (origins.has('secret')) creds.push('provider API key saved');
-    if (origins.has('env')) creds.push('provider API key in environment');
-    if (origins.has('unknown')) {
-      creds.push('provider API key status unavailable');
-    }
-    if (summary.credentials.usableCredentialStatus === 'unknown') {
-      creds.push('overall credential status unavailable');
-    }
-    if (summary.credentials.chatGptSubscription.enabled) {
-      creds.push('ChatGPT subscription enabled');
-    }
-    if (summary.credentials.researcherAccess.authenticated)
-      creds.push('signed in');
-    if (
-      summary.credentials.hasAnyUsableCredential &&
-      !summary.credentials.anyApiKeySet &&
-      !summary.credentials.researcherAccess.authenticated &&
-      !summary.credentials.chatGptSubscription.enabled
-    ) {
-      creds.push('usable credential');
-    }
-    parts.push(`credentials: ${creds.length > 0 ? creds.join(' + ') : 'none'}`);
-    const headline = parts.join('; ');
-
-    return executed(
-      headline +
-        '\n\n<probe-json>\n' +
-        JSON.stringify(summary, null, 2) +
-        '\n</probe-json>',
-      headline,
-    );
+  protected execute(_input: ProbeInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(probe());
   }
 }

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -1,8 +1,11 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
+import { hostPort } from '@common/hostPort';
 import { TERMINAL_OUTPUT_MAX_CHARS } from '@common/terminalOutput';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import {
   buildBashApprovalRejectedResult,
@@ -48,6 +51,44 @@ const SendToTerminalInputSchema = z.strictObject({
 
 type SendToTerminalInput = z.infer<typeof SendToTerminalInputSchema>;
 
+const sendToTerminal = Effect.fn('SendToTerminalTool.execute')(function* (
+  input: SendToTerminalInput,
+) {
+  const terminal = getSetupPlatform().terminal;
+  if (!terminal) {
+    return yield* Effect.fail(
+      new ToolError(
+        'VS Code integrated terminal execution is unavailable in this host.',
+      ),
+    );
+  }
+  const command = input.command.trim();
+
+  const approval = yield* hostPort(() => requestBashApproval({ command }));
+  if (approval.action !== 'approve') {
+    return buildBashApprovalRejectedResult(command, approval);
+  }
+
+  const name = TERMINAL_NAME_PREFIX + input.label.trim();
+  const timeoutMs = input.timeout ?? DEFAULT_TIMEOUT_MS;
+
+  const { exitCode, output, timedOut } = yield* hostPort(() =>
+    terminal.runCommand({
+      name,
+      command,
+      timeoutMs,
+    }),
+  );
+
+  const exitLabel = exitCode === undefined ? 'unknown' : String(exitCode);
+  const summary = timedOut
+    ? `"${name}" timed out after ${Math.round(timeoutMs / 1000)}s`
+    : `"${name}" exited ${exitLabel}`;
+  const outputText = output.trim() ? `\n\n${output}` : '';
+
+  return executed(summary + outputText, summary);
+});
+
 export class SendToTerminalTool extends defineTool({
   name: 'send_to_terminal',
   // Requires a VS Code terminal.
@@ -56,35 +97,7 @@ export class SendToTerminalTool extends defineTool({
   description: `Run a command in a VS Code integrated terminal: use this instead of \`bash\` when the command needs a real TTY: \`sudo\` password prompts, package managers that ask for confirmation (e.g. \`brew install --cask\`), or anything that drops the user into an interactive UI. Approval reuses the regular \`bash\` approval dialog. Returns an exit code and an ANSI-stripped output tail of up to ${TERMINAL_OUTPUT_MAX_CHARS} characters when shell integration is active (bash/zsh/pwsh/fish in VS Code-launched terminals); returns an undefined exit code with empty output otherwise: re-probe with \`verify_setup\` to confirm what actually happened. Do NOT use this to bypass \`bash\` approvals on commands that would work in \`bash\`.`,
   schema: SendToTerminalInputSchema,
 }) {
-  protected async execute(input: SendToTerminalInput): Promise<ToolResult> {
-    const terminal = getSetupPlatform().terminal;
-    if (!terminal) {
-      throw new ToolError(
-        'VS Code integrated terminal execution is unavailable in this host.',
-      );
-    }
-    const command = input.command.trim();
-
-    const approval = await requestBashApproval({ command });
-    if (approval.action !== 'approve') {
-      return buildBashApprovalRejectedResult(command, approval);
-    }
-
-    const name = TERMINAL_NAME_PREFIX + input.label.trim();
-    const timeoutMs = input.timeout ?? DEFAULT_TIMEOUT_MS;
-
-    const { exitCode, output, timedOut } = await terminal.runCommand({
-      name,
-      command,
-      timeoutMs,
-    });
-
-    const exitLabel = exitCode === undefined ? 'unknown' : String(exitCode);
-    const summary = timedOut
-      ? `"${name}" timed out after ${Math.round(timeoutMs / 1000)}s`
-      : `"${name}" exited ${exitLabel}`;
-    const outputText = output.trim() ? `\n\n${output}` : '';
-
-    return executed(summary + outputText, summary);
+  protected execute(input: SendToTerminalInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(sendToTerminal(input));
   }
 }

--- a/src/tools/setup/UnsetApiKeyTool.ts
+++ b/src/tools/setup/UnsetApiKeyTool.ts
@@ -1,13 +1,16 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
+import { hostPort } from '@common/hostPort';
 import {
   API_PROVIDERS,
   apiKeyEnvName,
   invalidateApiKeyCache,
   isApiProvider,
 } from '@model/apiProviders';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 
 // Local file imports
@@ -24,67 +27,78 @@ const UnsetApiKeyInputSchema = z.strictObject({
 
 type UnsetApiKeyInput = z.infer<typeof UnsetApiKeyInputSchema>;
 
+const unsetApiKey = Effect.fn('UnsetApiKeyTool.execute')(function* (
+  input: UnsetApiKeyInput,
+) {
+  const platform = getSetupPlatform();
+  const provider = input.provider.trim();
+  if (!isApiProvider(provider)) {
+    return yield* Effect.fail(
+      new ToolError(
+        `Unknown provider "${provider}". Supported: ${API_PROVIDERS.join(', ')}.`,
+      ),
+    );
+  }
+  const envVar = apiKeyEnvName(provider);
+
+  const storedExists = yield* setupSecrets.storedApiKeyExists(provider);
+  if (!storedExists) {
+    // If no persisted entry exists but a *usable* (non-blank) key
+    // is still reported, it's coming from the `<PROVIDER>_API_KEY`
+    // env var — `deleteApiKey` can't touch that, so be explicit.
+    const envExists = yield* setupSecrets.hasUsableApiKey(provider);
+    if (envExists) {
+      return executed(
+        `No stored API key for "${provider}" to remove, but one is still active via the ${envVar} environment variable. The credential store has nothing to clear: unset ${envVar} in your shell (or the source that sets it) to remove this credential.`,
+        `${provider} key is env-var-backed`,
+      );
+    }
+    return executed(
+      `There was no stored API key for provider "${provider}" to remove.`,
+      `No stored ${provider} API key`,
+    );
+  }
+
+  yield* setupSecrets.deleteApiKey(provider);
+  // Mirror the manual `texra.setApiKey` command ordering: drop the cached
+  // key lookups so models that just lost their credential stop appearing
+  // selectable, then refresh the status surfaces.
+  invalidateApiKeyCache();
+  const commands = platform.commands;
+  if (commands) {
+    // Credential changes must remain successful when a host cannot refresh
+    // its status surfaces; the next ordinary refresh reconciles stale UI.
+    // `Effect.exit` per command keeps the settled-not-fail-fast semantics.
+    yield* Effect.forEach(
+      ['texra.refreshApiKeyStatus', 'texra.refreshAllOptions'],
+      (commandId) => Effect.exit(hostPort(() => commands.invoke(commandId))),
+      { concurrency: 'unbounded', discard: true },
+    );
+  }
+
+  // A shell env var can shadow the deletion — flag that so the agent can
+  // tell the user why the key still appears to exist after removal.
+  const stillPresent = yield* setupSecrets.hasUsableApiKey(provider);
+  if (stillPresent) {
+    return executed(
+      `Removed stored API key for provider "${provider}", but the ${envVar} environment variable is still set and will continue to provide a credential. Unset ${envVar} in your shell to fully remove it.`,
+      `Removed stored ${provider} key (env var still active)`,
+    );
+  }
+
+  return executed(
+    `Removed stored API key for provider "${provider}".`,
+    `Removed ${provider} API key`,
+  );
+});
+
 export class UnsetApiKeyTool extends defineTool({
   name: 'unset_api_key',
   requiresApproval: true,
   description: `Remove a provider's API key from TeXRA's persisted credential store. Use when the user wants to rotate or clear credentials. Non-destructive of any other state: just deletes that one secret. If the key is actually coming from a \`<PROVIDER>_API_KEY\` environment variable, this tool will report that: the credential store has nothing to remove, and the env var must be cleared in the user's shell.`,
   schema: UnsetApiKeyInputSchema,
 }) {
-  protected async execute(input: UnsetApiKeyInput): Promise<ToolResult> {
-    const platform = getSetupPlatform();
-    const provider = input.provider.trim();
-    if (!isApiProvider(provider)) {
-      throw new ToolError(
-        `Unknown provider "${provider}". Supported: ${API_PROVIDERS.join(', ')}.`,
-      );
-    }
-    const envVar = apiKeyEnvName(provider);
-
-    const storedExists = await setupSecrets.storedApiKeyExists(provider);
-    if (!storedExists) {
-      // If no persisted entry exists but a *usable* (non-blank) key
-      // is still reported, it's coming from the `<PROVIDER>_API_KEY`
-      // env var — `deleteApiKey` can't touch that, so be explicit.
-      const envExists = await setupSecrets.hasUsableApiKey(provider);
-      if (envExists) {
-        return executed(
-          `No stored API key for "${provider}" to remove, but one is still active via the ${envVar} environment variable. The credential store has nothing to clear: unset ${envVar} in your shell (or the source that sets it) to remove this credential.`,
-          `${provider} key is env-var-backed`,
-        );
-      }
-      return executed(
-        `There was no stored API key for provider "${provider}" to remove.`,
-        `No stored ${provider} API key`,
-      );
-    }
-
-    await setupSecrets.deleteApiKey(provider);
-    // Mirror the manual `texra.setApiKey` command ordering: drop the cached
-    // key lookups so models that just lost their credential stop appearing
-    // selectable, then refresh the status surfaces.
-    invalidateApiKeyCache();
-    if (platform.commands) {
-      // Credential changes must remain successful when a host cannot refresh
-      // its status surfaces; the next ordinary refresh reconciles stale UI.
-      await Promise.allSettled([
-        platform.commands.invoke('texra.refreshApiKeyStatus'),
-        platform.commands.invoke('texra.refreshAllOptions'),
-      ]);
-    }
-
-    // A shell env var can shadow the deletion — flag that so the agent can
-    // tell the user why the key still appears to exist after removal.
-    const stillPresent = await setupSecrets.hasUsableApiKey(provider);
-    if (stillPresent) {
-      return executed(
-        `Removed stored API key for provider "${provider}", but the ${envVar} environment variable is still set and will continue to provide a credential. Unset ${envVar} in your shell to fully remove it.`,
-        `Removed stored ${provider} key (env var still active)`,
-      );
-    }
-
-    return executed(
-      `Removed stored API key for provider "${provider}".`,
-      `Removed ${provider} API key`,
-    );
+  protected execute(input: UnsetApiKeyInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(unsetApiKey(input));
   }
 }

--- a/src/tools/setup/VerifySetupTool.ts
+++ b/src/tools/setup/VerifySetupTool.ts
@@ -1,7 +1,9 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 
 // Local file imports
@@ -21,100 +23,113 @@ const VerifySetupInputSchema = z.strictObject({
 
 type VerifySetupInput = z.infer<typeof VerifySetupInputSchema>;
 
+const verify = Effect.fn('VerifySetupTool.execute')(function* (
+  input: VerifySetupInput,
+) {
+  const platform = getSetupPlatform();
+
+  if (input.tool != null) {
+    const name = input.tool.trim();
+    if (!name) {
+      return yield* Effect.fail(
+        new ToolError(
+          'tool must be a non-empty command name (e.g. "pdflatex"). Call verify_setup with no arguments for a full check.',
+        ),
+      );
+    }
+    // Accept `gm/magick` as an alias since that's how the full-check path
+    // reports a missing image tool; the agent naturally reuses that token.
+    if (name === 'gm/magick') {
+      const [gm, magick] = yield* Effect.all(
+        [locateTool('gm'), locateTool('magick')],
+        { concurrency: 'unbounded' },
+      );
+      const ok = gm.installed || magick.installed;
+      return executed(
+        ok
+          ? `Verified: ${gm.installed ? '"gm"' : '"magick"'} is installed and on PATH.`
+          : `Not found: neither "gm" nor "magick" is on PATH. The install may not have completed, or the shell PATH needs to be refreshed.`,
+        `Verify gm/magick: ${ok ? 'ok' : 'missing'}`,
+      );
+    }
+    // First char must be alphanumeric — rejects punctuation-only
+    // tokens like `"."` or `".."`, which would otherwise path-join
+    // through BinaryResolver to existing directories (e.g.
+    // `/usr/bin/.`) and produce a false "ok" verification result.
+    if (!/^[A-Za-z0-9][A-Za-z0-9._+\-]*$/.test(name)) {
+      return yield* Effect.fail(
+        new ToolError(
+          `Invalid tool name "${name}". Must start with an alphanumeric character; only \`A-Za-z0-9._+-\` are allowed thereafter (or the alias "gm/magick").`,
+        ),
+      );
+    }
+    const { installed: ok } = yield* locateTool(name);
+    return executed(
+      ok
+        ? `Verified: "${name}" is installed and on PATH.`
+        : `Not found: "${name}" is still missing. The install may not have completed, or the shell PATH needs to be refreshed.`,
+      `Verify ${name}: ${ok ? 'ok' : 'missing'}`,
+    );
+  }
+
+  const [core, hasUsableCredential] = yield* Effect.all(
+    [
+      collectCoreSetupStatus(platform),
+      setupSecrets.anyUsableCredentialExists(),
+    ],
+    { concurrency: 'unbounded' },
+  );
+
+  const { auth, missingCore, latexWorkshopInstalled } = core;
+
+  const lines: string[] = [];
+  if (missingCore.length === 0) {
+    lines.push('Core LaTeX tools: all present.');
+  } else {
+    lines.push(`Core LaTeX tools MISSING: ${missingCore.join(', ')}.`);
+  }
+  lines.push(
+    latexWorkshopInstalled === undefined
+      ? 'LaTeX Workshop extension: not applicable outside VS Code.'
+      : `LaTeX Workshop extension: ${latexWorkshopInstalled ? 'installed' : 'NOT installed'}.`,
+  );
+  // A usable model credential can be a direct provider key or a provider
+  // subscription. A bare auth.authenticated is NOT a working credential,
+  // so we don't let it count toward "ready".
+  let credSummary: string;
+  if (hasUsableCredential) {
+    credSummary = 'usable model credential available';
+  } else if (auth.authenticated) {
+    credSummary =
+      'signed in but no provider API key is configured. Add one to run models';
+  } else {
+    credSummary = 'NONE: need an API key or sign-in';
+  }
+  lines.push(`Credentials: ${credSummary}.`);
+
+  const ready =
+    missingCore.length === 0 &&
+    (latexWorkshopInstalled === undefined || latexWorkshopInstalled) &&
+    hasUsableCredential;
+
+  let verificationSummary: string;
+  if (ready) {
+    verificationSummary = 'Setup verification: ready to go';
+  } else if (missingCore.length > 0) {
+    verificationSummary = `Setup verification: ${missingCore.length} missing tools`;
+  } else {
+    verificationSummary = 'Setup verification: gaps remain';
+  }
+
+  return executed(lines.join('\n'), verificationSummary);
+});
+
 export class VerifySetupTool extends defineTool({
   name: 'verify_setup',
   description: `Verify installation status. With no input, runs a full check of TeXRA's core LaTeX dependencies (pdflatex, latexmk, latexindent, perl, gs, gm or magick, texcount, latexdiff) and the LaTeX Workshop extension, returning a short plain-text report. With {"tool": "<name>"}, checks only that tool (falls back to a PATH search for names that don't have a known --version command). Use after running an install command to confirm it worked, or as the final step of a setup session.`,
   schema: VerifySetupInputSchema,
 }) {
-  protected async execute(input: VerifySetupInput): Promise<ToolResult> {
-    const platform = getSetupPlatform();
-
-    if (input.tool != null) {
-      const name = input.tool.trim();
-      if (!name) {
-        throw new ToolError(
-          'tool must be a non-empty command name (e.g. "pdflatex"). Call verify_setup with no arguments for a full check.',
-        );
-      }
-      // Accept `gm/magick` as an alias since that's how the full-check path
-      // reports a missing image tool; the agent naturally reuses that token.
-      if (name === 'gm/magick') {
-        const [gm, magick] = await Promise.all([
-          locateTool('gm'),
-          locateTool('magick'),
-        ]);
-        const ok = gm.installed || magick.installed;
-        return executed(
-          ok
-            ? `Verified: ${gm.installed ? '"gm"' : '"magick"'} is installed and on PATH.`
-            : `Not found: neither "gm" nor "magick" is on PATH. The install may not have completed, or the shell PATH needs to be refreshed.`,
-          `Verify gm/magick: ${ok ? 'ok' : 'missing'}`,
-        );
-      }
-      // First char must be alphanumeric — rejects punctuation-only
-      // tokens like `"."` or `".."`, which would otherwise path-join
-      // through BinaryResolver to existing directories (e.g.
-      // `/usr/bin/.`) and produce a false "ok" verification result.
-      if (!/^[A-Za-z0-9][A-Za-z0-9._+\-]*$/.test(name)) {
-        throw new ToolError(
-          `Invalid tool name "${name}". Must start with an alphanumeric character; only \`A-Za-z0-9._+-\` are allowed thereafter (or the alias "gm/magick").`,
-        );
-      }
-      const { installed: ok } = await locateTool(name);
-      return executed(
-        ok
-          ? `Verified: "${name}" is installed and on PATH.`
-          : `Not found: "${name}" is still missing. The install may not have completed, or the shell PATH needs to be refreshed.`,
-        `Verify ${name}: ${ok ? 'ok' : 'missing'}`,
-      );
-    }
-
-    const [core, hasUsableCredential] = await Promise.all([
-      collectCoreSetupStatus(platform),
-      setupSecrets.anyUsableCredentialExists(),
-    ]);
-
-    const { auth, missingCore, latexWorkshopInstalled } = core;
-
-    const lines: string[] = [];
-    if (missingCore.length === 0) {
-      lines.push('Core LaTeX tools: all present.');
-    } else {
-      lines.push(`Core LaTeX tools MISSING: ${missingCore.join(', ')}.`);
-    }
-    lines.push(
-      latexWorkshopInstalled === undefined
-        ? 'LaTeX Workshop extension: not applicable outside VS Code.'
-        : `LaTeX Workshop extension: ${latexWorkshopInstalled ? 'installed' : 'NOT installed'}.`,
-    );
-    // A usable model credential can be a direct provider key or a provider
-    // subscription. A bare auth.authenticated is NOT a working credential,
-    // so we don't let it count toward "ready".
-    let credSummary: string;
-    if (hasUsableCredential) {
-      credSummary = 'usable model credential available';
-    } else if (auth.authenticated) {
-      credSummary =
-        'signed in but no provider API key is configured. Add one to run models';
-    } else {
-      credSummary = 'NONE: need an API key or sign-in';
-    }
-    lines.push(`Credentials: ${credSummary}.`);
-
-    const ready =
-      missingCore.length === 0 &&
-      (latexWorkshopInstalled === undefined || latexWorkshopInstalled) &&
-      hasUsableCredential;
-
-    let verificationSummary: string;
-    if (ready) {
-      verificationSummary = 'Setup verification: ready to go';
-    } else if (missingCore.length > 0) {
-      verificationSummary = `Setup verification: ${missingCore.length} missing tools`;
-    } else {
-      verificationSummary = 'Setup verification: gaps remain';
-    }
-
-    return executed(lines.join('\n'), verificationSummary);
+  protected execute(input: VerifySetupInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(verify(input));
   }
 }

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -8,10 +8,14 @@
  * Keep this interface narrow — add methods only when a setup tool needs them.
  */
 
+// Third-party imports
+import { Effect } from 'effect';
+
 // Local imports
 import type { ToolHost } from '@agent/core/tools/ToolTypes';
 import { getCodexStatus } from '@auth/codex';
 import { SupabaseClient } from '@auth/SupabaseClient';
+import { hostPort } from '@common/hostPort';
 import type { TerminalRunner } from '@hosts/uiHosts';
 import { createLog } from '@logger/logUtils';
 import {
@@ -33,32 +37,32 @@ const credentialLog = createLog('Setup Credentials');
 
 /** Per-provider API key surface. */
 interface SetupSecretsAdapter {
-  deleteApiKey(provider: ApiProvider): Promise<void>;
+  deleteApiKey(provider: ApiProvider): Effect.Effect<void, unknown>;
   /**
    * Whether a usable key is resolved for the provider (secret storage, then
    * environment; blank values already filtered — see `hasUsableApiKey` in
    * `@model/apiProviders`). Named for the launch/retry-readiness call sites
    * here, which want the "is this actually usable" framing.
    */
-  hasUsableApiKey(provider: ApiProvider): Promise<boolean>;
+  hasUsableApiKey(provider: ApiProvider): Effect.Effect<boolean, unknown>;
   /** Whether a usable key comes from TeXRA secrets, the environment, or neither. */
-  apiKeyOrigin(provider: ApiProvider): Promise<ApiKeyOrigin>;
+  apiKeyOrigin(provider: ApiProvider): Effect.Effect<ApiKeyOrigin, unknown>;
   /**
    * Unlike `hasUsableApiKey`, only reports persisted entries — ignores
    * environment-variable-backed keys. Needed by `unset_api_key` so the
    * agent doesn't claim to have removed a key that still comes from
    * `PROVIDER_API_KEY` in the user's shell.
    */
-  storedApiKeyExists(provider: ApiProvider): Promise<boolean>;
+  storedApiKeyExists(provider: ApiProvider): Effect.Effect<boolean, unknown>;
   /** True when any credential can launch a setup model right now. */
-  anyUsableCredentialExists(): Promise<boolean>;
-  gitHubTokenExists(): Promise<'secret' | 'env' | 'none'>;
+  anyUsableCredentialExists(): Effect.Effect<boolean, unknown>;
+  gitHubTokenExists(): Effect.Effect<'secret' | 'env' | 'none', unknown>;
   /** List of provider names known to TeXRA. */
   providers: readonly ApiProvider[];
   /**
    * All persisted secret key names. Values are never returned — only names.
    */
-  listStoredKeys(): Promise<readonly string[]>;
+  listStoredKeys(): Effect.Effect<readonly string[], unknown>;
 }
 
 /** Per-command surface. */
@@ -86,80 +90,101 @@ export interface SetupPlatform {
   terminal?: TerminalRunner;
 }
 
-function assertTexraScopedKey(key: string): void {
-  if (!key.startsWith('texra.')) {
-    throw new Error(
-      `Setup config adapter is scoped to texra.* keys; refused: ${key}`,
-    );
-  }
+/**
+ * The scope violation for a non-`texra.*` key, or `undefined` when the key is
+ * in scope. Returned rather than thrown so the synchronous reader can throw it
+ * while the update program fails with it in the error channel.
+ */
+function texraScopeViolation(key: string): Error | undefined {
+  return key.startsWith('texra.')
+    ? undefined
+    : new Error(
+        `Setup config adapter is scoped to texra.* keys; refused: ${key}`,
+      );
 }
 
 /** TeXRA account status shared by every host. */
-export async function getSetupAuthStatus(): Promise<{
-  authenticated: boolean;
-  email?: string;
-}> {
-  const authenticated = await SupabaseClient.isAuthenticated();
-  if (!authenticated) {
-    return { authenticated: false };
-  }
+export const getSetupAuthStatus = Effect.fn('getSetupAuthStatus')(
+  function* (): Effect.fn.Return<
+    { authenticated: boolean; email?: string },
+    unknown
+  > {
+    const authenticated = yield* hostPort(() =>
+      SupabaseClient.isAuthenticated(),
+    );
+    if (!authenticated) {
+      return { authenticated: false };
+    }
 
-  const user = await SupabaseClient.getUser();
-  return { authenticated: true, email: user?.email };
-}
+    const user = yield* hostPort(() => SupabaseClient.getUser());
+    return { authenticated: true, email: user?.email };
+  },
+);
 
 /** Value-free credential capability exposed to setup tools. */
 export const setupSecrets: SetupSecretsAdapter =
   Object.freeze<SetupSecretsAdapter>({
     providers: API_PROVIDERS,
     deleteApiKey: (provider) =>
-      currentPlatform().secrets.delete(apiKeySecretName(provider)),
+      hostPort(() =>
+        currentPlatform().secrets.delete(apiKeySecretName(provider)),
+      ),
     hasUsableApiKey: (provider) =>
-      hasUsableApiKey(currentPlatform().secrets, provider),
+      hostPort(() => hasUsableApiKey(currentPlatform().secrets, provider)),
     apiKeyOrigin: (provider) =>
-      lookupApiKeyOrigin(currentPlatform().secrets, provider),
-    storedApiKeyExists: async (provider) =>
-      (await currentPlatform().secrets.listStoredKeys()).includes(
-        apiKeySecretName(provider),
+      hostPort(() => lookupApiKeyOrigin(currentPlatform().secrets, provider)),
+    storedApiKeyExists: (provider) =>
+      hostPort(() => currentPlatform().secrets.listStoredKeys()).pipe(
+        Effect.map((keys) => keys.includes(apiKeySecretName(provider))),
       ),
     anyUsableCredentialExists: () =>
-      hasUsableSetupCredential(currentPlatform().secrets, credentialLog.warn),
+      hostPort(() =>
+        hasUsableSetupCredential(currentPlatform().secrets, credentialLog.warn),
+      ),
     gitHubTokenExists: () =>
-      resolveGitHubTokenSource(currentPlatform().secrets),
-    listStoredKeys: () => currentPlatform().secrets.listStoredKeys(),
+      hostPort(() => resolveGitHubTokenSource(currentPlatform().secrets)),
+    listStoredKeys: () =>
+      hostPort(() => currentPlatform().secrets.listStoredKeys()),
   });
 
 /** Subscription access reported separately from provider API keys. */
-export async function getChatGptSubscriptionStatus(): Promise<{
-  signedIn: boolean;
-  enabled: boolean;
-}> {
-  const status = await getCodexStatus();
-  return {
-    signedIn: status.signedIn,
-    enabled:
-      status.signedIn && (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)),
-  };
-}
+export const getChatGptSubscriptionStatus = Effect.fn(
+  'getChatGptSubscriptionStatus',
+)(function* (): Effect.fn.Return<
+  { signedIn: boolean; enabled: boolean },
+  unknown
+> {
+  const status = yield* hostPort(() => getCodexStatus());
+  // Routing is only consulted for a signed-in account, as the `&&` did.
+  if (!status.signedIn) return { signedIn: false, enabled: false };
+  const enabled = yield* hostPort(() =>
+    isCodexSubscriptionActive(CHATGPT_SETUP_MODEL),
+  );
+  return { signedIn: true, enabled };
+});
 
 /** Configuration operations scoped to `texra.*` keys. */
 export const texraScopedConfig = Object.freeze({
   get(key: string): unknown {
-    assertTexraScopedKey(key);
+    const violation = texraScopeViolation(key);
+    if (violation) throw violation;
     return workspaceRoots().config.get(key);
   },
-  async update(
+  update: Effect.fn('texraScopedConfig.update')(function* (
     key: string,
     value: unknown,
     target: 'user' | 'workspace',
-  ): Promise<void> {
-    assertTexraScopedKey(key);
-    await workspaceRoots().config.update(
-      key,
-      value,
-      target === 'workspace' ? 'workspace' : 'global',
+  ): Effect.fn.Return<void, unknown> {
+    const violation = texraScopeViolation(key);
+    if (violation) return yield* Effect.fail(violation);
+    yield* hostPort(() =>
+      workspaceRoots().config.update(
+        key,
+        value,
+        target === 'workspace' ? 'workspace' : 'global',
+      ),
     );
-  },
+  }),
 });
 
 let override: SetupPlatform | undefined;

--- a/src/tools/setup/toolProbing.ts
+++ b/src/tools/setup/toolProbing.ts
@@ -1,4 +1,8 @@
+// Third-party imports
+import { Effect } from 'effect';
+
 // Local imports
+import { hostPort } from '@common/hostPort';
 import {
   CORE_LATEX_TOOLS,
   IMAGE_TOOLS,
@@ -31,15 +35,17 @@ const IMAGE_TOOL_NAMES: ReadonlySet<string> = new Set(IMAGE_TOOLS);
  * (e.g. `node`, `git`, or an arbitrary binary the user asks about). The PATH
  * search also supplies the absolute path presented alongside the flag.
  */
-export async function locateTool(name: string): Promise<ToolStatus> {
-  const knownInstalled = await checkToolInstalled(name, false);
+export const locateTool = Effect.fn('locateTool')(function* (
+  name: string,
+): Effect.fn.Return<ToolStatus, unknown> {
+  const knownInstalled = yield* hostPort(() => checkToolInstalled(name, false));
   const resolvedPath = BinaryResolver.findPath(name);
   return {
     name,
     installed: knownInstalled || resolvedPath !== null,
     path: resolvedPath ?? undefined,
   };
-}
+});
 
 /**
  * Names of the missing core dependencies, given statuses for the whole of
@@ -64,14 +70,17 @@ function missingCoreTools(statuses: readonly ToolStatus[]): string[] {
  * means. Each tool's divergent credential/optional-tool handling stays in the
  * tool.
  */
-export async function collectCoreSetupStatus(platform: SetupPlatform) {
-  const auth = await getSetupAuthStatus();
-  const coreTools = await Promise.all(
-    PROBED_CORE_TOOLS.map((name) => locateTool(name)),
-  );
-  const missingCore = missingCoreTools(coreTools);
-  const latexWorkshopInstalled = platform.extensions?.isInstalled(
-    LATEX_WORKSHOP_EXT_ID,
-  );
-  return { auth, coreTools, missingCore, latexWorkshopInstalled };
-}
+export const collectCoreSetupStatus = Effect.fn('collectCoreSetupStatus')(
+  function* (platform: SetupPlatform) {
+    const auth = yield* getSetupAuthStatus();
+    const coreTools = yield* Effect.all(
+      PROBED_CORE_TOOLS.map((name) => locateTool(name)),
+      { concurrency: 'unbounded' },
+    );
+    const missingCore = missingCoreTools(coreTools);
+    const latexWorkshopInstalled = platform.extensions?.isInstalled(
+      LATEX_WORKSHOP_EXT_ID,
+    );
+    return { auth, coreTools, missingCore, latexWorkshopInstalled };
+  },
+);

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -7,10 +7,12 @@
  */
 
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports - tools
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
+import { effectRuntime } from '@platform/processRuntime';
 import { TodoItemSchema, countByStatus } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { defineTool } from '@tools/core/define';
@@ -29,6 +31,32 @@ const TodoWriteInputSchema = z.strictObject({
 
 type TodoWriteInput = z.infer<typeof TodoWriteInputSchema>;
 
+const writeTodos = Effect.fn('TodoWriteTool.execute')(function* (
+  input: TodoWriteInput,
+) {
+  const context = getCurrentToolCallContext();
+
+  if (!context?.workPlanState) {
+    return yield* Effect.fail(
+      new ToolError(
+        'todo_write requires an active agent tool-use turn: there is no work plan to update.',
+      ),
+    );
+  }
+
+  // Update the todos in workspace state
+  // This triggers the onUpdate callback which emits events to the UI
+  context.workPlanState.updateTodos(input.todos);
+
+  const { completed, inProgress, pending } = countByStatus(input.todos);
+
+  // Return minimal output - the UI already shows the input, no need to repeat the list
+  return executed(
+    'OK',
+    `Todo list updated: ${completed} completed, ${inProgress} in progress, ${pending} pending`,
+  );
+});
+
 /** Tool for managing task lists during agent sessions. */
 export class TodoWriteTool extends defineTool({
   name: 'todo_write',
@@ -38,25 +66,7 @@ Each task needs two forms: content (imperative, e.g. "Run tests") and activeForm
 Keep the list current as you work; one task in_progress at a time.`,
   schema: TodoWriteInputSchema,
 }) {
-  protected async execute(input: TodoWriteInput): Promise<ToolResult> {
-    const context = getCurrentToolCallContext();
-
-    if (!context?.workPlanState) {
-      throw new ToolError(
-        'todo_write requires an active agent tool-use turn: there is no work plan to update.',
-      );
-    }
-
-    // Update the todos in workspace state
-    // This triggers the onUpdate callback which emits events to the UI
-    context.workPlanState.updateTodos(input.todos);
-
-    const { completed, inProgress, pending } = countByStatus(input.todos);
-
-    // Return minimal output - the UI already shows the input, no need to repeat the list
-    return executed(
-      'OK',
-      `Todo list updated: ${completed} completed, ${inProgress} in progress, ${pending} pending`,
-    );
+  protected execute(input: TodoWriteInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(writeTodos(input));
   }
 }

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -14,13 +14,20 @@
  *     `getUnavailableToolNamesCached()`
  */
 
+// Third-party imports
+import { Deferred, Effect } from 'effect';
+
 // Local imports
+import { hostPort } from '@common/hostPort';
 import { appSignals } from '@eventBus/AppSignals';
 import { createLog } from '@logger/logUtils';
 import type { StateStore } from '@platform/interfaces';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import type { RegisteredToolName } from '@tools/registry';
-import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
+import {
+  EXTERNAL_TOOL_DEFS,
+  type ExternalToolDef,
+} from '@tools/externalToolDefs';
 import { getDisabledToolIds } from '@utils/config/constants';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -77,22 +84,23 @@ export function getDisabledToolNames(): ReadonlySet<string> {
  * the extension/desktop, `CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION` for the
  * CLI) because each tracks its own bundled-agent version independently.
  */
-export async function seedDisabledToolDefaults(
-  state: StateStore,
-  versionStateKey: string,
-): Promise<void> {
-  const lastKnownVersion = state.get<string>(versionStateKey);
-  const disabledTools = state.get<string[]>(GlobalStateKey.DISABLED_TOOLS);
-  if (lastKnownVersion !== undefined || disabledTools !== undefined) return;
+export const seedDisabledToolDefaults = Effect.fn('seedDisabledToolDefaults')(
+  function* (state: StateStore, versionStateKey: string) {
+    const lastKnownVersion = state.get<string>(versionStateKey);
+    const disabledTools = state.get<string[]>(GlobalStateKey.DISABLED_TOOLS);
+    if (lastKnownVersion !== undefined || disabledTools !== undefined) return;
 
-  const defaults = EXTERNAL_TOOL_DEFS.filter((def) => def.toggleable).map(
-    (def) => def.id,
-  );
-  await state.update(GlobalStateKey.DISABLED_TOOLS, defaults);
-  log.info(
-    `First install: default-disabled toggleable tools: ${defaults.join(', ')}`,
-  );
-}
+    const defaults = EXTERNAL_TOOL_DEFS.filter((def) => def.toggleable).map(
+      (def) => def.id,
+    );
+    yield* hostPort(() =>
+      state.update(GlobalStateKey.DISABLED_TOOLS, defaults),
+    );
+    log.info(
+      `First install: default-disabled toggleable tools: ${defaults.join(', ')}`,
+    );
+  },
+);
 
 /**
  * Run all external tool checks in parallel.
@@ -100,7 +108,7 @@ export async function seedDisabledToolDefaults(
  * availability cache.
  *
  * Concurrent calls are coalesced: while a probe is in flight, additional
- * callers share the same Promise and receive its results. If any caller
+ * callers join the same deferred and receive its results. If any caller
  * arrives AFTER the active probe started reading inputs, a follow-up probe
  * is scheduled so the cache ultimately reflects the most recent state and
  * a stale probe can't overwrite a fresh one by finishing last.
@@ -112,103 +120,122 @@ export async function seedDisabledToolDefaults(
  * @returns Per-group results with availability status and an optional
  *   human-readable `statusDetail`.
  */
-let inflightProbe: Promise<ExternalToolCheckResult[]> | null = null;
+let inflightProbe: Deferred.Deferred<ExternalToolCheckResult[]> | null = null;
 let pendingRerun = false;
-export function runExternalToolChecks(): Promise<ExternalToolCheckResult[]> {
-  if (inflightProbe) {
-    pendingRerun = true;
-    return inflightProbe;
-  }
-  inflightProbe = (async () => {
-    let results: ExternalToolCheckResult[] = [];
-    try {
-      do {
-        pendingRerun = false;
-        results = await runProbes();
-        lastResults = results;
-      } while (pendingRerun);
-    } finally {
-      inflightProbe = null;
+export function runExternalToolChecks(): Effect.Effect<
+  ExternalToolCheckResult[]
+> {
+  return Effect.suspend(() => {
+    if (inflightProbe) {
+      pendingRerun = true;
+      return Deferred.await(inflightProbe);
     }
-    return results;
-  })();
-  return inflightProbe;
+    // The deferred is claimed here, synchronously, before the first suspension
+    // point: a caller that arrives while this probe runs must find the slot
+    // taken and join it rather than start a second probe.
+    const deferred = Deferred.makeUnsafe<ExternalToolCheckResult[]>();
+    inflightProbe = deferred;
+    return probeUntilSettled.pipe(
+      Effect.onExit((exit) => {
+        inflightProbe = null;
+        return Deferred.done(deferred, exit);
+      }),
+    );
+  });
 }
 
-async function runProbes(): Promise<ExternalToolCheckResult[]> {
-  return Promise.all(
-    EXTERNAL_TOOL_DEFS.map(
-      async ({
-        id,
-        tools,
-        name,
-        probe,
-        check,
-        statusLabel: getStatusLabel,
-        detailCheck,
-        comingSoon,
-      }): Promise<ExternalToolCheckResult> => {
-        // Run check/status/detail from one shared probe result. Some groups
-        // (Codex, Zotero, GitHub PR) touch async local state, so running the
-        // callbacks independently can duplicate the same probe work.
-        let probeResult: unknown;
-        let probedStatus: 'available' | 'not-found' | 'unknown';
-        let probeFailed = false;
-        let probeFailure: unknown;
-        try {
-          probeResult = await probe?.();
-          probedStatus = (await check(probeResult)) ? 'available' : 'not-found';
-        } catch (error) {
-          probeFailed = true;
-          probeFailure = error;
-          probedStatus = 'unknown';
-          log.warn(`Availability probe failed for ${name}`, { data: error });
-        }
-        const statusDetail = !probeFailed
-          ? await resolveOptionalStatus(
-              detailCheck,
-              probeResult,
-              name,
-              'status detail',
-            )
-          : `Availability check failed: ${toErrorMessage(probeFailure)}`;
-        const statusLabel = !probeFailed
-          ? await resolveOptionalStatus(
-              getStatusLabel,
-              probeResult,
-              name,
-              'status label',
-            )
-          : undefined;
-        return {
-          id,
-          tools,
-          name,
-          status: comingSoon ? 'coming-soon' : probedStatus,
-          detected:
-            probedStatus === 'unknown' ? null : probedStatus === 'available',
-          statusLabel,
-          statusDetail,
-        };
-      },
+const probeUntilSettled = Effect.gen(function* () {
+  let results: ExternalToolCheckResult[] = [];
+  do {
+    pendingRerun = false;
+    results = yield* runProbes;
+    lastResults = results;
+  } while (pendingRerun);
+  return results;
+});
+
+const runProbes: Effect.Effect<ExternalToolCheckResult[]> = Effect.suspend(() =>
+  // Same fan-out as the Promise.all this replaces: every group probes at once
+  // and no group's failure cancels a sibling, because each one resolves to a
+  // result of its own below.
+  Effect.forEach(EXTERNAL_TOOL_DEFS, probeToolGroup, {
+    concurrency: 'unbounded',
+  }),
+);
+
+const probeToolGroup = Effect.fn('probeToolGroup')(function* ({
+  id,
+  tools,
+  name,
+  probe,
+  check,
+  statusLabel: getStatusLabel,
+  detailCheck,
+  comingSoon,
+}: ExternalToolDef): Effect.fn.Return<ExternalToolCheckResult, never> {
+  // Run check/status/detail from one shared probe result. Some groups
+  // (Codex, Zotero, GitHub PR) touch async local state, so running the
+  // callbacks independently can duplicate the same probe work.
+  const probed = yield* Effect.gen(function* () {
+    const probeResult = probe ? yield* probe() : undefined;
+    const available = yield* check(probeResult);
+    return { failure: undefined, probeResult, available };
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.sync(() => {
+        log.warn(`Availability probe failed for ${name}`, { data: error });
+        return { failure: { error }, probeResult: undefined, available: false };
+      }),
     ),
   );
-}
+  const detectedStatus = probed.available ? 'available' : 'not-found';
+  const probedStatus: 'available' | 'not-found' | 'unknown' = probed.failure
+    ? 'unknown'
+    : detectedStatus;
+  const statusDetail = probed.failure
+    ? `Availability check failed: ${toErrorMessage(probed.failure.error)}`
+    : yield* resolveOptionalStatus(
+        detailCheck,
+        probed.probeResult,
+        name,
+        'status detail',
+      );
+  const statusLabel = probed.failure
+    ? undefined
+    : yield* resolveOptionalStatus(
+        getStatusLabel,
+        probed.probeResult,
+        name,
+        'status label',
+      );
+  return {
+    id,
+    tools,
+    name,
+    status: comingSoon ? 'coming-soon' : probedStatus,
+    detected: probedStatus === 'unknown' ? null : probedStatus === 'available',
+    statusLabel,
+    statusDetail,
+  };
+});
 
-async function resolveOptionalStatus(
+function resolveOptionalStatus(
   getStatus:
-    ((probeResult?: unknown) => Promise<string | undefined>) | undefined,
+    | ((probeResult?: unknown) => Effect.Effect<string | undefined, unknown>)
+    | undefined,
   probeResult: unknown,
   toolName: string,
   field: string,
-): Promise<string | undefined> {
-  if (!getStatus) return undefined;
-  try {
-    return await getStatus(probeResult);
-  } catch (error) {
-    log.warn(`Failed to resolve ${field} for ${toolName}`, { data: error });
-    return undefined;
-  }
+): Effect.Effect<string | undefined> {
+  if (!getStatus) return Effect.succeed(undefined);
+  return getStatus(probeResult).pipe(
+    Effect.catch((error) =>
+      Effect.sync(() => {
+        log.warn(`Failed to resolve ${field} for ${toolName}`, { data: error });
+        return undefined;
+      }),
+    ),
+  );
 }
 
 /** Build the set of unavailable tool names from external check results only. */
@@ -243,10 +270,12 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
  * `runExternalToolChecks`, so the dashboard-load probe and a refresh-triggered
  * probe can't race.
  */
-export async function refreshToolAvailability(): Promise<void> {
-  await runExternalToolChecks();
-  appSignals.emit('toolAvailabilityChanged', undefined);
-}
+export const refreshToolAvailability = Effect.fn('refreshToolAvailability')(
+  function* () {
+    yield* runExternalToolChecks();
+    appSignals.emit('toolAvailabilityChanged', undefined);
+  },
+);
 
 /**
  * Non-blocking read — derives the unavailable tool names from the last check

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 import { classifyRejection } from '@agent/runtime/HostInteractions';
@@ -6,7 +7,9 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { currentSession } from '@agent/runtime/SessionHandle';
+import { hostPort } from '@common/hostPort';
 import { createLog } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import {
   UserQuestionAnswersSchema,
   UserQuestionPromptSchema,
@@ -40,6 +43,65 @@ const AskUserQuestionInputSchema = z.strictObject({
 
 type AskUserQuestionInput = z.infer<typeof AskUserQuestionInputSchema>;
 
+const askUserQuestion = Effect.fn('AskUserQuestionTool.execute')(function* (
+  input: AskUserQuestionInput,
+) {
+  const context = tryUseRunContext();
+  requireInteractions('ask_user_question', context);
+  const streamId = getRunContextStreamId(context);
+  const requestId = `user-question-${generateShortId()}`;
+
+  logger.info('User question requested', {
+    data: input.questions[0]?.question.slice(0, 100) ?? '',
+  });
+
+  const permission = {
+    requestId,
+    questions: input.questions,
+    context: input.context ?? undefined,
+    allowBypass: false,
+    streamId: streamId ?? '',
+  };
+  const session = currentSession();
+  const result = yield* hostPort(() =>
+    session.interactions.askUserQuestion(permission),
+  );
+
+  if (result.action !== 'submit') {
+    const classification = classifyRejection(result);
+    switch (classification.kind) {
+      case 'cancelled':
+        return executed(
+          withDetail('The user question was cancelled', classification.cause),
+        );
+      case 'policy':
+        return executed(
+          withDetail('The user question was denied', classification.reason),
+        );
+      case 'feedback':
+        return executed(
+          withDetail('The user declined to answer', classification.feedback),
+        );
+      default:
+        return assertNever(
+          classification,
+          'Unhandled rejection classification',
+        );
+    }
+  }
+
+  const answers = UserQuestionAnswersSchema.parse(result.answers);
+  const answerCount = Object.keys(answers).length;
+  if (answerCount === 0) {
+    return executed('The user submitted no answers.');
+  }
+
+  return executed(
+    JSON.stringify({ answers }, null, 2),
+    `Answered ${answerCount} user question(s).`,
+  );
+});
+
 export class AskUserQuestionTool extends defineTool({
   name: 'ask_user_question',
   requiresApproval: true,
@@ -50,58 +112,7 @@ Use this when the task has several reasonable paths and continuing without the u
 The tool returns a JSON object whose keys are the original question texts and whose values are the selected option labels, arrays of labels for multi-select questions, or free-text answers.`,
   schema: AskUserQuestionInputSchema,
 }) {
-  protected async execute(input: AskUserQuestionInput): Promise<ToolResult> {
-    const context = tryUseRunContext();
-    requireInteractions('ask_user_question', context);
-    const streamId = getRunContextStreamId(context);
-    const requestId = `user-question-${generateShortId()}`;
-
-    logger.info('User question requested', {
-      data: input.questions[0]?.question.slice(0, 100) ?? '',
-    });
-
-    const permission = {
-      requestId,
-      questions: input.questions,
-      context: input.context ?? undefined,
-      allowBypass: false,
-      streamId: streamId ?? '',
-    };
-    const session = currentSession();
-    const result = await session.interactions.askUserQuestion(permission);
-
-    if (result.action !== 'submit') {
-      const classification = classifyRejection(result);
-      switch (classification.kind) {
-        case 'cancelled':
-          return executed(
-            withDetail('The user question was cancelled', classification.cause),
-          );
-        case 'policy':
-          return executed(
-            withDetail('The user question was denied', classification.reason),
-          );
-        case 'feedback':
-          return executed(
-            withDetail('The user declined to answer', classification.feedback),
-          );
-        default:
-          return assertNever(
-            classification,
-            'Unhandled rejection classification',
-          );
-      }
-    }
-
-    const answers = UserQuestionAnswersSchema.parse(result.answers);
-    const answerCount = Object.keys(answers).length;
-    if (answerCount === 0) {
-      return executed('The user submitted no answers.');
-    }
-
-    return executed(
-      JSON.stringify({ answers }, null, 2),
-      `Answered ${answerCount} user question(s).`,
-    );
+  protected execute(input: AskUserQuestionInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(askUserQuestion(input));
   }
 }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,6 +1,5 @@
 // Local imports - common
 import { ToolError } from '@shared/schemas';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 
 /**
  * Trim a string and throw a ToolError if the result is empty.
@@ -15,24 +14,4 @@ export function requireNonEmptyString(
     throw new ToolError(`${fieldName} cannot be empty.`);
   }
   return trimmed;
-}
-
-/**
- * Wrap an async API call and convert any error to a ToolError.
- * Simplifies the common try-catch-rethrow-as-ToolError pattern.
- * ToolErrors from nested calls pass through unwrapped so the original
- * message and cause chain survive.
- */
-export async function wrapApiCall<T>(
-  operation: () => Promise<T>,
-  errorPrefix: string,
-): Promise<T> {
-  try {
-    return await operation();
-  } catch (error) {
-    if (error instanceof ToolError) throw error;
-    throw new ToolError(`${errorPrefix}: ${toErrorMessage(error)}`, {
-      cause: error,
-    });
-  }
 }

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -1,3 +1,6 @@
+// Node imports
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 // Third-party imports
 import { Effect } from 'effect';
 import { z } from 'zod';
@@ -53,20 +56,33 @@ const WolframInputSchema = z.strictObject({
 
 type WolframInput = z.infer<typeof WolframInputSchema>;
 
+/**
+ * The calling turn's ambient collaborators, taken in `execute` rather than
+ * read from the program's fiber: the approval prompt and the command runner
+ * both resolve the session, its bypass state and its workspace roots from
+ * ambient storage, and the in-progress card belongs to this tool call.
+ */
+interface WolframPorts {
+  readonly requestApproval: typeof requestBashApproval;
+  readonly runTool: typeof runToolWithCheck;
+  readonly onExecutionReady: (() => void) | undefined;
+}
+
 const runWolfram = Effect.fn('WolframTool.execute')(function* (
+  ports: WolframPorts,
   input: WolframInput,
 ) {
   const command = wolframApprovalCommand(input.code);
-  const approval = yield* hostPort(() => requestBashApproval({ command }));
+  const approval = yield* hostPort(() => ports.requestApproval({ command }));
   if (approval.action !== 'approve') {
     return buildBashApprovalRejectedResult(command, approval);
   }
 
-  getCurrentToolContexts()?.callContext?.hooks?.onExecutionReady?.();
+  ports.onExecutionReady?.();
 
   const effectiveTimeout = input.timeout ?? WOLFRAM_CODE_TIMEOUT_MS;
   const result = yield* hostPort(() =>
-    runToolWithCheck('wolframscript', ['-code', input.code], {
+    ports.runTool('wolframscript', ['-code', input.code], {
       showError: false,
       truncate: false,
       timeout: effectiveTimeout,
@@ -108,6 +124,12 @@ export class WolframTool extends defineTool({
   schema: WolframInputSchema,
 }) {
   protected execute(input: WolframInput): Promise<ToolResult> {
-    return effectRuntime().runPromise(runWolfram(input));
+    const ports: WolframPorts = {
+      requestApproval: AsyncLocalStorage.bind(requestBashApproval),
+      runTool: AsyncLocalStorage.bind(runToolWithCheck),
+      onExecutionReady:
+        getCurrentToolContexts()?.callContext?.hooks?.onExecutionReady,
+    };
+    return effectRuntime().runPromise(runWolfram(ports, input));
   }
 }

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -1,8 +1,11 @@
 // Third-party imports
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
+import { hostPort } from '@common/hostPort';
+import { effectRuntime } from '@platform/processRuntime';
 import { ToolResult, ToolError } from '@shared/schemas';
 import { defineTool } from '@tools/core/define';
 import {
@@ -50,6 +53,52 @@ const WolframInputSchema = z.strictObject({
 
 type WolframInput = z.infer<typeof WolframInputSchema>;
 
+const runWolfram = Effect.fn('WolframTool.execute')(function* (
+  input: WolframInput,
+) {
+  const command = wolframApprovalCommand(input.code);
+  const approval = yield* hostPort(() => requestBashApproval({ command }));
+  if (approval.action !== 'approve') {
+    return buildBashApprovalRejectedResult(command, approval);
+  }
+
+  getCurrentToolContexts()?.callContext?.hooks?.onExecutionReady?.();
+
+  const effectiveTimeout = input.timeout ?? WOLFRAM_CODE_TIMEOUT_MS;
+  const result = yield* hostPort(() =>
+    runToolWithCheck('wolframscript', ['-code', input.code], {
+      showError: false,
+      truncate: false,
+      timeout: effectiveTimeout,
+      channel: 'WolframTool',
+    }),
+  );
+  if (!result) {
+    return yield* Effect.fail(new ToolError(WOLFRAM_NOT_INSTALLED_ERROR));
+  }
+  if (result.success) {
+    return executed(result.stdout, wolframRunSummary(input.code));
+  }
+
+  const parts: string[] = [];
+  if (result.timedOut) {
+    parts.push(
+      `Execution timed out after ${effectiveTimeout / 1000}s.\n` +
+        `To fix: increase the timeout parameter up to 600s (600000ms): { "timeout": 600000 }`,
+    );
+  }
+  if (result.exitCode !== 0) {
+    parts.push(`exit code ${result.exitCode}`);
+  }
+  if (result.stderr) parts.push(`<stderr>${result.stderr}</stderr>`);
+  if (result.stdout) parts.push(`<stdout>${result.stdout}</stdout>`);
+
+  const details = parts.join('\n') || 'No error details available';
+  return yield* Effect.fail(
+    new ToolError(`Wolfram execution failed: ${details}`),
+  );
+});
+
 export class WolframTool extends defineTool({
   name: 'wolfram',
   requiresApproval: true,
@@ -58,47 +107,7 @@ export class WolframTool extends defineTool({
   description: `Execute approval-gated Wolfram Language code. Use this tool for quick calculations, symbolic math, and one-off evaluations only when Wolfram/external computation is allowed by the user. Do not use it when the user requested a specific verification method or prohibited external computation. Sessions do NOT persist between calls - each execution starts fresh with no memory of previous variables or definitions. For complex scripts requiring session persistence, iterative development, or saving intermediate results, write to a .wl file and run via bash instead. Compute and print actual results: do not hardcode expected values in Print statements; use VerificationTest or assertions so output reflects real computation.`,
   schema: WolframInputSchema,
 }) {
-  protected async execute(input: WolframInput): Promise<ToolResult> {
-    const command = wolframApprovalCommand(input.code);
-    const approval = await requestBashApproval({ command });
-    if (approval.action !== 'approve') {
-      return buildBashApprovalRejectedResult(command, approval);
-    }
-
-    getCurrentToolContexts()?.callContext?.hooks?.onExecutionReady?.();
-
-    const effectiveTimeout = input.timeout ?? WOLFRAM_CODE_TIMEOUT_MS;
-    const result = await runToolWithCheck(
-      'wolframscript',
-      ['-code', input.code],
-      {
-        showError: false,
-        truncate: false,
-        timeout: effectiveTimeout,
-        channel: 'WolframTool',
-      },
-    );
-    if (!result) {
-      throw new ToolError(WOLFRAM_NOT_INSTALLED_ERROR);
-    }
-    if (result.success) {
-      return executed(result.stdout, wolframRunSummary(input.code));
-    }
-
-    const parts: string[] = [];
-    if (result.timedOut) {
-      parts.push(
-        `Execution timed out after ${effectiveTimeout / 1000}s.\n` +
-          `To fix: increase the timeout parameter up to 600s (600000ms): { "timeout": 600000 }`,
-      );
-    }
-    if (result.exitCode !== 0) {
-      parts.push(`exit code ${result.exitCode}`);
-    }
-    if (result.stderr) parts.push(`<stderr>${result.stderr}</stderr>`);
-    if (result.stdout) parts.push(`<stdout>${result.stdout}</stdout>`);
-
-    const details = parts.join('\n') || 'No error details available';
-    throw new ToolError(`Wolfram execution failed: ${details}`);
+  protected execute(input: WolframInput): Promise<ToolResult> {
+    return effectRuntime().runPromise(runWolfram(input));
   }
 }


### PR DESCRIPTION
Continues the Effect 4 runtime migration into `src/tools`, taking the
directory from 58/159 Effect-typed files to 86/159. Zero-bridge and
file-at-a-time: every converted callee has its call sites converted in the
same change, so no adapter or pass-through layer is introduced.

Converted, by area:

- `setup/` — `setup/platform.ts` is the cluster's shared adapter surface;
  `SetupSecretsAdapter`, `getSetupAuthStatus`, `getChatGptSubscriptionStatus`
  and `texraScopedConfig.update` are now Effect-typed, and the nine setup tool
  classes run their programs at the `execute()` boundary. `Promise.all` becomes
  `Effect.all` with the same unbounded parallelism; the `Promise.allSettled`
  best-effort refresh in `UnsetApiKeyTool` becomes `Effect.forEach` over
  `Effect.exit`. `InstallVscodeExtensionTool`'s `node:timers/promises` grace
  delay becomes `Effect.sleep`.
- `delegation/` — `delegationAvailability.ts`, collapsing the `hostPort`
  wrappers at its already-Effect call sites.
- `approval/` — `tempFileManager.ts`, with its desktop and extension hosts
  updated to run at their own boundaries.
- `plan/`, `todo/`, `wolfram/` — `PlanTool`, `TodoTool`, `WolframTool`.
- top-level tool classes — `ReadTool`, `WriteTool`, `EditTool`, `OpenPdfTool`,
  `DiagnosticsTool`, `ReportReviewIssueTool`.
- registry and availability — `externalToolDefs.ts`, `toolAvailability.ts`,
  and `controllers/settingsView/ToolDashboardData.ts`.
- fs and path helpers — `gitignore.ts`, `glob.ts`, `grep.ts`, `emlParser.ts`.

The `Effect.run*` boundary rule (R1) is held throughout: every new run sits in
a `src/tools/**/*Tool.ts` class extending `defineTool`, or in a host entry
under `packages/{extension,desktop,cli}/src/`. `ApplyTeamTool` had an inner
below-boundary run that collapses into its `execute()` program, leaving one.

Every converted file ends with zero raw `catch` clauses and zero `.catch(`
calls, as the `catch:effect-importer` ratchet row requires of any file that
newly imports `effect` — the row's per-file allowlist admits no new file.
Degradation paths keep their behaviour: `ProbeEnvironmentTool`'s four
swallowed failures become `Effect.catch` returning the same fallback values,
so the same "status unavailable" strings still reach the model.

`config/ratchets/effect-migration-baseline.json` is unchanged and needed no
regeneration: this change removed no *tracked* debt. The catches it deleted
lived in files that did not previously import `effect`, so they were never
counted; the seven `platform()` calls in `setup/platform.ts` are preserved
inside `hostPort` callbacks rather than removed.

Behaviour-preserving refactor, so no new tests. Thirteen existing kernel
suites were updated in place for the now-Effect-typed signatures — failure
paths kept their coverage by moving from `mockRejectedValue` to
`mockReturnValue(Effect.fail(...))` rather than being dropped.

Verified: typecheck clean, lint clean, prettier clean, effect-migration
ratchet exit 0 with every row equal to baseline, dead-code ratchet OK,
browser-safe-utils and guidance-refs OK, and the full suite green at
750 files / 9118 tests passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0173H8rQF3Askx45rYwHgkgp