### PR TITLE
fix(session): stop blanking finalized responses, and delete the dead paths behind it

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -102,7 +102,6 @@
       "packages/cli/src/chat/chatSessionController.ts": 1,
       "src/agent/followUp/FollowUpQueue.ts": 1,
       "src/agent/runtime/ModelRetryGate.ts": 1,
-      "src/agent/runtime/SessionHandle.ts": 1,
       "src/agent/storage/executionLease.ts": 1
     },
     "import:async-mutex": {
@@ -126,7 +125,7 @@
       "packages/desktop/src/main/index.ts": 1,
       "packages/extension/src/progressView/ProgressViewProvider.ts": 1,
       "src/agent/remote/RemoteAgentLoader.ts": 1,
-      "src/agent/runtime/SessionHandle.ts": 3,
+      "src/agent/runtime/SessionHandle.ts": 2,
       "src/agent/runtime/bundledPrompts.ts": 1,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/utils/files/relativeFS.ts": 2

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -40,7 +40,6 @@ import {
   SubscriptionRef,
   type Stream,
 } from 'effect';
-import pDefer, { type DeferredPromise } from 'p-defer';
 
 import type {
   AgentEvent,
@@ -219,9 +218,6 @@ export class SessionHandle {
   private disposed = false;
   private readonly publicationGate = Semaphore.makeUnsafe(1);
   private readonly publications = new Set<Promise<Exit.Exit<unknown>>>();
-  private readonly artifactFlushers = new Set<() => Promise<void>>();
-  private pendingArtifactFlush: DeferredPromise<void> | undefined;
-  private artifactFlushWorkerRunning = false;
   /** Session-scoped host interaction owner. */
   readonly interactions: SessionHostInteractions;
   /** Session-owned approval queues, pending registries, and bypass state. */
@@ -291,8 +287,8 @@ export class SessionHandle {
 
     this.status = status;
     // The sidecar store is a session artifact exactly like `transcripts`: the
-    // session projects its own run events into it and flushes it below, so no
-    // host has to construct, attach, and flush one of its own.
+    // session projects its own run events into it, so no host has to
+    // construct or attach one of its own.
     this.snapshots = init.snapshots;
     this.applySnapshotEvent = this.snapshots.attachSessionEvents();
     this.interactions = interactions;
@@ -301,8 +297,6 @@ export class SessionHandle {
     this.responseTextProcessing =
       init.responseTextProcessing ?? createNeutralResponseTextProcessing();
     this.workflowControls = new WorkflowControlRegistry();
-    // Every session owns exactly one trace-flusher map. There is no
-    // process-wide registry: a host drains the session it is shutting down.
     if (init.interactions) this.interactions.use(init.interactions);
     liveSessions.add(this);
     // Register teardown in reverse LIFO order so `teardown.dispose()` runs the
@@ -318,7 +312,6 @@ export class SessionHandle {
       this.disposed = true;
     });
     this.teardown.add(() => this.resultListeners.clear());
-    this.teardown.add(() => this.artifactFlushers.clear());
     this.teardown.add(() => this.interactions.dispose());
     this.teardown.add(() => this.modelRetries.dispose());
     // Drop bypass state before the interaction slot settles pending approvals.
@@ -374,16 +367,10 @@ export class SessionHandle {
     ]);
   }
 
-  /** Register a session-owned durable writer such as a snapshot store. */
-  useArtifactFlusher(flush: () => Promise<void>): () => void {
-    this.artifactFlushers.add(flush);
-    return () => this.artifactFlushers.delete(flush);
-  }
-
   /**
-   * End ownership of one execution after every session-owned durable writer
-   * has drained. An optional post-drain operation publishes lifecycle state
-   * that belongs after those artifacts; it runs before the claim is unlinked.
+   * End ownership of one execution after the facts it queued have committed.
+   * An optional post-drain operation publishes lifecycle state that belongs
+   * after those facts; it runs before the claim is unlinked.
    * The claim is unlinked whatever the drain did: resumability is the
    * checkpoint, so a failed flush is logged and rethrown but never changes
    * who owns the run. A release failure never masks a drain failure: the
@@ -408,8 +395,11 @@ export class SessionHandle {
           yield* afterArtifactsDrained;
         }),
       );
-      // A rejected artifact flush cannot let claim release overtake facts that
-      // were already queued by the same owner.
+      // Settle whatever the drain did. When the drain rejected
+      // (including in `validateOwnedExecutionLease`), the post-drain step
+      // never ran, and this settle still stops claim release from overtaking
+      // facts the owner already queued. On success it also covers the facts
+      // `afterArtifactsDrained` published.
       const published = yield* Effect.exit(
         Effect.tryPromise({
           try: () => this.settlePublications(),
@@ -458,52 +448,14 @@ export class SessionHandle {
     );
   }
 
-  /** Drain registered artifact writers and all pending event publications. */
-  flushArtifacts(): Promise<void> {
-    this.pendingArtifactFlush ??= pDefer<void>();
-    const batch = this.pendingArtifactFlush;
-    if (!this.artifactFlushWorkerRunning) {
-      this.artifactFlushWorkerRunning = true;
-      queueMicrotask(() => {
-        void this.drainArtifactFlushBatches();
-      });
-    }
-    return batch.promise;
-  }
-
   /**
-   * Drain one current batch and, when calls arrived during it, one trailing
-   * batch at a time. This preserves each caller's durability boundary without
-   * repeating a full session flush for every execution ending in one burst.
+   * The host-facing name for "everything this session owes storage has
+   * landed": a session's durable artifacts are the facts it publishes, so
+   * this is exactly {@link settlePublications}. Hosts call it on shutdown and
+   * every run driver reaches it through {@link releaseExecutionLease}.
    */
-  private async drainArtifactFlushBatches(): Promise<void> {
-    while (this.pendingArtifactFlush) {
-      const batch = this.pendingArtifactFlush;
-      this.pendingArtifactFlush = undefined;
-      try {
-        await this.flushArtifactsOnce();
-        batch.resolve();
-      } catch (error) {
-        batch.reject(error);
-      }
-    }
-    this.artifactFlushWorkerRunning = false;
-  }
-
-  private async flushArtifactsOnce(): Promise<void> {
-    const results = await Promise.allSettled([
-      this.settlePublications(),
-      ...[...this.artifactFlushers].map((flush) =>
-        Promise.resolve().then(flush),
-      ),
-    ]);
-    const failures = results.flatMap((result) =>
-      result.status === 'rejected' ? [result.reason] : [],
-    );
-    throwAggregated(
-      failures,
-      'Multiple session artifact writers failed to flush',
-    );
+  flushArtifacts(): Promise<void> {
+    return this.settlePublications();
   }
 
   /**

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -119,9 +119,9 @@ interface ExecutionRegistryInit {
   readonly approvals: SessionApprovals;
   readonly publishResult: (event: ResultEvent, streamId: StreamTabId) => void;
   /**
-   * The session's one exit choreography (`SessionHandle.releaseExecutionLease`)
-   * — required so no construction path can silently release a lease without
-   * draining the session's durable writers first.
+   * The session's one exit choreography (`SessionHandle.releaseExecutionLease`),
+   * required so no construction path can silently release a lease without
+   * settling the session's queued publications first.
    */
   readonly releaseRootExecutionLease: WaitingTerminationContext['releaseRootExecutionLease'];
   readonly finalizeExecution: WaitingTerminationContext['finalizeExecution'];

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -714,8 +714,8 @@ const closeSession = (root: string, signal?: AbortSignal) =>
     // is armed on the settlement, whatever the flush's exit, and a flush
     // that fails still fails this close.
     //
-    // `flushArtifacts` does reject when a trace or shared artifact writer
-    // fails, and `Effect.promise` is deliberate rather than an oversight:
+    // `flushArtifacts` does reject when a session publication failed, and
+    // `Effect.promise` is deliberate rather than an oversight:
     // `close` answers a `SessionCloseReport` and names no error, so the
     // defect is the channel a failed flush travels on, and `ProcessHold.release`
     // (packages/agent/src/effect/runtime.ts) documents the embedder seeing

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -86,9 +86,3 @@ export const FileListEntrySchema = z.object({
 });
 
 export type FileListEntry = z.infer<typeof FileListEntrySchema>;
-
-const StreamLogTextDeltaSchema = z.strictObject({
-  id: z.string().min(1),
-  appendText: z.string().min(1),
-});
-export type StreamLogTextDelta = z.infer<typeof StreamLogTextDeltaSchema>;

--- a/src/shared/schemas/traceEvent.ts
+++ b/src/shared/schemas/traceEvent.ts
@@ -54,7 +54,7 @@ export const ResultEventSchema = trace('result', {
 }).readonly();
 export type ResultEvent = z.infer<typeof ResultEventSchema>;
 
-/** Named arms let the durable vocabulary omit the transient chunk explicitly. */
+/** Durable transcript vocabulary; session events extend each arm. */
 export const TranscriptEventSchemas = {
   log: trace('log', {
     level: LogLevelSchema,
@@ -116,16 +116,9 @@ export const TranscriptEventSchemas = {
   }),
 };
 
-/** Deltas are fold inputs only; they never enter the durable event vocabulary. */
-const TranscriptChunkSchema = trace('stream.chunk', {
-  id: z.string(),
-  text: z.string(),
-});
-const TranscriptEventSchema = z.discriminatedUnion('type', [
-  TranscriptChunkSchema,
-  ...Object.values(TranscriptEventSchemas),
-]);
-export type TranscriptEvent = z.infer<typeof TranscriptEventSchema>;
+export type TranscriptEvent = z.infer<
+  (typeof TranscriptEventSchemas)[keyof typeof TranscriptEventSchemas]
+>;
 
 const TRANSCRIPT_EVENT_TYPES = new Set<string>(
   Object.values(TranscriptEventSchemas).map(
@@ -137,7 +130,5 @@ const TRANSCRIPT_EVENT_TYPES = new Set<string>(
 export function isTranscriptEvent<T extends { type: string }>(
   event: T,
 ): event is Extract<T, { type: TranscriptEvent['type'] }> {
-  return (
-    event.type === 'stream.chunk' || TRANSCRIPT_EVENT_TYPES.has(event.type)
-  );
+  return TRANSCRIPT_EVENT_TYPES.has(event.type);
 }

--- a/src/shared/session/sessionFold.ts
+++ b/src/shared/session/sessionFold.ts
@@ -16,10 +16,10 @@
  *
  * Three rules govern the event arm before any fact applies (5.2). A listing
  * fact is ordered by commit within its `(aggregate, listing type)` entry in
- * `view.latest` and ignored when it is not above it, whichever read
- * delivered it. A transcript row folds only for an aggregate in the
- * subscription set (its `view.folded` entry), and only when its seq is above
- * that entry, which it then advances. `view.cursor` moves on tail rows
+ * the session's `latest` index and ignored when it is not above it,
+ * whichever read delivered it. A transcript row folds only for an aggregate
+ * in the subscription set (its `view.folded` entry), and only when its seq
+ * is above that entry, which it then advances. `view.cursor` moves on tail rows
  * alone. Existence: a stream exists iff its `run.start` has folded and its
  * `stream.removed` has not; the two share one `latest` entry, so the
  * tombstone is final under every read, ids are never reused (decision 9),
@@ -35,26 +35,27 @@
  *
  * The publication contract (decision D5): every view `fold` returns is
  * immutable, and untouched branches are shared by reference between levels.
- * `view.streams`, `view.policy`, `view.folded`, `view.latest`,
- * `view.inflight`, `view.queuedFollowUps`, and a transcript's `rows` and
- * `taskGroups` are copied at most once per `fold` call, by the write that
- * touches them (`writableMap`, `writableTranscriptArray`), and never
- * written after the call returns. The copy belongs to the write, not to the
- * input: an entry that projects no row, one that lands no task group, and a
- * delete of a key its map never held all leave those branches the objects
- * the previous level published. Every `StreamView` value, every
- * `TranscriptView` value, and the `SessionView` envelope are replaced on
- * change and never mutated. A host that compares any of these by identity
- * sees exactly what changed, and an older view is stable to read for as
- * long as it is held. It is not a fold
+ * `view.streams`, `view.policy`, `view.folded`, `view.queuedFollowUps`, and
+ * a transcript's `rows` and `taskGroups` are copied at most once per `fold`
+ * call, by the write that touches them (`writableMap`,
+ * `writableTranscriptArray`), and never written after the call returns.
+ * The copy belongs to the write, not to the input: an entry that projects no
+ * row, one that lands no task group, and a delete of a key its map never
+ * held all leave those branches the objects the previous level published.
+ * Every `StreamView` value, every `TranscriptView` value, and the
+ * `SessionView` envelope are replaced on change and never mutated. A host
+ * that compares any of these by identity sees exactly what changed, and an
+ * older view is stable to read for as long as it is held. It is not a fold
  * input: the fold's own indexes live in module-private maps keyed by the
  * value they index, per transcript (row and group positions, the measured
- * live text, the newest thinking row) and per view (streams by owner, the
- * streams whose lifecycle ended, the aggregates the listing named), and
- * those are single-owner, advancing with the latest level only. The
- * invariant the copy rests on: an arm that writes a container reports
- * `changed`, so `foldWith` publishes the envelope holding the copy; a write
- * followed by "no change" would be dropped, not shared.
+ * live text, the newest thinking row) and per view (the current claims, the
+ * newest commit per listing entry, the live text per row, the local
+ * snapshot, streams by owner, the streams whose lifecycle ended, the
+ * aggregates the listing named), and those are single-owner, advancing with
+ * the latest level only. The invariant the copy rests on: an arm that writes
+ * a container reports `changed`, so `foldWith` publishes the envelope
+ * holding the copy; a write followed by "no change" would be dropped, not
+ * shared.
  */
 
 import {
@@ -237,12 +238,9 @@ function reconcileExistence(
   existence: ExistenceReconciliation,
   deferred: DeferredRunModels,
 ): void {
+  const { claims } = sessionIndexesOf(view);
   for (const { aggregateId, ownerId } of existence.claims) {
-    if (
-      !view.claims.has(aggregateId) ||
-      view.claims.get(aggregateId) !== ownerId
-    )
-      writableMap(view, 'claims').set(aggregateId, ownerId);
+    claims.set(aggregateId, ownerId);
     const target = aggregateTarget(aggregateId);
     if (target.kind !== 'stream') continue;
     const stream = view.streams.get(target.id);
@@ -251,7 +249,7 @@ function reconcileExistence(
     walkUp(view, stream.id, stream.id, deferred);
   }
   for (const id of existence.removedAggregateIds) {
-    if (view.claims.has(id)) writableMap(view, 'claims').delete(id);
+    claims.delete(id);
     if (view.folded.has(id)) writableMap(view, 'folded').delete(id);
     const target = aggregateTarget(id);
     if (target.kind === 'stream') foldStreamRemoved(view, target.id, deferred);
@@ -279,6 +277,22 @@ interface SessionIndexes {
   /** Streams by their current claimant, so a local snapshot
    *  recomputes exactly the streams a changed owner holds. */
   readonly byOwner: Map<string, Set<StreamTabId>>;
+  /** Current sequence-row claims for the checked resident scope. */
+  readonly claims: Map<AggregateId, string | null>;
+  /** One entry per `${aggregate}/${listing type}`: the commit of the latest
+   *  listing fact folded for it, so a replayed older one is ignored. The
+   *  lifecycle entry outlives its stream: it is what keeps a tombstone
+   *  final when a read replays the `run.start` beneath it. */
+  readonly latest: Map<string, number>;
+  /** Live text per `${stream}/${row}`, beside the rows rather than inside
+   *  them: a chunk can reach the fold before its row (5.2). A row paints
+   *  its durable text joined with this entry; the entry goes when the row
+   *  finalizes, the stream ends, the stream is removed, or its transcript
+   *  tier is evicted. */
+  readonly inflight: Map<string, string>;
+  /** This process's local truth, the snapshot the next one diffs against:
+   *  a fold input, never durable. */
+  local: LocalRuntimeState;
 }
 
 /** Keyed by the stream index; a copied index inherits its predecessor's
@@ -288,7 +302,15 @@ const SESSION_INDEXES = new WeakMap<SessionView['streams'], SessionIndexes>();
 function sessionIndexesOf(view: SessionView): SessionIndexes {
   let indexes = SESSION_INDEXES.get(view.streams);
   if (!indexes) {
-    indexes = { listed: new Set(), ended: new Set(), byOwner: new Map() };
+    indexes = {
+      listed: new Set(),
+      ended: new Set(),
+      byOwner: new Map(),
+      claims: new Map(),
+      latest: new Map(),
+      inflight: new Map(),
+      local: { self: [], dead: [], unreadable: [] },
+    };
     SESSION_INDEXES.set(view.streams, indexes);
   }
   return indexes;
@@ -306,14 +328,7 @@ function sessionIndexesOf(view: SessionView): SessionIndexes {
  */
 let owned = new WeakSet<object>();
 
-type ViewMapKey =
-  | 'streams'
-  | 'policy'
-  | 'folded'
-  | 'claims'
-  | 'latest'
-  | 'inflight'
-  | 'queuedFollowUps';
+type ViewMapKey = 'streams' | 'policy' | 'folded' | 'queuedFollowUps';
 
 /** The view's map under `key`, copied once per call before its first write. */
 function writableMap<K extends ViewMapKey>(
@@ -362,8 +377,9 @@ function inflightKey(streamId: StreamTabId, rowId: string): string {
  *  was removed, or lost its transcript tier (5.2, "In-flight text"). */
 function clearInflight(view: SessionView, stream: StreamView): void {
   const prefix = `${stream.id}/`;
-  for (const key of [...view.inflight.keys()]) {
-    if (key.startsWith(prefix)) writableMap(view, 'inflight').delete(key);
+  const { inflight } = sessionIndexesOf(view);
+  for (const key of inflight.keys()) {
+    if (key.startsWith(prefix)) inflight.delete(key);
   }
   indexesOf(stream.transcript).streaming.clear();
 }
@@ -372,8 +388,8 @@ function clearInflight(view: SessionView, stream: StreamView): void {
 // Transcript indexes (fold-owned, never on the view)
 // ---------------------------------------------------------------------------
 
-/** One streaming row's measured live text: the projection of its
- *  `view.inflight` entry, extended per chunk rather than re-measured. */
+/** One streaming row's measured live text: the projection of its session
+ *  `inflight` entry, extended per chunk rather than re-measured. */
 interface StreamingCursor {
   /** The last durable entry for the row: a first chunk projects it when the
    *  entry's own text was blank and gave no row. */
@@ -460,7 +476,7 @@ function createStream(view: SessionView, event: RunStartEvent): StreamView {
     executionId: event.executionId,
     identity,
     isRemote: event.isRemote,
-    ownerId: view.claims.get(event.aggregateId) ?? null,
+    ownerId: sessionIndexesOf(view).claims.get(event.aggregateId) ?? null,
     label: runIdentityDisplayName(identity),
     description: null,
     model: null,
@@ -689,7 +705,7 @@ function refreshAncestors(view: SessionView, streamId: StreamTabId): void {
  * so a resume can re-ask.
  */
 function withAggregates(view: SessionView, stream: StreamView): StreamView {
-  const { local } = view;
+  const { local } = sessionIndexesOf(view);
   const owner = stream.ownerId;
   const own = owner !== null && local.self.includes(owner);
   const heldBy =
@@ -1008,7 +1024,7 @@ function projectRow(
 /**
  * Fold one transcript row into the slice: the row, task-group, compaction,
  * and run-marker reducers, each called unchanged. A streaming row joins its
- * durable fields with its `view.inflight` entry, which may have arrived
+ * durable fields with its session `inflight` entry, which may have arrived
  * first (5.2, "In-flight text"); a finalizing row drops that entry, so a
  * late chunk cannot reopen settled text.
  */
@@ -1038,15 +1054,17 @@ function applyEntry(
     applyCompactionActivityEntries(indexes.compactionState, [entry]),
   );
   const key = inflightKey(stream.id, entry.id);
-  // One holder of a row's live text, `view.inflight`, whichever arrives
-  // first: chunks extend it, and an entry that folds before any chunk seeds
-  // it with the text it carried, so the chunk re-delivering that text from
-  // offset zero (the bridge seeds one for every running row it publishes)
-  // ends within the length held and is dropped (5.2, "In-flight text").
-  if (isStreamingEntry(entry) && entry.text && !view.inflight.has(key)) {
-    writableMap(view, 'inflight').set(key, entry.text);
+  const { inflight } = sessionIndexesOf(view);
+  // One holder of a row's live text, the session `inflight` index, whichever
+  // arrives first: chunks extend it, and an entry that folds before any chunk
+  // seeds it with the text it carried, so the chunk re-delivering that text
+  // from offset zero (the bridge seeds one for every running row it
+  // publishes) ends within the length held and is dropped (5.2, "In-flight
+  // text").
+  if (isStreamingEntry(entry) && entry.text && !inflight.has(key)) {
+    inflight.set(key, entry.text);
   }
-  const live = isStreamingEntry(entry) ? view.inflight.get(key) : undefined;
+  const live = isStreamingEntry(entry) ? inflight.get(key) : undefined;
   projectRow(
     next,
     live === undefined ? entry : { ...entry, text: live },
@@ -1069,7 +1087,7 @@ function applyEntry(
     });
   } else {
     indexes.streaming.delete(entry.id);
-    if (view.inflight.has(key)) writableMap(view, 'inflight').delete(key);
+    inflight.delete(key);
   }
   return next;
 }
@@ -1275,7 +1293,8 @@ function foldTextChunk(view: SessionView, chunk: TextChunk): boolean {
   const cursor = indexes.streaming.get(chunk.rowId);
   if (!cursor && rowById(stream.transcript, chunk.rowId)) return false;
   const key = inflightKey(chunk.streamId, chunk.rowId);
-  const held = view.inflight.get(key) ?? '';
+  const { inflight } = sessionIndexesOf(view);
+  const held = inflight.get(key) ?? '';
   if (chunk.to <= held.length) return false;
   if (chunk.from > held.length) {
     throw new Error(
@@ -1283,7 +1302,7 @@ function foldTextChunk(view: SessionView, chunk: TextChunk): boolean {
     );
   }
   const text = held.slice(0, chunk.from) + chunk.text;
-  writableMap(view, 'inflight').set(key, text);
+  inflight.set(key, text);
   // The row projects when its entry folds, joined with this entry.
   if (!cursor) return true;
   cursor.text =
@@ -1611,12 +1630,13 @@ function foldDurable(
   // Listing facts are ordered by commit per (aggregate, listing type),
   // whichever read delivered them (5.2, "Duplicates").
   const listingKey = `${event.aggregateId}/${listingTypeOf(event)}`;
-  const latest = view.latest.get(listingKey);
-  if (latest !== undefined && event.commit <= latest) return traceChanged;
+  const { latest } = sessionIndexesOf(view);
+  const newest = latest.get(listingKey);
+  if (newest !== undefined && event.commit <= newest) return traceChanged;
 
   const streamId = streamOf(event);
   if (streamId === null) {
-    writableMap(view, 'latest').set(listingKey, event.commit);
+    latest.set(listingKey, event.commit);
     applySessionSlices(view, null, event);
     return true;
   }
@@ -1625,7 +1645,7 @@ function foldDurable(
   // the view has no `run.start` for changes nothing and leaves no entry (its
   // publisher logs it).
   if (!known && event.type !== 'run.start') return false;
-  writableMap(view, 'latest').set(listingKey, event.commit);
+  latest.set(listingKey, event.commit);
   if (event.type === 'stream.removed') {
     return foldStreamRemoved(view, streamId, deferred);
   }
@@ -1811,8 +1831,9 @@ function foldLocal(
   local: LocalRuntimeState,
   deferred: DeferredRunModels,
 ): void {
-  const previous = view.local;
-  view.local = local;
+  const indexes = sessionIndexesOf(view);
+  const previous = indexes.local;
+  indexes.local = local;
   const heldBefore = new Set([...previous.self, ...previous.dead]);
   const heldAfter = new Set([...local.self, ...local.dead]);
   const changedOwners = new Set<string>();
@@ -1831,9 +1852,10 @@ function foldLocal(
     }
   }
   const touched = new Set<StreamTabId>();
-  const { byOwner } = sessionIndexesOf(view);
   for (const owner of changedOwners) {
-    for (const streamId of byOwner.get(owner) ?? []) touched.add(streamId);
+    for (const streamId of indexes.byOwner.get(owner) ?? []) {
+      touched.add(streamId);
+    }
   }
   const unreadableBefore = new Map(
     previous.unreadable.map((u) => [u.streamId, u.detail]),

--- a/src/shared/session/sessionView.ts
+++ b/src/shared/session/sessionView.ts
@@ -22,7 +22,6 @@ import {
   ExecutionIdSchema,
   GoalStateSchema,
   InquiryThreadUpdatedEventSchema,
-  LocalRuntimeStateSchema,
   OwnerIdSchema,
   PermissionPayloadSchema,
   PlanSchema,
@@ -217,19 +216,6 @@ const SessionViewSchema = z.object({
    *  Created when the aggregate enters the subscription set, deleted with
    *  its transcript tier on eviction; never a commit ordinal. */
   folded: z.map(AggregateIdSchema, z.int().nonnegative()),
-  /** Current sequence-row claims for the checked resident scope. */
-  claims: z.map(AggregateIdSchema, OwnerIdSchema.nullable()),
-  /** One entry per `${aggregate}/${listing type}`: the commit of the latest
-   *  listing fact folded for it, so a replayed older one is ignored. The
-   *  lifecycle entry outlives its stream: it is what keeps a tombstone
-   *  final when a read replays the `run.start` beneath it. */
-  latest: z.map(z.string(), CommitOrdinalSchema),
-  /** Live text per `${stream}/${row}`, beside the rows rather than inside
-   *  them: a chunk can reach the fold before its row (5.2). A row paints
-   *  its durable text joined with this entry; the entry goes when the row
-   *  finalizes, the stream ends, the stream is removed, or its transcript
-   *  tier is evicted. */
-  inflight: z.map(z.string(), z.string()),
   /** Paper-level aggregate; a rail badge reads it and derives nothing. */
   rollup: z.object({
     running: z.int().nonnegative(),
@@ -240,8 +226,6 @@ const SessionViewSchema = z.object({
   /** Latest snapshot per run. */
   policy: z.map(StreamTabIdSchema, ApprovalPolicySnapshotSchema),
   inquiries: z.array(InquiryThreadUpdatedEventSchema),
-  /** This process's local truth: a fold input, never durable. */
-  local: LocalRuntimeStateSchema,
   queuedFollowUps: z.map(StreamTabIdSchema, z.array(z.string())),
 });
 export type SessionView = z.infer<typeof SessionViewSchema>;
@@ -258,14 +242,10 @@ export function emptySessionView(key: string, cursor = 0): SessionView {
     order: [],
     cursor,
     folded: new Map(),
-    claims: new Map(),
-    latest: new Map(),
-    inflight: new Map(),
     rollup: { running: 0, waiting: 0, interrupted: 0 },
     approvals: [],
     policy: new Map(),
     inquiries: [],
-    local: { self: [], dead: [], unreadable: [] },
     queuedFollowUps: new Map(),
   };
 }

--- a/src/shared/session/traceEntries.ts
+++ b/src/shared/session/traceEntries.ts
@@ -5,7 +5,6 @@ import {
   STREAMING_TEXT_MESSAGE_TYPES,
   isTerminalWorkflowCallProgress,
   type StreamLogEntry,
-  type StreamLogTextDelta,
   type WorkflowCallLiveProgress,
 } from '@shared/schemas';
 import { clamp, isObject } from '@utils/core';
@@ -17,82 +16,6 @@ export type StreamLogAppendInput = Omit<
 export type StreamLogUpdatePatch = Partial<
   Omit<StreamLogEntry, 'id' | 'seqNo' | 'settlementSeqNo'>
 >;
-
-/**
- * One store notification's worth of entry-level change, multicast to every
- * `StreamLogStore.onChange` listener. Entry values are the immutable
- * post-mutation objects (`StreamLog` replaces the entry object on every
- * mutation), so a delta stays valid after later mutations. A dirtied entry
- * supersedes any earlier buffered value for its id.
- */
-export interface StreamLogDelta {
-  /** Entries appended since the previous emission, in seqNo order. */
-  readonly appended: readonly StreamLogEntry[];
-  /**
-   * Current values of entries mutated in place since the previous emission
-   * (excluding ones also in `appended`, which already carry the latest
-   * value), in seqNo order.
-   */
-  readonly dirtied: readonly StreamLogEntry[];
-  /**
-   * Streaming-text appends since the previous emission, merged to one chunk
-   * per entry id. An `appendText` mutation emits here *instead of* `dirtied`.
-   * An entry present in `appended`/`dirtied` already carries its full current
-   * text, so no id appears both by value and as a chunk within one delta;
-   * and across deltas, an entry-by-value supersedes any chunks a consumer
-   * has buffered for its id.
-   */
-  readonly textChunks: readonly StreamLogTextDelta[];
-  /**
-   * The resident log instance was replaced by an event-prefix fold.
-   * Consumers must reread entries before applying further deltas.
-   */
-  readonly reset: boolean;
-}
-
-/**
- * Chunked accumulation for one streaming entry's text. Provider chunks are
- * collected in `chunks` and joined lazily, so a hot appendText path costs
- * O(chunk) instead of re-copying the whole entry text per chunk. `joined` is
- * the memoized join so far; `length` is the full text length including the
- * unjoined tail.
- */
-interface StreamingTextAccumulator {
-  joined: string;
-  chunks: string[];
-  length: number;
-}
-
-function materializeText(acc: StreamingTextAccumulator, end: number): string {
-  if (acc.joined.length < end) {
-    acc.joined += acc.chunks.join('');
-    acc.chunks.length = 0;
-  }
-  return end === acc.joined.length ? acc.joined : acc.joined.slice(0, end);
-}
-
-/**
- * The immutable post-mutation entry object for a text append: every field of
- * `current` is carried over by descriptor (never invoking `current`'s own
- * lazy getter), while `text` becomes a memoized getter that joins the
- * accumulator's chunks up to this entry's point-in-time length on first read.
- * Readers that never touch `.text` (delta buffering, superseded emissions)
- * pay nothing.
- */
-function entryWithLazyText(
-  current: StreamLogEntry,
-  acc: StreamingTextAccumulator,
-  end: number,
-): StreamLogEntry {
-  const descriptors = Object.getOwnPropertyDescriptors(current);
-  let memo: string | undefined;
-  descriptors.text = {
-    get: () => (memo ??= materializeText(acc, end)),
-    enumerable: true,
-    configurable: true,
-  };
-  return Object.defineProperties({}, descriptors) as StreamLogEntry;
-}
 
 export function isRunningGroupEntry(entry: StreamLogEntry): boolean {
   if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_START) return false;
@@ -141,22 +64,8 @@ export function nonterminalWorkflowCall(
 export class StreamLog {
   private entries: StreamLogEntry[] = [];
   private readonly indexById = new Map<string, number>();
-  /**
-   * Per-entry chunk accumulators for in-flight streaming text. An entry whose
-   * id is present here carries a lazy `text` getter over the accumulator;
-   * settle/update materializes the join into a plain value and drops the
-   * accumulator, so persisted and settled entries are always plain.
-   */
-  private readonly streamingText = new Map<string, StreamingTextAccumulator>();
   private pendingAppendedIds: string[] = [];
   private readonly pendingDirtiedIds = new Set<string>();
-  /**
-   * Streaming-text appends since the last drain, per id in arrival order.
-   * Drained into the emission's `textChunks` arm, except for ids the same
-   * emission carries by value (`appended`/`dirtied`), whose current text
-   * already includes them.
-   */
-  private readonly pendingTextChunks = new Map<string, string[]>();
   private settlementSeqCounter = 0;
   private runningGroupCount = 0;
   private runningStreamingTextCount = 0;
@@ -203,36 +112,29 @@ export class StreamLog {
   }
 
   /**
-   * Drain the entries changed since the previous notification into a delta.
-   * `StreamLogStore` calls this once and passes the result to its listeners.
+   * Drain the entries changed since the previous drain. Entry values are the
+   * immutable post-mutation objects (every mutation replaces the entry
+   * object), so a drained value stays valid after later mutations.
+   * `appended` holds entries appended since the previous drain, in seqNo
+   * order; `dirtied` holds the current values of entries mutated in place
+   * since then, in seqNo order, excluding ones in `appended`, which already
+   * carry the latest value.
    */
-  drainEmission(): Omit<StreamLogDelta, 'reset'> {
+  drainEmission(): { appended: StreamLogEntry[]; dirtied: StreamLogEntry[] } {
     if (
       this.pendingAppendedIds.length === 0 &&
-      this.pendingDirtiedIds.size === 0 &&
-      this.pendingTextChunks.size === 0
+      this.pendingDirtiedIds.size === 0
     ) {
-      return { appended: [], dirtied: [], textChunks: [] };
+      return { appended: [], dirtied: [] };
     }
     const appendedIds = new Set(this.pendingAppendedIds);
     const appended = this.resolveEntries(this.pendingAppendedIds);
     const dirtied = this.resolveEntries(
       [...this.pendingDirtiedIds].filter((id) => !appendedIds.has(id)),
     ).sort((a, b) => a.seqNo - b.seqNo);
-    // An entry emitted by value resolves to its *current* object, whose text
-    // already includes every chunk accumulated in this window. Emitting its
-    // chunks too would double-apply them, so they are dropped here. This is
-    // the precedence rule consumers rely on: value supersedes chunks.
-    const textChunks: StreamLogTextDelta[] = [];
-    for (const [id, chunks] of this.pendingTextChunks) {
-      if (!appendedIds.has(id) && !this.pendingDirtiedIds.has(id)) {
-        textChunks.push({ id, appendText: chunks.join('') });
-      }
-    }
     this.pendingAppendedIds = [];
     this.pendingDirtiedIds.clear();
-    this.pendingTextChunks.clear();
-    return { appended, dirtied, textChunks };
+    return { appended, dirtied };
   }
 
   /** Current entry objects for `ids`; entries are never removed, so every id resolves. */
@@ -276,7 +178,6 @@ export class StreamLog {
     } else {
       this.countEntry(this.entries[index], -1);
       this.entries[index] = entry;
-      this.streamingText.delete(entry.id);
       this.pendingDirtiedIds.add(entry.id);
     }
     this.countEntry(entry, 1);
@@ -345,8 +246,6 @@ export class StreamLog {
     // Merge directly without parsing. update() is on the streaming hot path
     // (tool output chunks at ~200/sec) and receives trusted data from
     // AgentTrace. Persisted entries are parsed when loaded from storage.
-    // Spreading `current` reads its (possibly lazy) text getter, so this is
-    // where a streaming entry's chunks are joined into a plain value.
     const updated = {
       ...current,
       ...patch,
@@ -362,39 +261,7 @@ export class StreamLog {
     this.countEntry(updated, 1);
 
     this.entries[index] = updated;
-    this.streamingText.delete(id);
     this.pendingDirtiedIds.add(id);
-    return updated;
-  }
-
-  appendText(id: string, appendText: string): StreamLogEntry | undefined {
-    if (appendText.length === 0) return undefined;
-
-    const index = this.indexById.get(id);
-    if (index === undefined) return undefined;
-
-    const current = this.entries[index];
-    if (current.type !== STREAM_LOG_ENTRY_TYPES.LOG) return undefined;
-
-    let acc = this.streamingText.get(id);
-    if (!acc) {
-      // Reading `current.text` here materializes any lazy value left behind
-      // by a log merge; on the ordinary path it is already a plain value.
-      const base = current.text ?? '';
-      acc = { joined: base, chunks: [], length: base.length };
-      this.streamingText.set(id, acc);
-    }
-    acc.chunks.push(appendText);
-    acc.length += appendText.length;
-
-    const updated = entryWithLazyText(current, acc, acc.length);
-    this.entries[index] = updated;
-    const chunks = this.pendingTextChunks.get(id);
-    if (chunks) {
-      chunks.push(appendText);
-    } else {
-      this.pendingTextChunks.set(id, [appendText]);
-    }
     return updated;
   }
 

--- a/src/shared/session/traceFold.ts
+++ b/src/shared/session/traceFold.ts
@@ -46,7 +46,7 @@ function asMessageType(candidate: string | undefined): MessageType {
 }
 
 /** The source event's stable coordinates and the surface's display policy. */
-export interface TraceStamp {
+interface TraceStamp {
   readonly at: number;
   readonly id: string;
   readonly debug: boolean;
@@ -59,15 +59,10 @@ type StageMetadata = Pick<
 
 /** Build the transcript projection for one subscribed aggregate. */
 export function createTranscriptFold(
-  writer: Pick<
-    StreamLog,
-    'append' | 'appendSettled' | 'update' | 'settle' | 'appendText'
-  >,
+  writer: Pick<StreamLog, 'append' | 'appendSettled' | 'update' | 'settle'>,
 ) {
-  const streams = new Map<
-    string,
-    { groupId: string | undefined; messageType: MessageType; chunks: string[] }
-  >();
+  /** Stream rows opened by `stream.start` that nothing has settled yet. */
+  const streams = new Set<string>();
   const activeToolEntries = new Map<string, ToolUseLog>();
   const stageMetadata = new Map<string, StageMetadata>();
   const workflowCallEntries = new Set<string>();
@@ -330,43 +325,29 @@ export function createTranscriptFold(
 
       case 'stream.start': {
         if (transcriptBoundaryClosed) return;
-        const state = {
-          groupId: event.stageId,
-          messageType: asMessageType(event.kind),
-          chunks: [] as string[],
-        };
-        streams.set(event.id, state);
-        if (state.messageType === MESSAGE_TYPES.MODEL_RESPONSE)
+        const messageType = asMessageType(event.kind);
+        streams.add(event.id);
+        if (messageType === MESSAGE_TYPES.MODEL_RESPONSE)
           pendingModelResponseId = event.id;
         writer.append({
           id: event.id,
           type: STREAM_LOG_ENTRY_TYPES.LOG,
           level: 'info',
           timestamp: stamp.at,
-          groupId: state.groupId,
-          messageType: state.messageType,
+          groupId: event.stageId,
+          messageType,
           text: '',
           data: { status: 'running' },
           verbose: stamp.debug,
         });
         return;
       }
-      case 'stream.chunk': {
-        if (transcriptBoundaryClosed) return;
-        const state = streams.get(event.id);
-        if (!state) return;
-        state.chunks.push(event.text);
-        // Partial chunks can split a secret. The complete text is redacted
-        // again at settlement or when the transcript boundary closes.
-        writer.appendText(event.id, redactSecrets(event.text));
-        return;
-      }
       case 'stream.end': {
-        const state = streams.get(event.id);
-        if (!state || transcriptBoundaryClosed) return;
-        const text = event.finalText ?? state.chunks.join('');
+        if (!streams.has(event.id) || transcriptBoundaryClosed) return;
         writer.settle(event.id, {
-          text: redactSecrets(text),
+          ...(event.finalText !== undefined && {
+            text: redactSecrets(event.finalText),
+          }),
           data: { status: 'completed' },
         });
         streams.delete(event.id);
@@ -377,11 +358,14 @@ export function createTranscriptFold(
         if (!event.text) return;
         // Upsert by id, not by text: if this round's own MODEL_RESPONSE
         // stream already wrote a (possibly raw, pre-replacement) entry,
-        // reconcile it to the authoritative text; otherwise this round never
-        // streamed (e.g. a non-streaming provider call), so append it fresh.
+        // reconcile it to the authoritative text and close the stream, so no
+        // later stream.end or boundary settlement can replace that text;
+        // otherwise this round never streamed (e.g. a non-streaming provider
+        // call), so append it fresh.
         const correlatorId = pendingModelResponseId;
         pendingModelResponseId = undefined;
         if (correlatorId) {
+          streams.delete(correlatorId);
           writer.settle(correlatorId, {
             text: redactSecrets(event.text),
             data: { status: 'completed' },
@@ -448,11 +432,8 @@ export function createTranscriptFold(
       return;
     transcriptBoundaryClosed = true;
     pendingModelResponseId = undefined;
-    for (const [id, state] of streams) {
-      writer.settle(id, {
-        text: redactSecrets(state.chunks.join('')),
-        data: { status: 'completed' },
-      });
+    for (const id of streams) {
+      writer.settle(id, { data: { status: 'completed' } });
     }
     streams.clear();
     for (const [id, data] of activeToolEntries) {

--- a/src/shared/session/traceRedaction.ts
+++ b/src/shared/session/traceRedaction.ts
@@ -1,9 +1,6 @@
 /** Existing transcript redaction rules, shared by publication and display. */
 import { redactDisplayValue, redactSecrets } from '@logger/redaction';
-import {
-  SessionEventDraftSchema,
-  type SessionEventDraft,
-} from '@shared/schemas';
+import type { SessionEventDraft } from '@shared/schemas';
 import { isObject } from '@utils/core';
 
 /** Apply the existing transcript rules before source facts enter the event table. */
@@ -14,10 +11,7 @@ export function redactTraceDraft(event: SessionEventDraft): SessionEventDraft {
     case 'run.config':
       return { ...event, config: redactDisplayValue(event.config) };
     case 'result':
-      return SessionEventDraftSchema.parse({
-        ...event,
-        error: redactLogData(event.error),
-      });
+      return { ...event, error: redactLogData(event.error) };
     case 'log':
       return {
         ...event,
@@ -81,8 +75,11 @@ export function redactTraceDraft(event: SessionEventDraft): SessionEventDraft {
  * whose `message` and `stack` are non-enumerable own properties that a spread
  * would silently drop; such an object serializes to `{}` on the wire and on
  * disk anyway, so it is left untouched.
+ *
+ * The result keeps the input's type: redaction replaces existing string fields
+ * with strings and adds no keys.
  */
-export function redactLogData(data: unknown): unknown {
+export function redactLogData<T>(data: T): T {
   if (
     !isObject(data) ||
     Object.getPrototypeOf(data) !== Object.prototype ||
@@ -94,7 +91,7 @@ export function redactLogData(data: unknown): unknown {
   // rawErrorBody carry provider error bodies (which can echo request URLs or
   // Authorization headers), statusText is the provider's HTTP status line,
   // partialText carries truncated model output.
-  const redacted: Record<string, unknown> = { ...data };
+  const redacted: Record<string, string> = {};
   for (const key of [
     'message',
     'rawMessage',
@@ -102,9 +99,10 @@ export function redactLogData(data: unknown): unknown {
     'statusText',
     'partialText',
   ]) {
-    if (typeof redacted[key] === 'string') {
-      redacted[key] = redactSecrets(redacted[key] as string);
+    const value = data[key];
+    if (typeof value === 'string') {
+      redacted[key] = redactSecrets(value);
     }
   }
-  return redacted;
+  return { ...data, ...redacted };
 }

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -2,11 +2,7 @@ import '@test/support/defaultSessionTestSetup';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  SessionHandle,
-  defaultSession,
-  forEachLiveSession,
-} from '@agent/runtime/SessionHandle';
+import { SessionHandle, defaultSession } from '@agent/runtime/SessionHandle';
 import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { type Plan, type StreamTabId } from '@shared/schemas';
 import { testExecutionHandle } from '@test/support/executionHandleFixtures';
@@ -30,107 +26,6 @@ function trackAgent(
 }
 
 describe('SessionHandle', () => {
-  it('awaits artifact writers before disposal and leaves the live-session registry', async () => {
-    const session = createTestSession();
-    let releaseWriter!: () => void;
-    const writerGate = new Promise<void>((resolve) => {
-      releaseWriter = resolve;
-    });
-    session.useArtifactFlusher(() => writerGate);
-    const dispose = vi.spyOn(session, 'dispose');
-    const killBackgroundProcesses = vi
-      .spyOn(session.executions, 'killBackgroundProcesses')
-      .mockImplementation(() => undefined);
-
-    const shutdown = (async () => {
-      await session.flushArtifacts();
-      session.dispose();
-    })();
-
-    await Promise.resolve();
-    expect(dispose).not.toHaveBeenCalled();
-    forEachLiveSession((live) => {
-      live.executions.killBackgroundProcesses();
-    });
-    expect(killBackgroundProcesses).toHaveBeenCalledOnce();
-
-    releaseWriter();
-    await shutdown;
-    expect(dispose).toHaveBeenCalledOnce();
-
-    forEachLiveSession((live) => {
-      live.executions.killBackgroundProcesses();
-    });
-    expect(killBackgroundProcesses).toHaveBeenCalledOnce();
-  });
-
-  it('waits for every artifact writer and reports all failures', async () => {
-    const session = createTestSession();
-    const firstError = new Error('first artifact failed');
-    const snapshotError = new Error('snapshot failed');
-    const laterWriter = vi.fn();
-    session.useArtifactFlusher(async () => {
-      throw firstError;
-    });
-    session.useArtifactFlusher(() => {
-      throw snapshotError;
-    });
-    session.useArtifactFlusher(async () => laterWriter());
-
-    try {
-      const failure = await session.flushArtifacts().catch((error) => error);
-      expect(failure).toBeInstanceOf(AggregateError);
-      expect((failure as AggregateError).errors).toEqual([
-        firstError,
-        snapshotError,
-      ]);
-      expect(laterWriter).toHaveBeenCalledOnce();
-    } finally {
-      session.dispose();
-    }
-  });
-
-  it('coalesces durability calls made in the same synchronous burst', async () => {
-    const session = createTestSession();
-    const flush = vi.fn(async () => {});
-    session.useArtifactFlusher(flush);
-    try {
-      const first = session.flushArtifacts();
-      const second = session.flushArtifacts();
-
-      expect(second).toBe(first);
-      await Promise.all([first, second]);
-      expect(flush).toHaveBeenCalledOnce();
-    } finally {
-      session.dispose();
-    }
-  });
-
-  it('runs one trailing durability batch for calls arriving mid-flush', async () => {
-    const session = createTestSession();
-    let releaseFirst = (): void => undefined;
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    const flush = vi
-      .fn<() => Promise<void>>()
-      .mockImplementationOnce(() => firstGate)
-      .mockResolvedValue(undefined);
-    session.useArtifactFlusher(flush);
-    try {
-      const first = session.flushArtifacts();
-      await vi.waitFor(() => expect(flush).toHaveBeenCalledOnce());
-      const trailing = session.flushArtifacts();
-
-      expect(trailing).not.toBe(first);
-      releaseFirst();
-      await Promise.all([first, trailing]);
-      expect(flush).toHaveBeenCalledTimes(2);
-    } finally {
-      session.dispose();
-    }
-  });
-
   it('defaultSession is a stable process-wide singleton', () => {
     const first = defaultSession();
     const second = defaultSession();

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -70,7 +70,7 @@ describe('AgentTrace stream output', () => {
       const entries = streamEntries(store);
       expect(entries).toHaveLength(1);
       expect(entries[0]?.messageType).toBe(MESSAGE_TYPES.THINKING);
-      expect(entries[0]?.text).toBe('reasoning delta');
+      expect(entries[0]?.text).toBe('');
 
       expect(thinking.finalize()).toBe('reasoning delta');
       expect(events.at(-1)).toMatchObject({

--- a/src/test-kernel/controllers/session/sessionFramer.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionFramer.vitest.ts
@@ -33,6 +33,8 @@ import {
   aggregateId as qualifyAggregateId,
   AgentCategory,
   FoldEventSchema,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
   type ExecutionId,
   type SessionEventDraft,
@@ -85,6 +87,25 @@ const running: SessionEventDraft = {
   cause: 'resume',
 };
 
+/** A running model reply with no text of its own: the row the live text for
+ *  `rowId` paints into once its entry folds. */
+function streamingRow(streamId: StreamTabId, rowId: string): SessionEventDraft {
+  return {
+    type: 'transcript.entry',
+    aggregateId: qualifyAggregateId('stream', streamId),
+    entry: {
+      seqNo: 1,
+      id: rowId,
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: 'info',
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+      timestamp: 0,
+      text: '',
+      data: { status: 'running' },
+    },
+  };
+}
+
 /** The runtime graph, as `sessionLayer` composes it without the host bits. */
 const runtimeGraph = (history: readonly SessionEventDraft[]) => {
   const roots = createFakeWorkspaceRoots({ storagePath: KEY });
@@ -132,6 +153,15 @@ const settle = (
 ) =>
   SubscriptionRef.changes(view).pipe(Stream.takeUntil(ready), Stream.runDrain);
 
+/** The text a row paints: its durable text joined with the live text the
+ *  fold holds for it, once the row's entry has folded. */
+function rowText(view: SessionView, streamId: StreamTabId, rowId: string) {
+  const row = view.streams
+    .get(streamId)
+    ?.transcript.rows.find((each) => each.id === rowId);
+  return row?.kind === 'assistant' ? row.text.full : undefined;
+}
+
 /** What a renderer draws of a view: the same for both hosts of one log. */
 function drawn(view: SessionView) {
   const stream = view.streams.get(STREAM);
@@ -140,7 +170,11 @@ function drawn(view: SessionView) {
     status: stream?.status ?? null,
     group: stream?.group ?? null,
     approvals: view.approvals.map((a) => a.requestId),
-    inflight: [...view.inflight.entries()],
+    rows:
+      stream?.transcript.rows.map((row) => [
+        row.id,
+        rowText(view, STREAM, row.id),
+      ]) ?? [],
   };
 }
 
@@ -316,23 +350,13 @@ describe('session framer', () => {
         const webview = yield* WebviewSessions.open(KEY);
         const { frames, view } = webview;
         const shell = webview.subscriptions;
-        // The shell names the second stream ahead of its run.start: live
-        // text is framed only for the aggregates a Subscribe names.
-        const child = 'stream:second';
-        const named: Subscribe = {
-          ...subscribe,
-          aggregates: [
-            ...subscribe.aggregates,
-            { id: qualifyAggregateId('stream', child), fromSeq: 0 },
-          ],
-        };
         // The shell: begin the generation and set its transcript set, then
         // post the Subscribe; the decoder feeds every frame that answers it.
-        yield* frames.begin(named.generation);
-        yield* shell.set('shell', named.aggregates);
-        const decoder = yield* Effect.forkScoped(
+        yield* frames.begin(subscribe.generation);
+        yield* shell.set('shell', subscribe.aggregates);
+        const parentDecoder = yield* Effect.forkScoped(
           Stream.runForEach(
-            frameSubscription(source, PORT, host, named),
+            frameSubscription(source, PORT, host, subscribe),
             (frame) => frames.feed(frame),
           ),
         );
@@ -365,13 +389,10 @@ describe('session framer', () => {
           existence: null,
         });
         const ticker = yield* Effect.forkScoped(ticking);
-        yield* settle(
-          view.ref,
-          (v) => v.inflight.get(`${STREAM}/row-1`) === 'Hello',
-        );
+        yield* settle(view.ref, (v) => rowText(v, STREAM, 'row-1') === 'Hello');
         yield* settle(
           runtimeView.ref,
-          (v) => v.inflight.get(`${STREAM}/row-1`) === 'Hello',
+          (v) => rowText(v, STREAM, 'row-1') === 'Hello',
         );
         expect(drawn(yield* SubscriptionRef.get(view.ref))).toEqual(
           drawn(yield* SubscriptionRef.get(runtimeView.ref)),
@@ -386,7 +407,7 @@ describe('session framer', () => {
           view.ref,
           (v) =>
             v.streams.get(STREAM)?.status === STREAM_PHASE.RUNNING &&
-            v.inflight.get(`${STREAM}/row-1`) === 'Hello again',
+            rowText(v, STREAM, 'row-1') === 'Hello again',
         );
         yield* settle(
           runtimeView.ref,
@@ -396,9 +417,13 @@ describe('session framer', () => {
         expect(drawn(folded)).toEqual(
           drawn(yield* SubscriptionRef.get(runtimeView.ref)),
         );
-        expect(folded.cursor).toBe(3);
+        expect(folded.cursor).toBe(4);
 
-        // A new stream and its first prefix can become ready in one turn.
+        // A new stream: its run.start is a listing fact, framed to a shell
+        // that has not named it. The shell names a stream only once its view
+        // holds it (`transcriptAggregates`), and live text is framed only for
+        // the aggregates a Subscribe names, so it resubscribes naming it.
+        const child = 'stream:second' as StreamTabId;
         yield* events.publish([
           {
             ...runStart,
@@ -406,14 +431,34 @@ describe('session framer', () => {
             executionId: 'dec0de',
           },
         ]);
+        yield* settle(view.ref, (v) => v.streams.has(child));
+        yield* settle(runtimeView.ref, (v) => v.streams.has(child));
+        yield* Fiber.interrupt(parentDecoder);
+        const named: Subscribe = {
+          ...subscribe,
+          generation: 2,
+          cursor: (yield* SubscriptionRef.get(view.ref)).cursor,
+          aggregates: [
+            ...subscribe.aggregates,
+            { id: qualifyAggregateId('stream', child), fromSeq: 0 },
+          ],
+        };
+        yield* frames.begin(named.generation);
+        yield* shell.set('shell', named.aggregates);
+        const decoder = yield* Effect.forkScoped(
+          Stream.runForEach(
+            frameSubscription(source, PORT, host, named),
+            (frame) => frames.feed(frame),
+          ),
+        );
+        // The named stream's streaming row and the row's first prefix can
+        // become ready in one turn.
+        yield* events.publish([streamingRow(child, 'row-2')]);
         yield* SubscriptionRef.update(
           chunks.ref,
           (held) => new Map([...held, [`${child}/row-2`, textTail('First')]]),
         );
-        yield* settle(
-          view.ref,
-          (v) => v.inflight.get(`${child}/row-2`) === 'First',
-        );
+        yield* settle(view.ref, (v) => rowText(v, child, 'row-2') === 'First');
         yield* SubscriptionRef.update(
           chunks.ref,
           (held) =>
@@ -427,11 +472,11 @@ describe('session framer', () => {
         );
         yield* settle(
           view.ref,
-          (v) => v.inflight.get(`${child}/row-2`) === 'First suffix',
+          (v) => rowText(v, child, 'row-2') === 'First suffix',
         );
         yield* settle(
           runtimeView.ref,
-          (v) => v.inflight.get(`${child}/row-2`) === 'First suffix',
+          (v) => rowText(v, child, 'row-2') === 'First suffix',
         );
 
         // Neither a partial replay nor its superseded generation may mutate
@@ -481,14 +526,14 @@ describe('session framer', () => {
         yield* settle(view.ref, (v) => v.streams.get(STREAM)?.ownerId === null);
         const afterLive = yield* SubscriptionRef.get(view.ref);
         expect(afterLive.cursor).toBe(beforeLive.cursor);
-        expect(afterLive.inflight.get(`${STREAM}/row-1`)).toBe('Hello again!');
+        expect(rowText(afterLive, STREAM, 'row-1')).toBe('Hello again!');
         const beforeReplay = yield* SubscriptionRef.get(view.ref);
-        yield* frames.begin(2);
+        yield* frames.begin(3);
         yield* shell.set('shell', named.aggregates);
         yield* frames.feed({
           kind: 'events',
           session: KEY,
-          generation: 2,
+          generation: 3,
           cursor: 4,
           events: [
             {
@@ -514,13 +559,13 @@ describe('session framer', () => {
         expect(beforeReplay.streams.get(STREAM)?.status).toBe(
           STREAM_PHASE.RUNNING,
         );
-        yield* frames.begin(3);
+        yield* frames.begin(4);
         yield* shell.set('shell', named.aggregates);
         const resumed = yield* Effect.forkScoped(
           Stream.runForEach(
             frameSubscription(source, PORT, host, {
               ...named,
-              generation: 3,
+              generation: 4,
               cursor: beforeReplay.cursor,
             }),
             (frame) => frames.feed(frame),
@@ -535,7 +580,7 @@ describe('session framer', () => {
       }).pipe(
         Effect.provide(
           Layer.merge(
-            runtimeGraph([runStart, waiting]),
+            runtimeGraph([runStart, waiting, streamingRow(STREAM, 'row-1')]),
             WebviewSessions.layerNoDeps,
           ),
         ),

--- a/src/test-kernel/shared/session/sessionFold.vitest.ts
+++ b/src/test-kernel/shared/session/sessionFold.vitest.ts
@@ -376,7 +376,6 @@ describe('sessionFold', () => {
 
   it('folds a pending approval to waiting only with a held owner', () => {
     const withOwner = foldAll([...scenario.pending, alive]);
-    expect(withOwner.local.self).toStrictEqual([OWNER]);
     expect(stream(withOwner, CHILD).group).toBe('waiting');
     expect(stream(withOwner, CHILD).approval).toBe('own');
     expect(stream(withOwner, CHILD).forceExpanded).toBe(true);
@@ -465,7 +464,7 @@ describe('sessionFold', () => {
     expect(stream(dead, CHILD).group).toBe('interrupted');
   });
 
-  it('keeps live text in inflight by offsets and joins it to its row whichever arrives first', () => {
+  it('keeps live text by offsets and joins it to its row whichever arrives first', () => {
     const log = new Log();
     log.emit(CHILD, 1500, {
       type: 'run.start',
@@ -512,8 +511,6 @@ describe('sessionFold', () => {
     expect(child.transcript.rows).toHaveLength(1);
     expect(first.kind === 'assistant' && first.text.full).toBe('Hello');
     expect(first.kind === 'assistant' && first.streaming).toBe(true);
-    expect(streaming.inflight.get(`${CHILD}/response-1`)).toBe('Hello');
-    expect(streaming.inflight.get(`${CHILD}/response-2`)).toBe('Ear');
     // A streaming reply is not settled and not yet the latest line.
     expect(child.transcript.settledRows).toBe(0);
     expect(child.latestLine).toBeNull();
@@ -534,7 +531,6 @@ describe('sessionFold', () => {
     );
     const third = stream(buffered, CHILD).transcript.rows[2];
     expect(third.kind === 'assistant' && third.text.full).toBe('Buffer');
-    expect(buffered.inflight.get(`${CHILD}/response-3`)).toBe('Buffer');
 
     // Durable text wins: the finalizing row drops its entry and a late chunk
     // cannot reopen it; a replacement chunk truncates at `from`.
@@ -551,8 +547,7 @@ describe('sessionFold', () => {
       'Hello world',
     );
     expect(rows[1].kind === 'assistant' && rows[1].text.full).toBe('Late');
-    expect(settled.inflight.has(`${CHILD}/response-1`)).toBe(false);
-    // A terminal status ends every live row.
+    // A terminal status ends every live row: a later chunk reaches none.
     const done = fold(
       settled,
       tail(
@@ -564,7 +559,7 @@ describe('sessionFold', () => {
         }),
       ),
     );
-    expect(done.inflight.size).toBe(0);
+    expect(fold(done, chunk('response-2', 4, 5, '!'))).toBe(done);
   });
 
   it('keeps listing facts in commit order and transcript rows in seq order, whichever read delivers them', () => {
@@ -746,7 +741,6 @@ describe('sessionFold', () => {
     const childBefore = stream(before, CHILD);
     const rowsBefore = childBefore.transcript.rows;
     const rowCount = rowsBefore.length;
-    const key = `${CHILD}/late`;
     const after = fold(before, [
       tail({
         aggregateId: qualifyAggregateId('stream', CHILD),
@@ -779,11 +773,11 @@ describe('sessionFold', () => {
     expect(before.streams.get(CHILD)).toBe(childBefore);
     expect(childBefore.transcript.rows).toBe(rowsBefore);
     expect(rowsBefore).toHaveLength(rowCount);
-    expect(before.inflight.has(key)).toBe(false);
     // The next level holds the writes ...
     const childAfter = stream(after, CHILD);
     expect(childAfter.transcript.rows).toHaveLength(rowCount + 1);
-    expect(after.inflight.get(key)).toBe('Late!!');
+    const late = childAfter.transcript.rows.find((row) => row.id === 'late');
+    expect(late?.kind === 'assistant' && late.text.full).toBe('Late!!');
     expect(after.streams).not.toBe(before.streams);
     // ... and shares every branch it did not touch by reference.
     expect(after.streams.get(PROCESS)).toBe(before.streams.get(PROCESS));
@@ -791,11 +785,10 @@ describe('sessionFold', () => {
       stream(before, PROCESS).transcript.rows,
     );
     expect(after.policy).toBe(before.policy);
-    expect(after.latest).toBe(before.latest);
     expect(after.queuedFollowUps).toBe(before.queuedFollowUps);
     // A copy belongs to a write, not to an entry: a settled log row projects
-    // a row and nothing else, so the touched stream's own task groups and
-    // the session's in-flight map (which never held its key) keep theirs.
+    // a row and nothing else, so the touched stream's own task groups keep
+    // theirs.
     const logged = fold(
       after,
       tail({
@@ -822,6 +815,5 @@ describe('sessionFold', () => {
     expect(childLogged.transcript.taskGroups).toBe(
       childAfter.transcript.taskGroups,
     );
-    expect(logged.inflight).toBe(after.inflight);
   });
 });

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -665,9 +665,14 @@ describe('headless delegation', () => {
       const phase = (value as { phase?: string }).phase;
       if (phase) order.push(phase);
     });
-    const detachFlusher = defaultSession().useArtifactFlusher(async () => {
-      order.push('drain');
-    });
+    const session = defaultSession();
+    const settle = session.flushArtifacts.bind(session);
+    const drain = vi
+      .spyOn(session, 'flushArtifacts')
+      .mockImplementation(async () => {
+        order.push('drain');
+        await settle();
+      });
     mocks.releaseOwnedExecutionLease.mockImplementationOnce(async () => {
       order.push('release');
     });
@@ -676,7 +681,7 @@ describe('headless delegation', () => {
     try {
       await runInBand(delegationOptions(), logicalExecutionId);
     } finally {
-      detachFlusher();
+      drain.mockRestore();
     }
 
     expect(order).toContain('launched');
@@ -1109,9 +1114,9 @@ describe('headless delegation', () => {
       return await write?.(key, value);
     });
     useStableStores(stableSequenceStore(logicalExecutionId), childStore);
-    const detachFlusher = defaultSession().useArtifactFlusher(async () => {
-      throw cleanupFailure;
-    });
+    const cleanup = vi
+      .spyOn(defaultSession(), 'flushArtifacts')
+      .mockRejectedValue(cleanupFailure);
 
     try {
       await expect(
@@ -1121,7 +1126,7 @@ describe('headless delegation', () => {
         cause: cleanupFailure,
       });
     } finally {
-      detachFlusher();
+      cleanup.mockRestore();
     }
     mocks.inspectExecutionLease.mockResolvedValueOnce({
       status: 'held',
@@ -1151,9 +1156,9 @@ describe('headless delegation', () => {
       return await write?.(key, value);
     });
     useStableStores(stableSequenceStore(logicalExecutionId), childStore);
-    const detachFlusher = defaultSession().useArtifactFlusher(async () => {
-      throw cleanupFailure;
-    });
+    const cleanup = vi
+      .spyOn(defaultSession(), 'flushArtifacts')
+      .mockRejectedValue(cleanupFailure);
 
     try {
       await expect(
@@ -1163,7 +1168,7 @@ describe('headless delegation', () => {
         cause: cleanupFailure,
       });
     } finally {
-      detachFlusher();
+      cleanup.mockRestore();
     }
 
     // Perform the restart repair's observable lease transition before the

--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -4,22 +4,8 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
-  type StreamLogEntry,
 } from '@shared/schemas';
 import { StreamLog } from '@shared/session/traceEntries';
-
-function logWithMessage(text = ''): StreamLog {
-  const log = new StreamLog();
-  log.append({
-    id: 'message',
-    type: STREAM_LOG_ENTRY_TYPES.LOG,
-    level: LOG_LEVELS.INFO,
-    timestamp: 1,
-    text,
-    messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-  });
-  return log;
-}
 
 describe('StreamLog', () => {
   it('appends trusted entries while preserving sequence and lookup invariants', () => {
@@ -91,7 +77,6 @@ describe('StreamLog', () => {
     const delta = log.drainEmission();
     expect(delta.appended).toEqual([]);
     expect(delta.dirtied).toEqual([]);
-    expect(delta.textChunks).toEqual([]);
   });
 
   it('assigns one durable settlement order when rows become printable', () => {
@@ -138,157 +123,5 @@ describe('StreamLog', () => {
     expect(completed?.settlementSeqNo).toBe(2);
     expect(revised?.settlementSeqNo).toBe(2);
     expect(later.settlementSeqNo).toBe(3);
-  });
-
-  it('emits text appends as merged chunks, not dirtied entries', () => {
-    const log = logWithMessage();
-    log.drainEmission();
-
-    log.appendText('message', 'hello');
-    log.appendText('message', ' world');
-
-    expect(log.getRange(0, log.head)[0]?.text).toBe('hello world');
-    const delta = log.drainEmission();
-    expect(delta.dirtied).toEqual([]);
-    expect(delta.textChunks).toEqual([
-      { id: 'message', appendText: 'hello world' },
-    ]);
-  });
-
-  it('starts a fresh chunk window after each drain, across materialization', () => {
-    const log = logWithMessage();
-    log.drainEmission();
-
-    log.appendText('message', 'hello');
-    // Materialize the joined prefix, then keep streaming unjoined chunks:
-    // the chunk window is captured at append time, not re-derived from text.
-    expect(log.getRange(0, log.head)[0]?.text).toBe('hello');
-    log.appendText('message', ' wor');
-    log.appendText('message', 'ld');
-
-    expect(log.drainEmission().textChunks).toEqual([
-      { id: 'message', appendText: 'hello world' },
-    ]);
-
-    log.appendText('message', '!');
-    expect(log.drainEmission().textChunks).toEqual([
-      { id: 'message', appendText: '!' },
-    ]);
-  });
-
-  it('lets a same-window update supersede text chunks with its full value', () => {
-    const log = logWithMessage();
-    log.drainEmission();
-
-    log.appendText('message', 'hel');
-    log.update('message', { text: 'rewritten' });
-
-    const delta = log.drainEmission();
-    expect(delta.textChunks).toEqual([]);
-    expect(delta.dirtied.map((entry) => entry.text)).toEqual(['rewritten']);
-  });
-
-  it('folds same-window chunks into a newly appended entry by value', () => {
-    const log = logWithMessage();
-
-    log.appendText('message', 'hello');
-
-    const delta = log.drainEmission();
-    expect(delta.textChunks).toEqual([]);
-    expect(delta.dirtied).toEqual([]);
-    expect(delta.appended.map((entry) => entry.text)).toEqual(['hello']);
-  });
-
-  it('carries chunks appended after a same-window update inside the dirtied value', () => {
-    const log = logWithMessage('base');
-    log.drainEmission();
-
-    log.update('message', { text: 'rewritten' });
-    log.appendText('message', ' plus');
-
-    // The dirtied entry resolves to the current object at drain time, whose
-    // text already includes the trailing chunk — so the chunk is dropped.
-    const delta = log.drainEmission();
-    expect(delta.textChunks).toEqual([]);
-    expect(delta.dirtied.map((entry) => entry.text)).toEqual([
-      'rewritten plus',
-    ]);
-  });
-
-  it('returns point-in-time text on emitted entries across later appends', () => {
-    const log = logWithMessage();
-
-    const first = log.appendText('message', 'hel');
-    const second = log.appendText('message', 'lo');
-    log.appendText('message', '!');
-
-    // Each emitted entry object keeps the text as of its own mutation, even
-    // though the chunks live in one shared accumulator that keeps growing.
-    expect(second?.text).toBe('hello');
-    expect(first?.text).toBe('hel');
-    expect(log.getRange(0, log.head)[0]?.text).toBe('hello!');
-  });
-
-  it('keeps materialized text equal to the chunk-join oracle across interleavings', () => {
-    // Deterministic LCG so the append/update/settle interleaving corpus is
-    // reproducible without a fixture file.
-    let seed = 42;
-    const rand = (bound: number): number => {
-      seed = (seed * 1_103_515_245 + 12_345) % 2_147_483_648;
-      return seed % bound;
-    };
-
-    const log = new StreamLog();
-    const oracle = new Map<string, string>();
-    const ids: string[] = [];
-    const snapshots: Array<{ entry: StreamLogEntry; text: string }> = [];
-
-    for (let step = 0; step < 400; step += 1) {
-      const op = rand(10);
-      if (op < 2 || ids.length === 0) {
-        const id = `row-${ids.length}`;
-        ids.push(id);
-        log.append({
-          id,
-          type: STREAM_LOG_ENTRY_TYPES.LOG,
-          level: LOG_LEVELS.INFO,
-          timestamp: step,
-          text: 'seed',
-          messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-        });
-        oracle.set(id, 'seed');
-        continue;
-      }
-      const id = ids[rand(ids.length)];
-      if (op < 8) {
-        const chunk = `c${step}|`;
-        const updated = log.appendText(id, chunk);
-        oracle.set(id, `${oracle.get(id) ?? ''}${chunk}`);
-        const expected = oracle.get(id);
-        if (updated && expected !== undefined) {
-          snapshots.push({ entry: updated, text: expected });
-        }
-      } else if (op === 8) {
-        const text = `rewritten-${step}`;
-        if (log.update(id, { text })) oracle.set(id, text);
-      } else {
-        log.settle(id, { data: { status: 'completed', step } });
-      }
-    }
-
-    for (const entry of log.getRange(0)) {
-      expect(entry.text).toBe(oracle.get(entry.id));
-    }
-    // Emitted entries stay point-in-time even after later chunks landed.
-    for (const { entry, text } of snapshots) {
-      expect(entry.text).toBe(text);
-    }
-    // Export serialization sees the same materialized text.
-    const persisted = JSON.parse(
-      JSON.stringify(log.toJSON()),
-    ) as StreamLogEntry[];
-    for (const entry of persisted) {
-      expect(entry.text).toBe(oracle.get(entry.id));
-    }
   });
 });

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -348,11 +348,6 @@ describe('attachTestTranscriptFold workflow task state', () => {
     // streams/tools. Late provider cleanup cannot mutate a row already made
     // printable in append-only Static scrollback.
     trace.emit({
-      type: 'stream.chunk',
-      id: response.id,
-      text: ' late text',
-    });
-    trace.emit({
       type: 'stream.end',
       id: response.id,
       finalText: 'Late replacement',
@@ -364,7 +359,7 @@ describe('attachTestTranscriptFold workflow task state', () => {
     });
     expect(row(response.id)).toMatchObject({
       settlementSeqNo: 2,
-      text: 'Partial answer',
+      text: '',
       data: { status: 'completed' },
     });
     expect(row('tool:pending')).toMatchObject({
@@ -405,7 +400,7 @@ describe('attachTestTranscriptFold workflow task state', () => {
       {
         id: response.id,
         settlementSeqNo: 2,
-        text: 'Partial answer',
+        text: '',
       },
       {
         settlementSeqNo: 5,
@@ -437,7 +432,7 @@ describe('attachTestTranscriptFold workflow task state', () => {
       {
         id: waitingResponse.id,
         settlementSeqNo: 1,
-        text: 'Waiting response',
+        text: '',
         data: { status: 'completed' },
       },
       {
@@ -472,7 +467,7 @@ describe('attachTestTranscriptFold workflow task state', () => {
       {
         id: waitingResponse.id,
         settlementSeqNo: 1,
-        text: 'Waiting response',
+        text: '',
         data: { status: 'completed' },
       },
       {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -9,15 +9,13 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import type { Database } from '@shared/session/database';
-import { StreamLog, type StreamLogDelta } from '@shared/session/traceEntries';
+import { StreamLog } from '@shared/session/traceEntries';
 import { createTranscriptFold } from '@shared/session/traceFold';
-import { createListenerSet } from '@utils/core/listenerSet';
 
 type TranscriptDatabase = Pick<
   Context.Service.Shape<typeof Database>,
   'readAggregate' | 'readListing'
 >;
-type StreamLogListener = (streamId: StreamTabId, delta: StreamLogDelta) => void;
 export type StreamLogStoreMode =
   | { readonly kind: 'persistent' }
   | { readonly kind: 'ephemeral'; readonly reason: string };
@@ -71,7 +69,6 @@ export class StreamLogStore {
   private readonly streams = new Map<StreamTabId, StreamState>();
   private readonly known = new Set<StreamTabId>();
   private readonly releaseRequests = new Set<StreamTabId>();
-  private readonly listeners = createListenerSet<StreamLogListener>();
   private readonly gate = Semaphore.makeUnsafe(1);
 
   private constructor(
@@ -106,9 +103,6 @@ export class StreamLogStore {
     return new StreamLogStore({ kind: 'ephemeral', reason: normalized });
   }
 
-  onChange(listener: StreamLogListener): () => void {
-    return this.listeners.add(listener);
-  }
   get(streamId: StreamTabId): StreamLog | undefined {
     return this.streams.get(streamId)?.log;
   }
@@ -215,7 +209,6 @@ export class StreamLogStore {
       }
       this.known.add(streamId);
       Object.assign(this.ensureStreamState(streamId), entries);
-      this.notify(streamId, true);
     });
   }
 
@@ -246,7 +239,9 @@ export class StreamLogStore {
         state.fold ??= createTranscriptFold(state.log);
         applyEvent(state.log, state.fold, event);
         state.seq = event.seq;
-        this.notify(streamId);
+        // Nothing here reads the log's change buffers; drain them so they do
+        // not grow with the resident log.
+        state.log.drainEmission();
       }),
     );
   }
@@ -369,12 +364,5 @@ export class StreamLogStore {
       this.streams.set(streamId, state);
     }
     return state;
-  }
-
-  private notify(streamId: StreamTabId, reset = false): void {
-    const log = this.get(streamId);
-    if (log === undefined) return;
-    const delta = { ...log.drainEmission(), reset };
-    for (const listener of this.listeners) listener(streamId, delta);
   }
 }


### PR DESCRIPTION
Fixes a data-loss bug in the session transcript, and deletes the dead code that
made it possible.

## The bug

A run that reached a terminal phase without a `stream.end` lost its finalized
model response text.

`traceFold` registers a row on `stream.start`. The `response.finalized` arm
settled that row's text but left its id in the fold's local `streams` map. The
terminal-phase boundary then walked the map and re-settled every surviving row
from its joined chunk buffer. That buffer is always empty, because chunks never
reach this fold. So a crash, a cancel, or a torn-down trace overwrote the
authoritative finalized text with the empty string, and the row still rendered,
just blank.

**The fix** removes the settled id from the map in `response.finalized`, and the
boundary walk now settles status only. The broken state cannot be represented,
instead of being guarded against.

## What goes with it

| Issue | Deleted |
| --- | --- |
| #12177 | The `stream.chunk` arm of the fold, the lazy streaming-text accumulator, `TranscriptChunkSchema` from the durable union, the `StreamLogStore` change multicast, `StreamLogDelta`, `StreamLogTextDelta` |
| #12180 | The artifact-flusher registry and its `p-defer` batcher; `flushArtifacts` is now `settlePublications` |
| #12179 | Four fold-private fields off `SessionView`, moved into the fold's module-private indexes |
| #12182 | The `TraceStamp` export, and a full union parse on every run completion |

Removing `TranscriptChunkSchema` from the durable union matters beyond cleanup.
Before, the fold accepted `stream.chunk` by type and dropped it with no case and
no signal, which is exactly the silent-degradation shape this repo treats as a
defect. Now it is a type error.

## Why these were safe to delete

- **Chunks never become durable.** `runEventDraft` returns null for
  `stream.chunk`, `SessionHandle.publishRunEvent` routes chunks to the live text
  path, and both production callers of the trace fold narrow to durable events.
- **The multicast had no subscriber.** Its last one was deleted by `c40f38ef71`
  on 2026-09-07. The pending-buffer drain it also performed is kept where
  commits are accepted, so nothing leaks.
- **No writer was ever registered** with the artifact flusher in production.
  `settlePublications` awaits a copy of the in-flight set and resets nothing, so
  collapsing the batcher introduces no race.

## The framer test

This change was attempted once before and reverted. The framer test watched live
text through `view.inflight`, and once that index became private the test could
no longer see it. Weakening its settle predicates broke a real identity assertion
further down.

The test now does what a renderer does: it publishes a real transcript row and
reads the live text from the row itself. The child section resubscribes after
the child's `run.start` commits, matching the extension transport's `subscribe()`
order. Every original predicate and both identity assertions are kept, and the
test passes repeatedly with no hang.

That investigation found a latent defect in the same area, filed separately: a
stream named in a subscription before its `run.start` silently loses its
transcript tier.

## Merge order with the S1a rename

This overlaps 17 files with #12208, the mechanical "execution and stream to run" rename.
That rename is deterministic and regenerable, so whichever PR merges second gets the
same recipe re-run on its branch, which makes both sides' identifiers identical and
removes the conflict.

## Tests

Three expectations pinned chunk text reaching the durable fold, a path
production never feeds, and now expect what production produces. Every
settlement-order, length and finalize assertion is kept, since those still prove
real behavior. The accumulator's own tests are deleted with the accumulator.

## Net elements

| Measure | Delta |
| --- | --- |
| Files changed | 19 |
| Net LoC | 269 insertions, 732 deletions |

## Verified

`npm run typecheck` across every project, `npm run lint`, `npm test` (Tests  9040 passed | 2 skipped (9042)), `npm run check:dead-code-ratchet`, the effect-migration ratchet, `npm run check:guidance-refs`, and `prettier --check` on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QtWawFHNreKY2RkrRRHg4
