### PR TITLE
simplify: effect-areas sweep (waves 1–5, net −303)

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -14,7 +14,7 @@
       "packages/extension/src/frontend/secretManager.ts": 1,
       "packages/extension/src/frontend/ui/instruction.ts": 2,
       "packages/extension/src/progressView/ProgressViewProvider.ts": 2,
-      "packages/extension/src/settingsView/SettingsViewMessageHandler.ts": 3,
+      "packages/extension/src/settingsView/SettingsViewMessageHandler.ts": 2,
       "packages/extension/src/settingsView/handlers/agentHandlers.ts": 1,
       "packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts": 2,
       "src/agent/followUp/ToolUseFollowUp.ts": 1,

--- a/packages/agent/src/effect/sessions.ts
+++ b/packages/agent/src/effect/sessions.ts
@@ -521,16 +521,14 @@ export function makeSessions(
   return {
     open: (roots?: WorkspaceRoots) =>
       Effect.map(
-        Effect.suspend(() =>
-          openSessionEffect({
-            roots: roots ?? runtime.roots,
-            transcriptMode: {
-              kind: 'ephemeral',
-              reason: 'npm package consumer',
-            },
-            interactions: HEADLESS_HOST,
-          }),
-        ),
+        openSessionEffect({
+          roots: roots ?? runtime.roots,
+          transcriptMode: {
+            kind: 'ephemeral',
+            reason: 'npm package consumer',
+          },
+          interactions: HEADLESS_HOST,
+        }),
         sessionOf,
       ),
     close: (roots?: WorkspaceRoots, signal?: AbortSignal) =>

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -691,26 +691,28 @@ export function createChatSessionController(
         store.readMeta(),
       ]);
       const streamId = meta?.streamId;
-      let failure: string | undefined;
-      if (!config || !streamId) {
-        failure = `Execution not found: ${id}`;
-      } else if (config.agentCategory !== AgentCategory.ToolUse) {
-        failure = `Execution ${id} is a workflow; resume it with \`texra resume ${id}\`.`;
-      }
-      if (failure || !config || !streamId) {
+      // Refusal tail every early exit below shares: put back what the
+      // synchronous prologue superseded, surface the reason, settle the slot.
+      const refuseResume = (reason: string): void => {
         restoreInterruptedRecovery(supersededRecovery);
-        appendLocalErrorTranscript(failure ?? `Execution not found: ${id}`);
+        appendLocalErrorTranscript(reason);
         session.markRunCompleted();
         resolveRunPromise();
+      };
+      if (!config || !streamId) {
+        refuseResume(`Execution not found: ${id}`);
+        return;
+      }
+      if (config.agentCategory !== AgentCategory.ToolUse) {
+        refuseResume(
+          `Execution ${id} is a workflow; resume it with \`texra resume ${id}\`.`,
+        );
         return;
       }
 
       recovery = runtimeSession.followUps.claimRecovery(streamId, true);
       if (!recovery) {
-        restoreInterruptedRecovery(supersededRecovery);
-        appendLocalErrorTranscript(describeFollowUpFailure('not_resumable'));
-        session.markRunCompleted();
-        resolveRunPromise();
+        refuseResume(describeFollowUpFailure('not_resumable'));
         return;
       }
 

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -30,7 +30,7 @@ import {
 } from '@cli/chat/tui/state/transcript';
 import { activeSubscriptionUsageRoute } from '@model/codingPlanSubscriptions';
 import { effectRuntime } from '@platform/processRuntime';
-import { MESSAGE_TYPES, type StreamTabId } from '@shared/schemas';
+import { MESSAGE_TYPES } from '@shared/schemas';
 import { GoalStore } from '@tools/goal';
 import type { StreamSnapshotStore } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -410,10 +410,6 @@ export async function runChat(
   });
   disposables.add(setCliAgentResumeHandler(chatController.tryResumeStream));
 
-  const interruptActive = (): void => {
-    chatController.stop();
-  };
-
   const resetSessionForClear = (): void => {
     const currentStreamId = session.streamId ?? activeStreamIdSignal.get();
     const activeStatus = streamPhaseOf(
@@ -567,7 +563,7 @@ export async function runChat(
     resumeTerminalTitle: terminalTitleUpdates.resume,
     canStopActiveRun,
     isResumableIdle,
-    interruptActive,
+    interruptActive: () => chatController.stop(),
   });
   // Transfer signal ownership from the platform handler and arm this session's
   // handlers, not any earlier: everything above (initInteractiveCliPlatform,

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -96,7 +96,7 @@ export interface PendingApproval {
 export type PendingApprovalKind = ProgressPermissionKind;
 
 /** One request the user's attention is on: a fold fact, read once. */
-export interface AttentionRequest {
+interface AttentionRequest {
   readonly requestId: string;
   readonly streamId: StreamTabId;
   readonly kind: PendingApprovalKind;
@@ -569,11 +569,10 @@ export function settleHostRequestsWhere(
 
 /** Approve every delegated request pending on `streamId` once its bypass is
  *  on: the decisions the user's super-YOLO choice implied. */
-function approveQueuedDelegatedWorkForStream(streamId: StreamTabId): number {
+function approveQueuedDelegatedWorkForStream(streamId: StreamTabId): void {
   const view = sessionView().get();
   const host = hostRequests.get();
   const done = decided.get();
-  let count = 0;
   for (const request of attentionRequests(view, host, undefined)) {
     if (request.streamId !== streamId || done.has(request.requestId)) continue;
     if (
@@ -586,9 +585,7 @@ function approveQueuedDelegatedWorkForStream(streamId: StreamTabId): number {
     const payload = presentedPayload(request, host);
     if (!payload) continue;
     decideRequest(request, payload, { accepted: true });
-    count += 1;
   }
-  return count;
 }
 
 /** Forget every host entry and decision latch: the Surface reset (`/clear`). */

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -93,7 +93,6 @@ import {
   reserveHostRequest,
   settleHostRequestsWhere,
   type ApprovalDecision,
-  type ApprovalPayload,
   type RetryApprovalPayload,
 } from './approvalQueue';
 

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -248,7 +248,7 @@ export const runMultiAgentPreset = Effect.fn('runMultiAgentPreset')(function* (
             name: plan.preset.name,
             source: plan.preset.source,
           },
-          rootAgent: plan.rootAgent?.name,
+          rootAgent: rootAgent.name,
           result: execution.result,
         };
         emitCliResult(runContext, {

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -76,7 +76,7 @@ const decideGated = Effect.fn('approvalAdapter.decideGated')(function* (
   options: { writeRejectionToStderr?: boolean } = {},
 ) {
   if (immediate) {
-    return { decision: immediate as ApprovalDecision, prompted: false };
+    return { decision: immediate, prompted: false };
   }
 
   const decision = yield* askApproval(context, content, hooks);
@@ -87,7 +87,7 @@ const decideGated = Effect.fn('approvalAdapter.decideGated')(function* (
         : content.summary,
     );
   }
-  return { decision: decision as ApprovalDecision, prompted: true };
+  return { decision, prompted: true };
 });
 
 /** Approve/reject settlement shared by the bash, plan, proposal, and tool-edit
@@ -118,7 +118,7 @@ export function toApprovalSettlement(
 }
 
 function toPromptedApprovalSettlement(
-  decision: ApprovalDecision & { readonly rejectionCause?: string },
+  decision: CliApprovalDecision,
   prompted: boolean,
 ): BashSettlement {
   if (prompted || decision.accepted) return toApprovalSettlement(decision);

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -212,17 +212,6 @@ export function writeErrorStderr(error: unknown): void {
   writeTextStderr(toErrorMessage(error));
 }
 
-/** Swallows readline's echo so a typed secret never reaches the terminal. */
-class SilentWritable extends Writable {
-  override _write(
-    _chunk: unknown,
-    _encoding: BufferEncoding,
-    callback: (error?: Error | null) => void,
-  ): void {
-    callback();
-  }
-}
-
 export async function askCliQuestion(
   question: string,
   options: {
@@ -242,7 +231,8 @@ export async function askCliQuestion(
   const prompt = createInterface({
     input,
     output: options.hidden
-      ? new SilentWritable()
+      ? // Swallow readline's echo so the typed secret never reaches the terminal.
+        new Writable({ write: (_chunk, _encoding, callback) => callback() })
       : (options.output ?? process.stderr),
     // A swallowing non-TTY output would otherwise leave stdin in canonical
     // mode, where the TTY driver echoes the secret itself.

--- a/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
+++ b/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
@@ -1,4 +1,3 @@
-// Standard library imports
 import { randomBytes } from 'node:crypto';
 import {
   createServer,
@@ -8,7 +7,6 @@ import {
 
 import { z } from 'zod';
 
-// Local imports - auth
 import { Cause, Deferred, Effect, Exit, Result, Scope } from 'effect';
 import { unwrapAuthPortCause } from '@auth/authProgram';
 import { AUTH_CALLBACK_TIMEOUT_MS } from '@auth/config';

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -180,7 +180,7 @@ const HomebrewInfoSchema = z.object({
 
 function parseHomebrewFormulaVersion(
   stdout: string,
-  formula = CLI_HOMEBREW_FORMULA,
+  formula: string,
 ): string | undefined {
   const parsed = parseJsonWith(stdout, HomebrewInfoSchema);
   if (Result.isFailure(parsed)) return undefined;

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -136,14 +136,12 @@ const materializeStdinWorkflowInput = Effect.fn(
  *
  * `flagLabel` is the CLI flag name (e.g. `--input`, `--context`) used in
  * Usage-error messages so a missing file is attributed to the right flag.
- * Defaults to `--input` for the common case; callers that pass context paths
- * (multi-agent `--context`) should override.
  */
 const expandWorkflowInputSpec = Effect.fn('expandWorkflowInputSpec')(function* (
   inputSpec: string,
   cwd: string,
-  flagLabel: string = '--input',
-  options: WorkflowInputExpansionOptions = {},
+  flagLabel: string,
+  options: WorkflowInputExpansionOptions,
 ): Effect.fn.Return<string[], Error> {
   const trimmed = inputSpec.trim();
   if (!trimmed) return [];

--- a/packages/desktop/src/main/desktopHostRequests.ts
+++ b/packages/desktop/src/main/desktopHostRequests.ts
@@ -138,10 +138,9 @@ export function createDesktopHostRequests(
     options.snapshot.setRecording(recording),
   );
   const snapshots = session.snapshots;
-  const view = () => SubscriptionRef.getUnsafe(session.view);
 
   const stream = (streamId: StreamTabId) => {
-    const found = view().streams.get(streamId);
+    const found = SubscriptionRef.getUnsafe(session.view).streams.get(streamId);
     if (!found) {
       throw new Unavailable({
         streamId,
@@ -159,10 +158,7 @@ export function createDesktopHostRequests(
     // desktop that means opening the Models tab rather than a modal prompt.
     // The controller re-reads the secret store after this returns.
     promptForApiKey: async () => {
-      postDesktopSettingsView(
-        (message) => options.postToRenderer(message),
-        'models',
-      );
+      postDesktopSettingsView(options.postToRenderer, 'models');
       await host.showInfoMessage(
         'Add a provider API key in Models, then use "Retry" on the request.',
       );
@@ -531,7 +527,7 @@ export function createDesktopHostRequests(
     switch (request.action) {
       case 'edit':
         postDesktopSettingsView(
-          (message) => options.postToRenderer(message),
+          options.postToRenderer,
           'agents',
           request.sessionType === 'toolUse' ? 'toolUse' : 'workflow',
         );
@@ -540,10 +536,7 @@ export function createDesktopHostRequests(
         if (request.customDirSet === true) {
           await host.openPath(await options.getCustomAgentDirectory());
         } else {
-          postDesktopSettingsView(
-            (message) => options.postToRenderer(message),
-            'agents',
-          );
+          postDesktopSettingsView(options.postToRenderer, 'agents');
         }
         return;
       case 'docs':
@@ -560,10 +553,7 @@ export function createDesktopHostRequests(
         await options.onboarding.signInWithChatGpt();
         return;
       case 'setApiKey':
-        postDesktopSettingsView(
-          (message) => options.postToRenderer(message),
-          'models',
-        );
+        postDesktopSettingsView(options.postToRenderer, 'models');
         return;
       case 'skip':
         await options.onboarding.skipOnboarding();
@@ -664,7 +654,7 @@ export function createDesktopHostRequests(
       case 'popBack':
         throw notOnDesktop('Pop-out to editor');
       case 'openDashboard':
-        postDesktopSettingsView((message) => options.postToRenderer(message));
+        postDesktopSettingsView(options.postToRenderer);
         return done;
       case 'refreshCommits':
         await effectRuntime().runPromise(options.snapshot.refreshCommits);
@@ -674,7 +664,7 @@ export function createDesktopHostRequests(
         return done;
       case 'openSettings':
         postDesktopSettingsView(
-          (message) => options.postToRenderer(message),
+          options.postToRenderer,
           request.section === 'teams' ? 'multi-agent' : request.section,
           request.sessionType === 'toolUse' ? 'toolUse' : undefined,
         );
@@ -726,10 +716,7 @@ export function createDesktopHostRequests(
         return done;
       case 'apiKeyBanner':
         if (request.action === 'set') {
-          postDesktopSettingsView(
-            (message) => options.postToRenderer(message),
-            'models',
-          );
+          postDesktopSettingsView(options.postToRenderer, 'models');
         } else {
           await options.openExternalUrl(
             'https://texra.ai/guide/configuration.html',
@@ -743,10 +730,7 @@ export function createDesktopHostRequests(
         await options.recheckTools();
         return done;
       case 'openInstallGuide':
-        postDesktopSettingsView(
-          (message) => options.postToRenderer(message),
-          'tools',
-        );
+        postDesktopSettingsView(options.postToRenderer, 'tools');
         return done;
       case 'signIn':
         await options.signIn();

--- a/packages/desktop/src/main/desktopProjects.ts
+++ b/packages/desktop/src/main/desktopProjects.ts
@@ -35,10 +35,9 @@ import {
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
 import { StreamLogStore } from '@transcript';
-import { ensureError } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import { withPerKeyLane, type PerKeyLane } from '@utils/core/perKeyQueue';
 import { readPlatformSetting } from '@utils/config/platformSettings';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { DesktopProjectRecords } from './desktopProjectRecords.js';
 
 import type { DesktopProjectsMessage } from '../shared/desktopProjectMessages.js';

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -447,13 +447,6 @@ function createWindow(options: {
     });
     return prompt.actions[response]?.choice ?? 'cancel';
   };
-  const chooseTeamAvailability = (
-    unavailableNames: readonly string[],
-    presetName?: string,
-  ) =>
-    presentTeamAvailabilityPrompt(
-      teamAvailabilityPrompt(unavailableNames, presetName),
-    );
   // Lightweight update check: at most once/day, notifies at most once per
   // release via a native dialog linking to the GitHub release page. Not a full
   // updater: no download, no install, no feed files. Disable with
@@ -727,7 +720,8 @@ function createWindow(options: {
     openDiff: desktopDiffHost.openDiff,
     confirmAcceptFile: (message) =>
       confirmDialog({ message, confirmLabel: 'Replace file' }),
-    chooseTeamAvailability,
+    chooseTeamAvailability: (unavailableNames) =>
+      presentTeamAvailabilityPrompt(teamAvailabilityPrompt(unavailableNames)),
     signInForRemoteAgentCatalog,
     // Presentation failures are reported, never raised: an execution must not
     // fail because a dialog could not be shown. The caller still awaits the
@@ -1294,28 +1288,19 @@ function createWindow(options: {
                       ? primaryError.reason
                       : toErrorMessage(primaryError),
                 });
-                if (presentation?.type === 'instruction') {
+                if (
+                  presentation?.type === 'instruction' ||
+                  presentation?.type === 'error'
+                ) {
                   yield* Effect.tryPromise({
                     try: () =>
                       Promise.resolve(
                         setupSession.interactions.emit(
-                          'requestShowInstruction',
+                          presentation.type === 'instruction'
+                            ? 'requestShowInstruction'
+                            : 'requestShowError',
                           presentation.payload,
                           { replayWhenAttached: true },
-                        ),
-                      ),
-                    catch: (emitError) => emitError,
-                  });
-                } else if (presentation?.type === 'error') {
-                  yield* Effect.tryPromise({
-                    try: () =>
-                      Promise.resolve(
-                        setupSession.interactions.emit(
-                          'requestShowError',
-                          presentation.payload,
-                          {
-                            replayWhenAttached: true,
-                          },
                         ),
                       ),
                     catch: (emitError) => emitError,
@@ -1565,8 +1550,7 @@ function createWindow(options: {
     promptController.dispose();
     hostBridge.dispose();
   });
-  const mainViewIpc = { postToRenderer: hostBridge.postToRenderer };
-  ipcRef.current = mainViewIpc;
+  ipcRef.current = { postToRenderer: hostBridge.postToRenderer };
   syncProjectBindings();
   attachActiveProject();
   Menu.setApplicationMenu(

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -112,7 +112,6 @@ import { gitHubTokenRejectedMessage } from '@tools/github/githubAuth';
 import { killActiveRecording } from '@tools/media/audio';
 import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { setInlineCommentProvider } from '@tools/comment/InlineCommentTool';
-import { StreamLogStore } from '@transcript';
 import {
   initProcessSettingHost,
   readPlatformSetting,

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -342,7 +342,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   /** Every credential-dependent surface: catalogs, sign-in, the funnel. */
-  public async refreshAfterCredentialChange(): Promise<void> {
+  private async refreshAfterCredentialChange(): Promise<void> {
     await effectRuntime().runPromise(refresh());
     await Promise.all([
       effectRuntime().runPromise(this.snapshot.refreshCatalogs),

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -128,16 +128,17 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     // Must build inside the constructor: the platform is initialized by
     // extension.ts during activation, so destructuring its stores at module
     // load would throw before that happens.
+    const { globalState } = platform();
     this.settingsHost = new SettingsViewHost({
       state: {
         workspaceState: workspaceRoots().workspaceState,
-        globalState: platform().globalState,
+        globalState,
       },
       memoryPrompt: new VscodePromptHost(),
     });
     this.profileController = new SettingsProfileController({
       host: 'vscode',
-      globalState: platform().globalState,
+      globalState,
       loadProviderKeyStatuses: () =>
         loadApiKeyStatusMap(platform().secrets, SecretManager.API_PROVIDERS),
       getConfig,
@@ -560,21 +561,22 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       },
     });
     if (result.kind === 'ignored') return;
+    const label = result.entry.title ?? result.entry.key;
     if (result.kind === 'rejected') {
       await showLoggedErrorMessage(
         this.channel,
-        `Invalid value for “${result.entry.title ?? result.entry.key}”`,
+        `Invalid value for “${label}”`,
         result.error,
       );
     } else if (result.kind === 'workspace-required') {
       void showLoggedInfoMessage(
         this.channel,
-        `Open a workspace folder before changing the “${result.entry.title ?? result.entry.key}” setting.`,
+        `Open a workspace folder before changing the “${label}” setting.`,
       );
     } else if (result.kind === 'failed') {
       await showLoggedErrorMessage(
         this.channel,
-        `Failed to update “${result.entry.title ?? result.entry.key}”`,
+        `Failed to update “${label}”`,
         result.error,
       );
     }

--- a/packages/llm/src/openaiChat.ts
+++ b/packages/llm/src/openaiChat.ts
@@ -348,6 +348,10 @@ const chatMessages = Effect.fn('llm.chatMessages')(function* (
           'image/heif',
         ]
       : ['image/jpeg', 'image/png'];
+  const textJoinSeparator =
+    origin.protocol === 'dashscope-chat' || origin.protocol === 'minimax-chat'
+      ? '\n'
+      : '';
   let calls: Array<
     OpenAI.Chat.Completions.ChatCompletionMessageFunctionToolCall & {
       index?: number;
@@ -415,14 +419,7 @@ const chatMessages = Effect.fn('llm.chatMessages')(function* (
       messages.push({
         role: 'user',
         content: content.every((part) => part.type === 'text')
-          ? content
-              .map((part) => part.text)
-              .join(
-                origin.protocol === 'dashscope-chat' ||
-                  origin.protocol === 'minimax-chat'
-                  ? '\n'
-                  : '',
-              )
+          ? content.map((part) => part.text).join(textJoinSeparator)
           : content,
       });
       continue;
@@ -523,14 +520,7 @@ const chatMessages = Effect.fn('llm.chatMessages')(function* (
                     ? { type: 'text', text: child.text }
                     : { type: 'refusal', refusal: child.text },
                 )
-              : part.content
-                  .map((child) => child.text)
-                  .join(
-                    origin.protocol === 'dashscope-chat' ||
-                      origin.protocol === 'minimax-chat'
-                      ? '\n'
-                      : '',
-                  ),
+              : part.content.map((child) => child.text).join(textJoinSeparator),
         };
         messages.push(assistant);
       } else {
@@ -1430,14 +1420,10 @@ export function openaiChatModel(
                       cause,
                     }),
                 });
-                if (
-                  event.event === 'error' ||
-                  (typeof raw === 'object' && raw !== null && 'error' in raw)
-                ) {
-                  const payload =
-                    typeof raw === 'object' && raw !== null && 'error' in raw
-                      ? raw.error
-                      : raw;
+                const embedsError =
+                  typeof raw === 'object' && raw !== null && 'error' in raw;
+                if (event.event === 'error' || embedsError) {
+                  const payload = embedsError ? raw.error : raw;
                   return yield* openaiFailure(
                     new OpenAI.APIError(
                       undefined,

--- a/packages/llm/src/openrouterChat.ts
+++ b/packages/llm/src/openrouterChat.ts
@@ -664,9 +664,7 @@ export function openrouterChatModel(
     },
   );
 
-  const streamTurn = (
-    input: ResolvedTurn,
-  ): Stream.Stream<TurnEvent, ModelError> =>
+  const streamTurn: Model['streamTurn'] = (input) =>
     Stream.suspend(() => {
       let responseId: string | undefined;
       let returnedModel: string | undefined;

--- a/packages/llm/src/turn.ts
+++ b/packages/llm/src/turn.ts
@@ -423,6 +423,13 @@ const EVIDENCE_PROTOCOL = {
   'minimax-reasoning': 'minimax-chat',
   'minimax-message': 'minimax-chat',
   'minimax-function-call': 'minimax-chat',
+  google: 'google-interactions',
+  anthropic: 'anthropic-messages',
+  xai: 'xai-chat',
+  openrouter: 'openrouter-chat',
+  minimax: 'minimax-chat',
+  'google-interactions': 'google-interactions',
+  'openai-responses': 'openai-responses',
 } as const;
 
 function validateAssistantContent(
@@ -799,6 +806,45 @@ const EditorControlsSchema = z.strictObject({
   toolChoice: z.literal('auto'),
 });
 
+function validateTemperatureDefault(
+  configuration: {
+    readonly supportsTemperature: boolean;
+    readonly defaults: { readonly temperature: number | null };
+  },
+  ctx: z.RefinementCtx,
+): void {
+  if (
+    !configuration.supportsTemperature &&
+    configuration.defaults.temperature !== null
+  ) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['defaults', 'temperature'],
+      message: 'A model without temperature support requires a null default.',
+    });
+  }
+}
+
+function validateEffortDefault<E extends string>(
+  configuration: {
+    readonly supportedEfforts: readonly E[];
+    readonly defaults: { readonly effort: E | null };
+  },
+  ctx: z.RefinementCtx,
+): void {
+  if (
+    configuration.defaults.effort !== null &&
+    !configuration.supportedEfforts.includes(configuration.defaults.effort)
+  ) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['defaults', 'effort'],
+      message:
+        'The default reasoning effort must be supported by the selected route.',
+    });
+  }
+}
+
 /** Already-selected protocol binding and defaults, provided by the application. */
 export const ModelConfigurationSchema = z.discriminatedUnion('protocol', [
   BindingSchema.extend({
@@ -826,28 +872,8 @@ export const ModelConfigurationSchema = z.discriminatedUnion('protocol', [
     defaults: OpenRouterControlsSchema.omit({ toolChoice: true }).readonly(),
   })
     .superRefine((configuration, ctx) => {
-      if (
-        !configuration.supportsTemperature &&
-        configuration.defaults.temperature !== null
-      ) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['defaults', 'temperature'],
-          message:
-            'A model without temperature support requires a null default.',
-        });
-      }
-      if (
-        configuration.defaults.effort !== null &&
-        !configuration.supportedEfforts.includes(configuration.defaults.effort)
-      ) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['defaults', 'effort'],
-          message:
-            'The default reasoning effort must be supported by the selected route.',
-        });
-      }
+      validateTemperatureDefault(configuration, ctx);
+      validateEffortDefault(configuration, ctx);
     })
     .readonly(),
   BindingSchema.extend({
@@ -857,28 +883,8 @@ export const ModelConfigurationSchema = z.discriminatedUnion('protocol', [
     defaults: OpenAIChatControlsSchema.omit({ toolChoice: true }).readonly(),
   })
     .superRefine((configuration, ctx) => {
-      if (
-        !configuration.supportsTemperature &&
-        configuration.defaults.temperature !== null
-      ) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['defaults', 'temperature'],
-          message:
-            'A model without temperature support requires a null default.',
-        });
-      }
-      if (
-        configuration.defaults.effort !== null &&
-        !configuration.supportedEfforts.includes(configuration.defaults.effort)
-      ) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['defaults', 'effort'],
-          message:
-            'The default reasoning effort must be supported by the selected route.',
-        });
-      }
+      validateTemperatureDefault(configuration, ctx);
+      validateEffortDefault(configuration, ctx);
     })
     .readonly(),
   BindingSchema.extend({
@@ -927,17 +933,7 @@ export const ModelConfigurationSchema = z.discriminatedUnion('protocol', [
     defaults: XaiControlsSchema.omit({ toolChoice: true }).readonly(),
   })
     .superRefine((configuration, ctx) => {
-      if (
-        configuration.defaults.effort !== null &&
-        !configuration.supportedEfforts.includes(configuration.defaults.effort)
-      ) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['defaults', 'effort'],
-          message:
-            'The default reasoning effort must be supported by the selected route.',
-        });
-      }
+      validateEffortDefault(configuration, ctx);
     })
     .readonly(),
   BindingSchema.extend({
@@ -1021,17 +1017,7 @@ export const ModelConfigurationSchema = z.discriminatedUnion('protocol', [
     defaults: AnthropicControlsSchema.omit({ toolChoice: true }).readonly(),
   })
     .superRefine((configuration, ctx) => {
-      if (
-        !configuration.supportsTemperature &&
-        configuration.defaults.temperature !== null
-      ) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['defaults', 'temperature'],
-          message:
-            'A model without temperature support requires a null default.',
-        });
-      }
+      validateTemperatureDefault(configuration, ctx);
     })
     .readonly(),
 ]);
@@ -1366,26 +1352,16 @@ const HttpTurnResultSchema = z
           'A stop-sequence outcome requires its exact matched sequence, and no other outcome has one.',
       });
     }
+    const usageKind = result.usage?.providerUsage?.kind;
+    const finishKind = result.finishEvidence?.kind;
     if (
       (result.refusalEvidence !== undefined &&
         result.requestedOrigin.protocol !== 'anthropic-messages') ||
       (result.refusalEvidence != null && result.finishReason !== 'refusal') ||
-      (result.usage?.providerUsage?.kind === 'google' &&
-        result.requestedOrigin.protocol !== 'google-interactions') ||
-      (result.usage?.providerUsage?.kind === 'anthropic' &&
-        result.requestedOrigin.protocol !== 'anthropic-messages') ||
-      (result.usage?.providerUsage?.kind === 'xai' &&
-        result.requestedOrigin.protocol !== 'xai-chat') ||
-      ((result.usage?.providerUsage?.kind === 'openrouter' ||
-        result.finishEvidence?.kind === 'openrouter') &&
-        result.requestedOrigin.protocol !== 'openrouter-chat') ||
-      ((result.usage?.providerUsage?.kind === 'minimax' ||
-        result.finishEvidence?.kind === 'minimax') &&
-        result.requestedOrigin.protocol !== 'minimax-chat') ||
-      (result.finishEvidence?.kind === 'google-interactions' &&
-        result.requestedOrigin.protocol !== 'google-interactions') ||
-      (result.finishEvidence?.kind === 'openai-responses' &&
-        result.requestedOrigin.protocol !== 'openai-responses')
+      (usageKind != null &&
+        result.requestedOrigin.protocol !== EVIDENCE_PROTOCOL[usageKind]) ||
+      (finishKind != null &&
+        result.requestedOrigin.protocol !== EVIDENCE_PROTOCOL[finishKind])
     ) {
       ctx.addIssue({
         code: 'custom',

--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -434,9 +434,10 @@ export function normalizeConversationForExport(
           nodes.push({ kind: 'tool-result', text: textParts.join('\n') });
         }
       } else {
-        const outputText =
-          typeof output === 'string' ? output : prettyJson(output ?? '');
-        nodes.push({ kind: 'tool-result', text: outputText });
+        nodes.push({
+          kind: 'tool-result',
+          text: toolResultContentText(output),
+        });
       }
       lastAssistantHadToolUse = false;
       continue;

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -12,7 +12,7 @@ import {
 import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { AgentResumePort } from '@platform/interfaces';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import {
   streamHeldMessage,
   streamUnreadableMessage,
@@ -124,12 +124,10 @@ export function enqueueLiveFollowUp(
   session.followUps.submit(streamId, followUp, 'live_owner');
 }
 
-interface PendingResume {
-  readonly resume: Promise<boolean>;
-}
-
 type Admission =
-  SubmitFollowUpResult | PendingResume | { status: 'no_session' };
+  | SubmitFollowUpResult
+  | { readonly resume: Promise<boolean> }
+  | { status: 'no_session' };
 
 /**
  * Route and admit one submission. Synchronous from the registry snapshot to

--- a/src/agent/implementations/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/agentCreator/agentCreatorFlow.ts
@@ -30,10 +30,9 @@ const log = createLog('AgentCreator');
 
 // ── Types ───────────────────────────────────────────────────
 
-interface AgentPromptPair {
-  systemPrompt: string;
-  userRequest: string;
-}
+// Derived from the prompts block the template parser validates — the schema
+// is the SSOT for this shape.
+type AgentPromptPair = z.infer<typeof ParsedCreatorYamlSchema>['prompts'];
 
 export interface CreatorConfig {
   workflow: AgentPromptPair;

--- a/src/agent/implementations/flows/reflection/ResponseCycleFlow.ts
+++ b/src/agent/implementations/flows/reflection/ResponseCycleFlow.ts
@@ -262,12 +262,6 @@ class ResponseProcessNode extends BaseNode<
         };
       }
 
-      const common = {
-        stopReason,
-        useStreaming,
-        normalizedUsage,
-      };
-
       const bestConnector =
         await this.services.runScope.session.responseTextProcessing.connectResponseText(
           prepRes.lastResponse.slice(-K_SLICE),
@@ -279,7 +273,9 @@ class ResponseProcessNode extends BaseNode<
       return {
         kind: 'success',
         value: {
-          ...common,
+          stopReason,
+          useStreaming,
+          normalizedUsage,
           hasResponse: true,
           processedResponse,
           bestConnector,
@@ -469,7 +465,7 @@ class ResponseContinuationNode extends BaseNode<
     const continuationLimitExceeded = round.continuationCount > CONTINUE_LIMIT;
     const inputTokenLimitExceeded = totals.totalInputTokens > INPUT_TOKEN_LIMIT;
     const maxOutputTokensExceeded = totals.totalOutputTokens > maxOutputTokens;
-    const shouldEndTurn = END_TURN_REASONS.includes(stopReason ?? '');
+    const shouldEndTurn = END_TURN_REASONS.includes(stopReason);
     const encounterDocumentTag = processedResponse.includes(OUTPUT_END_TAG);
 
     // Warn-only by design: this multiplier has never fed `shouldStop`, it just

--- a/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
@@ -577,32 +577,21 @@ export class ToolUseDispatchNode extends BaseNode<
       result: execResult.extracted.sanitizedResult,
       attachments: execResult.extracted.attachments,
     }));
-    if (
-      toolResults.length > 1 &&
-      modelHandler.requiresBatchedParallelToolResults
-    ) {
+    // One batched message when the handler requires it (see above);
+    // otherwise one message per call. Assistant text rides the first.
+    const batches =
+      toolResults.length > 1 && modelHandler.requiresBatchedParallelToolResults
+        ? [toolResults]
+        : toolResults.map((toolResult) => [toolResult]);
+    for (const [index, batch] of batches.entries()) {
       const followUpMsgs =
         await modelHandler.createBatchedToolUseFollowUpMessages(
-          toolResults,
+          batch,
           workspace,
-          assistantText || undefined,
+          index === 0 ? assistantText || undefined : undefined,
           client,
         );
       shared.messages.push(...followUpMsgs);
-    } else {
-      for (const [
-        index,
-        { call, result, attachments },
-      ] of toolResults.entries()) {
-        const followUpMsgs =
-          await modelHandler.createBatchedToolUseFollowUpMessages(
-            [{ call, result, attachments }],
-            workspace,
-            index === 0 ? assistantText || undefined : undefined,
-            client,
-          );
-        shared.messages.push(...followUpMsgs);
-      }
     }
 
     // Note: userInstruction is already included in the tool_result content

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1228,27 +1228,10 @@ export abstract class ModelHandler<
   }
 
   /**
-   * Shared threshold check for input-token-based compaction, used by handlers
-   * that track a single last-known input-token count. Compaction triggers only
-   * in tool-use mode, on a manual request, or when `inputTokens` exceeds the
-   * configured percentage of the context window.
-   */
-  protected shouldCompactByInputTokens(inputTokens: number): boolean {
-    if (!this.isToolUseMode()) return false;
-    if (this.isCompactionRequested()) return true;
-
-    const thresholdPercent = this.getCompactionThresholdPercent();
-    if (thresholdPercent <= 0) return false;
-
-    const threshold = Math.floor(
-      (thresholdPercent / 100) * this.getEffectiveContextWindow(),
-    );
-    return inputTokens > threshold;
-  }
-
-  /**
    * Runs input-token-driven compaction when the shared threshold policy selects
-   * the current conversation. The trigger, request consumption, and diagnostic
+   * the current conversation. Compaction triggers only in tool-use mode, on a
+   * manual request, or when `inputTokens` exceeds the configured percentage of
+   * the context window. The trigger, request consumption, and diagnostic
    * context stay uniform while each provider retains its SDK-specific summary
    * request and message representation.
    */
@@ -1266,14 +1249,19 @@ export abstract class ModelHandler<
     }
     this.pendingClientCompaction = undefined;
 
-    if (!this.shouldCompactByInputTokens(inputTokens)) {
+    if (!this.isToolUseMode()) {
+      return { compactedMessages: messages, didCompact: false };
+    }
+    const manuallyRequested = this.consumeCompactionRequest();
+    const thresholdPercent = this.getCompactionThresholdPercent();
+    const contextWindow = this.getEffectiveContextWindow();
+    const exceedsThreshold =
+      thresholdPercent > 0 &&
+      inputTokens > Math.floor((thresholdPercent / 100) * contextWindow);
+    if (!manuallyRequested && !exceedsThreshold) {
       return { compactedMessages: messages, didCompact: false };
     }
 
-    const manuallyRequested = this.consumeCompactionRequest();
-
-    const thresholdPercent = this.getCompactionThresholdPercent();
-    const contextWindow = this.getEffectiveContextWindow();
     this.logger.debug(
       manuallyRequested
         ? 'Compacting conversation (manually requested)'
@@ -1728,18 +1716,10 @@ export abstract class ModelHandler<
     );
     const availableTokens = contextWindow - inputTokens;
 
-    if (availableTokens >= maxTokens) {
-      return {
-        adjustedMaxTokens: maxTokens,
-        inputTokens,
-        utilizationPercent,
-      };
-    }
-
-    const adjustedMaxTokens = computeReducedMaxTokens(
-      availableTokens,
-      tokenBuffer,
-    );
+    const adjustedMaxTokens =
+      availableTokens >= maxTokens
+        ? maxTokens
+        : computeReducedMaxTokens(availableTokens, tokenBuffer);
 
     return {
       adjustedMaxTokens,

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -78,10 +78,6 @@ export class MediaAttachmentProcessor {
     return this.options.getCapabilities();
   }
 
-  private get isOpenAIProvider(): boolean {
-    return this.options.isOpenAIProvider();
-  }
-
   private async processImage(
     mediaFile: string,
     ext: string,
@@ -254,7 +250,8 @@ export class MediaAttachmentProcessor {
 
     try {
       // Process as audio or image based on mime type
-      const processed = this.isAudio(fileExtension)
+      const isAudio = getMimeType(fileExtension)?.startsWith('audio/') ?? false;
+      const processed = isAudio
         ? await this.processAudio(absolutePath, fileExtension)
         : await this.processImage(absolutePath, fileExtension);
       this.logger.debug('Processed media', {
@@ -310,7 +307,7 @@ export class MediaAttachmentProcessor {
     if (
       isPdf &&
       processed.mediaType === 'application/pdf' &&
-      this.isOpenAIProvider &&
+      this.options.isOpenAIProvider() &&
       this.capabilities.supportsVision &&
       this.capabilities.supportsNativePdf
     ) {
@@ -378,9 +375,5 @@ export class MediaAttachmentProcessor {
     }
 
     return entry;
-  }
-
-  private isAudio(ext: string): boolean {
-    return getMimeType(ext)?.startsWith('audio/') ?? false;
   }
 }

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -99,9 +99,9 @@ function prependUserText(
 }
 
 function appendText(
-  message: LanguageModelMessage,
+  message: Extract<LanguageModelMessage, { role: 'assistant' }>,
   text: string,
-): LanguageModelMessage {
+): Extract<LanguageModelMessage, { role: 'assistant' }> {
   const content = [...message.content];
   const last = content.at(-1);
   if (last?.kind === 'text') {
@@ -109,7 +109,7 @@ function appendText(
   } else {
     content.push(textPart(text));
   }
-  return { role: message.role, content } as LanguageModelMessage;
+  return { role: 'assistant', content };
 }
 
 /** Fold a system prompt into the first user turn because VS Code has no system role. */

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -207,8 +207,11 @@ export class PersistedFlow<
    * steps served from the self-cache skip the per-transition re-parse.
    */
   private cachedSharedTrusted = false;
-  private nodeIds: Map<BaseNode, string> | null = null;
-  private nodesById: Map<string, BaseNode> | null = null;
+  /** Lazily built graph index; both halves are built and cached together. */
+  private nodeIndexCache: {
+    readonly ids: Map<BaseNode, string>;
+    readonly byId: Map<string, BaseNode>;
+  } | null = null;
 
   /**
    * Optional write-through projection callback.
@@ -431,9 +434,7 @@ export class PersistedFlow<
     readonly ids: Map<BaseNode, string>;
     readonly byId: Map<string, BaseNode>;
   } {
-    if (this.nodeIds && this.nodesById) {
-      return { ids: this.nodeIds, byId: this.nodesById };
-    }
+    if (this.nodeIndexCache) return this.nodeIndexCache;
 
     const ids = new Map<BaseNode, string>();
     const byId = new Map<string, BaseNode>();
@@ -459,9 +460,9 @@ export class PersistedFlow<
       }
     }
 
-    this.nodeIds = ids;
-    this.nodesById = byId;
-    return { ids, byId };
+    const built = { ids, byId };
+    this.nodeIndexCache = built;
+    return built;
   }
 
   /**

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -6,7 +6,6 @@ import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
 import { isRemoteAgent, resolveAgentForLaunch } from '@agent/index';
 import {
-  logSdkError,
   logUserMessage,
   type AgentTrace,
   type StageHandle,
@@ -56,8 +55,6 @@ import {
   INSTRUCTION_ACTION,
   RUN_OUTCOME,
   STREAM_PHASE,
-  STREAM_SUBSTATE,
-  USER_FOLLOW_UP_SUPPORT,
 } from '@shared/schemas';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { createRunTrace, type RunTrace } from '@transcript';
@@ -69,7 +66,6 @@ import { createRunScope } from './RunScope';
 import { mediaNeedsVisionWarning } from './mediaVisionWarning';
 import { getStreamTabId } from './streamTab';
 import type { SessionHandle } from './SessionHandle';
-import type { StreamStatusMachine } from './StreamStatusService';
 import type { SessionHostInteractions } from './HostInteractions';
 import type {
   RuntimePresentationEvent,
@@ -132,15 +128,12 @@ interface AgentLaunchInput {
   toolPolicy?: ToolPolicy;
 }
 
-const STATUS_MESSAGES: Record<string, string> = {
-  [STREAM_SUBSTATE.STARTING]: 'already launching',
-  [STREAM_SUBSTATE.RESUMING]: 'resuming',
-  [STREAM_PHASE.RUNNING]: 'already running',
-  [STREAM_PHASE.WAITING]: 'waiting for retry',
-  [STREAM_PHASE.COMPLETED]: 'completed',
-  [STREAM_PHASE.CANCELLED]: 'stopped',
-  [STREAM_PHASE.FAILED]: 'failed',
-};
+/** Fail the effect with an `Error` when the launch signal has aborted. */
+const failIfAborted = (signal: AbortSignal | undefined) =>
+  Effect.try({
+    try: () => signal?.throwIfAborted(),
+    catch: ensureError,
+  });
 
 export function withExecutionRunContext<T>(
   ctx: AgentLaunchContext,
@@ -309,10 +302,7 @@ export const prepareAgentDefinition = Effect.fn('prepareAgentDefinition')(
       suppressErrorNotification?: boolean;
     } & { session: SessionHandle },
   ) {
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
+    yield* failIfAborted(input.signal);
     const fullConfig = input.config;
     const interactions = input.session.interactions;
     // Resolve by the source the delegation captured at validation time, so launch
@@ -331,10 +321,7 @@ export const prepareAgentDefinition = Effect.fn('prepareAgentDefinition')(
         ),
       catch: ensureError,
     });
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
+    yield* failIfAborted(input.signal);
     // `loadAgentSettingAndPrompts` already fills the built-in tool-use category
     // default before parsing, and `AgentSettingSchema` prefaults `agentCategory`
     // (to Workflow when absent), so `setting.agentCategory` is always populated
@@ -346,10 +333,7 @@ export const prepareAgentDefinition = Effect.fn('prepareAgentDefinition')(
         ),
       catch: ensureError,
     });
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
+    yield* failIfAborted(input.signal);
 
     // Block category mismatch: prevent launching a tool-use agent as a workflow
     // (or vice versa). Source-pinned resolution already guarantees launch lands on
@@ -398,24 +382,17 @@ const assembleAgentLaunchContext = Effect.fn('assembleAgentLaunchContext')(
     streamId: StreamTabId,
     resources: Array<() => void | Promise<void>>,
   ): Effect.fn.Return<AgentLaunchContext, Error> {
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
+    yield* failIfAborted(input.signal);
     const { config, setting, prompt, resolution } = input.definition;
-    const fullConfig = config;
     const interactions = input.session.interactions;
     const modelConfig = yield* Effect.tryPromise({
       try: async () =>
         runInSession(input.session, () =>
-          validateModelExists(fullConfig.model, interactions),
+          validateModelExists(config.model, interactions),
         ),
       catch: ensureError,
     });
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
+    yield* failIfAborted(input.signal);
 
     // The session is resolved once at the boundary (buildAgentLaunchContext)
     // and carried in, so a delegated launch inherits the parent run's session
@@ -424,10 +401,7 @@ const assembleAgentLaunchContext = Effect.fn('assembleAgentLaunchContext')(
     const modelHandlerCompatibilityKey =
       input.modelHandlerCompatibilityKey ??
       (yield* inferLaunchModelHandlerCompatibilityKey(executionId, session));
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
+    yield* failIfAborted(input.signal);
     const modelHandler = yield* Effect.tryPromise({
       try: async () =>
         runInSession(session, () =>
@@ -446,10 +420,7 @@ const assembleAgentLaunchContext = Effect.fn('assembleAgentLaunchContext')(
       catch: ensureError,
     });
     resources.push(() => modelHandler.dispose());
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
+    yield* failIfAborted(input.signal);
     const modelCell = new ModelCell(modelHandler, config.model);
 
     const residency = yield* session.transcripts.acquireRunResidency(
@@ -471,21 +442,15 @@ const assembleAgentLaunchContext = Effect.fn('assembleAgentLaunchContext')(
       },
     };
     resources.push(() => runTrace.dispose());
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
+    yield* failIfAborted(input.signal);
     attachment.detach = session.attachRunTrace(rawRunTrace.trace, streamId);
 
     const agentLogger = runTrace.trace;
     modelHandler.setAgentCategory(setting.agentCategory);
     modelHandler.setLogger(agentLogger);
 
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
-    const isRemote = isRemoteAgent(fullConfig.agent);
+    yield* failIfAborted(input.signal);
+    const isRemote = isRemoteAgent(config.agent);
     // Registration committed creation, configuration and initial activation.
     // A resumed turn appends only its new activation.
     const background = input.isSubagent ?? false;
@@ -536,7 +501,7 @@ const assembleAgentLaunchContext = Effect.fn('assembleAgentLaunchContext')(
       config.mediaFiles,
       modelHandler.capabilities,
       'attached',
-      fullConfig.model,
+      config.model,
     );
     if (visionWarning) agentLogger.warn(visionWarning);
 
@@ -559,7 +524,7 @@ const assembleAgentLaunchContext = Effect.fn('assembleAgentLaunchContext')(
       executionId,
       agentName: config.agent,
       workingDirectory,
-      delegationAgentScope: fullConfig.delegationAgentScope,
+      delegationAgentScope: config.delegationAgentScope,
       session,
       signal: runSignal,
     });
@@ -587,10 +552,7 @@ const assembleAgentLaunchContext = Effect.fn('assembleAgentLaunchContext')(
         ),
       catch: ensureError,
     });
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
+    yield* failIfAborted(input.signal);
 
     const userVarChannels: UserVariableChannels = { ...baseVars };
     const attachedMemoryMisses = baseVars.ATTACHED_MEMORY_MISSES;
@@ -636,10 +598,7 @@ const assembleAgentLaunchContext = Effect.fn('assembleAgentLaunchContext')(
 /** Resolve the context of a run already admitted and created by registration. */
 export const buildAgentLaunchContext = Effect.fn('buildAgentLaunchContext')(
   function* (input: AgentLaunchInput & { session: SessionHandle }) {
-    yield* Effect.try({
-      try: () => input.signal?.throwIfAborted(),
-      catch: ensureError,
-    });
+    yield* failIfAborted(input.signal);
     const { session: launchSession, executionId } = input;
     const { config } = input.definition;
     const streamStatus = launchSession.status;

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -33,7 +33,6 @@ import type {
 import {
   agentName as baseAgentName,
   RUN_OUTCOME,
-  STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
   toRetryErrorInfo,
 } from '@shared/schemas';

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -68,6 +68,7 @@ import {
 import {
   aggregateId as qualifyAggregateId,
   aggregateTarget,
+  interruptedWorkflowCall,
   isTranscriptEvent,
   RUN_OUTCOME,
   STREAM_PHASE,
@@ -80,7 +81,6 @@ import {
   type StreamPhase,
   type TranscriptSubscription,
 } from '@shared/schemas';
-import { interruptedWorkflowCall } from '@shared/schemas';
 import type { SessionView } from '@shared/session/sessionView';
 import type { SessionEventsShape } from '@shared/session/sessionEvents';
 import {
@@ -256,8 +256,7 @@ export class SessionHandle {
   ) {
     // Forced dependency order, every cross-reference explicit — never let a
     // member fall back to a neighboring module singleton (silent-state-split).
-    const transcripts = init.transcripts;
-    this.transcripts = transcripts;
+    this.transcripts = init.transcripts;
     this.roots = init.roots;
     const graph = init.graph(this);
     this.graph = graph;
@@ -272,7 +271,7 @@ export class SessionHandle {
       (event) => this.publishStatus(event),
       (streamId, detail) => this.setUnreadable(streamId, detail),
     );
-    const followUps = new ToolUseFollowUpQueue();
+    this.followUps = new ToolUseFollowUpQueue();
     const interactions = new SessionHostInteractions(this);
     // The approval authority publishes a stream's full policy snapshot on
     // every effective bypass change; `setApprovalPolicy` below publishes the
@@ -280,7 +279,7 @@ export class SessionHandle {
     const approvals = createSessionApprovals(interactions, (streamId) =>
       this.publishApprovalPolicy(streamId),
     );
-    const executions = new ExecutionRegistry({
+    this.executions = new ExecutionRegistry({
       streamStatus: status,
       publish: (events) => this.publish(events),
       approvals,
@@ -290,9 +289,7 @@ export class SessionHandle {
         this.releaseExecutionLease(executionId),
     });
 
-    this.executions = executions;
     this.status = status;
-    this.followUps = followUps;
     // The sidecar store is a session artifact exactly like `transcripts`: the
     // session projects its own run events into it and flushes it below, so no
     // host has to construct, attach, and flush one of its own.
@@ -494,10 +491,11 @@ export class SessionHandle {
   }
 
   private async flushArtifactsOnce(): Promise<void> {
-    const writers = this.artifactFlushers;
     const results = await Promise.allSettled([
       this.settlePublications(),
-      ...[...writers].map((flush) => Promise.resolve().then(flush)),
+      ...[...this.artifactFlushers].map((flush) =>
+        Promise.resolve().then(flush),
+      ),
     ]);
     const failures = results.flatMap((result) =>
       result.status === 'rejected' ? [result.reason] : [],

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -31,8 +31,7 @@ import {
   type ExecutionId,
   type ExecutionMeta,
 } from '@shared/schemas';
-import { ensureError } from '@utils/errors/errorMessage';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 
 import { ResultMetaSchema, type ResultMeta } from './resultMeta';
 import { runWithExecutionLeaseWriteFence } from './executionLease';
@@ -154,30 +153,22 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   // -- Typed readers --------------------------------------------------------
 
   /**
-   * Read a key and validate it against a schema, returning the parsed value
-   * or `null` when the key is absent. These readers are permissive: malformed
-   * turn-state data warns and also reads as `null`, preserving the existing
-   * turn-state policy. Canonical execution metadata uses the strict event accessor.
+   * Permissive read: a missing or malformed turn-state entry resolves to
+   * `null`, with malformed data leaving a warn trace. Canonical execution
+   * metadata uses the strict event accessor.
    */
-  private async readValidated<T>(
-    key: string,
-    schema: z.ZodType<T>,
-  ): Promise<T | null> {
-    const raw = await this.read(key);
+  async readTurnState(): Promise<ChildTurnState | null> {
+    const raw = await this.read(KEYS.TURN_STATE);
     if (raw === undefined) return null;
-    const result = schema.safeParse(raw);
+    const result = ChildTurnStateSchema.safeParse(raw);
     if (result.success) return result.data;
     log.warn(
-      `Failed to parse execution ${this.executionId} ${key}.json: ${toErrorMessage(
+      `Failed to parse execution ${this.executionId} ${KEYS.TURN_STATE}.json: ${toErrorMessage(
         result.error,
       )}`,
       { data: result.error },
     );
     return null;
-  }
-
-  async readTurnState(): Promise<ChildTurnState | null> {
-    return this.readValidated(KEYS.TURN_STATE, ChildTurnStateSchema);
   }
 
   async writeTurnState(state: ChildTurnState): Promise<void> {
@@ -191,54 +182,48 @@ export function executionMetaFromEvents(
   executionId: ExecutionId,
 ): ExecutionMeta | null {
   const id = aggregateId('execution', executionId);
-  const startOf = (rows: readonly SessionEvent[]) =>
-    rows.find(
-      (row): row is Extract<SessionEvent, { type: 'run.start' }> =>
-        row.type === 'run.start' && row.executionId === executionId,
-    );
-  const metaOf = (rows: readonly SessionEvent[]): ExecutionMeta | null => {
-    const start = startOf(rows);
-    if (
-      !start ||
-      rows.some(
-        (row) =>
-          row.aggregateId === start.aggregateId &&
-          row.type === 'stream.removed',
-      )
+  const start = rows.find(
+    (row): row is Extract<SessionEvent, { type: 'run.start' }> =>
+      row.type === 'run.start' && row.executionId === executionId,
+  );
+  if (
+    !start ||
+    rows.some(
+      (row) =>
+        row.aggregateId === start.aggregateId && row.type === 'stream.removed',
     )
-      return null;
-    const status = rows.findLast(
-      (row) => row.aggregateId === start.aggregateId && row.type === 'status',
-    );
-    const description = rows.findLast(
-      (row) => row.aggregateId === id && row.type === 'execution.description',
-    );
-    const workflow = rows.findLast(
-      (row) => row.aggregateId === id && row.type === 'execution.workflow',
-    );
-    return ExecutionMetaSchema.parse({
-      schemaVersion: EXECUTION_META_SCHEMA_VERSION,
-      timestamp: new Date(start.at).toISOString(),
-      streamId: aggregateTarget(start.aggregateId).id,
-      identity: start.identity ?? undefined,
-      userFollowUpSupport: start.userFollowUpSupport,
-      parentExecutionId: start.parentExecutionId,
-      outcome:
-        status?.type === 'status' &&
-        (status.phase === RUN_OUTCOME.COMPLETED ||
-          status.phase === RUN_OUTCOME.CANCELLED ||
-          status.phase === RUN_OUTCOME.FAILED)
-          ? status.phase
-          : undefined,
-      description:
-        description?.type === 'execution.description'
-          ? description.description
-          : undefined,
-      workflow:
-        workflow?.type === 'execution.workflow' ? workflow.workflow : undefined,
-    });
-  };
-  return metaOf(rows);
+  )
+    return null;
+  const status = rows.findLast(
+    (row) => row.aggregateId === start.aggregateId && row.type === 'status',
+  );
+  const description = rows.findLast(
+    (row) => row.aggregateId === id && row.type === 'execution.description',
+  );
+  const workflow = rows.findLast(
+    (row) => row.aggregateId === id && row.type === 'execution.workflow',
+  );
+  return ExecutionMetaSchema.parse({
+    schemaVersion: EXECUTION_META_SCHEMA_VERSION,
+    timestamp: new Date(start.at).toISOString(),
+    streamId: aggregateTarget(start.aggregateId).id,
+    identity: start.identity ?? undefined,
+    userFollowUpSupport: start.userFollowUpSupport,
+    parentExecutionId: start.parentExecutionId,
+    outcome:
+      status?.type === 'status' &&
+      (status.phase === RUN_OUTCOME.COMPLETED ||
+        status.phase === RUN_OUTCOME.CANCELLED ||
+        status.phase === RUN_OUTCOME.FAILED)
+        ? status.phase
+        : undefined,
+    description:
+      description?.type === 'execution.description'
+        ? description.description
+        : undefined,
+    workflow:
+      workflow?.type === 'execution.workflow' ? workflow.workflow : undefined,
+  });
 }
 
 /** Read the current configuration from the same committed prefix as metadata. */

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -138,13 +138,13 @@ function ownershipKey(root: string, executionId: ExecutionId): string {
   return `${root}\0${executionId}`;
 }
 
-function leaseDir(root: string): string {
-  return path.join(root, WORKSPACE_STORAGE_LAYOUT.executionLeases);
-}
-
 function claimDir(root: string, executionId: ExecutionId): string {
   const safeExecutionId = LeaseExecutionIdSchema.parse(executionId);
-  return path.join(leaseDir(root), safeExecutionId);
+  return path.join(
+    root,
+    WORKSPACE_STORAGE_LAYOUT.executionLeases,
+    safeExecutionId,
+  );
 }
 
 function claimPath(root: string, executionId: ExecutionId, ownerToken: string) {

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -17,8 +17,6 @@ import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { runInSession } from '@agent/runtime/RunContext';
 import { flowKey } from '@agent/node/persistedFlow';
 
-import { createLog } from '@logger/logUtils';
-import { type WorkspaceRoots } from '@platform/workspaceRoots';
 import {
   RUN_OUTCOME,
   AgentCategory,
@@ -30,17 +28,14 @@ import {
   USER_FOLLOW_UP_SUPPORT,
   type AggregateId,
   type ExecutionId,
-  type ExecutionMeta,
   type RunIdentity,
   type RunOutcome,
   type StreamTabId,
   type UserFollowUpSupport,
 } from '@shared/schemas';
-import { KeyedMutex } from '@utils/core';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { launchWorktreeInfo } from '@utils/git/worktreeInfo';
-import { ensureError } from '@utils/errors/errorMessage';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import {
   getExecutionStore,
   getExecutionRecords,
@@ -52,8 +47,6 @@ import {
   acquireResumedExecutionLease,
   releaseOwnedExecutionLease,
 } from './executionLease';
-
-const log = createLog('ExecutionLifecycle');
 
 function pinExecutionWorkingDirectory(record: RunRecord): RunRecord {
   // First non-blank candidate wins, stored verbatim (untrimmed) — trimming

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -553,17 +553,13 @@ export async function runWorkflowScript(
     ) {
       recoverySource = { implicitIndex: prior.index, journalProven: true };
     }
-    if (
-      callOptions.phase !== undefined &&
-      executionState.currentPhaseIndex === -1
-    ) {
-      try {
-        executionState.enterStage(callOptions.phase);
-      } catch (error) {
-        throw contractFault(error);
-      }
-    }
     try {
+      if (
+        callOptions.phase !== undefined &&
+        executionState.currentPhaseIndex === -1
+      ) {
+        executionState.enterStage(callOptions.phase);
+      }
       executionState.issueCall(
         {
           id: progressId,

--- a/src/auth/supabaseSessionTypes.ts
+++ b/src/auth/supabaseSessionTypes.ts
@@ -11,7 +11,7 @@ const SupabaseSessionSchema = z.object({
   refreshToken: z.string(),
   account: z.object({
     id: z.string(),
-    label: z.string().transform((label) => label.trim()),
+    label: z.string().trim(),
   }),
   expiresAt: z.number(),
 });
@@ -104,7 +104,6 @@ type StorableSessionInput = {
   refresh_token: string;
   expires_at?: number;
   expires_in?: number;
-  token_type?: string;
   user: {
     id: string;
     email?: string | null;

--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -23,14 +23,14 @@ export function errorBodyCandidates(
  *  loosely-typed provider JSON. */
 export function pickStringField(v: unknown, key: string): string | undefined {
   if (!isObject(v)) return undefined;
-  const value = (v as Record<string, unknown>)[key];
+  const value = v[key];
   return isNonEmptyString(value) ? value : undefined;
 }
 
 /** Pick a finite-number field off an error-body object. See {@link pickStringField}. */
 export function pickNumberField(v: unknown, key: string): number | undefined {
   if (!isObject(v)) return undefined;
-  const value = (v as Record<string, unknown>)[key];
+  const value = v[key];
   return typeof value === 'number' && Number.isFinite(value)
     ? value
     : undefined;

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -36,10 +36,6 @@ interface ProgressApiKeyRetryRequest {
   chatGptSubscriptionEligible?: boolean;
 }
 
-interface ProgressApiRoutingSnapshot {
-  readonly quotaRoutes: ReadonlyMap<ExhaustionReason, boolean>;
-}
-
 export interface ProgressApiKeyRetryControllerDeps {
   providers: readonly ApiProvider[];
   readKey(
@@ -203,7 +199,12 @@ export class ProgressApiKeyRetryController {
     if (!this.deps.isRetryPending(request.stream, request.requestId)) {
       return false;
     }
-    const before = this.routingSnapshot();
+    const before = new Map(
+      this.fallbackRuntimes.map(
+        (runtime) =>
+          [runtime.descriptor.exhaustionReason, runtime.getEnabled()] as const,
+      ),
+    );
     // One chain: turn off every matching quota-fallback preference so the
     // retry rebuilds onto the fallback credential. Remark: prefer-off sticks
     // after the quota resets — users may forget to re-enable it.
@@ -230,7 +231,7 @@ export class ProgressApiKeyRetryController {
         Exit.isSuccess(exit) && exit.value === true
           ? Effect.void
           : hostPort(() =>
-              runtime.restoreEnabled(before.quotaRoutes.get(reason) ?? false),
+              runtime.restoreEnabled(before.get(reason) ?? false),
             ).pipe(
               Effect.tapError((error) =>
                 Effect.sync(() => {
@@ -311,17 +312,6 @@ export class ProgressApiKeyRetryController {
     // override travels only with the replacement launch; the standing
     // preference remains visible to concurrent and future runs.
     return this.commitOwnApiKeyRouting(request, () => start('direct'));
-  }
-
-  private routingSnapshot(): ProgressApiRoutingSnapshot {
-    return {
-      quotaRoutes: new Map(
-        this.fallbackRuntimes.map((runtime) => [
-          runtime.descriptor.exhaustionReason,
-          runtime.getEnabled(),
-        ]),
-      ),
-    };
   }
 
   private hasAnyUsableKey(

--- a/src/controllers/session/Database.ts
+++ b/src/controllers/session/Database.ts
@@ -53,7 +53,6 @@ import {
   listingTypeOf,
   referencedAggregates,
   type AggregateId,
-  type CommitOrdinal,
   type ExecutionId,
   type SessionEvent,
   type SessionEventDraft,
@@ -264,8 +263,6 @@ export const databaseLayer = (
         observedCommit,
         yield* currentCommit.pipe(mapDatabaseFailure(openFailed)),
       );
-      const listing = READ_LISTING;
-      const state = READ_STATE;
       const dependents = `WITH RECURSIVE dependents(aggregate_id) AS (
         SELECT aggregate_id FROM event_sequence WHERE aggregate_id = ?
         UNION ALL
@@ -480,7 +477,7 @@ export const databaseLayer = (
           AND closed = 0 LIMIT 1`;
       const readState = (ids: readonly AggregateId[]) =>
         Effect.gen(function* () {
-          return (yield* sql.unsafe<Record<string, unknown>>(state, [
+          return (yield* sql.unsafe<Record<string, unknown>>(READ_STATE, [
             JSON.stringify(ids),
           ])).map((row) => AggregateStateSchema.parse(row));
         });
@@ -811,7 +808,7 @@ export const databaseLayer = (
         readListing: () =>
           query(
             Effect.gen(function* () {
-              return (yield* sql.unsafe<Record<string, unknown>>(listing, [
+              return (yield* sql.unsafe<Record<string, unknown>>(READ_LISTING, [
                 JSON.stringify(LISTING_TYPES),
               ])).map(decodeEvent);
             }),
@@ -933,12 +930,7 @@ export const databaseLayer = (
               ])).map(decodeEvent);
             }),
           ),
-        aggregateState: (ids) =>
-          query(
-            Effect.gen(function* () {
-              return yield* readState(ids);
-            }),
-          ),
+        aggregateState: (ids) => query(readState(ids)),
         readInputBatch: (ids, fromCommit, checkedIds = ids) =>
           transaction(
             'read',
@@ -973,11 +965,7 @@ export const databaseLayer = (
         acquireClaims: (ids) =>
           Effect.gen(function* () {
             if (ids.length === 0) return [];
-            const observed = yield* query(
-              Effect.gen(function* () {
-                return yield* readState(ids);
-              }),
-            );
+            const observed = yield* query(readState(ids));
             if (
               observed.length !== new Set(ids).size ||
               observed.some((row) => row.closed)
@@ -1016,9 +1004,7 @@ export const databaseLayer = (
             });
             const observed = yield* transaction(
               'read',
-              Effect.gen(function* () {
-                return yield* readDependents(id);
-              }),
+              readDependents(id),
               readFailed,
             );
             if (observed.length === 0 || observed.some((row) => row.closed)) {
@@ -1202,11 +1188,7 @@ export const databaseLayer = (
               catch: writeFailed,
             });
             const at = yield* Clock.currentTimeMillis;
-            return yield* transact(
-              Effect.gen(function* () {
-                return yield* appendPrepared(prepared, at);
-              }),
-            );
+            return yield* transact(appendPrepared(prepared, at));
           }),
       };
     }),

--- a/src/controllers/session/SessionRequests.ts
+++ b/src/controllers/session/SessionRequests.ts
@@ -186,8 +186,7 @@ function deleteAdmittedStream(
 ): Effect.Effect<Outcome, RequestError> {
   const aggregateId = qualifyAggregateId('stream', streamId);
   return Effect.gen(function* () {
-    const row = admitted;
-    if (row.startCommit === null) {
+    if (admitted.startCommit === null) {
       return yield* Effect.fail(
         new Unavailable({
           streamId: streamId,
@@ -196,7 +195,7 @@ function deleteAdmittedStream(
       );
     }
     const [start] = yield* log
-      .readAll(row.startCommit - 1, row.startCommit)
+      .readAll(admitted.startCommit - 1, admitted.startCommit)
       .pipe(Effect.orDie);
     if (start?.type !== 'run.start' || start.aggregateId !== aggregateId) {
       return yield* Effect.fail(

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -62,7 +62,6 @@ import {
   type OwnerId,
   type SessionCloseReport,
   type SessionEvent,
-  type StreamTabId,
 } from '@shared/schemas';
 import { InquiryRecords } from '@shared/session/inquiryRecords';
 import { ProcessIdentity, SessionEvents } from '@shared/session/sessionEvents';

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -174,10 +174,6 @@ export function resolveArxivPaperDirectoryRelative(
  * @returns The normalized arXiv ID, or null if extraction fails
  */
 function normalizeArxivInput(input: string): string | null {
-  if (!input) {
-    return null;
-  }
-
   return normaliseArxivIdentifier(input.trim());
 }
 

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
@@ -1261,7 +1261,7 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
 
   it('B10: background (workflow) and input-token compaction (tool-use) are mutually exclusive', async () => {
     // Background eligibility is workflow-only (isBackgroundModeEligible ===
-    // isWorkflowMode), while input-token compaction (shouldCompactByInputTokens)
+    // isWorkflowMode), while input-token compaction (maybeCompactByInputTokens)
     // fires only in tool-use mode. So a TOOL-USE handler with both toggles on
     // does NOT use background: it takes the non-background path and compaction
     // composes there exactly as in the chaining suite. This documents that

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -158,7 +158,7 @@ Parameters map directly to subagent-result delivery attributes:
           try: prepareFiles,
           catch: (error) => error,
         });
-      }).pipe(Effect.catch((error) => Effect.die(error))),
+      }).pipe(Effect.orDie),
     );
   }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -292,7 +292,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         case 'kill':
           return yield* this.handleKill(context, executionId);
         case 'wait':
-          yield* this.waitForChange(context, executionId, input.timeout);
+          yield* this.waitForAnyChange(context, input.timeout, [executionId]);
           return yield* this.showSummary(context, executionId, {
             suppressAutoDeliveredSubagentReport: true,
           });
@@ -423,20 +423,6 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       pendingIds.every((id) => context.inRunScope(() => shouldSkipWait(id))),
     );
   });
-
-  /** Wait for a specific execution to change status, with timeout. */
-  private readonly waitForChange = Effect.fn('ExecutionsTool.waitForChange')(
-    function* (
-      context: ExecutionToolContext,
-      executionId: ExecutionId,
-      timeout: number,
-    ) {
-      if (context.inRunScope(() => shouldSkipWait(executionId))) return;
-      yield* awaitStatusChange(context, timeout, [executionId], () =>
-        context.inRunScope(() => shouldSkipWait(executionId)),
-      );
-    },
-  );
 
   private readonly listExecutions = Effect.fn('ExecutionsTool.listExecutions')(
     function* (context: ExecutionToolContext, offset: number, limit: number) {

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -60,7 +60,7 @@ import type {
 
 /** Session-keyed registry accessor (`codexThreadsFor`/`claudeAgentSessionsFor`);
  * dispatch and loop resolve it once against the ambient session. */
-export type AgentCliSessionStoreAccessor = (
+type AgentCliSessionStoreAccessor = (
   session: SessionHandle,
 ) => AgentCliSessionRegistry;
 
@@ -71,7 +71,7 @@ export type AgentCliSessionStoreAccessor = (
  * the cause itself, so the tool runner surfaces the same error instance the
  * collaborator raised, exactly as the previous `await` chain did.
  */
-export class AgentCliCallFailed extends Data.TaggedError('AgentCliCallFailed')<{
+class AgentCliCallFailed extends Data.TaggedError('AgentCliCallFailed')<{
   readonly cause: unknown;
 }> {}
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -17,7 +17,6 @@ import {
 import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
 import {
   getRunContextExecutionId,
-  runInSession,
   getRunContextWorkingDirectory,
 } from '@agent/runtime/RunContext';
 import {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -49,7 +49,6 @@ import {
   ClaudeAgentEffortSchema,
   ClaudeAgentPermissionModeSchema,
   MESSAGE_TYPES,
-  ToolError,
 } from '@shared/schemas';
 import type {
   ClaudeAgentEffort,

--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -11,7 +11,6 @@ import {
 import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { getStreamTabId } from '@agent/runtime/streamTab';
-import { runInSession } from '@agent/runtime/RunContext';
 import { classifyAgentError } from '@common/errors';
 import {
   aggregateId as qualifyAggregateId,

--- a/src/tools/delegation/stableSubagentAttempt.ts
+++ b/src/tools/delegation/stableSubagentAttempt.ts
@@ -106,18 +106,6 @@ export async function writeStableSubagentAttempt(
   );
 }
 
-function reservedStableSubagentAttempt(
-  logicalExecutionId: ExecutionId,
-  parentExecutionId: ExecutionId,
-): StableSubagentAttempt {
-  return {
-    schemaVersion: STABLE_SUBAGENT_STATE_SCHEMA_VERSION,
-    logicalExecutionId,
-    parentExecutionId,
-    phase: 'reserved',
-  };
-}
-
 /**
  * The existing physical-attempt protocol, including its recovery restrictions.
  * Reservation, reconciliation and commit operate on the same persisted keys;
@@ -482,10 +470,12 @@ export const reserveStableAttempt = Effect.fn('reserveStableAttempt')(
         ),
       );
     }
-    const attempt = reservedStableSubagentAttempt(
-      options.executionId,
-      options.parentExecutionId,
-    );
+    const attempt: StableSubagentAttempt = {
+      schemaVersion: STABLE_SUBAGENT_STATE_SCHEMA_VERSION,
+      logicalExecutionId: options.executionId,
+      parentExecutionId: options.parentExecutionId,
+      phase: 'reserved',
+    };
     if (candidateInspection.kind === 'absent')
       yield* stableStorageOperation(session, () =>
         writeStableSubagentAttempt(getExecutionStore(executionId), attempt),

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -6,7 +6,6 @@ import { getExecutionRecords } from '@agent/storage';
 import {
   WorkflowRunAbortError,
   type WorkflowAgentInvocation,
-  type WorkflowScriptRunOptions,
 } from '@agent/workflowScript';
 import type { AgentEntry } from '@agent/index/agentEntry';
 import { runInSession, type LaunchRunContext } from '@agent/runtime/RunContext';
@@ -73,9 +72,7 @@ interface WorkflowRunIdentity {
 
 /**
  * Resolve what one issued `agent()` call actually runs; agent, model, result
- * contract, and files; from the options the script declared. One owner for
- * both the launch (`prepare`) and the per-call review a host shows before
- * admitting the call, so the card the user approves is the config that runs.
+ * contract, and files; from the options the script declared.
  */
 const resolveWorkflowCallConfig = Effect.fn('resolveWorkflowCallConfig')(
   function* (

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -218,7 +218,7 @@ export function formatTodoSection(todos: readonly TodoItem[]): string[] {
 
 /** Format a todo header with counts. */
 export function formatTodoHeader(
-  executionId: string,
+  executionId: ExecutionId,
   todos: readonly TodoItem[],
 ): string {
   const { completed, inProgress, pending } = countByStatus(todos);
@@ -257,14 +257,10 @@ export function shouldSuppressAutoDeliveredSubagentReport(
 /** Format a single child execution as a summary line. */
 export const formatChildLine = Effect.fn('formatChildLine')(function* (
   child: ChildRecord,
-  childMeta: ExecutionMeta | null | undefined,
+  childMeta: ExecutionMeta | null,
   session: SessionHandle,
 ) {
-  const info = yield* getExecutionStatusInfo(
-    child.id,
-    session,
-    childMeta ?? null,
-  );
+  const info = yield* getExecutionStatusInfo(child.id, session, childMeta);
   const ts = formatTimestamp(child.timestamp);
   const desc = childMeta?.description ? `: ${childMeta.description}` : '';
   return `${child.id}  ${ts}  ${child.agent}  [${formatStatusInfo(info)}]${desc}`;

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -814,17 +814,19 @@ export class PRPollingSource extends PollingSourceBase<
       SharedAnnotationFetchBudget,
       now,
     ).pipe(
-      Effect.catchCause((cause) =>
-        Effect.failCause(
-          Cause.map(cause, (error) => new PollHookRejected({ cause: error })),
-        ),
-      ),
       Effect.map((annotations) => ({ ok: true as const, annotations })),
       Effect.catchCause((cause) => {
+        // Recover only a single typed failure, unwrapped — the caller
+        // classifies `.cause` directly. Anything else (interrupts, compound
+        // failures) re-raises on the PollHookRejected channel this hook
+        // reports.
         const reason = cause.reasons[0];
-        return cause.reasons.length === 1 && reason?._tag === 'Fail'
-          ? Effect.succeed({ ok: false as const, failure: reason.error })
-          : Effect.failCause(cause);
+        if (cause.reasons.length === 1 && reason?._tag === 'Fail') {
+          return Effect.succeed({ ok: false as const, failure: reason.error });
+        }
+        return Effect.failCause(
+          Cause.map(cause, (error) => new PollHookRejected({ cause: error })),
+        );
       }),
     );
     if (fetched.ok) {
@@ -834,10 +836,11 @@ export class PRPollingSource extends PollingSourceBase<
       }
       return true;
     }
-    const { failure } = fetched;
-    const err = failure.cause;
+    const err = fetched.failure;
     if (err instanceof AnnotationFetchBudgetExhaustedError) return false;
-    if (err instanceof GitHubRateLimitError) return yield* Effect.fail(failure);
+    if (err instanceof GitHubRateLimitError) {
+      return yield* Effect.fail(new PollHookRejected({ cause: err }));
+    }
     if (err instanceof GitHubPermanentError || err instanceof GitHubAuthError) {
       const reason =
         err instanceof GitHubAuthError ? 'forbidden' : 'unavailable';

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -120,7 +120,7 @@ async function addToIndex(streamId: StreamTabId): Promise<void> {
 /**
  * Mutate callbacks must return the same array reference (`index`, unchanged)
  * when nothing actually changed, so this can skip the write via reference
- * equality — all current callers (`addToIndex` and `forgetMany`'s inline
+ * equality — all current callers (`addToIndex` and `removeRecords`' inline
  * callback) already follow this contract.
  */
 async function mutateIndex(

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -246,32 +246,31 @@ export class ExternalInquiryTool extends defineTool({
     switch (input.command) {
       case 'ask':
         requireInteractions('inquiry', context);
-        operation = this.executeAsk({
+        operation = this.executeAsk(
           input,
           streamId,
           executionId,
-          session: currentSession(),
-        });
+          currentSession(),
+        );
         break;
       case 'read':
         operation = this.executeRead(input);
         break;
       case 'list':
-        operation = this.executeList({ input, streamId });
+        operation = this.executeList(input, streamId);
         break;
     }
     return effectRuntime().runPromise(operation, { signal });
   }
 
-  private executeAsk(args: {
-    input: Extract<InquiryInput, { command: 'ask' }>;
-    streamId: StreamTabId | undefined;
-    executionId?: ExecutionId;
-    session: SessionHandle;
-  }): Effect.Effect<ToolResult, Error, InquiryRecords> {
+  private executeAsk(
+    input: Extract<InquiryInput, { command: 'ask' }>,
+    streamId: StreamTabId | undefined,
+    executionId: ExecutionId | undefined,
+    session: SessionHandle,
+  ): Effect.Effect<ToolResult, Error, InquiryRecords> {
     return Effect.gen(function* () {
       const records = yield* InquiryRecords;
-      const { input, streamId, executionId, session } = args;
       if (!streamId) {
         return yield* Effect.fail(
           new ToolError(
@@ -365,13 +364,12 @@ export class ExternalInquiryTool extends defineTool({
     });
   }
 
-  private executeList(args: {
-    input: Extract<InquiryInput, { command: 'list' }>;
-    streamId: StreamTabId | undefined;
-  }): Effect.Effect<ToolResult, Error, InquiryRecords> {
+  private executeList(
+    input: Extract<InquiryInput, { command: 'list' }>,
+    streamId: StreamTabId | undefined,
+  ): Effect.Effect<ToolResult, Error, InquiryRecords> {
     return Effect.gen(function* () {
       const records = yield* InquiryRecords;
-      const { input, streamId } = args;
       if (input.scope === 'stream' && !streamId) {
         return yield* Effect.fail(
           new ToolError(

--- a/src/tools/lean/direct/leanServerPool.ts
+++ b/src/tools/lean/direct/leanServerPool.ts
@@ -30,7 +30,6 @@ import {
   RcMap,
   Ref,
   Result,
-  type Scope,
 } from 'effect';
 
 import { warn } from '@logger/logUtils';

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -16,7 +16,7 @@ import { Data, Effect, Semaphore, Stream } from 'effect';
 
 import { debug } from '@logger/logUtils';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
-import type { MemoryPreview, MemoryViewItem } from '@shared/schemas';
+import type { MemoryViewItem } from '@shared/schemas';
 import {
   MAX_PINNED_MEMORIES,
   MAX_PREVIEW_LINES,
@@ -241,13 +241,12 @@ function walkLevel(
   options: MemoryWalkOptions,
   permits: Semaphore.Semaphore,
 ): Stream.Stream<MemoryWalkEntry, MemoryEntryUnreadable> {
-  return Stream.fromEffect(
+  return Stream.fromIterableEffect(
     Effect.tryPromise({
       try: () => StorageFS.readDir(storagePath),
       catch: (cause) => new MemoryEntryUnreadable({ storagePath, cause }),
     }),
   ).pipe(
-    Stream.flatMap(Stream.fromIterable),
     // Skip symlinks to avoid cycles; we have no realpath/visited guard.
     Stream.filter(([name, type]) => !shouldSkipEntry(name) && !isSymlink(type)),
     Stream.mapEffect(

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -265,7 +265,7 @@ function workToZoteroItem(doi: string, work: Work): ZoteroConnectorItem {
     DOI: doi,
   };
   if (work.title?.[0]) item.title = work.title[0];
-  if (creators?.length) item.creators = creators;
+  if (creators) item.creators = creators;
   if (year != null) item.date = String(year);
   if (containerTitle) item.publicationTitle = containerTitle;
   if (work.volume) item.volume = String(work.volume);

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -39,7 +39,22 @@ interface StreamState {
   runOwner?: StreamRunOwnership;
 }
 
-/** Every entry is derived with the same projection used by the live recorder. */
+/** Apply one event with the same projection used by the live recorder. */
+function applyEvent(
+  log: StreamLog,
+  fold: ReturnType<typeof createTranscriptFold>,
+  event: SessionEvent,
+): void {
+  if (event.type === 'transcript.entry') log.record(event.entry);
+  else if (event.type === 'status') fold.status(event.phase);
+  else if (isTranscriptEvent(event))
+    fold.record(event, {
+      at: event.at,
+      id: JSON.stringify([event.aggregateId, event.seq]),
+      debug: event.transcriptDebug ?? false,
+    });
+}
+
 function foldEntries(events: readonly SessionEvent[]): StreamState | undefined {
   if (events.length === 0 || events.at(-1)?.type === 'stream.removed') return;
   if (events[0]?.type !== 'run.start' || events[0].seq !== 1) {
@@ -47,17 +62,7 @@ function foldEntries(events: readonly SessionEvent[]): StreamState | undefined {
   }
   const entries = new StreamLog();
   const fold = createTranscriptFold(entries);
-  for (const event of events) {
-    if (event.type === 'transcript.entry') entries.record(event.entry);
-    else if (event.type === 'status') fold.status(event.phase);
-    else if (isTranscriptEvent(event)) {
-      fold.record(event, {
-        at: event.at,
-        id: JSON.stringify([event.aggregateId, event.seq]),
-        debug: event.transcriptDebug ?? false,
-      });
-    }
-  }
+  for (const event of events) applyEvent(entries, fold, event);
   entries.drainEmission();
   return { log: entries, fold, seq: events.at(-1)!.seq };
 }
@@ -239,14 +244,7 @@ export class StreamLogStore {
         if (event.seq <= (state.seq ?? 0)) return;
         state.log ??= new StreamLog();
         state.fold ??= createTranscriptFold(state.log);
-        if (event.type === 'transcript.entry') state.log.record(event.entry);
-        else if (event.type === 'status') state.fold.status(event.phase);
-        else if (isTranscriptEvent(event))
-          state.fold.record(event, {
-            at: event.at,
-            id: JSON.stringify([event.aggregateId, event.seq]),
-            debug: event.transcriptDebug ?? false,
-          });
+        applyEvent(state.log, state.fold, event);
         state.seq = event.seq;
         this.notify(streamId);
       }),
@@ -314,14 +312,6 @@ export class StreamLogStore {
     };
   }
 
-  private ensureStreamState(streamId: StreamTabId): StreamState {
-    let state = this.streams.get(streamId);
-    if (!state) {
-      state = {};
-      this.streams.set(streamId, state);
-    }
-    return state;
-  }
   private pruneStreamState(streamId: StreamTabId): void {
     const state = this.streams.get(streamId);
     if (
@@ -372,6 +362,15 @@ export class StreamLogStore {
     state.seq = undefined;
     this.pruneStreamState(streamId);
   }
+  private ensureStreamState(streamId: StreamTabId): StreamState {
+    let state = this.streams.get(streamId);
+    if (!state) {
+      state = {};
+      this.streams.set(streamId, state);
+    }
+    return state;
+  }
+
   private notify(streamId: StreamTabId, reset = false): void {
     const log = this.get(streamId);
     if (log === undefined) return;

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -332,30 +332,14 @@ export async function runToolWithCheck(
 }
 
 /**
- * Check if multiple tools are installed
- * @param configs Array of tool names
- * @param showError Whether to show error messages for missing tools
- * @returns Promise<boolean[]> Array of booleans indicating which tools are installed
- */
-async function checkMultipleToolsInstalled(
-  configs: string[],
-  showError: boolean = true,
-): Promise<boolean[]> {
-  return Promise.all(
-    configs.map((config) => checkToolInstalled(config, showError)),
-  );
-}
-
-/**
  * Which of the two interchangeable image processors is installed, preferring
  * ImageMagick, or `null` when neither is. The single owner of the
  * "magick or gm" alternation that PDF rasterization, image resizing, and the
  * core-dependency check all decide on.
  */
 export async function detectImageTool(): Promise<'magick' | 'gm' | null> {
-  const [hasMagick, hasGm] = await checkMultipleToolsInstalled(
-    ['magick', 'gm'],
-    false,
+  const [hasMagick, hasGm] = await Promise.all(
+    ['magick', 'gm'].map((tool) => checkToolInstalled(tool, false)),
   );
   if (hasMagick) return 'magick';
   if (hasGm) return 'gm';
@@ -383,9 +367,8 @@ export async function checkCoreDependencies(
   try {
     // Check basic tools
     const basicTools = ['latexindent', 'perl', 'gs'];
-    const basicResults = await checkMultipleToolsInstalled(
-      basicTools,
-      showError,
+    const basicResults = await Promise.all(
+      basicTools.map((tool) => checkToolInstalled(tool, showError)),
     );
     const missingBasicTools = basicTools.filter((_, i) => !basicResults[i]);
 


### PR DESCRIPTION
Orchestrated `our-code-simplifier` sweep over the Effect-4 migration surface: **75 two/three-file batches across 5 waves** (15 concurrent agents/wave, per-wave central typecheck+ratchet gates), 160 files assigned, **62 production files changed, +367/−670**.

Consistent with the 2026-08-20 whole-tree and 2026-09-06 post-refactor sweeps, per-file simplification is largely exhausted: **~40% of batches reported zero edits**, and every edit clears the net-negative-element bar.

## Notable edits

**Dead code / impossible states**
- `executionLifecycle.ts`: unused `log` binding + 3 orphaned imports; `goalStore.ts`, `approvalQueue.ts` dead exports; `multiAgent.ts` dead `?.` on a type-predicate-proven non-null; `updateChecker.ts` dead default param; duplicate imports merged (desktopProjects, ExecutionKVStore)
- `persistedFlow.ts`: paired `nodeIds`/`nodesById` nullable fields → single `nodeIndexCache` (one-set-one-null state now unrepresentable; also deletes a per-hit wrapper allocation)

**Hand-rolled duplicates → dependency helpers**
- `AcceptRunFilesTool.ts`: `Effect.catch((e) => Effect.die(e))` → `Effect.orDie` (verified against the rc.112 implementation; idiom now extinct repo-wide)
- Stream combinator collapse via `Stream.fromIterableEffect` (verified `Stream.d.ts:844`)
- `agentCreatorFlow.ts`: hand-written `AgentPromptPair` interface → `z.infer<typeof ParsedCreatorYamlSchema>['prompts']` (fixes latent schema-drift)

**Pass-through / indirection collapses**
- `stableSubagentAttempt.ts`, `toolUtils.ts` (`checkMultipleToolsInstalled`), `StreamLogStore.ts` (genuine 2-caller dedup → module-level `applyEvent` fold), `logSinks.ts` (SilentWritable → `Writable` `write` option), `sessions.ts` redundant outer `Effect.suspend`, `MediaAttachmentProcessor` pass-throughs, `ToolUseDispatchNode` batched-vs-per-call collapse

**Type tightening**
- `modelHandlerVscodeLm.ts`: `as LanguageModelMessage` cast deleted via `Extract<…, { role: 'assistant' }>` signature; `approvalAdapter.ts` 3 cast deletions; `formatChildLine` nullability tightening

## Ratchet

- `SettingsViewMessageHandler.ts` `platform()` 3→2 — genuine shrink locked in via baseline regen (included)
- All other effect-migration counts unchanged; no catch/`AbortController`/`run*` sites touched

## Gates

| Gate | Result |
|---|---|
| `npm run typecheck` (all packages) | ✅ |
| `npm run lint` (all 7 eslint passes) | ✅ |
| effect-migration ratchet | ✅ |
| dead-code ratchet | ✅ |
| store-public-surface ratchet | ✅ |
| vitest (FORCE_COLOR=0) | 9260 passed, **1 pre-existing failure** |

The single vitest failure (`ExecutionsToolWorkspaceFiles > keeps completed wait summary reports inline…`, `waitResult.output` undefined) **reproduces identically on clean `main` @ 98afef5a7a** in a fresh worktree — not introduced here. Looks worth its own investigation.

## Defects noticed, not fixed (ledger)

- `normalizeConversation.ts` ~490: `role: 'tool'` branch omits `?? ''` its siblings use → `text: undefined` possible against the `ExportNode` contract
- `orchestrate.ts:219`: model-access-list failure degrades to `[]` silently (sibling path warns)
- `chatDefaults.ts:154`: `loadHistoryDefaults` is the one fully-silent defaults tier
- `DelegationTools.ts:339`: resume-ownership check skipped when caller has no stream id (permissive default)
- `AgentDirectoryManager.realDirectoryPath`: realpath failure silently degrades the symlink-dedup key
- `hostRunActions.ts:395`: `runCompileFixer` is the only span-nameless `Effect.fn` in its file
- `errorInspection.ts:242`: split-string marker lacks a comment
- `AnthropicStreamHandler.takePendingInputField`: JSON-null throw (theoretical)
- `store-public-surface-baseline.json`: StreamLogStore row is stale (lists removed symbols; ratchet tolerates, cosmetic)

## Port opportunities (recorded, not taken — Effect-4 PRD owns the lanes)

- `initPlatform.ts` 129-144 / 290-305 / 352-370: Effect→plain-promise candidates
- `inBandSubagentExecution` `stableExecutions` block: Effect-side twin of `@utils/core/keyedMutex`; collapses if the PRD ships a fiber-scoped keyed mutex
- `TokenCountOptions.tools: unknown[]` → `ToolDefinition[]` deletes `as` casts at ≥2 handler sites
- `foldToolExit` exists in 2 files with divergent shapes (LspTools, githubSubscriptionTool)
- `AcceptRunFilesTool` ALS-across-runtime scaffolding collapses when lane D makes the tool boundary Effect-native
- `resumeRun` re-resolves `useRecovery` 3×; `desktopSupabaseAuth` 4× `runPromiseExit`→`runSettled` (blocked by catch-row ratchet)