### PR TITLE
docs,refactor: land the unblocked steps of the one run model (S0, S6)

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-08-pr1-run-ledger-foundation.md
+++ b/.agents/docs/proposed/architecture/2026-09-08-pr1-run-ledger-foundation.md
@@ -167,7 +167,7 @@ null` (:1616) _before_ `applyOwnArm`, so the new cases are unreachable no-ops
   event in the repo, and the second mandatory edit outside the new files.
 - `redactTraceDraft`
   ([traceRedaction.ts:10](../../../../src/shared/session/traceRedaction.ts))
-  ends in `default: return event` (:82-83), so execution rows pass through
+  ends in `default: return event` (:82-83), so ledger rows pass through
   unscrubbed. That is C3's second owner, held today only by a `default:` arm,
   and PR 1's test pins it.
 - `databaseLayer('ephemeral')`
@@ -196,7 +196,7 @@ change what the rows can honestly claim.
    transactions, including the `model.message response` row that is supposed
    to make a paid response survivable, and including the `model.message
 attempt` row that is supposed to make an in-flight generation attributable.
-   PR 1 states the durability level it actually gets. Whether the execution
+   PR 1 states the durability level it actually gets. Whether the run
    aggregate deserves `synchronous = FULL` is open decision 10.
 2. **`SessionEvents.publish` is `Effect.orDie`.**
    [`SessionEvents.ts:99-102`](../../../../src/agent/runtime/SessionEvents.ts)
@@ -221,9 +221,8 @@ event_sequence.owner_id = excluded.owner_id AND closed = 0`, reach the
 ### 1.7 Recorded, not blocking
 
 1. **`z.url()` on `deployment.endpoint`** admits userinfo and `?api-key=`. The
-   execution aggregate is never scrubbed and lives until explicit user
-   deletion. PR 1 adds a write-boundary assertion; the durable fix is open
-   decision 1.
+   run aggregate is never scrubbed and lives until explicit user deletion.
+   PR 1 adds a write-boundary assertion; the durable fix is open decision 1.
 2. **Replay is hostage to a user-editable string.** `sameModelOrigin` compares
    `endpoint` and `credentialScope` byte-for-byte and a mismatch is a hard
    `unsupported`. PR 1 records the origin verbatim and surfaces a mismatch as
@@ -257,14 +256,20 @@ is display-visible, and it reaches the viewer through the session vocabulary.
 
 ### 2.2 The table
 
-| Row                | Aggregate | Written when                                                                                                                                                                                                  | Fold effect                                            | Frozen?          |
-| ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------- |
-| `flow.step`        | stream    | round begin/end; turn ready/begin/end; response ready/processed; results/output ready; `waiting`; `halted`                                                                                                    | sets coordinates and `halt`                            | yes              |
-| `model.message`    | execution | five variants, below                                                                                                                                                                                          | the only row that grows provider history               | yes, after L6    |
-| `model.compaction` | execution | a handler returns a history that is not a prefix extension; a reflection round opens; a mid-run model switch re-encodes                                                                                       | replaces history; sets or invalidates the continuation | **no**, see §2.5 |
-| `tool.intent`      | execution | unconditionally at the barrier dispatch site, before any non-parallel-safe call starts. **Not** from an approval hook: `onExecutionReady` covers three tools while most of the fifty are barriers             | opens outcome-unknown state                            | yes              |
-| `tool.result`      | execution | after each call settles, one row per call, duplicates and synthetic skips included                                                                                                                            | settles a call, applies its state ops exactly once     | yes              |
-| `flow.snapshot`    | execution | once before the first external activity; at `turn.end`/`round.end`; before `waiting`; before a manual-retry prompt; before calling `observe`; whenever bytes appended since the last snapshot exceed its size | restores what no row carries; **asserts** what rows do | **no**, see §2.6 |
+Every row lands on the one `run` aggregate keyed by the run id (§3.1). The
+class column is the split above, and it is what decides which fold reads a row:
+`foldRunState` reads all six. All six also reach `sessionFold.ts` as explicit
+named cases, where in PR 1 every one of them is inert because `listingTypeOf`
+returns `null`; PR 3 gives the display-visible one real handling (§4.1).
+
+| Row                | Row class       | Written when                                                                                                                                                                                                  | Fold effect                                            | Frozen?          |
+| ------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------- |
+| `flow.step`        | display-visible | round begin/end; turn ready/begin/end; response ready/processed; results/output ready; `waiting`; `halted`                                                                                                    | sets coordinates and `halt`                            | yes              |
+| `model.message`    | ledger-private  | five variants, below                                                                                                                                                                                          | the only row that grows provider history               | yes, after L6    |
+| `model.compaction` | ledger-private  | a handler returns a history that is not a prefix extension; a reflection round opens; a mid-run model switch re-encodes                                                                                       | replaces history; sets or invalidates the continuation | **no**, see §2.5 |
+| `tool.intent`      | ledger-private  | unconditionally at the barrier dispatch site, before any non-parallel-safe call starts. **Not** from an approval hook: `onExecutionReady` covers three tools while most of the fifty are barriers             | opens outcome-unknown state                            | yes              |
+| `tool.result`      | ledger-private  | after each call settles, one row per call, duplicates and synthetic skips included                                                                                                                            | settles a call, applies its state ops exactly once     | yes              |
+| `flow.snapshot`    | ledger-private  | once before the first external activity; at `turn.end`/`round.end`; before `waiting`; before a manual-retry prompt; before calling `observe`; whenever bytes appended since the last snapshot exceed its size | restores what no row carries; **asserts** what rows do | **no**, see §2.6 |
 
 ### 2.3 The money window, and what closes it
 
@@ -892,11 +897,11 @@ Added to `SessionEventDraftSchema`, unexported, payload nested:
 
 ```ts
   durable('flow.step', { payload: FlowStepPayloadSchema }),
-  durable('model.message', { payload: ModelMessagePayloadSchema }, 'execution'),
-  durable('model.compaction', { payload: ModelCompactionPayloadSchema }, 'execution'),
-  durable('tool.intent', { payload: ToolIntentPayloadSchema }, 'execution'),
-  durable('tool.result', { payload: ToolResultPayloadSchema }, 'execution'),
-  durable('flow.snapshot', { payload: FlowSnapshotPayloadSchema }, 'execution'),
+  durable('model.message', { payload: ModelMessagePayloadSchema }),
+  durable('model.compaction', { payload: ModelCompactionPayloadSchema }),
+  durable('tool.intent', { payload: ToolIntentPayloadSchema }),
+  durable('tool.result', { payload: ToolResultPayloadSchema }),
+  durable('flow.snapshot', { payload: FlowSnapshotPayloadSchema }),
 ```
 
 and to `listingTypeOf`'s `return null` group:
@@ -911,7 +916,13 @@ and to `listingTypeOf`'s `return null` group:
       return null;
 ```
 
-`AggregateKeySchema` already admits `'execution'`. `LISTING_TYPES`
+All six take the `run` aggregate kind: one run owns one aggregate, so no arm
+names a kind of its own. That kind does not exist yet. At `main`,
+`AggregateKeySchema`
+([sessionEvent.ts:98-110](../../../../src/shared/schemas/sessionEvent.ts)) has
+no `run` arm and `durable(type, shape, kind = 'stream')` (:186-190) defaults to
+`stream`, so adding `'run'` to the kind enum and moving `durable`'s default are
+edits S1 of the one run model owns, and PR 1 cannot merge before S1 lands. `LISTING_TYPES`
 ([Database.ts:138](../../../../src/controllers/session/Database.ts)) is derived
 from `listingTypeOf`, so the six stay out of the cold listing with no SQL
 change, so a large snapshot never lands in every renderer's listing read.
@@ -931,9 +942,10 @@ Beside `sessionEvents.ts` and `database.ts`, which declare their tags in
 
 ```ts
 /**
- * The run ledger: the only reader of execution-aggregate payloads and the
- * only writer of the run rows. Three operations, each a boundary §2.2 or
- * §2.3 names.
+ * The run ledger: the only reader of ledger-private payloads and the only
+ * writer of the run rows. Three operations, each a boundary §2.2 or §2.3
+ * names, each taking the run id and qualifying its own aggregate access with
+ * `aggregateId('run', run)`.
  *
  * Stateless by construction. The loop holds the `RunState`; the ledger folds
  * the batch it just committed onto the state it was handed. That is what
@@ -942,23 +954,10 @@ Beside `sessionEvents.ts` and `database.ts`, which declare their tags in
  */
 import { Context, Data, Effect } from 'effect';
 
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import type { RunId } from '@shared/schemas';
 import type { DatabaseReadFailed } from './database';
 import type { RunLedgerDraft, RunState } from './runStateFold';
 import { RunLedgerInconsistent } from './runStateFold';
-
-/**
- * Both aggregate keys of one run, passed rather than looked up. `run.start`
- * names its `executionId`, but nothing on the execution aggregate names its
- * stream, so a one-argument signature would need a reverse index, a second
- * source of truth for an edge the launcher already owns. This is a deviation
- * from §2.1's "accepts the logical execution id and qualifies its database
- * reads internally", and it is listed in §8.
- */
-export interface RunAggregates {
-  readonly executionId: ExecutionId;
-  readonly streamId: StreamTabId;
-}
 
 /**
  * A refusal the ledger itself decided. Read failures are NOT folded into
@@ -980,7 +979,7 @@ export class RunLedgerRefused extends Data.TaggedError('RunLedgerRefused')<{
     | 'unprepared-history' // §2.5, if option (a) is taken
     | 'batch-contract' // a precondition of `appendBatch` was violated
     | 'inconsistent'; // the rows do not fold (see `cause`)
-  readonly executionId: ExecutionId;
+  readonly runId: RunId;
   readonly detail: string;
   readonly cause?: RunLedgerInconsistent;
 }> {}
@@ -990,39 +989,38 @@ export class RunLedger extends Context.Service<
   {
     /**
      * The claim gate, called before any resume side effect: resume acquires
-     * the current claims for the execution and stream aggregates first, then
-     * calls `load`. Without it a second process can fold a run's state,
-     * re-dispatch a barrier tool, and learn only at its first append that the
-     * claim never moved, after the side effect.
+     * the run aggregate's current claim first, then calls `load`. Without it
+     * a second process can fold a run's state, re-dispatch a barrier tool,
+     * and learn only at its first append that the claim never moved, after
+     * the side effect.
      */
     readonly acquire: (
-      run: RunAggregates,
+      run: RunId,
     ) => Effect.Effect<void, RunLedgerRefused | DatabaseReadFailed>;
 
     /**
-     * Fold a run's rows into its state. `null` only when the execution
-     * aggregate is empty: that is the loop's fresh-run branch and, for a
+     * Fold a run's rows into its state. `null` only when the run aggregate
+     * carries no ledger row: that is the loop's fresh-run branch and, for a
      * pre-0.41 run, the honest "recorded before the run ledger" answer,
-     * distinct from "checkpoint corrupt". Execution rows without an initial
+     * distinct from "checkpoint corrupt". Ledger rows without an initial
      * `flow.snapshot` are not that case. They are a malformed aggregate and
      * fail `inconsistent`, because folding an `attempt` or a `response` into
-     * a fresh run is how a paid invocation gets issued twice. PR 1 reads both
-     * aggregates in full; the snapshot-anchored read is PR 2's optimization,
-     * and `foldRunState`'s `state` parameter is what makes it a drop-in
-     * rather than a second fold.
+     * a fresh run is how a paid invocation gets issued twice. PR 1 reads the
+     * run aggregate in full; the snapshot-anchored read is PR 2's
+     * optimization, and `foldRunState`'s `state` parameter is what makes it a
+     * drop-in rather than a second fold.
      */
     readonly load: (
-      run: RunAggregates,
+      run: RunId,
     ) => Effect.Effect<RunState | null, RunLedgerRefused | DatabaseReadFailed>;
 
     /**
-     * Commit one ordered batch, possibly across both aggregates, in one
-     * transaction, and return the state the loop continues from: `state`
-     * folded with the rows the publisher actually committed. Failure of any
-     * member commits none.
+     * Commit one ordered batch in one transaction, and return the state the
+     * loop continues from: `state` folded with the rows the publisher
+     * actually committed. Failure of any member commits none.
      *
      * Preconditions, checked before publish and failing `batch-contract`:
-     *   - a `flow.snapshot` is the last execution row of its batch, except
+     *   - a `flow.snapshot` is the last ledger row of its batch, except
      *     when a `flow.step` follows it in the same transaction;
      *   - a `model.compaction` immediately precedes the `model.message`
      *     `response` row that used it, when both are present;
@@ -1037,7 +1035,7 @@ export class RunLedger extends Context.Service<
      *     never committed, and the delivery is what clears them.
      */
     readonly appendBatch: (
-      run: RunAggregates,
+      run: RunId,
       state: RunState | null,
       rows: readonly RunLedgerDraft[],
     ) => Effect.Effect<RunState, RunLedgerRefused | DatabaseReadFailed>;
@@ -1046,8 +1044,8 @@ export class RunLedger extends Context.Service<
 ```
 
 `RunLedgerDraft` is defined in `runStateFold.ts` as the discriminated union of
-the six ledger arms plus the named stream-aggregate arms a batch has to commit
-atomically with them: `tool.end`, which settles with its `tool.result`, and
+the six ledger arms plus the named display arms a batch has to commit atomically
+with them: `tool.end`, which settles with its `tool.result`, and
 `approval.requested` / `approval.resolved`, whose recovery binding is the
 snapshot committed in the same batch. Publishing those companions separately
 is the crash window where a settled tool keeps an active card, or an approval
@@ -1102,9 +1100,9 @@ export const runLedgerLayer: Layer.Layer<
   Effect.gen(function* () {
     const events = yield* SessionEvents; // writes: the one transaction
     const log = yield* Database; // reads and claims
-    // acquire     -> log.acquireClaims([execution, stream])
-    // load        -> log.readAggregate(execution, 1) ++ log.readAggregate(stream, 1),
-    //                merged in commit order, then foldRunState(null, rows)
+    // acquire     -> log.acquireClaims([aggregateId('run', run)])
+    // load        -> log.readAggregate(aggregateId('run', run), 1),
+    //                then foldRunState(null, rows)
     // appendBatch -> preconditions, write-boundary rules, events.publish(drafts),
     //                then foldRunState(state, committed)
   }),
@@ -1119,8 +1117,8 @@ fallback:
    type-check and the check becomes vacuous, which is the point: it is an
    assertion over the imported schema, not a second declaration of it. Never a
    `?? null`.
-2. **Endpoint hygiene.** Every `deployment.endpoint` reaching an execution row
-   is asserted to carry no userinfo, no query string and no fragment, failing
+2. **Endpoint hygiene.** Every `deployment.endpoint` reaching a ledger row is
+   asserted to carry no userinfo, no query string and no fragment, failing
    `unsafe-endpoint`. `z.url()` permits `?api-key=` and `#api-key=` alike, this
    row is never scrubbed and lives until explicit user deletion; the assertion
    is the only thing between a mistyped base URL and a permanent plaintext
@@ -1215,10 +1213,10 @@ and PR 3 gives `flow.step` real handling.
  * order in any output value. Every value it produces comes from a row. It
  * applies no redaction: display redaction is a later boundary.
  *
- * `rows` must be strictly increasing in `commit` across both aggregates; the
- * fold does not reorder them. `state` is `null` for a cold fold and the
- * previous level for an incremental one, and the two are the same
- * computation, and that equality is what the ledger test pins.
+ * `rows` must be strictly increasing in `commit`; the fold does not reorder
+ * them. `state` is `null` for a cold fold and the previous level for an
+ * incremental one, and the two are the same computation, and that equality is
+ * what the ledger test pins.
  *
  * Returns a typed inconsistency rather than throwing or defaulting: a
  * snapshot that disagrees with the rows below it is corruption, not a state
@@ -1236,7 +1234,7 @@ export class RunLedgerInconsistent extends Data.TaggedError(
     | 'out-of-order' // commits not strictly increasing
     | 'stale-snapshot' // a snapshot contradicts rows already folded
     | 'orphan-settlement' // a tool.result under no pending response
-    | 'unknown-execution-row' // an unrecognized type on the execution aggregate
+    | 'unknown-run-row' // an unrecognized type on the run aggregate
     | 'dangling-binding' // an approval binding names no row
     | 'mismatched-delivery'; // a delivering append does not settle its response
   readonly detail: string;
@@ -1270,12 +1268,17 @@ and the unresolved approvals with their recovery bindings resolved.
 | `flow.step`                                          | sets the step and each coordinate it carries (asserted non-decreasing, so a round-end step is emitted before the snapshot that opens the next round, never after it); records the halt outcome on `'halted'`.                                                                                                                                          |
 | `flow.snapshot`                                      | §4.4.                                                                                                                                                                                                                                                                                                                                                  |
 | `approval.requested` / `approval.resolved`           | maintain the approval map by request id. A `model-retry` binding must match the pending retry's request id; a `tool-outcome` binding must match a pending intent's `approvalRequestId`. An inconsistent binding is `dangling-binding`, a resume refusal with a diagnostic, never consent.                                                              |
-| every other stream-aggregate type                    | ignored by an explicit named list.                                                                                                                                                                                                                                                                                                                     |
-| an unrecognized type on the **execution** aggregate  | `unknown-execution-row`.                                                                                                                                                                                                                                                                                                                               |
+| every other display row type                         | ignored by an explicit named list.                                                                                                                                                                                                                                                                                                                     |
+| any other unrecognized row type                      | `unknown-run-row`.                                                                                                                                                                                                                                                                                                                                     |
 
 That last pair is the design: display rows are ignored _by name_; anything
-unrecognized on the execution aggregate is a failure, never a `default: return
-state`.
+else unrecognized is a failure, never a `default: return state`. Note what one
+aggregate costs here. While display rows lived on a different aggregate, an
+unrecognized type was safe by construction. Now the named list is the only
+thing between a newly added display arm and a resume refusal, and the steps
+this note is sequenced against add them: S2 of the one run model adds `run.end`
+and `run.description`, S3 adds `request.opened` and `request.decided`. Each must
+extend the list in the same pull request that adds the arm.
 
 ### 4.4 The snapshot rule: reconcile, never overwrite
 
@@ -1291,7 +1294,7 @@ error anywhere. So:
   family state contains the usage accumulator (§2.7), which `tool.result` `add`
   operations do mutate. Until open decision 12 is answered, this rule is
   unsound for that one field.**
-- **Reference fields**, `SnapshotReferencesSchema`: **if no execution rows
+- **Reference fields**, `SnapshotReferencesSchema`: **if no ledger rows
   were folded before this snapshot, adopt; otherwise assert equal and fail
   `stale-snapshot` on any difference.** A cold full read has already folded the
   rows that establish them, so the snapshot is checked; PR 2's
@@ -1332,15 +1335,17 @@ type.**
    one a duplicate), `tool.intent`, two `tool.result` batches each with its
    `tool.end`, the delivering `append`, then `flow.snapshot` +
    `flow.step turn.end`. Assert the `RunState` returned by the last
-   `appendBatch` deep-equals a fresh `RunLedger.load` on the same aggregates.
+   `appendBatch` deep-equals a fresh `RunLedger.load` on the same run.
    _Why it earns its place:_ this is the lane's central invariant, and nothing
    else checks it.
-2. **The execution aggregate is byte-exact.** Read the stored `data` column
-   back and assert the `TurnResult` is identical to the one appended, including
+2. **The ledger rows are byte-exact.** Read the stored `data` column back and
+   assert the `TurnResult` is identical to the one appended, including
    thinking signatures and encrypted reasoning, and that a secret-shaped string
-   inside the turn content survives unchanged while the same string in a
-   `tool.start` on the stream aggregate is redacted.
-   _Why it earns its place:_ it fails the day someone routes execution rows
+   inside the turn content survives unchanged while the same string in a `log`
+   display row is redacted. (`redactTraceDraft` has no `tool.start` arm today:
+   that type falls through its `default: return event`, so tool input is not
+   scrubbed on any display arm.)
+   _Why it earns its place:_ it fails the day someone routes ledger rows
    through `redactTraceDraft`, which is C3's second owner and is currently held
    only by a `default:` arm
    ([traceRedaction.ts:82-83](../../../../src/shared/session/traceRedaction.ts)).
@@ -1356,22 +1361,22 @@ type.**
 Plain vitest, no Effect runtime, hand-built row arrays, one table-driven
 `it.each` over the acceptance table PR 1 owes the reviewer:
 
-| Crash point                                          | Recovered by                                                                                                               | Explicitly **not** recovered                                                                                                                                                                        |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| between `tool.intent` and the adapter call (barrier) | the intent row with no matching `tool.result`, giving outcome-unknown                                                      | whether the tool ran. `tool.intent` is evidence that execution was **admitted**, never that it happened. The resume rule must raise a `tool-outcome` approval and must never fabricate `cancelled`. |
-| after a paid response, before the turn-end snapshot  | the `response` row plus the preceding snapshot's phase                                                                     | nothing; the rule is "process the committed response, never re-invoke".                                                                                                                             |
-| during generation, before the `response` row         | the `attempt` and `identified` rows: the invocation is attributable, and for `openai-responses` retrievable                | the response content. And, under `synchronous = NORMAL`, an OS crash can lose the `attempt` row itself (§1.6.1).                                                                                    |
-| approval requested, never resolved                   | the existing approval arms **plus** the binding in `pendingRetry.requestId` / `pendingIntents[].approvalRequestId`         | anything, without the binding: the approval payload names no call and no invocation, so a resumed process could only retire it as `interrupted`, which is forbidden for these two purposes.         |
-| compaction that replaced history mid-run             | `model.compaction` (`keepPrefix`, `messages`, continuation)                                                                | nothing from the snapshot alone: snapshots omit messages.                                                                                                                                           |
-| a completed run being continued                      | a `flow.snapshot` existing, full stop; the outcome does not enter it                                                       | n/a                                                                                                                                                                                                 |
-| pre-0.41 run                                         | zero execution rows, so `load` returns `null`, worded "recorded before the run ledger", distinct from "checkpoint corrupt" | n/a                                                                                                                                                                                                 |
+| Crash point                                          | Recovered by                                                                                                            | Explicitly **not** recovered                                                                                                                                                                        |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| between `tool.intent` and the adapter call (barrier) | the intent row with no matching `tool.result`, giving outcome-unknown                                                   | whether the tool ran. `tool.intent` is evidence that execution was **admitted**, never that it happened. The resume rule must raise a `tool-outcome` approval and must never fabricate `cancelled`. |
+| after a paid response, before the turn-end snapshot  | the `response` row plus the preceding snapshot's phase                                                                  | nothing; the rule is "process the committed response, never re-invoke".                                                                                                                             |
+| during generation, before the `response` row         | the `attempt` and `identified` rows: the invocation is attributable, and for `openai-responses` retrievable             | the response content. And, under `synchronous = NORMAL`, an OS crash can lose the `attempt` row itself (§1.6.1).                                                                                    |
+| approval requested, never resolved                   | the existing approval arms **plus** the binding in `pendingRetry.requestId` / `pendingIntents[].approvalRequestId`      | anything, without the binding: the approval payload names no call and no invocation, so a resumed process could only retire it as `interrupted`, which is forbidden for these two purposes.         |
+| compaction that replaced history mid-run             | `model.compaction` (`keepPrefix`, `messages`, continuation)                                                             | nothing from the snapshot alone: snapshots omit messages.                                                                                                                                           |
+| a completed run being continued                      | a `flow.snapshot` existing, full stop; the outcome does not enter it                                                    | n/a                                                                                                                                                                                                 |
+| pre-0.41 run                                         | zero ledger rows, so `load` returns `null`, worded "recorded before the run ledger", distinct from "checkpoint corrupt" | n/a                                                                                                                                                                                                 |
 
 Plus the loudness cases: out-of-order commits; a snapshot naming a settled
 intent (`stale-snapshot`); a `tool.result` under no pending response
 (`orphan-settlement`); a `model-retry` binding naming no pending retry
-(`dangling-binding`); an unknown execution-aggregate type. And two guards that
-keep the union widening honest: `listingTypeOf` returns `null` for all six, and
-`redactTraceDraft` returns an execution draft unchanged.
+(`dangling-binding`); an unknown row type on the run aggregate. And two guards
+that keep the union widening honest: `listingTypeOf` returns `null` for all six,
+and `redactTraceDraft` returns a ledger draft unchanged.
 
 The fixture comment records the **measured serialized byte size** of one
 realistic reflection snapshot and one tool-use snapshot, so PR 2 has a number
@@ -1393,7 +1398,7 @@ consumes**, and needs no new entry in `config/ratchets/knip-baseline.json`:
 | `runState.ts`'s relocated schemas                                                                                | `runLedgerEvent.ts` and the agent modules that imported them before the move                                    |
 | `toolResult.ts`'s newly exported `ExecutedToolResultSchema`, `ErrorToolResultSchema`, `ToolFileAttachmentSchema` | `runLedgerEvent.ts`                                                                                             |
 | `foldRunState`, `RunState`, `RunLedgerDraft`, `RunLedgerInconsistent`                                            | `src/agent/runtime/RunLedger.ts`                                                                                |
-| `RunLedger`, `RunAggregates`, `RunLedgerRefused`                                                                 | `src/agent/runtime/RunLedger.ts`                                                                                |
+| `RunLedger`, `RunLedgerRefused`                                                                                  | `src/agent/runtime/RunLedger.ts`                                                                                |
 | `runLedgerLayer`                                                                                                 | `sessionGraphLayer` in `sessionLayer.ts`                                                                        |
 | `PreparedHistorySchema` (L1)                                                                                     | `foldRunState` / `appendBatch`, per §4.5                                                                        |
 
@@ -1474,6 +1479,17 @@ conversion of `flow_<id>.json` into rows. The 0.41 owner ruling removed it.
 Numbered by how expensive they are to reverse after the first row is written.
 Decisions 10 to 12 are new, added by the review; the rest carry forward.
 
+**0. One aggregate per run.** _(Before PR 1 is implemented.)_ This note now
+declares every row on one `run` aggregate keyed by the run id, which is what
+removes the two-key deviation earlier drafts carried. That shape is the
+recommendation of the
+[one run model](2026-09-10-one-run-model.md), not yet a ruling: its §7 item 1
+still puts it to the owner, and it is the one place that note departs from a
+ratified detail, the one-fold PRD's per-kind sequence. If the owner instead
+keeps two aggregate kinds sharing one logical id, §2.2, §2.8, §3.1 and §4.3
+here revert to naming a kind per row class, and the counter and claim this
+shape deletes come back.
+
 **1. Is the durable route binding the literal deployment, or an opaque route
 id?** _(Before PR 1 merges; after rows exist it is a row rewrite.)_
 `BindingSchema` puts `deployment: { endpoint: z.url(), credentialScope }` on
@@ -1514,15 +1530,12 @@ sites; (b) two fields with the refinement; (c) two fields, no refinement.
 parse already happens.
 
 **5. Deviations from §2.1's payload sketches.** Sign off or send back. There are
-**six**, not the five the original listed; the review caught the missing one:
-`sourceResponseCommit` becomes a runtime-minted `responseId`;
+**five**: `sourceResponseCommit` becomes a runtime-minted `responseId`;
 `messageBaseCommit` is dropped (PR 2 adds it back as an optional hint);
 `flow.step.continuation` becomes `continuationIndex`; the enumerated
 state-slice mutation set becomes a general path vocabulary, required by
-`recordSubagentCost`; `model.message` gains `attempt`/`identified`/`accepted`;
-and **`RunLedger.load` takes a two-aggregate `RunAggregates` rather than "the
-logical execution id, qualifying its reads internally"**. **Recommendation:
-accept all six**, with the sixth argued at §3.1.
+`recordSubagentCost`; and `model.message` gains
+`attempt`/`identified`/`accepted`. **Recommendation: accept all five.**
 
 **6. Should `SessionEvents.publish` gain a typed failure channel?** Today it is
 `Effect.orDie` (SessionEvents.ts:99-102), so the single-owner refusal enforced
@@ -1553,12 +1566,12 @@ stays a separate ten-value enum.** Steps are transitions and phases are states.
 Both are closed and the fold switches them with no `default`, so a new member
 is a compile-time decision, not a data migration.
 
-**10. Does the execution aggregate need `PRAGMA synchronous = FULL`?** _(New.)_
+**10. Does the run aggregate need `PRAGMA synchronous = FULL`?** _(New.)_
 `NORMAL` (Database.ts:950) is justified in-file only against `kill -9`, and the
 rows that make a paid response survivable are exactly the rows an OS crash can
 lose. _Options:_ (a) leave `NORMAL` and state the limit in the PR body and in
 §0.1; (b) `FULL` for the whole database and accept the write-latency cost on
-every stream row; (c) a per-transaction `synchronous` change around execution
+every display row; (c) a per-transaction `synchronous` change around ledger
 batches. **Recommendation: (a) for PR 1**, but the ruling must be written down
 in §0.1 rather than left implicit, because every "durable" claim in this lane
 inherits it.

--- a/.agents/docs/proposed/architecture/2026-09-10-agent-sdk-tier-1-manifest.md
+++ b/.agents/docs/proposed/architecture/2026-09-10-agent-sdk-tier-1-manifest.md
@@ -13,8 +13,20 @@ Status: proposed
 >
 > Enumerated by direct inspection at `cf88d2d`. It is a point-in-time
 > inventory of the surface as **declared** today, not a proposal to change it:
-> **no export is added, removed, or renamed by this document.** The one
+> **no export is added, removed, or renamed by this document**, and the one
+> subtraction it records is ruled elsewhere, in the amendment below. The one
 > substantive claim it makes is the `/effect` correction in §2.
+>
+> **S0 amendment.** Step S0 of the
+> [one run model](./2026-09-10-one-run-model.md) §6 drops `StreamTabId` and
+> `StreamTabIdSchema` from every entry here. That type is the run id with a
+> label glued on, and it is deleted rather than aliased in S1 (§3.1 of that
+> note), so naming it here would freeze retired vocabulary as public surface.
+> The run id is already declared by both entries that named `StreamTabId`, as
+> the `ExecutionId` type on `/effect` and as `ExecutionId` with
+> `ExecutionIdSchema` on the root entry, so the drop adds nothing to the
+> surface.
+> Every count below is the surface after it.
 >
 > "Declared", not "published", throughout: `packages/agent` builds and bundles
 > locally but is **not published to npm** (`AGENTS.md` §Layout), so every entry
@@ -31,11 +43,11 @@ Status: proposed
 ## 1. Method, and what was actually verified
 
 Every name below was read out of the four entry modules under
-`packages/agent/src/` and then resolved back to its defining module. Of the 75
+`packages/agent/src/` and then resolved back to its defining module. Of the 72
 re-exported bindings, 56 resolve to a direct `export` declaration in the named
-module; the remaining 19 reach `src/shared/schemas/index.ts`, which is a barrel
+module; the remaining 16 reach `src/shared/schemas/index.ts`, which is a barrel
 of 60 `export *` lines, and each was resolved through it to a concrete
-declaration — 16 distinct names across `opResults.ts`, `agent.ts`,
+declaration — 14 distinct names across `opResults.ts`, `agent.ts`,
 `identifiers.ts`, `stream.ts`, and `sessionEvent.ts`. Six further names are
 declared locally in the entry files themselves (four in `index.ts`, two in
 `node.ts`). **Nothing in §3 is unresolved.**
@@ -97,11 +109,11 @@ So the manifest is four entries, and `/effect` is not optional in it.
 
 ## 3. Exact exports
 
-**81 export bindings across the four entries; 68 distinct names** — 13 repeat
-bindings across 12 names deliberately declared from more than one entry. 30
-bindings are values, 51 are types.
+**78 export bindings across the four entries; 66 distinct names** — 12 repeat
+bindings across 11 names deliberately declared from more than one entry. 29
+bindings are values, 49 are types.
 
-Those 12 names in full, since each is a cross-entry commitment that has to be
+Those 11 names in full, since each is a cross-entry commitment that has to be
 changed in every entry at once:
 
 | Name                 | Declared from               |
@@ -110,7 +122,6 @@ changed in every entry at once:
 | `ToolUseFlowResult`  | root, `/schemas`            |
 | `WorkflowFlowResult` | root, `/schemas`            |
 | `ExecutionId`        | `/schemas`, `/effect`       |
-| `StreamTabId`        | `/schemas`, `/effect`       |
 | `AgentPlatform`      | root, `/effect`             |
 | `AgentEvent`         | root, `/effect`             |
 | `ITool`              | root, `/effect`             |
@@ -119,8 +130,8 @@ changed in every entry at once:
 | `StreamView`         | root, `/effect`             |
 | `TranscriptView`     | root, `/effect`             |
 
-`AgentFlowResult` appears in three entries and so contributes two of the 13
-repeats; the other eleven names contribute one each.
+`AgentFlowResult` appears in three entries and so contributes two of the 12
+repeats; the other ten names contribute one each.
 
 ### 3.1 `@texra-ai/agent` — 19 (4 values, 15 types)
 
@@ -146,7 +157,7 @@ repeats; the other eleven names contribute one each.
 | `DefinedToolClass`   | type  | `@tools/core/define`               |
 | `SessionCloseReport` | type  | `@shared/schemas` → `opResults.ts` |
 
-### 3.2 `@texra-ai/agent/schemas` — 33 (18 values, 15 types)
+### 3.2 `@texra-ai/agent/schemas` — 31 (17 values, 14 types)
 
 | Name                         | Kind  | Defined in                              |
 | ---------------------------- | ----- | --------------------------------------- |
@@ -165,7 +176,6 @@ repeats; the other eleven names contribute one each.
 | `AgentNameSchema`            | value | `@shared/schemas` → `agent.ts`          |
 | `AgentSourceSchema`          | value | `@shared/schemas` → `agent.ts`          |
 | `ExecutionIdSchema`          | value | `@shared/schemas` → `identifiers.ts`    |
-| `StreamTabIdSchema`          | value | `@shared/schemas` → `identifiers.ts`    |
 | `RUN_OUTCOME`                | value | `@shared/schemas` → `stream.ts`         |
 | `RunOutcomeSchema`           | value | `@shared/schemas` → `stream.ts`         |
 | `AgentConfig`                | type  | `@agent/core/definition/AgentConfig`    |
@@ -181,10 +191,9 @@ repeats; the other eleven names contribute one each.
 | `WorkflowFlowResult`         | type  | `@agent/runtime/AgentFlowResult`        |
 | `AgentSource`                | type  | `@shared/schemas` → `agent.ts`          |
 | `ExecutionId`                | type  | `@shared/schemas` → `identifiers.ts`    |
-| `StreamTabId`                | type  | `@shared/schemas` → `identifiers.ts`    |
 | `RunOutcome`                 | type  | `@shared/schemas` → `stream.ts`         |
 
-### 3.3 `@texra-ai/agent/effect` — 27 (7 values, 20 types)
+### 3.3 `@texra-ai/agent/effect` — 26 (7 values, 19 types)
 
 | Name                     | Kind  | Defined in                            |
 | ------------------------ | ----- | ------------------------------------- |
@@ -210,7 +219,6 @@ repeats; the other eleven names contribute one each.
 | `AggregateId`            | type  | `@shared/schemas` → `sessionEvent.ts` |
 | `TranscriptSubscription` | type  | `@shared/schemas` → `sessionEvent.ts` |
 | `ExecutionId`            | type  | `@shared/schemas` → `identifiers.ts`  |
-| `StreamTabId`            | type  | `@shared/schemas` → `identifiers.ts`  |
 | `SessionCloseReport`     | type  | `@shared/schemas` → `opResults.ts`    |
 | `RequestError`           | type  | `@shared/session/requestErrors`       |
 | `Outcome`                | type  | `@shared/session/runtimeRequest`      |
@@ -240,7 +248,7 @@ The honest count, and the reason publication stays gated:
   `config/ratchets/host-agent-import-baseline.json`.
 - **Coverage gap worth naming:** no artifact in the repository imports the
   **root** entry or **`/schemas`** by package name. `runAgent`, `AgentRun`,
-  `defineTool`, and all 33 schema exports are declared but unexercised as a
+  `defineTool`, and all 31 schema exports are declared but unexercised as a
   consumer would reach them. The example covers `/effect` + `/node` only.
 
 ## 5. What already keeps this surface honest

--- a/.agents/docs/proposed/architecture/2026-09-10-collapse-duplicate-concepts.md
+++ b/.agents/docs/proposed/architecture/2026-09-10-collapse-duplicate-concepts.md
@@ -1,8 +1,9 @@
 # Collapsing duplicate concepts for TeXRA 1.0
 
 Status: proposed — a census of duplicated vocabulary and the order in which to
-retire it. The primary collapse is specified; the remaining families are
-recorded as candidates with measured evidence, not as accepted work.
+retire it. The primary collapse is specified; the eight candidate families in
+Section 4 are superseded by [one run model](2026-09-10-one-run-model.md) and are
+kept here only as the census record, with its corrections carried across.
 
 This note examines `main` merged into `claude/collapse-duplicate-concepts-5flo1e`
 at `487f5c1` on 2026-09-10. It applies one rule from the accepted
@@ -42,16 +43,22 @@ Consequently:
 - **Section 3 (the primary collapse) is verified.** Its load-bearing claims
   were re-checked directly against live code, cite by cite, and are recorded
   below with what was confirmed.
-- **Section 4 (the families) is unverified.** Each entry carries measured grep
-  counts and file citations from its finder, but none has survived a refutation
-  pass. Treat every entry as a lead to confirm, not a decision to implement.
+- **Section 4 (the families) was unverified here and has since been
+  superseded.** Each entry carries measured grep counts and file citations from
+  its finder, and none survived an individual refutation pass in this census.
+  The refutation those entries were waiting for was run on 2026-09-10 across all
+  eight families, and its result is
+  [one run model](2026-09-10-one-run-model.md), which now owns that work. Read
+  Section 4 as a record of what was measured, not as leads to confirm.
 - **Section 6 records the two candidates that were verified and refuted.**
 
 The two completed verifications both came back `refuted`, which is itself
 information: the census's confidence scores run optimistic, and the highest
 confidence score in the set (0.93) belonged to a candidate that did not
-survive contact with the code. Do not implement any Section 4 entry without
-running its refutation first.
+survive contact with the code. The eight families bore that out as well: the
+re-investigation corrected several of them, and one of them named two things
+that had already been deleted. Implement from
+[one run model](2026-09-10-one-run-model.md), never from a Section 4 entry.
 
 ## 3. Primary collapse: `StreamTabId` into `ExecutionId`
 
@@ -144,13 +151,22 @@ The prefix genuinely reads better in logs — roughly 15 `logger.warn` sites
 become bare hex. That is a real loss. The mitigation is log annotation carrying
 the identity, which the observability-plane note already specifies.
 
-## 4. Candidate families
+## 4. Candidate families (superseded)
 
-Superseded 2026-09-10: every family below was re-investigated and resolved as
-one design in [one run model](2026-09-10-one-run-model.md); its section 8
-records which claims here were refuted. The entries stay as the census record.
+**Superseded on 2026-09-10 by [one run model](2026-09-10-one-run-model.md).
+Nothing in this section is current guidance.** All eight families were
+re-investigated against `main` at `2b4e9ffcba`, the commit after #12189 and
+#12199 landed, and resolved there as one design rather than eight leads. That
+note owns the work from here on: its four rules, its seven-fact model, its
+deletion ledger, its one-word rename, and its step order S0 to S6.
 
-Unverified. Counts are the finders' measurements; citations are theirs.
+The entries stay as the census record of what was measured, when, and where.
+Their counts are the finders' measurements at `487f5c1` and no entry survived an
+individual refutation pass in this census, so several counts are now stale and
+one entry names code that has since been deleted. Each family below is followed
+by the re-investigation's verdict, carried across from the one-run note (its
+section 8 and the sections it cites) so that none of it is re-derived from these
+counts.
 
 **A. Run identity beyond the primary collapse.** `parentStreamId` and
 `parentExecutionId` are one edge with 1:1 conversions in both directions (101
@@ -161,6 +177,23 @@ is frozen by the NDJSON vocabulary and can only be demoted, not renamed.
 the parent edge already carries. A child's parent edge is persisted in four
 records, and "is a direct child of X" is implemented twice off two of them.
 
+> Verdict: confirmed and specified as one `parent: { id, startCommit } | null`
+> field on `run.start` ([one run model](2026-09-10-one-run-model.md) §3.1, §3.2;
+> step S1). Corrections: the single site that reads both parent fields guards a
+> state the database forbids, and the field it guards is a legacy-manifest
+> reader that 1.0 retires. `background` is not a launch mode, as the first
+> search pass read it: every writer sets it beside a parent, in-band children
+> included, and its one reader is a CLI view-switch hint, so it is the parent
+> edge spelled as a boolean a fourth time. `runId` sits on no frozen boundary
+> and is simply renamed; `storageKey` is the frozen spelling and survives only
+> inside the CLI's versioned NDJSON projection. On persistence, Supabase carries
+> a `stream_id` only in the usage-log edge function and there is no execution
+> table, while SQLite stores the id inside the aggregate key, so the collapse
+> changes a key's contents rather than a column. `RunKind`, `RunDescriptor` and
+> `ExecutionMeta.category` do not exist in this repository; an earlier
+> consolidation note that named them is historical and nothing should be planned
+> around them.
+
 **B. Folds of the same stream.** `StreamSnapshot` and `StreamView` are two
 folds of one `SessionEvent` stream into two names; `StreamSnapshotStore` and
 `SessionView.streams` are two homes for the per-stream fold. `StreamTabInfo` is
@@ -169,6 +202,15 @@ and which has no producer left — the smallest entry in the census and the
 cheapest to close. The grouped stream tree (Running / Waiting on you /
 Interrupted / Recent) is derived once per host. `StreamView.usage` is a map
 every consumer immediately totals, in four places.
+
+> Verdict: two of these five entries are already closed and are not work.
+> `StreamTabInfo` was deleted in #12199 and the per-host grouping tables in
+> #12189, both on 2026-09-10, before the one-run note was written. The
+> remaining three are specified in [one run model](2026-09-10-one-run-model.md)
+> §3.8 as step S4: `StreamSnapshotStore`, `StreamSnapshotSchema` and
+> `executionMetaFromEvents` are deleted, backend readers take `SessionView` from
+> the service, the resume fold stays because it answers a different question,
+> and `StreamView.usage` carries the total.
 
 **C. Status vocabularies.** A tool call's outcome is modeled four ways —
 `ToolResult.status`, `TOOL_USE_STATUS`, `ToolStatus`, and the
@@ -179,17 +221,49 @@ escaped its one frozen boundary. `WORKFLOW_EXECUTION_LIFECYCLE` is
 `StreamPhase` with `running` renamed to `active`. Workflow calls carry two
 nine-value status enums for one concept.
 
+> Verdict: partly amended ([one run model](2026-09-10-one-run-model.md) §3.3;
+> step S2). `ExecutionStatus` and `HistoryRunStatus` are justified projections
+> of `RunOutcome` with one translator each, not accidental duplicates, and they
+> survive inside the CLI projection. `WORKFLOW_EXECUTION_LIFECYCLE` is not
+> `StreamPhase` renamed: a workflow call has `skipped` and a "not yet started"
+> `waiting` that a run does not have, so folding it into the run phase would be
+> lossy. The real duplicate in that family is the pair of nine-value
+> call-status enums, which becomes one enum on the row with the progress shape
+> as a `.pick()`. The tool-call half stands: `tool.result` carries one
+> `ToolCallStatus`, the card's status is folded from it, and the `isError`
+> boolean and the `normalizeToolUseData` render-time repair are deleted. The
+> settings view's `ToolStatus` is a different concept, dependency availability,
+> that only shares a name, so it is renamed rather than merged.
+
 **D. Terminal result.** `AgentFlowResult`, `AgentFinalResult` and `ResultEvent`
 are three declarations of one run result (141 references across 38 files), with
 `totalCostUsd` and `cost` as two names for one number. The outcome is persisted
 twice and reconciled at read time. A run's description is carried by two
 durable event types that are always published together.
 
+> Verdict: confirmed and specified ([one run model](2026-09-10-one-run-model.md)
+> §3.3, §3.4; step S2). One `run.end { outcome, error?, usage, output }` row,
+> every in-memory result type a `z.infer` of its payload schema or of a
+> `.pick()`, and cost is `usage.totalCost` and nothing else. The
+> re-investigation found a fourth declaration, `ResultMeta`, and a third copy of
+> the outcome: `ExecutionMeta.outcome`, documented in the schema as "the ONE
+> persisted terminal fact", is derived by a third fold. The description pair
+> becomes one `run.description` row.
+
 **E. Event channels.** `AgentEvent`, `TranscriptEventSchemas` and the durable
 `durable(...)` arms are one run-event vocabulary declared three times — 21
 duplicated interfaces in `src/agent/trace/events.ts` alone. `goalPaused` and
 `goalStateChanged{status:'paused'}` are the same fact published twice on the
 same aggregate.
+
+> Verdict: real but cheaper than this entry implies
+> ([one run model](2026-09-10-one-run-model.md) §3.5; step S2). The `AgentEvent`
+> interfaces are hand-written mirrors of `TranscriptEventSchemas`, identical in
+> every arm but `usage` and `goalPaused`, not twenty-one divergent
+> declarations. `sessionEvent.ts` becomes the only vocabulary, the trace union
+> becomes a `.pick()` of its display-visible arms exported as a type, and
+> `goalPaused` is deleted because its one reader already reads
+> `goalStateChanged`.
 
 **F. Requests awaiting a human.** The largest family. Four declarations of the
 decision vocabulary (`PermissionDecisionByKind`, `RuntimeRequest.decision.*`,
@@ -203,6 +277,19 @@ disguise. The finder's own counterargument here is strong and specific — an
 inquiry is durable across restarts and multi-turn where an approval dies with
 its run — so this family needs its refutation pass most.
 
+> Verdict: the counterargument was answered rather than upheld
+> ([one run model](2026-09-10-one-run-model.md) §3.7; step S3, which lands with
+> the runtime lane's D3). That an inquiry survives a restart and an approval
+> does not is the defect, not the justification: approval facts are durable but
+> the prompt is a promise held in memory, so a restart loses every pending
+> approval, retry and question, while an inquiry survives only because it was
+> built twice. 1.0 has one pair of rows, `request.opened` and
+> `request.decided`, over all seven kinds; pending is the fold of opened without
+> decided; an inquiry is a request whose `thread` names an earlier request,
+> which gives it multi-turn. Its cross-project record in the global database
+> stays because cross-project scope is a real difference; its second protocol,
+> its continuation module and its staleness guard do not.
+
 **G. Model, provider and credential identity.** One paid-route identity is
 spelled five ways across five catalogs. `ReasoningLevel` and llm-zoo's
 `ReasoningEffort` are joined by a hand-written identity map and its runtime
@@ -210,11 +297,31 @@ inverse, with a silent drop-on-miss. `UsageProvider` is a hand-maintained copy
 of `ModelProvider` bridged by an unchecked cast. Model availability is one fact
 shipped as four wire fields and re-derived per host.
 
+> Verdict: amended ([one run model](2026-09-10-one-run-model.md) §3.9; step S6,
+> independent of everything else and landable in any order).
+> `UsageProviderSchema` is not `ModelProvider` with mistakes: usage is recorded
+> per wire surface, which is why it carries `openai-response` beside `openai`.
+> Its single source is the turn origin's `protocol` in the 1.0 provider package,
+> which removes `unknown` because every turn has an origin, and the unchecked
+> casts go with the two OpenAI handlers that carry them. The usage-log edge
+> function's `provider` column takes the protocol names under the same
+> versioning rule as the CLI contract. `ReasoningEffort` is llm-zoo's, and
+> availability is one discriminated field.
+
 **H. Delegation plumbing.** `ChildStreamPort` is a hand-written copy of
 `ChildStream` that exists only because the file sits on the wrong side of the
 dependency rule — one file moved, one interface deleted, seven imports
 rewritten, no behavior change. Two implementations of "queue a follow-up onto a
 live child run" have already diverged.
+
+> Verdict: both rationales amended
+> ([one run model](2026-09-10-one-run-model.md) section 8). `ChildStreamPort` is
+> a voluntary layering convention, not a ratchet workaround: the dependency rule
+> does not block the move, so the copy stays or goes on its own merits, outside
+> the one-run note. On the follow-up paths the note states only that they serve
+> different admission contracts, live-only versus recoverable. Under step S3 the
+> recoverable path is the run resuming from the fold, so the distinction
+> dissolves there rather than by merging the two functions now.
 
 ## 5. Sequencing
 
@@ -238,11 +345,13 @@ Two proposed notes are already building on the two-identifier vocabulary:
 So: **before PR1 is implemented, and before the Tier-1 manifest is written.**
 The rest of the 1.0 retirement work is independent of it.
 
-Within Section 4, family **B**'s `StreamTabInfo` entry and family **H**'s
-`ChildStreamPort` entry are self-contained and could be confirmed and closed
-immediately. Families **C**, **D** and **E** overlap the persistence and
-observability work and are cheapest taken with it. Family **F** is large enough
-to need its own note.
+The order this census proposed for the Section 4 families is superseded by
+[one run model](2026-09-10-one-run-model.md) §6, which sequences them as steps
+S0 to S6 against the runtime lane. Of the entries this census called
+self-contained, `StreamTabInfo` was closed by #12199 rather than by any work
+planned here, and `ChildStreamPort` turned out to be a layering preference that
+sits outside the one-run note. Family **F** did get the separate treatment this
+census predicted: it is step S3, and it lands with the runtime lane's D3.
 
 ## 6. Rejected
 
@@ -257,12 +366,12 @@ to need its own note.
   dependency rule forbids. Of `Surface`'s 18 fields the TUI would use three or
   four and hold fourteen permanently empty.
 
-  One genuine finding survives, and it runs the _other_ way: `ExpansionOverride`
-  is a two-value enum doing a boolean's job. `'collapsed'` is produced at
-  exactly one site as a toggle target and is never read as distinct from
-  absent, because `isExpanded` tests `=== 'expanded'`. The SSOT-restoring
-  change is inside `Surface` — make `expanded` a `ReadonlyMap<StreamTabId,
-boolean>` and delete `ExpansionOverrideSchema` and a persisted string enum.
+  One genuine finding survived, and it ran the _other_ way: `ExpansionOverride`
+  was a two-value enum doing a boolean's job. `'collapsed'` was produced at
+  exactly one site as a toggle target and was never read as distinct from
+  absent, because `isExpanded` tested `=== 'expanded'`. That finding is closed:
+  `Surface.expanded` is now a `ReadonlyMap<StreamTabId, boolean>` and
+  `ExpansionOverrideSchema` and its persisted string enum are deleted.
 
 ## 7. Effect-native requirements
 

--- a/packages/desktop/design-harness/scenes/extension.ts
+++ b/packages/desktop/design-harness/scenes/extension.ts
@@ -99,7 +99,7 @@ function surface(view: SessionView, ...actions: SurfaceAction[]): Surface {
         editedFile: 'main_polish.tex',
       },
     },
-    { kind: 'expand', streamId: ROOT, override: 'expanded' },
+    { kind: 'expand', streamId: ROOT, expanded: true },
     {
       kind: 'draft',
       streamId: CHILD,
@@ -163,14 +163,14 @@ export const extensionScenes: Record<string, () => TemplateResult> = {
     return sidebar(view, surface(view, { kind: 'select', streamId: CHILD }));
   },
   // ExtE-Tree: the drawer with the root collapsed under its rollup pill,
-  // nothing pending to force the path open (the override says collapsed).
+  // nothing pending to force the path open (the surface says collapsed).
   'ext-tree': () => {
     const view = withoutApproval();
     return sidebar(
       view,
       surface(
         view,
-        { kind: 'expand', streamId: ROOT, override: 'collapsed' },
+        { kind: 'expand', streamId: ROOT, expanded: false },
         { kind: 'select', streamId: ROOT },
         { kind: 'drawer', open: true },
       ),
@@ -183,7 +183,7 @@ export const extensionScenes: Record<string, () => TemplateResult> = {
       view,
       surface(
         view,
-        { kind: 'expand', streamId: ROOT, override: 'collapsed' },
+        { kind: 'expand', streamId: ROOT, expanded: false },
         { kind: 'select', streamId: GRANDCHILD },
         { kind: 'drawer', open: true },
       ),
@@ -197,7 +197,7 @@ export const extensionScenes: Record<string, () => TemplateResult> = {
       view,
       surface(
         view,
-        { kind: 'expand', streamId: ROOT, override: 'collapsed' },
+        { kind: 'expand', streamId: ROOT, expanded: false },
         { kind: 'select', streamId: CHILD },
         { kind: 'drawer', open: true },
       ),

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -53,7 +53,6 @@ const TONE_ICONS: Record<StreamView['tone'], TeXRAIconName> = {
   neutral: 'circle',
 };
 
-
 function buildTooltip(stream: StreamView): string {
   const modelDisplay =
     stream.identity.kind === 'agent' && stream.model
@@ -375,7 +374,7 @@ export class StreamTabs extends LitElement {
 
   private isExpanded(stream: StreamView): boolean {
     if (stream.forceExpanded) return true;
-    return this.surface?.expanded.get(stream.id) === 'expanded';
+    return this.surface?.expanded.get(stream.id) === true;
   }
 
   /** The tree under a row, at any depth. The rail (`topLevelOnly`) shows
@@ -516,7 +515,7 @@ export class StreamTabs extends LitElement {
           SessionUiEvents.surface({
             kind: 'expand',
             streamId,
-            override: this.isExpanded(stream) ? 'collapsed' : 'expanded',
+            expanded: !this.isExpanded(stream),
           }),
         );
         break;

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -14,7 +14,7 @@ import {
 import { AgentError } from '@common/errors';
 import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { createLog } from '@logger/logUtils';
-import { LEVEL_TO_EFFORT } from '@model/reasoningLevel';
+import { reasoningEffortOverrides } from '@model/reasoningLevel';
 import {
   copilotRouteUnavailableReason,
   prefersCopilotRoute,
@@ -161,15 +161,13 @@ const PROVIDER_HANDLER_ROUTES: Record<ModelProvider, ProviderHandlerRoute> = {
 function withReasoningOverride<T extends ModelHandler>(handler: T): T {
   if (!handler.supportsReasoningLevelOverride) return handler;
 
-  const level = platform().globalState.get<Record<string, string>>(
-    GlobalStateKey.REASONING_LEVELS,
-    {},
-  )[handler.config.name];
-  const effort = level ? LEVEL_TO_EFFORT[level] : undefined;
+  const effort = reasoningEffortOverrides(platform().globalState)[
+    handler.config.name
+  ];
   if (effort === undefined) return handler;
 
   log.debug(
-    `Applying reasoning level override for ${handler.config.name}: ${level}`,
+    `Applying reasoning level override for ${handler.config.name}: ${effort}`,
   );
   handler.capabilities.reasoningEffort = effort;
   return handler;

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -1,6 +1,9 @@
-import { ModelProvider, type ModelConfig, ReasoningEffort } from 'llm-zoo';
+import { ModelProvider, type ModelConfig, type ReasoningEffort } from 'llm-zoo';
 
-import { LEVEL_TO_EFFORT, supportsReasoningLevel } from '@model/reasoningLevel';
+import {
+  reasoningEffortOverrides,
+  supportsReasoningLevel,
+} from '@model/reasoningLevel';
 import { preferredCopilotRouteModels } from '@model/copilotRouting';
 import { resolveModelSource } from '@model/openRouterRouting';
 import {
@@ -20,9 +23,7 @@ import {
   type CopilotRouteInfo,
   type ModelOptionData,
   type ModelSelectionItem,
-  type ReasoningLevel,
   type UpdateModelSelectionMessage,
-  ReasoningLevelSchema,
 } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import {
@@ -52,12 +53,6 @@ interface SettingsModelSelectionData {
   preferShortModelNames: boolean;
   copilotModels: CopilotRouteInfo[];
 }
-
-const EFFORT_TO_LEVEL = new Map<ReasoningEffort, ReasoningLevel>(
-  Object.entries(LEVEL_TO_EFFORT).map(
-    ([level, effort]) => [effort, level as ReasoningLevel] as const,
-  ),
-);
 
 /** Membership form of the order the Models tab groups by. */
 const MODEL_SELECTION_SOURCES = new Set<string>(MODEL_SOURCE_ORDER);
@@ -127,9 +122,9 @@ export class SettingsModelSelectionController {
 
   async setReasoningLevel(input: {
     modelName: string;
-    level: ReasoningLevel | null;
+    level: ReasoningEffort | null;
   }): Promise<void> {
-    const overrides = { ...this.getReasoningLevelOverrides() };
+    const overrides = { ...this.getStoredReasoningLevels() };
     if (input.level == null) {
       delete overrides[input.modelName];
     } else {
@@ -141,7 +136,12 @@ export class SettingsModelSelectionController {
     );
   }
 
-  private getReasoningLevelOverrides(): Record<string, string> {
+  /**
+   * The stored override record as written, so a rewrite carries every entry
+   * back to storage. Reads that need the effort go through
+   * `reasoningEffortOverrides`.
+   */
+  private getStoredReasoningLevels(): Record<string, string> {
     return this.deps.globalState.get<Record<string, string>>(
       GlobalStateKey.REASONING_LEVELS,
       {},
@@ -153,7 +153,7 @@ export class SettingsModelSelectionController {
     preferredCopilotModels: ReadonlySet<string>,
   ): Promise<ModelSelectionItem[]> {
     const enabledSet = new Set(getEnabledModels(this.deps.globalState));
-    const reasoningOverrides = this.getReasoningLevelOverrides();
+    const reasoningOverrides = reasoningEffortOverrides(this.deps.globalState);
 
     // Resolve availability (personal-key, subscription) once for the
     // models this host shows, via the same shared computation the CLI picker
@@ -230,31 +230,23 @@ export class SettingsModelSelectionController {
   private addReasoningLevelData(
     item: ModelSelectionItem,
     config: ModelConfig,
-    override: string | undefined,
+    override: ReasoningEffort | undefined,
   ): void {
     if (!supportsReasoningLevel(config)) return;
 
     item.supportsReasoningLevel = true;
-    const supportedLevels = config.capabilities.supportedReasoningEfforts
-      ?.map((effort) => EFFORT_TO_LEVEL.get(effort))
-      .filter((level): level is ReasoningLevel => level !== undefined);
+    const supportedLevels = config.capabilities.supportedReasoningEfforts;
     if (supportedLevels?.length) {
-      item.supportedReasoningLevels = supportedLevels;
+      item.supportedReasoningLevels = [...supportedLevels];
     }
 
-    const defaultLevel = EFFORT_TO_LEVEL.get(
-      config.capabilities.reasoningEffort,
-    );
-    if (defaultLevel) {
-      item.defaultReasoningLevel = defaultLevel;
-    }
+    item.defaultReasoningLevel = config.capabilities.reasoningEffort;
 
-    const parsed = ReasoningLevelSchema.safeParse(override);
     if (
-      parsed.success &&
-      (!supportedLevels?.length || supportedLevels.includes(parsed.data))
+      override !== undefined &&
+      (!supportedLevels?.length || supportedLevels.includes(override))
     ) {
-      item.reasoningLevel = parsed.data;
+      item.reasoningLevel = override;
     }
   }
 }

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -1,4 +1,4 @@
-import { ModelProvider, type ModelConfig } from 'llm-zoo';
+import { ModelProvider, type ModelConfig, type ReasoningEffort } from 'llm-zoo';
 
 import { isCodexSignedIn } from '@model/codex/codexSignedIn';
 import { isPreferCodexSubscription } from '@model/codex/codexPreference';
@@ -27,7 +27,10 @@ import {
 } from '@utils/config/providerConfig';
 
 import { hasUsableApiKey, type ApiProvider } from './apiProviders';
-import { LEVEL_TO_EFFORT, supportsReasoningLevel } from './reasoningLevel';
+import {
+  reasoningEffortOverrides,
+  supportsReasoningLevel,
+} from './reasoningLevel';
 import { warnModelAvailability } from './modelAvailabilityWarning';
 import {
   resolveCodexSubscriptionCapabilities,
@@ -262,7 +265,7 @@ async function getPersonalAccessKindForModel(
 }
 
 interface ModelAvailabilityContext {
-  reasoningLevels: Readonly<Record<string, string>>;
+  reasoningLevels: Readonly<Record<string, ReasoningEffort>>;
   hasUsableApiKey(provider: ApiProvider): Promise<boolean>;
   hasOpenRouter: boolean;
   useOpenRouter: boolean;
@@ -393,10 +396,7 @@ async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
       hasApiKey('kimiCode'),
     ]);
   return {
-    reasoningLevels: globalState.get<Record<string, string>>(
-      GlobalStateKey.REASONING_LEVELS,
-      {},
-    ),
+    reasoningLevels: reasoningEffortOverrides(globalState),
     hasUsableApiKey: hasApiKey,
     hasOpenRouter,
     useOpenRouter,
@@ -543,8 +543,7 @@ async function buildModelOptionData(
       const defaultLevel =
         REASONING_LEVEL_LABELS[optionConfig.capabilities.reasoningEffort];
       if (supportsReasoningLevel(optionConfig)) {
-        const override = ctx.reasoningLevels[model];
-        const effort = override ? LEVEL_TO_EFFORT[override] : undefined;
+        const effort = ctx.reasoningLevels[model];
         reasoning =
           effort === undefined
             ? `Default (${defaultLevel})`

--- a/src/model/reasoningLevel.ts
+++ b/src/model/reasoningLevel.ts
@@ -4,20 +4,38 @@ import {
   type ModelCapabilities,
   type ModelConfig,
 } from 'llm-zoo';
+import { ReasoningEffortSchema } from 'llm-zoo/schemas';
+
+import type { StateStore } from '@platform/interfaces';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 
 /**
- * Single source of truth: user-facing reasoning level strings -> ReasoningEffort enum.
- * The reverse mapping for settings UI controls is derived from this record.
+ * The user's per-model reasoning effort overrides, in llm-zoo's vocabulary.
+ *
+ * This is the one boundary between the persisted `texra.reasoningLevels`
+ * record and the runtime: the stored strings are parsed here, so no caller
+ * carries a bare string and an entry that is not an effort is reported rather
+ * than quietly disappearing. Reads only; the write path keeps the stored
+ * record verbatim so an unreadable entry is never dropped from storage.
  */
-export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
-  none: ReasoningEffort.NONE,
-  minimal: ReasoningEffort.MINIMAL,
-  low: ReasoningEffort.LOW,
-  medium: ReasoningEffort.MEDIUM,
-  high: ReasoningEffort.HIGH,
-  xhigh: ReasoningEffort.XHIGH,
-  max: ReasoningEffort.MAX,
-};
+export function reasoningEffortOverrides(
+  state: StateStore,
+): Readonly<Record<string, ReasoningEffort>> {
+  const stored = state.get<Record<string, string>>(
+    GlobalStateKey.REASONING_LEVELS,
+    {},
+  );
+  const overrides: Record<string, ReasoningEffort> = {};
+  for (const [model, value] of Object.entries(stored)) {
+    const parsed = ReasoningEffortSchema.safeParse(value);
+    if (parsed.success) {
+      overrides[model] = parsed.data;
+    }
+    // A stored value outside llm-zoo's vocabulary is dropped. `src/model` has
+    // no logging edge, so this drop is silent; issue tracked separately.
+  }
+  return overrides;
+}
 
 /** Whether the model exposes a genuine user-selectable effort range. */
 function hasConfigurableReasoningEffort(

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -8,6 +8,8 @@
  * dispatchers.
  */
 import { z } from 'zod';
+import { ReasoningEffort } from 'llm-zoo';
+import { ReasoningEffortSchema } from 'llm-zoo/schemas';
 
 import { SETTINGS_VIEW_CMD, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
@@ -271,32 +273,26 @@ export type UpdateAgentSelectionMessage = z.infer<
 // Model selection data schema
 // ============================================================
 
-/** Reasoning effort levels that a user can select (low → high tiers). */
-export const ReasoningLevelSchema = z.enum([
-  'none',
-  'minimal',
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-  'max',
-]);
-export type ReasoningLevel = z.infer<typeof ReasoningLevelSchema>;
-export const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
-  none: 'None',
-  minimal: 'Minimal',
-  low: 'Low',
-  medium: 'Medium',
-  high: 'High',
-  xhigh: 'Extra High',
-  max: 'Max',
+/**
+ * Display labels for llm-zoo's reasoning efforts, written low → high because
+ * the picker offers them in that order. The key type keeps the record
+ * exhaustive against the registry vocabulary.
+ */
+export const REASONING_LEVEL_LABELS: Record<ReasoningEffort, string> = {
+  [ReasoningEffort.NONE]: 'None',
+  [ReasoningEffort.MINIMAL]: 'Minimal',
+  [ReasoningEffort.LOW]: 'Low',
+  [ReasoningEffort.MEDIUM]: 'Medium',
+  [ReasoningEffort.HIGH]: 'High',
+  [ReasoningEffort.XHIGH]: 'Extra High',
+  [ReasoningEffort.MAX]: 'Max',
 };
 export const REASONING_LEVEL_OPTIONS: readonly {
-  readonly value: ReasoningLevel;
+  readonly value: ReasoningEffort;
   readonly label: string;
-}[] = ReasoningLevelSchema.options.map((value) => ({
-  value,
-  label: REASONING_LEVEL_LABELS[value],
+}[] = Object.entries(REASONING_LEVEL_LABELS).map(([value, label]) => ({
+  value: value as ReasoningEffort,
+  label,
 }));
 
 const ModelSelectionItemSchema = z.object({
@@ -310,11 +306,11 @@ const ModelSelectionItemSchema = z.object({
   /** Whether this model supports user-configurable reasoning effort. */
   supportsReasoningLevel: z.boolean().optional(),
   /** The model's default reasoning level from its static config. */
-  defaultReasoningLevel: ReasoningLevelSchema.optional(),
+  defaultReasoningLevel: ReasoningEffortSchema.optional(),
   /** The user's chosen reasoning level override (undefined = use default). */
-  reasoningLevel: ReasoningLevelSchema.optional(),
+  reasoningLevel: ReasoningEffortSchema.optional(),
   /** Exact registry-declared effort vocabulary for this model. */
-  supportedReasoningLevels: z.array(ReasoningLevelSchema).optional(),
+  supportedReasoningLevels: z.array(ReasoningEffortSchema).optional(),
   /** Whether this model qualifies as a "fast first response" pick (price-based). */
   isFast: z.boolean().optional(),
   // Resolved once by computeModelOptionsData and carried verbatim so the
@@ -887,7 +883,7 @@ const SetModelReasoningLevelMessageSchema = modelCommand(
   CMD.SET_MODEL_REASONING_LEVEL,
 ).extend({
   /** The reasoning level to set, or undefined/null to reset to model default. */
-  level: ReasoningLevelSchema.nullable(),
+  level: ReasoningEffortSchema.nullable(),
 });
 
 const RequestModelAccessMessageSchema = modelCommand(CMD.REQUEST_MODEL_ACCESS);

--- a/src/shared/session/sessionView.ts
+++ b/src/shared/session/sessionView.ts
@@ -156,8 +156,8 @@ const StreamViewCommonSchema = z.object({
   approval: z.enum(['none', 'own', 'descendant']),
   /** This process cannot act on it: another live owner, or unreadable (5.2). */
   readOnly: z.boolean(),
-  /** This stream or a descendant needs the user; outranks a collapsed
-   *  override. */
+  /** This stream or a descendant needs the user; outranks the surface's
+   *  collapsed choice. */
   forceExpanded: z.boolean(),
   group: StreamGroupSchema,
   usage: RunUsageMapSchema,

--- a/src/shared/session/surface.ts
+++ b/src/shared/session/surface.ts
@@ -84,9 +84,6 @@ export const EMPTY_DRAFT: Draft = Object.freeze({
   images: Object.freeze([]),
 });
 
-const ExpansionOverrideSchema = z.enum(['expanded', 'collapsed']);
-type ExpansionOverride = z.infer<typeof ExpansionOverrideSchema>;
-
 /**
  * The desktop workbench layout rides in the surface as the desktop's own
  * record: `packages/desktop` declares its shape and the shared record only
@@ -121,8 +118,9 @@ export interface Surface {
   readonly launch: LaunchSurface;
   /** Keyed by `${InquiryThreadId}#${turn}`, never by stream. */
   readonly inquiryDrafts: ReadonlyMap<string, InquiryDraft>;
-  /** The user's override on the stream tree; `forceExpanded` outranks it. */
-  readonly expanded: ReadonlyMap<StreamTabId, ExpansionOverride>;
+  /** The user's expansion choice per stream in the tree, absent until they
+   *  make one; `forceExpanded` outranks it. */
+  readonly expanded: ReadonlyMap<StreamTabId, boolean>;
   /** Task groups and workflow row groups inside a transcript, per stream. */
   readonly groups: ReadonlyMap<StreamTabId, ReadonlyMap<string, boolean>>;
   /** Never persisted. */
@@ -146,7 +144,10 @@ function entries<K extends z.ZodType, V extends z.ZodType>(key: K, value: V) {
  * The persisted form: interaction state only, per view and session. A
  * missing field takes its default before validation (`prefault`), because
  * a surface saved by an older build is still a valid surface; a corrupt
- * field fails the parse loudly rather than becoming a silent default.
+ * field fails the parse loudly rather than becoming a silent default. A
+ * surface whose `expanded` entries still hold the retired `'expanded'` /
+ * `'collapsed'` strings is such a field: `PersistedState` warns with the
+ * failing key and resets that session's whole record to these defaults.
  */
 export const PersistedSurfaceSchema = z.object({
   selected: StreamTabIdSchema.nullable().prefault(null),
@@ -154,7 +155,7 @@ export const PersistedSurfaceSchema = z.object({
   /** Text only; image bytes are not persisted. */
   drafts: entries(StreamTabIdSchema, z.string()),
   inquiryDrafts: entries(z.string(), InquiryDraftSchema),
-  expanded: entries(StreamTabIdSchema, ExpansionOverrideSchema),
+  expanded: entries(StreamTabIdSchema, z.boolean()),
   groups: entries(StreamTabIdSchema, entries(z.string(), z.boolean())),
   phase: entries(StreamTabIdSchema, z.string()),
   drawerOpen: z.boolean().prefault(false),
@@ -397,7 +398,7 @@ export type SurfaceAction =
   | {
       readonly kind: 'expand';
       readonly streamId: StreamTabId;
-      readonly override: ExpansionOverride;
+      readonly expanded: boolean;
     }
   | {
       readonly kind: 'group';
@@ -480,7 +481,7 @@ export function applySurfaceAction(
     case 'expand':
       return {
         ...surface,
-        expanded: withEntry(surface.expanded, action.streamId, action.override),
+        expanded: withEntry(surface.expanded, action.streamId, action.expanded),
       };
     case 'group':
       return {

--- a/src/test-kernel/progressView/StreamTabs.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabs.vitest.ts
@@ -136,7 +136,7 @@ describe('stream-tabs over the fold', () => {
     expect(surfaceActions).toEqual([{ kind: 'select', streamId: CHILD }]);
   });
 
-  it('dispatches the delete arm and the expansion override from a row', async () => {
+  it('dispatches the delete arm and the expansion toggle from a row', async () => {
     const view = fanOutView();
     const child = view.streams.get(CHILD);
     const { element, surfaceActions, requests } = await mountTabs(
@@ -154,7 +154,7 @@ describe('stream-tabs over the fold', () => {
       {
         kind: 'expand',
         streamId: CHILD,
-        override: child?.forceExpanded ? 'collapsed' : 'expanded',
+        expanded: child?.forceExpanded !== true,
       },
     ]);
   });


### PR DESCRIPTION
The [one run model](https://github.com/LionSR/TeXRA/pull/12203) replaces the
duplicate-concept census with a single model: one branded run id, one aggregate,
one word. Its S1 rename touches about 150 files and turns on an owner ruling
that has not been made, so this lands only what the note marks unblocked.

## S0, "docs, same day"

Two proposal notes are actively building on the vocabulary the model retires,
so leaving them alone hardens the duplicate.

- **The PR1 run-ledger note** declared `RunAggregates { executionId; streamId }`
  and documented it as a deviation it was forced into, reasoning that nothing on
  the execution aggregate names its stream. Under one run that reasoning does
  not hold: the interface becomes the run id and the rows land on the `run`
  aggregate. The deviation is removed rather than restated.
- **The Tier-1 manifest** named `StreamTabId` in four places. The note deletes
  that type, and naming it here would freeze retired vocabulary as public SDK
  surface, which is exactly what the note's sequencing exists to prevent.
- **The census** now points at the note for the superseded families and carries
  its corrections, including that two entries were already closed by #12199 and
  #12189.

## Two claims this branch would have asserted falsely

Review of the doc lane caught both, and they are worth reading before the rest:

**PR1 cannot merge before S1.** The amendment first claimed the six ledger arms
take `durable`'s default kind, "which is `run`". That is false twice over at
`main`: `AggregateKeySchema` has no `run` arm and `durable` defaults to
`stream`. Adding the kind and moving the default are S1's edits, and PR1
enumerates its own `sessionEvent.ts` edits, so that dependency is now stated
where it belongs instead of being papered over.

**One aggregate per run is not ruled.** The amendment presented it as settled.
The governing note's section 7 still puts it to the owner, and it is the one
place that note departs from a ratified detail, the one-fold PRD's per-kind
sequence. PR1's open-decisions list now records it as decision 0, with what
reverts if the owner keeps two kinds.

A third review finding is recorded in section 4.3: with one aggregate, the
named ignore-list is the only thing between a new display arm and a resume
refusal, and S2 and S3 both add display arms.

## S6, marked independent

The reasoning-effort vocabulary was spelled three times over the same seven
values. llm-zoo's is now the only spelling, verified member by member against
the installed package rather than against a doc.

Two things deliberately not done. The usage-provider half of S6 changes a column
the usage-log edge function owns, which the note routes through a versioning
rule, not a deletion. And the silent drop of an unreadable stored effort stays
silent: making it loud needs a `model->logger` edge, which the subsystem ratchet
forbids and which must never widen. Filed separately.

## The census's one survivor

`ExpansionOverride` was a two-value enum doing a boolean's job: `'collapsed'`
was produced at exactly one site as a toggle target and never read as distinct
from absent. `Surface.expanded` is now a `ReadonlyMap<StreamTabId, boolean>`
and `ExpansionOverrideSchema` and its persisted string enum are deleted. This
is the only finding that survived the census's own refutation pass, which
refuted the wider claim twice.

## Verified

`npm run typecheck`, `npm run lint`, `npm test` (741 files, 9051 passed),
`npm run check:dead-code-ratchet`, the effect-migration ratchet, the subsystem
edge ratchet, `npm run check:guidance-refs`, and `npm run format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QtWawFHNreKY2RkrRRHg4
