### PR TITLE
refactor(github): move AnnotationFetchBudget onto Effect Ref/Clock

### DIFF
--- a/src/test-kernel/tools/PRPollingSource.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSource.vitest.ts
@@ -90,7 +90,7 @@ function createDrainSource(): PRPollingSource {
 
 describe('PRPollingSource annotation drain', () => {
   beforeEach(() => {
-    PRPollingSource.resetAnnotationFetchBudgetForTests();
+    Effect.runSync(PRPollingSource.resetAnnotationFetchBudgetForTests());
     mocks.fetchAnnotations.mockReset();
   });
 

--- a/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
@@ -39,7 +39,7 @@ interface PRPollingSourceClass {
   resetAnnotationFetchBudgetForTests(
     remainingRequests?: number,
     nowMs?: number,
-  ): void;
+  ): Effect.Effect<void>;
 }
 
 type AnnotationFetchFn = (
@@ -213,7 +213,7 @@ describe('PRPollingSource annotation pagination', () => {
         );
         const source = new PRPollingSource();
         source.has = vi.fn().mockReturnValue(true);
-        PRPollingSource.resetAnnotationFetchBudgetForTests(0);
+        yield* PRPollingSource.resetAnnotationFetchBudgetForTests(0);
         const runs = [checkRun(7), checkRun(8)];
         const state = drainState(runs);
 
@@ -233,8 +233,8 @@ describe('AnnotationFetchBudget', () => {
   it('does not stall refills after the clock moves backward', () => {
     const budget = new AnnotationFetchBudget(1, 1000);
 
-    expect(budget.tryClaim(1000)).toBe(true);
-    expect(budget.tryClaim(900)).toBe(false);
-    expect(budget.tryClaim(1900)).toBe(true);
+    expect(Effect.runSync(budget.tryClaim(1000))).toBe(true);
+    expect(Effect.runSync(budget.tryClaim(900))).toBe(false);
+    expect(Effect.runSync(budget.tryClaim(1900))).toBe(true);
   });
 });

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -213,8 +213,8 @@ export class PRPollingSource extends PollingSourceBase<
   static resetAnnotationFetchBudgetForTests(
     remainingFetches?: number,
     nowMs?: number,
-  ): void {
-    SharedAnnotationFetchBudget.resetForTests(remainingFetches, nowMs);
+  ): Effect.Effect<void> {
+    return SharedAnnotationFetchBudget.resetForTests(remainingFetches, nowMs);
   }
 
   subscribe(

--- a/src/tools/github/annotationFetchBudget.ts
+++ b/src/tools/github/annotationFetchBudget.ts
@@ -11,12 +11,16 @@
  * infrastructure `fetchAnnotations` claims against it and `PRPollingSource`
  * exposes a test-only reset that targets the same instance.
  *
- * This is a small hand-rolled token bucket rather than a library (e.g.
- * `p-throttle`) because callers need a synchronous, non-blocking
- * claim-or-defer check (`tryClaim`) with an injectable clock for
- * deterministic tests (`resetForTests`) — `p-throttle` only offers an async
- * queue-and-wait contract, which doesn't fit either requirement.
+ * Token state lives in a `Ref` and `tryClaim` reads its time from Effect's
+ * `Clock` by default, rather than a bespoke injectable-clock parameter — the
+ * same clock every other retry/backoff path in this codebase uses. This is
+ * still a small purpose-built token bucket rather than a library (e.g.
+ * `p-throttle`) because callers need a non-blocking claim-or-defer check
+ * (`tryClaim`), and `p-throttle` only offers an async queue-and-wait
+ * contract.
  */
+
+import { Clock, Effect, Ref } from 'effect';
 
 import { clamp } from '@utils/core';
 
@@ -35,49 +39,82 @@ export class AnnotationFetchBudgetExhaustedError extends Error {
   }
 }
 
+interface TokenBucketState {
+  readonly tokens: number;
+  readonly lastRefillMs: number;
+}
+
 export class AnnotationFetchBudget {
-  private tokens: number;
-  private lastRefillMs: number;
+  private readonly state: Ref.Ref<TokenBucketState>;
 
   constructor(
     private readonly maxRequestsPerWindow: number,
     private readonly windowMs: number,
   ) {
-    this.tokens = maxRequestsPerWindow;
-    this.lastRefillMs = Date.now();
+    // `SharedAnnotationFetchBudget` below is constructed eagerly at module
+    // load, before any Effect runtime exists to run a `Ref.make` program —
+    // `makeUnsafe` is `Ref`'s documented synchronous constructor for exactly
+    // that case, not an `Effect.run*` boundary call.
+    this.state = Ref.makeUnsafe<TokenBucketState>({
+      tokens: maxRequestsPerWindow,
+      lastRefillMs: Date.now(),
+    });
   }
 
   /**
    * Refill continuously (tokens/ms) rather than resetting the full
    * allowance at fixed window boundaries — a fixed-window reset lets a
    * caller burst up to 2x the budget across a boundary (all of one window's
-   * allowance immediately followed by all of the next).
+   * allowance immediately followed by all of the next). A backward clock
+   * jump leaves `tokens` unchanged rather than draining it, but still
+   * advances `lastRefillMs` so a later forward jump refills from that point.
    */
-  private refill(nowMs: number): void {
-    const elapsedMs = nowMs - this.lastRefillMs;
-    if (elapsedMs > 0) {
-      const refillRate = this.maxRequestsPerWindow / this.windowMs;
-      this.tokens = Math.min(
+  private readonly refill = (
+    current: TokenBucketState,
+    nowMs: number,
+  ): TokenBucketState => {
+    const elapsedMs = nowMs - current.lastRefillMs;
+    if (elapsedMs <= 0) return { ...current, lastRefillMs: nowMs };
+    const refillRate = this.maxRequestsPerWindow / this.windowMs;
+    return {
+      tokens: Math.min(
         this.maxRequestsPerWindow,
-        this.tokens + elapsedMs * refillRate,
-      );
-    }
-    this.lastRefillMs = nowMs;
-  }
+        current.tokens + elapsedMs * refillRate,
+      ),
+      lastRefillMs: nowMs,
+    };
+  };
 
-  tryClaim(nowMs = Date.now()): boolean {
-    this.refill(nowMs);
-    if (this.tokens < 1) return false;
-    this.tokens -= 1;
-    return true;
+  /** Claim one token against `nowMs`, defaulting to Effect's `Clock`. */
+  tryClaim(nowMs?: number): Effect.Effect<boolean> {
+    const { state, refill } = this;
+    return Effect.gen(function* () {
+      const now = nowMs ?? (yield* Clock.currentTimeMillis);
+      return yield* Ref.modify(state, (current) => {
+        const refilled = refill(current, now);
+        return refilled.tokens < 1
+          ? ([false, refilled] as const)
+          : ([true, { ...refilled, tokens: refilled.tokens - 1 }] as const);
+      });
+    });
   }
 
   resetForTests(
-    remainingRequests = this.maxRequestsPerWindow,
-    nowMs = Date.now(),
-  ): void {
-    this.lastRefillMs = nowMs;
-    this.tokens = clamp(remainingRequests, 0, this.maxRequestsPerWindow);
+    remainingRequests?: number,
+    nowMs?: number,
+  ): Effect.Effect<void> {
+    const { state, maxRequestsPerWindow } = this;
+    return Effect.gen(function* () {
+      const now = nowMs ?? (yield* Clock.currentTimeMillis);
+      yield* Ref.set(state, {
+        tokens: clamp(
+          remainingRequests ?? maxRequestsPerWindow,
+          0,
+          maxRequestsPerWindow,
+        ),
+        lastRefillMs: now,
+      });
+    });
   }
 }
 

--- a/src/tools/github/checkRunsClient.ts
+++ b/src/tools/github/checkRunsClient.ts
@@ -347,11 +347,11 @@ export const fetchAnnotations = Effect.fn('fetchAnnotations')(
     checkRunId: number,
     logger: AgentTrace,
     budget: AnnotationFetchBudget,
-    now = Date.now(),
+    now?: number,
   ): Effect.fn.Return<GhCheckAnnotation[], unknown> {
     const annotations: GhCheckAnnotation[] = [];
     for (let page = 1; page <= MAX_ANNOTATION_PAGES_PER_RUN; page += 1) {
-      if (!budget.tryClaim(now)) {
+      if (!(yield* budget.tryClaim(now))) {
         return yield* Effect.fail(new AnnotationFetchBudgetExhaustedError());
       }
       const path = `/repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=${ANNOTATIONS_PAGE_SIZE}&page=${page}`;


### PR DESCRIPTION
## Summary

`AnnotationFetchBudget` (`src/tools/github/annotationFetchBudget.ts`) was a hand-rolled token bucket: mutable class fields (`tokens`, `lastRefillMs`) mutated in place, a bespoke `nowMs = Date.now()` parameter as its injectable clock, and a `resetForTests` escape hatch to reset that mutable state between tests. This PR replaces the mutable fields with a `Ref<TokenBucketState>` and makes `tryClaim`/`resetForTests` read time from Effect's `Clock` by default (still overridable by an explicit `nowMs`, preserving the "same timestamp for a whole poll tick" pattern `PRPollingSource.ts` already relies on elsewhere in this file). `tryClaim` and `resetForTests` now return `Effect.Effect<...>` instead of mutating synchronously.

This is the `annotationFetchBudget.ts` item named directly in the in-flight Effect 4 runtime migration PRD's "repeated mechanism families" survey (`.agents/docs/proposed/architecture/2026-08-26-effect-4-runtime-migration.md` §2.5, "Timers and backoff with injected clock seams" row) as a hand-rolled implementation the migration retires, with the same replacement (`Schedule`/`Ref`/one clock; delete the injection seam and `resetForTests`'s bespoke shape). Its two production callers (`checkRunsClient.ts`, `PRPollingSource.ts`) already run on Effect today, so this lands standalone without waiting on the PocketFlow/runtime rewrite the rest of that migration is sequenced behind.

## Issue acceptance gates

No tracked issue — this is a scoped follow-up to an ad hoc dependency/architecture audit, pulled forward as the one candidate whose full call graph was already Effect-based.

## Single source of truth

`AnnotationFetchBudget`'s internal `Ref<TokenBucketState>` is still the sole authority for the process-wide token count (via the `SharedAnnotationFetchBudget` singleton); this PR changes how that state is held and read, not who owns it.

## Duplication and abstraction budget

No duplication removed or added; no new abstraction. The class keeps its existing external shape (constructor, `tryClaim`, `resetForTests`, `SharedAnnotationFetchBudget`) — only the internals and two method return types changed.

## Net elements (R6)

No exported symbols added or removed (`git diff --stat HEAD~1` over `main` shows 0 new/removed `export` lines). One new module-private interface (`TokenBucketState`, not exported). Net: 5 files changed, +77/-40 lines, no new files.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed. `tryClaim`/`resetForTests` changed return type (`boolean`/`void` → `Effect<boolean>`/`Effect<void>`), so all 2 production call sites (`checkRunsClient.ts:354`, `PRPollingSource.ts:217`) and all 3 test call sites (grepped via `\.tryClaim\(` and `resetAnnotationFetchBudgetForTests`) were updated in this PR to `yield*`/`Effect.runSync` the result.

## Host impact

Extension: none — GitHub PR polling is host-neutral (`src/tools/github/`), unaffected by host layer.

Desktop: none, same reason.

CLI: none, same reason.

## Scheduled refactoring

None. The remaining two candidates from the same audit (`ModelRetryGate`, `coalesceAsync`) are already tracked by the in-flight Effect 4 runtime migration PRD and are blocked on that migration's PocketFlow/runtime rewrite landing first — no new follow-up issue needed since that tracking already exists.

## Validation

- `npx tsc --noEmit -p .` — clean, 0 errors, full repo.
- `npx vitest run src/test-kernel/tools/` — 96 files / 773 tests passed, including the two files touched by this change (`PRPollingSource.vitest.ts`, `PRPollingSourceAnnotationPages.vitest.ts`, 9 tests) which exercise the token-bucket math directly (including the "clock moves backward" regression case) and the budget-exhaustion/pagination paths through `fetchAnnotations`.
- `npx eslint` on all 5 changed files — clean.
- `npx prettier --check` on all 5 changed files — clean.
- `node scripts/check-effect-migration-ratchet.mjs` — passes; no `Effect.run*` count grew and no new below-boundary file was introduced (this file returns `Effect` values, it never runs them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCbDyzHAoQEEykKgaEKDku

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCbDyzHAoQEEykKgaEKDku)_