### PR TITLE
test: convert 52 test-kernel suites to @effect/vitest

### DIFF
--- a/src/test-kernel/agent/AgentRegistry.vitest.ts
+++ b/src/test-kernel/agent/AgentRegistry.vitest.ts
@@ -3,8 +3,9 @@ import { resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, vi } from 'vitest';
 
 // Local imports
 import {
@@ -197,17 +198,19 @@ describe('agent registry', () => {
     }
   });
 
-  it('reloads local-only definitions after sign-out invalidation', async () => {
-    useAgentDirectories();
-    await Effect.runPromise(refresh({ includeRemote: true }));
-    expect(isRemoteAgent('orchestrator')).toBe(true);
-    const remoteFetchCount = listRemoteAgents.mock.calls.length;
+  it.effect('reloads local-only definitions after sign-out invalidation', () =>
+    Effect.gen(function* () {
+      useAgentDirectories();
+      yield* refresh({ includeRemote: true });
+      expect(isRemoteAgent('orchestrator')).toBe(true);
+      const remoteFetchCount = listRemoteAgents.mock.calls.length;
 
-    await Effect.runPromise(invalidateRemoteAgentsAfterSignOut());
+      yield* invalidateRemoteAgentsAfterSignOut();
 
-    expect(isRemoteAgent('orchestrator')).toBe(false);
-    expect(listRemoteAgents).toHaveBeenCalledTimes(remoteFetchCount);
-  });
+      expect(isRemoteAgent('orchestrator')).toBe(false);
+      expect(listRemoteAgents).toHaveBeenCalledTimes(remoteFetchCount);
+    }),
+  );
 
   it('removes remote definitions even when the local rebuild fails', async () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
@@ -284,42 +287,45 @@ describe('agent registry', () => {
     }
   });
 
-  it('keeps the registry serving when a later refresh fails', async () => {
-    expect(getAgent('assistant')?.name).toBe('assistant');
-
-    useAgentDirectories({
-      builtInToolUse: async () => {
-        throw new Error('refresh failed');
-      },
-    });
-
-    try {
-      await expect(Effect.runPromise(loadAgents())).rejects.toThrow(
-        'refresh failed',
-      );
-
+  it.effect('keeps the registry serving when a later refresh fails', () =>
+    Effect.gen(function* () {
       expect(getAgent('assistant')?.name).toBe('assistant');
-    } finally {
-      useAgentDirectories();
-    }
-  });
 
-  it('includes remote agents in launcher options after local-only startup load', async () => {
-    try {
-      await Effect.runPromise(refresh({ includeRemote: false }));
-      expect(
-        getVisibleAgents('toolUse').map((agent) => agent.name),
-      ).not.toContain('orchestrator');
+      useAgentDirectories({
+        builtInToolUse: async () => {
+          throw new Error('refresh failed');
+        },
+      });
 
-      const options = await Effect.runPromise(computeAgentOptionsData());
+      try {
+        const failure = yield* Effect.flip(loadAgents());
+        expect(String(failure)).toContain('refresh failed');
 
-      expect(options.toolUse.map((option) => option.label)).toContain(
-        'orchestrator',
-      );
-    } finally {
-      await Effect.runPromise(refresh({ includeRemote: false }));
-    }
-  });
+        expect(getAgent('assistant')?.name).toBe('assistant');
+      } finally {
+        useAgentDirectories();
+      }
+    }),
+  );
+
+  it.effect(
+    'includes remote agents in launcher options after local-only startup load',
+    () =>
+      Effect.gen(function* () {
+        yield* refresh({ includeRemote: false });
+        expect(
+          getVisibleAgents('toolUse').map((agent) => agent.name),
+        ).not.toContain('orchestrator');
+
+        const options = yield* computeAgentOptionsData();
+
+        expect(options.toolUse.map((option) => option.label)).toContain(
+          'orchestrator',
+        );
+      }).pipe(
+        Effect.ensuring(refresh({ includeRemote: false }).pipe(Effect.orDie)),
+      ),
+  );
 
   it('includes remote agents in launcher options after pending local-only startup load', async () => {
     const builtInToolUseDir = createDeferred<void>();

--- a/src/test-kernel/agent/AgentYamlScanner.vitest.ts
+++ b/src/test-kernel/agent/AgentYamlScanner.vitest.ts
@@ -3,8 +3,9 @@ import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect } from 'vitest';
 
 // Local imports
 import { scanDirectory } from '@agent/index/agentYamlScanner';
@@ -25,6 +26,10 @@ async function createAgentDir(
   return agentDir;
 }
 
+/** The temp directory as an Effect, so the scan reads real files on disk. */
+const agentDir = (files: Record<string, readonly string[]>) =>
+  Effect.promise(() => createAgentDir(files));
+
 function toolUseAgent(name: string, systemPrompt: string): string[] {
   return [
     `name: ${name}`,
@@ -38,137 +43,141 @@ function toolUseAgent(name: string, systemPrompt: string): string[] {
 describe('agent YAML scanner', () => {
   beforeAll(() => installPlatform({}, { fs: nodeFilesystem }));
 
-  it('derives workflow round counts from inherited settings and prompts', async () => {
-    const agentDir = await createAgentDir({
-      'base.yaml': [
-        'name: base',
-        'settings:',
-        '  agentCategory: workflow',
-        '  rounds: 4',
-        'prompts:',
-        '  userRequest: base',
-      ],
-      'child.yaml': [
-        'name: child',
-        'inherits: base',
-        'prompts:',
-        '  userRequest: child',
-      ],
-      'prompt-base.yaml': [
-        'name: prompt-base',
-        'settings:',
-        '  agentCategory: workflow',
-        '  rounds: 1',
-        'prompts:',
-        '  userRequest:',
-        '    - first',
-        '    - second',
-        '    - third',
-      ],
-      'prompt-child.yaml': ['name: prompt-child', 'inherits: prompt-base'],
-      'missing-parent.yaml': [
-        'name: missing-parent',
-        'inherits: no-such-parent',
-      ],
-    });
+  it.live(
+    'derives workflow round counts from inherited settings and prompts',
+    () =>
+      Effect.gen(function* () {
+        const dir = yield* agentDir({
+          'base.yaml': [
+            'name: base',
+            'settings:',
+            '  agentCategory: workflow',
+            '  rounds: 4',
+            'prompts:',
+            '  userRequest: base',
+          ],
+          'child.yaml': [
+            'name: child',
+            'inherits: base',
+            'prompts:',
+            '  userRequest: child',
+          ],
+          'prompt-base.yaml': [
+            'name: prompt-base',
+            'settings:',
+            '  agentCategory: workflow',
+            '  rounds: 1',
+            'prompts:',
+            '  userRequest:',
+            '    - first',
+            '    - second',
+            '    - third',
+          ],
+          'prompt-child.yaml': ['name: prompt-child', 'inherits: prompt-base'],
+          'missing-parent.yaml': [
+            'name: missing-parent',
+            'inherits: no-such-parent',
+          ],
+        });
 
-    const { entries } = await Effect.runPromise(
-      scanDirectory(agentDir, 'custom'),
-    );
+        const { entries } = yield* scanDirectory(dir, 'custom');
 
-    expect(entries.find((entry) => entry.name === 'child')?.rounds).toBe(4);
-    expect(entries.find((entry) => entry.name === 'prompt-child')?.rounds).toBe(
-      3,
-    );
-    expect(
-      entries.find((entry) => entry.name === 'missing-parent')?.rounds,
-    ).toBeUndefined();
-  });
-
-  it('uses the YAML name as the canonical registry name', async () => {
-    const agentDir = await createAgentDir({
-      'Readable Helper.yaml': toolUseAgent('helper', 'help'),
-    });
-
-    const { entries } = await Effect.runPromise(
-      scanDirectory(agentDir, 'custom'),
-    );
-
-    expect(entries.map((entry) => entry.name)).toEqual(['helper']);
-  });
-
-  it('skips agent names that are not identifiers', async () => {
-    const agentDir = await createAgentDir({
-      'review.yaml': [
-        'name: review team',
-        'description: Verifies manuscripts.',
-        'settings:',
-        '  agentCategory: toolUse',
-        'prompts:',
-        '  systemPrompt: review',
-      ],
-    });
-
-    const { entries } = await Effect.runPromise(
-      scanDirectory(agentDir, 'custom'),
-    );
-
-    expect(entries).toEqual([]);
-  });
-
-  it('skips duplicate YAML names instead of returning colliding entries', async () => {
-    const agentDir = await createAgentDir({
-      'first.yaml': toolUseAgent('shared', 'first'),
-      'second.yaml': toolUseAgent('shared', 'second'),
-      'unique.yaml': toolUseAgent('unique', 'unique'),
-    });
-
-    const { entries } = await Effect.runPromise(
-      scanDirectory(agentDir, 'custom'),
-    );
-
-    expect(entries.map((entry) => entry.name)).toEqual(['unique']);
-  });
-
-  it('skips a file with malformed YAML instead of throwing', async () => {
-    const agentDir = await createAgentDir({
-      'broken.yaml': ['name: "unterminated'],
-      'valid.yaml': toolUseAgent('valid', 'hi'),
-    });
-
-    const { entries } = await Effect.runPromise(
-      scanDirectory(agentDir, 'custom'),
-    );
-
-    expect(entries.map((entry) => entry.name)).toEqual(['valid']);
-  });
-
-  it('reports skipped custom YAML files as scan issues', async () => {
-    const agentDir = await createAgentDir({
-      'broken.yaml': ['name: "unterminated'],
-      'retired.yaml': [
-        'name: retired',
-        'settings:',
-        '  agentCategory: workflow',
-        '  documentTag: documents',
-      ],
-      'valid.yaml': toolUseAgent('valid', 'hi'),
-    });
-
-    const { entries, issues } = await Effect.runPromise(
-      scanDirectory(agentDir, 'custom'),
-    );
-
-    expect(entries.map((entry) => entry.name)).toEqual(['valid']);
-    expect(issues).toEqual([
-      expect.objectContaining({
-        path: 'broken.yaml',
-        message: expect.stringMatching(/unterminated|Nested mappings|YAML/iu),
+        expect(entries.find((entry) => entry.name === 'child')?.rounds).toBe(4);
+        expect(
+          entries.find((entry) => entry.name === 'prompt-child')?.rounds,
+        ).toBe(3);
+        expect(
+          entries.find((entry) => entry.name === 'missing-parent')?.rounds,
+        ).toBeUndefined();
       }),
-      expect.objectContaining({
-        path: 'retired.yaml',
-        message: expect.stringContaining('documentTag'),
+  );
+
+  it.live('uses the YAML name as the canonical registry name', () =>
+    Effect.gen(function* () {
+      const dir = yield* agentDir({
+        'Readable Helper.yaml': toolUseAgent('helper', 'help'),
+      });
+
+      const { entries } = yield* scanDirectory(dir, 'custom');
+
+      expect(entries.map((entry) => entry.name)).toEqual(['helper']);
+    }),
+  );
+
+  it.live('skips agent names that are not identifiers', () =>
+    Effect.gen(function* () {
+      const dir = yield* agentDir({
+        'review.yaml': [
+          'name: review team',
+          'description: Verifies manuscripts.',
+          'settings:',
+          '  agentCategory: toolUse',
+          'prompts:',
+          '  systemPrompt: review',
+        ],
+      });
+
+      const { entries } = yield* scanDirectory(dir, 'custom');
+
+      expect(entries).toEqual([]);
+    }),
+  );
+
+  it.live(
+    'skips duplicate YAML names instead of returning colliding entries',
+    () =>
+      Effect.gen(function* () {
+        const dir = yield* agentDir({
+          'first.yaml': toolUseAgent('shared', 'first'),
+          'second.yaml': toolUseAgent('shared', 'second'),
+          'unique.yaml': toolUseAgent('unique', 'unique'),
+        });
+
+        const { entries } = yield* scanDirectory(dir, 'custom');
+
+        expect(entries.map((entry) => entry.name)).toEqual(['unique']);
       }),
-    ]);
-  });
+  );
+
+  it.live('skips a file with malformed YAML instead of throwing', () =>
+    Effect.gen(function* () {
+      const dir = yield* agentDir({
+        'broken.yaml': ['name: "unterminated'],
+        'valid.yaml': toolUseAgent('valid', 'hi'),
+      });
+
+      const { entries } = yield* scanDirectory(dir, 'custom');
+
+      expect(entries.map((entry) => entry.name)).toEqual(['valid']);
+    }),
+  );
+
+  it.live('reports skipped custom YAML files as scan issues', () =>
+    Effect.gen(function* () {
+      const dir = yield* agentDir({
+        'broken.yaml': ['name: "unterminated'],
+        'retired.yaml': [
+          'name: retired',
+          'settings:',
+          '  agentCategory: workflow',
+          '  documentTag: documents',
+        ],
+        'valid.yaml': toolUseAgent('valid', 'hi'),
+      });
+
+      const { entries, issues } = yield* scanDirectory(dir, 'custom');
+
+      expect(entries.map((entry) => entry.name)).toEqual(['valid']);
+      expect(issues).toEqual([
+        expect.objectContaining({
+          path: 'broken.yaml',
+          message: expect.stringMatching(/unterminated|Nested mappings|YAML/iu),
+        }),
+        expect.objectContaining({
+          path: 'retired.yaml',
+          message: expect.stringContaining('documentTag'),
+        }),
+      ]);
+    }),
+  );
 });

--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -1,5 +1,6 @@
-import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { Cause, Effect, Exit } from 'effect';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 import { getExecutionRecords, getExecutionStore } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
@@ -11,7 +12,6 @@ import {
   registerExecution,
 } from '@agent/storage/executionLifecycle';
 import { inspectExecutionLease } from '@agent/storage/executionLease';
-import { effectRuntime } from '@platform/processRuntime';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
 
@@ -29,21 +29,23 @@ const options = {
   userFollowUpSupport: 'nativeInteractive',
 } as const;
 let session: ReturnType<typeof createTestSession>;
-const run = <A, E>(effect: Effect.Effect<A, E>) =>
-  effectRuntime().runPromise(effect);
+/** The failure an exit carries, or undefined when it succeeded. */
+const failureOf = (exit: Exit.Exit<unknown, unknown>): unknown =>
+  Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined;
 const register = (workingDirectory?: string) =>
-  run(
-    registerExecution(
-      session,
-      executionId,
-      {
-        ...baseConfig,
-        ...(workingDirectory === undefined ? {} : { workingDirectory }),
-      },
-      'chat',
-      options,
-    ),
+  registerExecution(
+    session,
+    executionId,
+    {
+      ...baseConfig,
+      ...(workingDirectory === undefined ? {} : { workingDirectory }),
+    },
+    'chat',
+    options,
   );
+/** Lease and store reads run through the session's run context, not Effect. */
+const inSession = <T>(fn: () => Promise<T>): Effect.Effect<T> =>
+  Effect.promise(() => runInSession(session, fn));
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -51,173 +53,207 @@ beforeEach(() => {
 });
 
 describe('execution registration and finalization', () => {
-  it.each([undefined, '/workspace/paper '])(
+  it.effect.each([undefined, '/workspace/paper '])(
     'pins the execution working directory for %s',
-    async (workingDirectory) => {
-      await register(workingDirectory);
-      expect(
-        await run(getExecutionRecords(session, executionId).readConfig()),
-      ).toMatchObject({
-        workingDirectory: workingDirectory ?? '/workspace/root',
-      });
-      expect(
-        await run(getExecutionRecords(session, executionId).readMeta()),
-      ).toMatchObject({
-        streamId: options.streamId,
-        identity: options.identity,
-        userFollowUpSupport: 'nativeInteractive',
-      });
-      expect(await getExecutionStore(executionId).listKeys()).toEqual([]);
-    },
-  );
-
-  it('rolls back file ownership when the registration transaction fails', async () => {
-    const failure = new Error('database write failed');
-    vi.spyOn(session, 'commitRegistration').mockReturnValueOnce(
-      Effect.die(failure),
-    );
-    await expect(register()).rejects.toBe(failure);
-    expect(
-      await runInSession(session, () => inspectExecutionLease(executionId)),
-    ).toEqual({ status: 'free' });
-    expect(
-      await run(getExecutionRecords(session, executionId).readMeta()),
-    ).toBeNull();
-  });
-
-  it.each([false, true])(
-    'preserves preexisting file ownership %s when database admission fails',
-    async (alreadyOwned) => {
-      await register();
-      if (!alreadyOwned) await run(session.releaseExecutionLease(executionId));
-      const failure = new Error('database admission rejected');
-      vi.spyOn(session, 'acquireExecutionClaims').mockReturnValueOnce(
-        Effect.fail(failure),
-      );
-      await expect(
-        run(
-          acquireResumedExecutionOwnership(
-            session,
-            executionId,
-            options.streamId,
+    (workingDirectory) =>
+      Effect.gen(function* () {
+        yield* register(workingDirectory);
+        expect(
+          yield* getExecutionRecords(session, executionId).readConfig(),
+        ).toMatchObject({
+          workingDirectory: workingDirectory ?? '/workspace/root',
+        });
+        expect(
+          yield* getExecutionRecords(session, executionId).readMeta(),
+        ).toMatchObject({
+          streamId: options.streamId,
+          identity: options.identity,
+          userFollowUpSupport: 'nativeInteractive',
+        });
+        expect(
+          yield* Effect.promise(() =>
+            getExecutionStore(executionId).listKeys(),
           ),
-        ),
-      ).rejects.toBe(failure);
-      const lease = await runInSession(session, () =>
-        inspectExecutionLease(executionId),
-      );
-      expect(lease.status).toBe(alreadyOwned ? 'owned' : 'free');
-    },
+        ).toEqual([]);
+      }),
   );
 
-  it('releases reacquired database claims when repeated registration fails', async () => {
-    await register();
-    await run(session.releaseExecutionLease(executionId));
-    const failure = new Error('registration rejected');
-    vi.spyOn(session, 'commitRegistration').mockReturnValueOnce(
-      Effect.die(failure),
-    );
-    await expect(register()).rejects.toBe(failure);
-    await expect(
-      run(getExecutionRecords(session, executionId).writeReport('unowned')),
-    ).rejects.toThrow();
-    await run(session.acquireExecutionClaims(executionId, options.streamId));
-    await run(getExecutionRecords(session, executionId).writeReport('owned'));
-    expect(
-      await run(getExecutionRecords(session, executionId).readReport()),
-    ).toBe('owned');
-  });
+  it.effect(
+    'rolls back file ownership when the registration transaction fails',
+    () =>
+      Effect.gen(function* () {
+        const failure = new Error('database write failed');
+        vi.spyOn(session, 'commitRegistration').mockReturnValueOnce(
+          Effect.die(failure),
+        );
+        expect(failureOf(yield* Effect.exit(register()))).toBe(failure);
+        expect(
+          yield* inSession(() => inspectExecutionLease(executionId)),
+        ).toEqual({ status: 'free' });
+        expect(
+          yield* getExecutionRecords(session, executionId).readMeta(),
+        ).toBeNull();
+      }),
+  );
 
-  it('keeps the existing local run claimed when a new birth collides with its stream', async () => {
-    await register();
-    await expect(
-      run(registerExecution(session, 'bcd234', baseConfig, 'chat', options)),
-    ).rejects.toThrow();
-    await run(
-      getExecutionRecords(session, executionId).writeReport('still owned'),
-    );
-    expect(
-      await run(getExecutionRecords(session, executionId).readReport()),
-    ).toBe('still owned');
-  });
+  it.effect.each([false, true])(
+    'preserves preexisting file ownership %s when database admission fails',
+    (alreadyOwned) =>
+      Effect.gen(function* () {
+        yield* register();
+        if (!alreadyOwned) yield* session.releaseExecutionLease(executionId);
+        const failure = new Error('database admission rejected');
+        vi.spyOn(session, 'acquireExecutionClaims').mockReturnValueOnce(
+          Effect.fail(failure),
+        );
+        expect(
+          failureOf(
+            yield* Effect.exit(
+              acquireResumedExecutionOwnership(
+                session,
+                executionId,
+                options.streamId,
+              ),
+            ),
+          ),
+        ).toBe(failure);
+        const lease = yield* inSession(() =>
+          inspectExecutionLease(executionId),
+        );
+        expect(lease.status).toBe(alreadyOwned ? 'owned' : 'free');
+      }),
+  );
 
-  it('releases fresh birth claims when the committed publication consumer fails', async () => {
-    vi.spyOn(session, 'receiveCommittedEvent').mockReturnValue(
-      Effect.die(new Error('consumer failed')),
-    );
-    await expect(register()).rejects.toThrow();
-    expect(
-      await run(getExecutionRecords(session, executionId).readMeta()),
-    ).not.toBeNull();
-    await expect(
-      run(getExecutionRecords(session, executionId).writeReport('unowned')),
-    ).rejects.toThrow();
-    expect(
-      await runInSession(session, () => inspectExecutionLease(executionId)),
-    ).toEqual({ status: 'free' });
-  });
+  it.effect(
+    'releases reacquired database claims when repeated registration fails',
+    () =>
+      Effect.gen(function* () {
+        yield* register();
+        yield* session.releaseExecutionLease(executionId);
+        const failure = new Error('registration rejected');
+        vi.spyOn(session, 'commitRegistration').mockReturnValueOnce(
+          Effect.die(failure),
+        );
+        expect(failureOf(yield* Effect.exit(register()))).toBe(failure);
+        expect(
+          failureOf(
+            yield* Effect.exit(
+              getExecutionRecords(session, executionId).writeReport('unowned'),
+            ),
+          ),
+        ).toBeInstanceOf(Error);
+        yield* session.acquireExecutionClaims(executionId, options.streamId);
+        yield* getExecutionRecords(session, executionId).writeReport('owned');
+        expect(
+          yield* getExecutionRecords(session, executionId).readReport(),
+        ).toBe('owned');
+      }),
+  );
 
-  it.each(['preserve', 'delete'] as const)(
+  it.effect(
+    'keeps the existing local run claimed when a new birth collides with its stream',
+    () =>
+      Effect.gen(function* () {
+        yield* register();
+        expect(
+          failureOf(
+            yield* Effect.exit(
+              registerExecution(session, 'bcd234', baseConfig, 'chat', options),
+            ),
+          ),
+        ).toBeInstanceOf(Error);
+        yield* getExecutionRecords(session, executionId).writeReport(
+          'still owned',
+        );
+        expect(
+          yield* getExecutionRecords(session, executionId).readReport(),
+        ).toBe('still owned');
+      }),
+  );
+
+  it.effect(
+    'releases fresh birth claims when the committed publication consumer fails',
+    () =>
+      Effect.gen(function* () {
+        vi.spyOn(session, 'receiveCommittedEvent').mockReturnValue(
+          Effect.die(new Error('consumer failed')),
+        );
+        expect(failureOf(yield* Effect.exit(register()))).toBeInstanceOf(Error);
+        expect(
+          yield* getExecutionRecords(session, executionId).readMeta(),
+        ).not.toBeNull();
+        expect(
+          failureOf(
+            yield* Effect.exit(
+              getExecutionRecords(session, executionId).writeReport('unowned'),
+            ),
+          ),
+        ).toBeInstanceOf(Error);
+        expect(
+          yield* inSession(() => inspectExecutionLease(executionId)),
+        ).toEqual({ status: 'free' });
+      }),
+  );
+
+  it.effect.each(['preserve', 'delete'] as const)(
     'retains the existing requested checkpoint disposition %s',
-    async (flowRecord) => {
-      await register();
-      const store = getExecutionStore(executionId);
-      await runInSession(session, () =>
-        store.write(flowKey(executionId), { checkpoint: 'existing format' }),
-      );
-      expect(
-        await run(
-          finalizeRun(session, {
+    (flowRecord) =>
+      Effect.gen(function* () {
+        yield* register();
+        const store = getExecutionStore(executionId);
+        yield* inSession(() =>
+          store.write(flowKey(executionId), { checkpoint: 'existing format' }),
+        );
+        expect(
+          yield* finalizeRun(session, {
             executionId,
             outcome: 'completed',
             flowRecord,
           }),
-        ),
-      ).toEqual({ ok: true, outcome: 'completed' });
-      expect(
-        await runInSession(session, () => store.exists(flowKey(executionId))),
-      ).toBe(flowRecord === 'preserve');
-    },
+        ).toEqual({ ok: true, outcome: 'completed' });
+        expect(yield* inSession(() => store.exists(flowKey(executionId)))).toBe(
+          flowRecord === 'preserve',
+        );
+      }),
   );
 
-  it.each([
+  it.effect.each([
     { statusFails: true, deletionFails: false },
     { statusFails: true, deletionFails: true },
     { statusFails: false, deletionFails: true },
   ])(
     'preserves independent finalization failures $statusFails/$deletionFails',
-    async ({ statusFails, deletionFails }) => {
-      await register();
-      const statusFailure = new Error('status write failed');
-      const deletionFailure = new Error('checkpoint delete failed');
-      if (statusFails)
-        vi.spyOn(session, 'updateRecordFacts').mockReturnValueOnce(
-          Effect.die(statusFailure),
-        );
-      const deletion = vi.spyOn(getExecutionStore(executionId), 'delete');
-      if (deletionFails) deletion.mockRejectedValueOnce(deletionFailure);
-      const result = await run(
-        finalizeRun(session, {
+    ({ statusFails, deletionFails }) =>
+      Effect.gen(function* () {
+        yield* register();
+        const statusFailure = new Error('status write failed');
+        const deletionFailure = new Error('checkpoint delete failed');
+        if (statusFails)
+          vi.spyOn(session, 'updateRecordFacts').mockReturnValueOnce(
+            Effect.die(statusFailure),
+          );
+        const deletion = vi.spyOn(getExecutionStore(executionId), 'delete');
+        if (deletionFails) deletion.mockRejectedValueOnce(deletionFailure);
+        const result = yield* finalizeRun(session, {
           executionId,
           outcome: 'failed',
           flowRecord: 'delete',
-        }),
-      );
-      expect(result).toMatchObject({
-        ok: false,
-        outcomePersisted: !statusFails,
-      });
-      expect(deletion).toHaveBeenCalledWith(flowKey(executionId));
-      const singleFailure = statusFails ? statusFailure : deletionFailure;
-      if (!result.ok)
-        expect(result.error).toEqual(
-          statusFails && deletionFails
-            ? new AggregateError(
-                [statusFailure, deletionFailure],
-                `Terminal status and flow deletion failed for ${executionId}`,
-              )
-            : singleFailure,
-        );
-    },
+        });
+        expect(result).toMatchObject({
+          ok: false,
+          outcomePersisted: !statusFails,
+        });
+        expect(deletion).toHaveBeenCalledWith(flowKey(executionId));
+        const singleFailure = statusFails ? statusFailure : deletionFailure;
+        if (!result.ok)
+          expect(result.error).toEqual(
+            statusFails && deletionFails
+              ? new AggregateError(
+                  [statusFailure, deletionFailure],
+                  `Terminal status and flow deletion failed for ${executionId}`,
+                )
+              : singleFailure,
+          );
+      }),
   );
 });

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -1,6 +1,7 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 import { z } from 'zod';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 import { noopTrace } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
@@ -522,47 +523,50 @@ describe('retrieveSessionResumeData', () => {
     });
   });
 
-  it('retrieves a workflow record in the current shape', async () => {
-    const executionId = 'workflow-current-shape' as ExecutionId;
-    const streamId = 'reflection@gpt54#workflow-current-shape' as StreamTabId;
-    await writeFlowRecord(
-      executionId,
-      reflectionFlowShared({ currentRound: 1 }),
-    );
+  it.effect('retrieves a workflow record in the current shape', () =>
+    Effect.gen(function* () {
+      const executionId = 'workflow-current-shape' as ExecutionId;
+      const streamId = 'reflection@gpt54#workflow-current-shape' as StreamTabId;
+      yield* Effect.promise(() =>
+        writeFlowRecord(executionId, reflectionFlowShared({ currentRound: 1 })),
+      );
 
-    await expect(
-      Effect.runPromise(
-        retrieveSessionResumeData(
+      expect(
+        yield* retrieveSessionResumeData(
           streamId,
           executionId,
           WORKFLOW_CONFIG,
           retrievalSession,
         ),
-      ),
-    ).resolves.toMatchObject({ type: 'workflow', executionId });
-  });
+      ).toMatchObject({ type: 'workflow', executionId });
+    }),
+  );
 
-  it('rejects a workflow record that only has the retired messages field', async () => {
-    const executionId = 'workflow-retired-messages' as ExecutionId;
-    const streamId =
-      'reflection@gpt54#workflow-retired-messages' as StreamTabId;
-    await writeFlowRecord(executionId, {
-      currentRound: 1,
-      totalRounds: 2,
-      messages: [{ role: 'user', content: 'Continue.' }],
-    });
+  it.effect(
+    'rejects a workflow record that only has the retired messages field',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'workflow-retired-messages' as ExecutionId;
+        const streamId =
+          'reflection@gpt54#workflow-retired-messages' as StreamTabId;
+        yield* Effect.promise(() =>
+          writeFlowRecord(executionId, {
+            currentRound: 1,
+            totalRounds: 2,
+            messages: [{ role: 'user', content: 'Continue.' }],
+          }),
+        );
 
-    await expect(
-      Effect.runPromise(
-        retrieveSessionResumeData(
-          streamId,
-          executionId,
-          WORKFLOW_CONFIG,
-          retrievalSession,
-        ),
-      ),
-    ).resolves.toBeNull();
-  });
+        expect(
+          yield* retrieveSessionResumeData(
+            streamId,
+            executionId,
+            WORKFLOW_CONFIG,
+            retrievalSession,
+          ),
+        ).toBeNull();
+      }),
+  );
 
   it('preserves structured output at the persisted shared-state boundary', () => {
     const result = parseToolUseShared({
@@ -675,73 +679,83 @@ describe('retrieveSessionResumeData', () => {
     expect(resume.parentStreamId).toBe(parentStreamId);
   });
 
-  it('throws when resumable tool-use storage cannot be read', async () => {
-    const executionId = 'abc129' as ExecutionId;
-    const streamId = 'chat@gpt54#abc129' as StreamTabId;
-    const store = getExecutionStore(executionId);
-    await writeFlowRecord(executionId, {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: defaultStateSlices(),
-    });
-    const originalRead = store.read.bind(store);
-    const readSpy = vi.spyOn(store, 'read').mockImplementation(async (key) => {
-      if (key === flowKey(executionId)) {
-        throw new Error('KV timeout');
-      }
-      return originalRead(key);
-    });
+  it.effect('throws when resumable tool-use storage cannot be read', () =>
+    Effect.gen(function* () {
+      const executionId = 'abc129' as ExecutionId;
+      const streamId = 'chat@gpt54#abc129' as StreamTabId;
+      const store = getExecutionStore(executionId);
+      yield* Effect.promise(() =>
+        writeFlowRecord(executionId, {
+          messages: [],
+          shouldSkipCycle: false,
+          stateSlices: defaultStateSlices(),
+        }),
+      );
+      const originalRead = store.read.bind(store);
+      const readSpy = vi
+        .spyOn(store, 'read')
+        .mockImplementation(async (key) => {
+          if (key === flowKey(executionId)) {
+            throw new Error('KV timeout');
+          }
+          return originalRead(key);
+        });
 
-    try {
-      await expect(
-        Effect.runPromise(
+      try {
+        const failure = yield* Effect.flip(
           retrieveSessionResumeData(
             streamId,
             executionId,
             CONFIG,
             retrievalSession,
           ),
-        ),
-      ).rejects.toThrow(
-        `Failed to retrieve tool-use resume data for stream: ${streamId}`,
-      );
-    } finally {
-      readSpy.mockRestore();
-    }
-  });
+        );
+        expect(failure.message).toContain(
+          `Failed to retrieve tool-use resume data for stream: ${streamId}`,
+        );
+      } finally {
+        readSpy.mockRestore();
+      }
+    }),
+  );
 
-  it('throws when tool-use metadata is invalid even if the flow record is valid', async () => {
-    const executionId = 'abc130' as ExecutionId;
-    const streamId = 'chat@gpt54#abc130' as StreamTabId;
-    const readMetadata = vi
-      .spyOn(retrievalSession, 'readExecutionRecords')
-      .mockReturnValue(
-        Effect.die(
-          new z.ZodError([
-            { code: 'custom', path: [], message: 'corrupt metadata' },
-          ]),
-        ),
-      );
-    await writeFlowRecord(executionId, {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: defaultStateSlices(),
-    });
+  it.effect(
+    'throws when tool-use metadata is invalid even if the flow record is valid',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'abc130' as ExecutionId;
+        const streamId = 'chat@gpt54#abc130' as StreamTabId;
+        const readMetadata = vi
+          .spyOn(retrievalSession, 'readExecutionRecords')
+          .mockReturnValue(
+            Effect.die(
+              new z.ZodError([
+                { code: 'custom', path: [], message: 'corrupt metadata' },
+              ]),
+            ),
+          );
+        yield* Effect.promise(() =>
+          writeFlowRecord(executionId, {
+            messages: [],
+            shouldSkipCycle: false,
+            stateSlices: defaultStateSlices(),
+          }),
+        );
 
-    await expect(
-      Effect.runPromise(
-        retrieveSessionResumeData(
-          streamId,
-          executionId,
-          CONFIG,
-          retrievalSession,
-        ),
-      ),
-    ).rejects.toThrow(
-      `Failed to retrieve tool-use resume data for stream: ${streamId}`,
-    );
-    readMetadata.mockRestore();
-  });
+        const failure = yield* Effect.flip(
+          retrieveSessionResumeData(
+            streamId,
+            executionId,
+            CONFIG,
+            retrievalSession,
+          ),
+        );
+        expect(failure.message).toContain(
+          `Failed to retrieve tool-use resume data for stream: ${streamId}`,
+        );
+        readMetadata.mockRestore();
+      }),
+  );
 });
 
 describe('runToolUseFlow consumes the resume boundary instead of re-parsing', () => {

--- a/src/test-kernel/agent/export/loadChatExportInput.vitest.ts
+++ b/src/test-kernel/agent/export/loadChatExportInput.vitest.ts
@@ -1,7 +1,8 @@
 /* eslint-disable import/order -- Vitest mocks must be declared before importing the module under test. */
 import { Effect } from 'effect';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas';
@@ -40,7 +41,7 @@ vi.mock('@transcript', () => ({
 import { loadChatExportInput as loadChatExportInputEffect } from '@agent/export/loadChatExportInput';
 
 const loadChatExportInput = (id: ExecutionId) =>
-  Effect.runPromise(loadChatExportInputEffect(id, {} as SessionHandle));
+  loadChatExportInputEffect(id, {} as SessionHandle);
 
 const config = {
   agent: 'correct',
@@ -69,77 +70,97 @@ describe('loadChatExportInput (shared CLI/extension chat-export loader)', () => 
     mocks.readMeta.mockResolvedValue(null);
   });
 
-  it('assembles a ChatExportInput when config and a non-empty conversation are both present', async () => {
-    mocks.readConfig.mockResolvedValue(config);
-    mocks.readConversation.mockResolvedValue(CONVERSATION);
-    mocks.readMeta.mockResolvedValue({
-      timestamp: '2026-05-18T08:00:00.000Z',
-      description: 'Polish pass',
-    });
+  it.effect(
+    'assembles a ChatExportInput when config and a non-empty conversation are both present',
+    () =>
+      Effect.gen(function* () {
+        mocks.readConfig.mockResolvedValue(config);
+        mocks.readConversation.mockResolvedValue(CONVERSATION);
+        mocks.readMeta.mockResolvedValue({
+          timestamp: '2026-05-18T08:00:00.000Z',
+          description: 'Polish pass',
+        });
 
-    const result = await loadChatExportInput('a1' as ExecutionId);
+        const result = yield* loadChatExportInput('a1' as ExecutionId);
 
-    expect(result.exportInput).toEqual({
-      timestamp: '2026-05-18T08:00:00.000Z',
-      description: 'Polish pass',
-      config: {
-        agent: 'correct',
-        model: 'deepseekT',
-        instruction: 'Polish the introduction.',
-        inputFiles: ['chapters/intro.tex'],
-        mediaFiles: [],
-        contextFiles: [],
-        outputFiles: ['chapters/intro.tex'],
-      },
-      messages: CONVERSATION,
-    });
-    expect(result.conversation).toEqual(CONVERSATION);
-    expect(result.hasTranscriptEvidence).toBe(true);
-  });
+        expect(result.exportInput).toEqual({
+          timestamp: '2026-05-18T08:00:00.000Z',
+          description: 'Polish pass',
+          config: {
+            agent: 'correct',
+            model: 'deepseekT',
+            instruction: 'Polish the introduction.',
+            inputFiles: ['chapters/intro.tex'],
+            mediaFiles: [],
+            contextFiles: [],
+            outputFiles: ['chapters/intro.tex'],
+          },
+          messages: CONVERSATION,
+        });
+        expect(result.conversation).toEqual(CONVERSATION);
+        expect(result.hasTranscriptEvidence).toBe(true);
+      }),
+  );
 
-  it('returns a null exportInput when nothing is stored at all', async () => {
-    const result = await loadChatExportInput('missing' as ExecutionId);
+  it.effect('returns a null exportInput when nothing is stored at all', () =>
+    Effect.gen(function* () {
+      const result = yield* loadChatExportInput('missing' as ExecutionId);
 
-    expect(result).toEqual({
-      meta: null,
-      config: null,
-      conversation: null,
-      hasTranscriptEvidence: false,
-      exportInput: null,
-    });
-  });
+      expect(result).toEqual({
+        meta: null,
+        config: null,
+        conversation: null,
+        hasTranscriptEvidence: false,
+        exportInput: null,
+      });
+    }),
+  );
 
-  it('normalizes a stored-but-empty conversation array to null, matching "no conversation"', async () => {
-    // An empty array is truthy in JS (`![]` is `false`) — a naive presence
-    // check on the raw store value would treat it as "a conversation is
-    // present". Every caller (CLI not_found/incomplete, extension
-    // config_missing/conversation_missing) needs `conversation`/`exportInput`
-    // to already reflect "absent" for this case, not just falsy-vs-array.
-    mocks.readConversation.mockResolvedValue([]);
+  it.effect(
+    'normalizes a stored-but-empty conversation array to null, matching "no conversation"',
+    () =>
+      Effect.gen(function* () {
+        // An empty array is truthy in JS (`![]` is `false`) — a naive presence
+        // check on the raw store value would treat it as "a conversation is
+        // present". Every caller (CLI not_found/incomplete, extension
+        // config_missing/conversation_missing) needs `conversation`/`exportInput`
+        // to already reflect "absent" for this case, not just falsy-vs-array.
+        mocks.readConversation.mockResolvedValue([]);
 
-    const result = await loadChatExportInput('missing' as ExecutionId);
+        const result = yield* loadChatExportInput('missing' as ExecutionId);
 
-    expect(result.conversation).toBeNull();
-    expect(result.exportInput).toBeNull();
-  });
+        expect(result.conversation).toBeNull();
+        expect(result.exportInput).toBeNull();
+      }),
+  );
 
-  it('reports a null exportInput when config is present but the conversation is empty', async () => {
-    mocks.readConfig.mockResolvedValue(config);
-    mocks.readConversation.mockResolvedValue([]);
+  it.effect(
+    'reports a null exportInput when config is present but the conversation is empty',
+    () =>
+      Effect.gen(function* () {
+        mocks.readConfig.mockResolvedValue(config);
+        mocks.readConversation.mockResolvedValue([]);
 
-    const result = await loadChatExportInput('a1' as ExecutionId);
+        const result = yield* loadChatExportInput('a1' as ExecutionId);
 
-    expect(result.config).toEqual(config);
-    expect(result.conversation).toBeNull();
-    expect(result.exportInput).toBeNull();
-  });
+        expect(result.config).toEqual(config);
+        expect(result.conversation).toBeNull();
+        expect(result.exportInput).toBeNull();
+      }),
+  );
 
-  it('reports a null exportInput when conversation is present but config is missing', async () => {
-    mocks.readConversation.mockResolvedValue([{ role: 'user', content: 'hi' }]);
+  it.effect(
+    'reports a null exportInput when conversation is present but config is missing',
+    () =>
+      Effect.gen(function* () {
+        mocks.readConversation.mockResolvedValue([
+          { role: 'user', content: 'hi' },
+        ]);
 
-    const result = await loadChatExportInput('a1' as ExecutionId);
+        const result = yield* loadChatExportInput('a1' as ExecutionId);
 
-    expect(result.config).toBeNull();
-    expect(result.exportInput).toBeNull();
-  });
+        expect(result.config).toBeNull();
+        expect(result.exportInput).toBeNull();
+      }),
+  );
 });

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect, Fiber } from 'effect';
-import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { afterEach, describe, expect, vi, type Mock } from 'vitest';
 
 import * as resumability from '@agent/storage/resumability';
 import {
@@ -48,104 +49,110 @@ describe('submitFollowUp', () => {
     vi.restoreAllMocks();
   });
 
-  it('uses the live child owner while waiting, between turns, and during a turn', async () => {
-    const streamId = id('stream:live-child');
-    const session = fakeSession({ kind: 'queue' });
-    const child = session.followUps.claimLive(streamId, 'child')!;
-    const tryResumeStream = mockTryResume();
+  it.effect(
+    'uses the live child owner while waiting, between turns, and during a turn',
+    () =>
+      Effect.gen(function* () {
+        const streamId = id('stream:live-child');
+        const session = fakeSession({ kind: 'queue' });
+        const child = session.followUps.claimLive(streamId, 'child')!;
+        const tryResumeStream = mockTryResume();
 
-    for (const text of ['while waiting', 'between turns', 'during turn']) {
-      await expect(
-        Effect.runPromise(
-          submitFollowUp(streamId, text, {
-            session,
-            resumePort: { tryResumeStream },
-          }),
-        ),
-      ).resolves.toMatchObject({ status: 'queued' });
-    }
+        for (const text of ['while waiting', 'between turns', 'during turn']) {
+          expect(
+            yield* submitFollowUp(streamId, text, {
+              session,
+              resumePort: { tryResumeStream },
+            }),
+          ).toMatchObject({ status: 'queued' });
+        }
 
-    expect(tryResumeStream).not.toHaveBeenCalled();
-    expect(
-      session.followUps
-        .queue(child)
-        .drainItems()
-        .map((item) => item.text),
-    ).toEqual(['while waiting', 'between turns', 'during turn']);
-  });
+        expect(tryResumeStream).not.toHaveBeenCalled();
+        expect(
+          session.followUps
+            .queue(child)
+            .drainItems()
+            .map((item) => item.text),
+        ).toEqual(['while waiting', 'between turns', 'during turn']);
+      }),
+  );
 
-  it('reports input admitted by a live flow as sent', async () => {
-    const streamId = id('stream:live-flow');
-    const session = fakeSession(activeTarget());
-    const sent: StreamTabId[] = [];
-    session.followUps.onSent((sentStreamId) => sent.push(sentStreamId));
-    const flow = session.followUps.claimLive(streamId, 'flow')!;
-    const tryResumeStream = mockTryResume();
+  it.effect('reports input admitted by a live flow as sent', () =>
+    Effect.gen(function* () {
+      const streamId = id('stream:live-flow');
+      const session = fakeSession(activeTarget());
+      const sent: StreamTabId[] = [];
+      session.followUps.onSent((sentStreamId) => sent.push(sentStreamId));
+      const flow = session.followUps.claimLive(streamId, 'flow')!;
+      const tryResumeStream = mockTryResume();
 
-    await expect(
-      Effect.runPromise(
-        submitFollowUp(streamId, 'during active turn', {
+      expect(
+        yield* submitFollowUp(streamId, 'during active turn', {
           session,
           resumePort: { tryResumeStream },
         }),
-      ),
-    ).resolves.toEqual({ status: 'sent' });
+      ).toEqual({ status: 'sent' });
 
-    expect(tryResumeStream).not.toHaveBeenCalled();
-    expect(session.followUps.queue(flow).drainItems()).toMatchObject([
-      { text: 'during active turn' },
-    ]);
-    expect(sent).toEqual([streamId]);
-  });
+      expect(tryResumeStream).not.toHaveBeenCalled();
+      expect(session.followUps.queue(flow).drainItems()).toMatchObject([
+        { text: 'during active turn' },
+      ]);
+      expect(sent).toEqual([streamId]);
+    }),
+  );
 
-  it('does not report an automatic live-flow notification as user input', async () => {
-    const streamId = id('stream:live-flow-notification');
-    const session = fakeSession(activeTarget());
-    const sent: StreamTabId[] = [];
-    session.followUps.onSent((sentStreamId) => sent.push(sentStreamId));
-    const flow = session.followUps.claimLive(streamId, 'flow')!;
+  it.effect(
+    'does not report an automatic live-flow notification as user input',
+    () =>
+      Effect.gen(function* () {
+        const streamId = id('stream:live-flow-notification');
+        const session = fakeSession(activeTarget());
+        const sent: StreamTabId[] = [];
+        session.followUps.onSent((sentStreamId) => sent.push(sentStreamId));
+        const flow = session.followUps.claimLive(streamId, 'flow')!;
 
-    await expect(
-      Effect.runPromise(
-        submitFollowUp(streamId, 'child progress', {
-          session,
-          mode: 'live_notification',
-        }),
-      ),
-    ).resolves.toEqual({ status: 'queued' });
+        expect(
+          yield* submitFollowUp(streamId, 'child progress', {
+            session,
+            mode: 'live_notification',
+          }),
+        ).toEqual({ status: 'queued' });
 
-    expect(session.followUps.queue(flow).drainItems()).toMatchObject([
-      { text: 'child progress' },
-    ]);
-    expect(sent).toEqual([]);
-  });
-
-  it('enqueues live notifications for a waiting parent without child owner', async () => {
-    const streamId = id('stream:waiting-notification');
-    const session = fakeSession({ kind: 'queue' });
-    const tryResumeStream = mockTryResume();
-
-    // Create a child-owned entry (simulates a running child loop), then
-    // release the lease so the entry exists but has no owner — the exact
-    // state of a WAITING parent queue after a child finishes its turn and
-    // a live_notification (progress update, execution event) arrives.
-    const child = session.followUps.claimLive(streamId, 'child')!;
-    session.followUps.release(child, 'recoverable');
-
-    // live_notification on a WAITING queue without child owner should enqueue
-    // without claiming recovery or triggering a stream resume.
-    const result = await Effect.runPromise(
-      submitFollowUp(streamId, 'child progress', {
-        session,
-        resumePort: { tryResumeStream },
-        mode: 'live_notification',
+        expect(session.followUps.queue(flow).drainItems()).toMatchObject([
+          { text: 'child progress' },
+        ]);
+        expect(sent).toEqual([]);
       }),
-    );
+  );
 
-    expect(result).toMatchObject({ status: 'queued' });
-    expect(tryResumeStream).not.toHaveBeenCalled();
-    expect(session.followUps.getAll(streamId)).toEqual(['child progress']);
-  });
+  it.effect(
+    'enqueues live notifications for a waiting parent without child owner',
+    () =>
+      Effect.gen(function* () {
+        const streamId = id('stream:waiting-notification');
+        const session = fakeSession({ kind: 'queue' });
+        const tryResumeStream = mockTryResume();
+
+        // Create a child-owned entry (simulates a running child loop), then
+        // release the lease so the entry exists but has no owner — the exact
+        // state of a WAITING parent queue after a child finishes its turn and
+        // a live_notification (progress update, execution event) arrives.
+        const child = session.followUps.claimLive(streamId, 'child')!;
+        session.followUps.release(child, 'recoverable');
+
+        // live_notification on a WAITING queue without child owner should enqueue
+        // without claiming recovery or triggering a stream resume.
+        const result = yield* submitFollowUp(streamId, 'child progress', {
+          session,
+          resumePort: { tryResumeStream },
+          mode: 'live_notification',
+        });
+
+        expect(result).toMatchObject({ status: 'queued' });
+        expect(tryResumeStream).not.toHaveBeenCalled();
+        expect(session.followUps.getAll(streamId)).toEqual(['child progress']);
+      }),
+  );
 
   it('claims one recovery and orders repeated submissions once', async () => {
     const streamId = id('stream:recovery');
@@ -212,100 +219,106 @@ describe('submitFollowUp', () => {
     ]);
   });
 
-  it('starts recovery after the child generation releases', async () => {
-    const streamId = id('stream:child-release');
-    const session = fakeSession({ kind: 'queue' });
-    const child = session.followUps.claimLive(streamId, 'child')!;
-    session.followUps.release(child, 'recoverable');
-    const tryResumeStream = mockTryResume();
+  it.effect('starts recovery after the child generation releases', () =>
+    Effect.gen(function* () {
+      const streamId = id('stream:child-release');
+      const session = fakeSession({ kind: 'queue' });
+      const child = session.followUps.claimLive(streamId, 'child')!;
+      session.followUps.release(child, 'recoverable');
+      const tryResumeStream = mockTryResume();
 
-    await expect(
-      Effect.runPromise(
-        submitFollowUp(streamId, 'continue', {
+      expect(
+        yield* submitFollowUp(streamId, 'continue', {
           session,
           resumePort: { tryResumeStream },
         }),
-      ),
-    ).resolves.toEqual({ status: 'queued' });
-    expect(tryResumeStream).toHaveBeenCalledTimes(1);
-  });
+      ).toEqual({ status: 'queued' });
+      expect(tryResumeStream).toHaveBeenCalledTimes(1);
+    }),
+  );
 
-  it('enqueues live notifications for children-running parent without recovery', async () => {
-    const streamId = id('stream:children-running-notification');
-    const session = fakeSession({ kind: 'queue' });
-    // Create a child-owned entry to simulate the parent having active children.
-    const child = session.followUps.claimLive(streamId, 'child')!;
-    // Release the child so the queue stays but loses its owner.
-    session.followUps.release(child, 'recoverable');
-    const tryResumeStream = mockTryResume();
+  it.effect(
+    'enqueues live notifications for children-running parent without recovery',
+    () =>
+      Effect.gen(function* () {
+        const streamId = id('stream:children-running-notification');
+        const session = fakeSession({ kind: 'queue' });
+        // Create a child-owned entry to simulate the parent having active children.
+        const child = session.followUps.claimLive(streamId, 'child')!;
+        // Release the child so the queue stays but loses its owner.
+        session.followUps.release(child, 'recoverable');
+        const tryResumeStream = mockTryResume();
 
-    const result = await Effect.runPromise(
-      submitFollowUp(streamId, 'child update', {
-        session,
-        resumePort: { tryResumeStream },
-        mode: 'live_notification',
+        const result = yield* submitFollowUp(streamId, 'child update', {
+          session,
+          resumePort: { tryResumeStream },
+          mode: 'live_notification',
+        });
+
+        expect(result).toMatchObject({ status: 'queued' });
+        expect(tryResumeStream).not.toHaveBeenCalled();
+        expect(session.followUps.getAll(streamId)).toEqual(['child update']);
       }),
-    );
+  );
 
-    expect(result).toMatchObject({ status: 'queued' });
-    expect(tryResumeStream).not.toHaveBeenCalled();
-    expect(session.followUps.getAll(streamId)).toEqual(['child update']);
-  });
+  it.effect(
+    'keeps children-running explicitly recoverable after child untracking',
+    () =>
+      Effect.gen(function* () {
+        const streamId = id('stream:children-running');
+        const session = fakeSession({ kind: 'queue' });
+        const tryResumeStream = mockTryResume();
 
-  it('keeps children-running explicitly recoverable after child untracking', async () => {
-    const streamId = id('stream:children-running');
-    const session = fakeSession({ kind: 'queue' });
-    const tryResumeStream = mockTryResume();
+        yield* submitFollowUp(streamId, 'child result', {
+          session,
+          resumePort: { tryResumeStream },
+        });
 
-    await Effect.runPromise(
-      submitFollowUp(streamId, 'child result', {
-        session,
-        resumePort: { tryResumeStream },
+        expect(tryResumeStream).toHaveBeenCalledTimes(1);
       }),
-    );
+  );
 
-    expect(tryResumeStream).toHaveBeenCalledTimes(1);
-  });
+  it.effect(
+    'admits a child delivery to the retained queue after the parent completes',
+    () =>
+      Effect.gen(function* () {
+        const streamId = id('stream:retained-child-generation');
+        const session = fakeSession({ kind: 'queue' });
+        const parent = session.followUps.claimLive(streamId, 'flow')!;
+        session.followUps.release(parent, 'recoverable');
+        const deriveSpy = vi.spyOn(resumability, 'deriveResumability');
+        const tryResumeStream = mockTryResume();
 
-  it('admits a child delivery to the retained queue after the parent completes', async () => {
-    const streamId = id('stream:retained-child-generation');
-    const session = fakeSession({ kind: 'queue' });
-    const parent = session.followUps.claimLive(streamId, 'flow')!;
-    session.followUps.release(parent, 'recoverable');
-    const deriveSpy = vi.spyOn(resumability, 'deriveResumability');
-    const tryResumeStream = mockTryResume();
+        expect(
+          yield* submitFollowUp(
+            streamId,
+            { text: 'retained child result', origin: 'subagent_result' },
+            {
+              session,
+              resumePort: { tryResumeStream },
+              mode: 'child_delivery',
+            },
+          ),
+        ).toEqual({ status: 'queued' });
 
-    await expect(
-      Effect.runPromise(
-        submitFollowUp(
-          streamId,
-          { text: 'retained child result', origin: 'subagent_result' },
-          {
-            session,
-            resumePort: { tryResumeStream },
-            mode: 'child_delivery',
-          },
-        ),
-      ),
-    ).resolves.toEqual({ status: 'queued' });
+        expect(deriveSpy).not.toHaveBeenCalled();
+        expect(session.followUps.getAll(streamId)).toEqual([
+          'retained child result',
+        ]);
+      }),
+  );
 
-    expect(deriveSpy).not.toHaveBeenCalled();
-    expect(session.followUps.getAll(streamId)).toEqual([
-      'retained child result',
-    ]);
-  });
+  it.effect('refuses child delivery to a parent with no session', () =>
+    Effect.gen(function* () {
+      const streamId = id('stream:terminal-child-delivery');
+      const session = fakeSession({
+        kind: 'no_session',
+        streamStatus: 'completed',
+      });
+      const tryResumeStream = mockTryResume();
 
-  it('refuses child delivery to a parent with no session', async () => {
-    const streamId = id('stream:terminal-child-delivery');
-    const session = fakeSession({
-      kind: 'no_session',
-      streamStatus: 'completed',
-    });
-    const tryResumeStream = mockTryResume();
-
-    await expect(
-      Effect.runPromise(
-        submitFollowUp(
+      expect(
+        yield* submitFollowUp(
           streamId,
           { text: 'late child result', origin: 'subagent_result' },
           {
@@ -314,48 +327,48 @@ describe('submitFollowUp', () => {
             mode: 'child_delivery',
           },
         ),
-      ),
-    ).resolves.toEqual({ status: 'failed', reason: 'not_resumable' });
-    expect(tryResumeStream).not.toHaveBeenCalled();
-  });
+      ).toEqual({ status: 'failed', reason: 'not_resumable' });
+      expect(tryResumeStream).not.toHaveBeenCalled();
+    }),
+  );
 
-  it('admits a replayed child delivery at most once and wakes at most once', async () => {
-    const streamId = id('stream:replay-child-delivery');
-    const session = fakeSession({ kind: 'queue' });
-    const tryResumeStream = mockTryResume();
-    const delivery = {
-      text: 'child result',
-      origin: 'subagent_result' as const,
-      deliveryId: 'exec-1:turn:1:delivery',
-    };
+  it.effect(
+    'admits a replayed child delivery at most once and wakes at most once',
+    () =>
+      Effect.gen(function* () {
+        const streamId = id('stream:replay-child-delivery');
+        const session = fakeSession({ kind: 'queue' });
+        const tryResumeStream = mockTryResume();
+        const delivery = {
+          text: 'child result',
+          origin: 'subagent_result' as const,
+          deliveryId: 'exec-1:turn:1:delivery',
+        };
 
-    await expect(
-      Effect.runPromise(
-        submitFollowUp(streamId, delivery, {
-          session,
-          resumePort: { tryResumeStream },
-          mode: 'child_delivery',
-        }),
-      ),
-    ).resolves.toEqual({ status: 'queued' });
-    expect(tryResumeStream).toHaveBeenCalledTimes(1);
-
-    // A producer repeating the same logical result callback must not append
-    // another parent message nor trigger another parent wake.
-    for (let replay = 0; replay < 100; replay++) {
-      await expect(
-        Effect.runPromise(
-          submitFollowUp(streamId, delivery, {
+        expect(
+          yield* submitFollowUp(streamId, delivery, {
             session,
             resumePort: { tryResumeStream },
             mode: 'child_delivery',
           }),
-        ),
-      ).resolves.toEqual({ status: 'sent' });
-    }
-    expect(tryResumeStream).toHaveBeenCalledTimes(1);
-    expect(session.followUps.getAll(streamId)).toEqual(['child result']);
-  });
+        ).toEqual({ status: 'queued' });
+        expect(tryResumeStream).toHaveBeenCalledTimes(1);
+
+        // A producer repeating the same logical result callback must not append
+        // another parent message nor trigger another parent wake.
+        for (let replay = 0; replay < 100; replay++) {
+          expect(
+            yield* submitFollowUp(streamId, delivery, {
+              session,
+              resumePort: { tryResumeStream },
+              mode: 'child_delivery',
+            }),
+          ).toEqual({ status: 'sent' });
+        }
+        expect(tryResumeStream).toHaveBeenCalledTimes(1);
+        expect(session.followUps.getAll(streamId)).toEqual(['child result']);
+      }),
+  );
 });
 
 describe('ToolUseFollowUpQueue claim exclusivity', () => {

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -1,7 +1,8 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 import '@test/support/defaultSessionTestSetup';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, vi } from 'vitest';
 
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
@@ -97,27 +98,29 @@ describe('tool-use follow-up progress events', () => {
     trackedExecutions.push({ session: owner, executionId });
   }
 
-  it('publishes sent follow-up events through the owning session fact hub', async () => {
-    const run = createRecordingHost();
-    const session = trackSession();
-    const sent = recordFollowUpsSent(session);
-    const lease = session.followUps.claimLive(streamId, 'flow')!;
+  it.effect(
+    'publishes sent follow-up events through the owning session fact hub',
+    () =>
+      Effect.gen(function* () {
+        const run = createRecordingHost();
+        const session = trackSession();
+        const sent = recordFollowUpsSent(session);
+        const lease = session.followUps.claimLive(streamId, 'flow')!;
 
-    trackToolUseFlow({ session });
+        trackToolUseFlow({ session });
 
-    const result = await Effect.runPromise(
-      submitFollowUp(streamId, 'please continue', {
-        session,
+        const result = yield* submitFollowUp(streamId, 'please continue', {
+          session,
+        });
+
+        expect(result).toEqual({ status: 'sent' });
+        expect(session.followUps.queue(lease).drainItems()).toMatchObject([
+          { text: 'please continue', origin: 'user' },
+        ]);
+        expect(sent.sent).toEqual([streamId]);
+        expect(run.events).toEqual([]);
       }),
-    );
-
-    expect(result).toEqual({ status: 'sent' });
-    expect(session.followUps.queue(lease).drainItems()).toMatchObject([
-      { text: 'please continue', origin: 'user' },
-    ]);
-    expect(sent.sent).toEqual([streamId]);
-    expect(run.events).toEqual([]);
-  });
+  );
 
   it('prefers an explicit session over the active run context when notifying follow-up sent', () => {
     const run = createRecordingHost();
@@ -183,59 +186,69 @@ describe('tool-use follow-up progress events', () => {
     expect(onFollowUp).not.toHaveBeenCalled();
   });
 
-  it('does not append through stale active contexts after final status', async () => {
-    seedStreamStatusForTest(defaultSession().status, streamId, {
-      phase: STREAM_PHASE.COMPLETED,
-    });
-    trackToolUseFlow();
+  it.effect(
+    'does not append through stale active contexts after final status',
+    () =>
+      Effect.gen(function* () {
+        seedStreamStatusForTest(defaultSession().status, streamId, {
+          phase: STREAM_PHASE.COMPLETED,
+        });
+        trackToolUseFlow();
 
-    const result = await Effect.runPromise(
-      submitFollowUp(streamId, 'late follow-up', { session: defaultSession() }),
-    );
-
-    expect(result).toEqual({ status: 'failed', reason: 'not_resumable' });
-    expect(defaultSession().followUps.getAll(streamId)).toEqual([]);
-  });
-
-  it('does not emit a follow-up sent fact when no follow-up reaches a live session', async () => {
-    const session = trackSession();
-    const recorded = recordSessionEvents(session);
-
-    const result = await Effect.runPromise(
-      submitFollowUp(
-        'stream:no-follow-up-session' as StreamTabId,
-        'cannot deliver',
-        { session },
-      ),
-    );
-
-    expect(result).toEqual({ status: 'failed', reason: 'not_resumable' });
-    expect(await recorded.read()).toEqual([]);
-  });
-
-  it('queues follow-ups for resuming streams through registry admission', async () => {
-    const resumingStreamId = 'stream:resuming-follow-up' as StreamTabId;
-
-    seedStreamStatusForTest(defaultSession().status, resumingStreamId, {
-      phase: STREAM_PHASE.RUNNING,
-      substate: STREAM_SUBSTATE.RESUMING,
-    });
-
-    try {
-      const result = await Effect.runPromise(
-        submitFollowUp(resumingStreamId, 'queued while resuming', {
+        const result = yield* submitFollowUp(streamId, 'late follow-up', {
           session: defaultSession(),
-        }),
-      );
+        });
 
-      // The fake platform's resume port refuses, so the input stays queued
-      // behind a failed wake.
-      expect(result).toEqual({ status: 'queued', wake: 'failed' });
-      expect(defaultSession().followUps.getAll(resumingStreamId)).toEqual([
-        'queued while resuming',
-      ]);
-    } finally {
-      defaultSession().followUps.terminalize(resumingStreamId);
-    }
-  });
+        expect(result).toEqual({ status: 'failed', reason: 'not_resumable' });
+        expect(defaultSession().followUps.getAll(streamId)).toEqual([]);
+      }),
+  );
+
+  it.effect(
+    'does not emit a follow-up sent fact when no follow-up reaches a live session',
+    () =>
+      Effect.gen(function* () {
+        const session = trackSession();
+        const recorded = recordSessionEvents(session);
+
+        const result = yield* submitFollowUp(
+          'stream:no-follow-up-session' as StreamTabId,
+          'cannot deliver',
+          { session },
+        );
+
+        expect(result).toEqual({ status: 'failed', reason: 'not_resumable' });
+        expect(yield* Effect.promise(() => recorded.read())).toEqual([]);
+      }),
+  );
+
+  it.effect(
+    'queues follow-ups for resuming streams through registry admission',
+    () =>
+      Effect.gen(function* () {
+        const resumingStreamId = 'stream:resuming-follow-up' as StreamTabId;
+
+        seedStreamStatusForTest(defaultSession().status, resumingStreamId, {
+          phase: STREAM_PHASE.RUNNING,
+          substate: STREAM_SUBSTATE.RESUMING,
+        });
+
+        try {
+          const result = yield* submitFollowUp(
+            resumingStreamId,
+            'queued while resuming',
+            { session: defaultSession() },
+          );
+
+          // The fake platform's resume port refuses, so the input stays queued
+          // behind a failed wake.
+          expect(result).toEqual({ status: 'queued', wake: 'failed' });
+          expect(defaultSession().followUps.getAll(resumingStreamId)).toEqual([
+            'queued while resuming',
+          ]);
+        } finally {
+          defaultSession().followUps.terminalize(resumingStreamId);
+        }
+      }),
+  );
 });

--- a/src/test-kernel/agent/remote/RemoteAgentLoader.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentLoader.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, vi } from 'vitest';
 
 import { loadRemoteAgent } from '@agent/remote/RemoteAgentLoader';
 import { listRemoteAgents } from '@agent/remote/remoteAgentList';
@@ -63,47 +64,53 @@ afterEach(() => {
 });
 
 describe('remote agent listing', () => {
-  it('drops remote rows with non-identifier agent names', async () => {
-    installRemoteAgentListClient({
-      data: [invalidAgentRow({}), canonicalReviewRow],
-      error: null,
-    });
+  it.effect('drops remote rows with non-identifier agent names', () =>
+    Effect.gen(function* () {
+      installRemoteAgentListClient({
+        data: [invalidAgentRow({}), canonicalReviewRow],
+        error: null,
+      });
 
-    const agents = await Effect.runPromise(listRemoteAgents());
+      const agents = yield* listRemoteAgents();
 
-    expect(agents.map((agent) => agent.name)).toEqual(['review']);
-  });
+      expect(agents.map((agent) => agent.name)).toEqual(['review']);
+    }),
+  );
 
-  it('drops remote rows without an agent category', async () => {
-    installRemoteAgentListClient({
-      data: [
-        invalidAgentRow({ name: 'uncategorized', agent_category: null }),
-        canonicalReviewRow,
-      ],
-      error: null,
-    });
+  it.effect('drops remote rows without an agent category', () =>
+    Effect.gen(function* () {
+      installRemoteAgentListClient({
+        data: [
+          invalidAgentRow({ name: 'uncategorized', agent_category: null }),
+          canonicalReviewRow,
+        ],
+        error: null,
+      });
 
-    const agents = await Effect.runPromise(listRemoteAgents());
+      const agents = yield* listRemoteAgents();
 
-    expect(agents.map((agent) => agent.name)).toEqual(['review']);
-  });
+      expect(agents.map((agent) => agent.name)).toEqual(['review']);
+    }),
+  );
 
-  it('returns no agents when the list query fails', async () => {
-    const selectedColumns = installRemoteAgentListClient({
-      data: null,
-      error: {
-        code: '42501',
-        message: 'permission denied for table remote_agents',
-      },
-    });
+  it.effect('returns no agents when the list query fails', () =>
+    Effect.gen(function* () {
+      const selectedColumns = installRemoteAgentListClient({
+        data: null,
+        error: {
+          code: '42501',
+          message: 'permission denied for table remote_agents',
+        },
+      });
 
-    const agents = await Effect.runPromise(listRemoteAgents());
+      const agents = yield* listRemoteAgents();
 
-    expect(agents).toEqual([]);
-    expect(selectedColumns).toEqual([
-      'id, name, description, tools, agent_category',
-    ]);
-  });
+      expect(agents).toEqual([]);
+      expect(selectedColumns).toEqual([
+        'id, name, description, tools, agent_category',
+      ]);
+    }),
+  );
 });
 
 describe('remote agent config parsing', () => {

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -1,7 +1,8 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 import '@test/support/defaultSessionTestSetup';
 
-import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { beforeEach, describe, expect, vi, type Mock } from 'vitest';
 
 import { noopTrace, TraceEmitter } from '@agent/trace';
 import type { FinalizeExecutionResult } from '@agent/storage/executionLifecycle';
@@ -227,88 +228,94 @@ describe('runFlowWithLifecycle', () => {
   // The run's category reaches the handle and the terminal `result` through
   // the one descriptor the lifecycle builds, so a workflow run reports
   // `workflow` on both without either side re-deriving the string.
-  it('reports the config agent category on the handle and terminal result', async () => {
-    await initLifecycleTestPlatform(true);
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-workflow-category',
-      'polish',
-      AgentCategory.Workflow,
-    );
-    let terminalResult: AgentRunHandle['result'] | undefined;
+  it.effect(
+    'reports the config agent category on the handle and terminal result',
+    () =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => initLifecycleTestPlatform(true));
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-workflow-category',
+          'polish',
+          AgentCategory.Workflow,
+        );
+        let terminalResult: AgentRunHandle['result'] | undefined;
 
-    try {
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(
-          ctx,
-          async () =>
-            workflowResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
-          {
-            onRun: async (handle) => {
-              expect(handle.category).toBe('workflow');
-              terminalResult = handle.result;
+        try {
+          const result = yield* runFlowWithLifecycle(
+            ctx,
+            async () =>
+              workflowResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
+            {
+              onRun: async (handle) => {
+                expect(handle.category).toBe('workflow');
+                terminalResult = handle.result;
+              },
             },
-          },
-        ),
-      );
+          );
 
-      expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
-      await expect(Effect.runPromise(terminalResult!)).resolves.toMatchObject({
-        category: 'workflow',
-        agentName: 'polish',
-      });
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
+          expect(yield* terminalResult!).toMatchObject({
+            category: 'workflow',
+            agentName: 'polish',
+          });
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
-  it('stops the Lean servers attributed to a run when the run ends', async () => {
-    await initLifecycleTestPlatform(true);
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-lean-server-stop',
-    );
-    const stopSessionsForRun = vi.fn(async (_runId: ExecutionId) => {});
+  it.effect(
+    'stops the Lean servers attributed to a run when the run ends',
+    () =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => initLifecycleTestPlatform(true));
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-lean-server-stop',
+        );
+        const stopSessionsForRun = vi.fn(async (_runId: ExecutionId) => {});
 
-    try {
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(
-          ctx,
-          async () =>
-            toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
-          { onRunEnd: stopSessionsForRun },
-        ),
-      );
+        try {
+          const result = yield* runFlowWithLifecycle(
+            ctx,
+            async () =>
+              toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
+            { onRunEnd: stopSessionsForRun },
+          );
 
-      expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
-      expect(stopSessionsForRun).toHaveBeenCalledWith(executionId);
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
+          expect(stopSessionsForRun).toHaveBeenCalledWith(executionId);
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
-  it('does not stop the Lean servers when a tool-use run parks at WAITING', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-lean-server-stop-waiting',
-    );
-    const stopSessionsForRun = vi.fn(async (_runId: ExecutionId) => {});
+  it.effect(
+    'does not stop the Lean servers when a tool-use run parks at WAITING',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-lean-server-stop-waiting',
+        );
+        const stopSessionsForRun = vi.fn(async (_runId: ExecutionId) => {});
 
-    try {
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(
-          ctx,
-          async () => waitingResult(executionId, streamId),
-          { onRunEnd: stopSessionsForRun },
-        ),
-      );
+        try {
+          const result = yield* runFlowWithLifecycle(
+            ctx,
+            async () => waitingResult(executionId, streamId),
+            { onRunEnd: stopSessionsForRun },
+          );
 
-      // WAITING is a suspension, not a terminal run end: the server must
-      // survive the parked run so a resume reuses it instead of paying a cold
-      // spawn.
-      expect(result.outcome).toBe(STREAM_PHASE.WAITING);
-      expect(stopSessionsForRun).not.toHaveBeenCalled();
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          // WAITING is a suspension, not a terminal run end: the server must
+          // survive the parked run so a resume reuses it instead of paying a cold
+          // spawn.
+          expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+          expect(stopSessionsForRun).not.toHaveBeenCalled();
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
   // A completed session marks first-run onboarding done, except for the
   // built-in setup agent, which must leave the flag untouched.
@@ -329,289 +336,311 @@ describe('runFlowWithLifecycle', () => {
   ] as const;
 
   for (const { label, slug, agent, expectedDone } of onboardingCases) {
-    it(label, async () => {
-      const fake = await initLifecycleTestPlatform(false);
-      const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-        `lifecycle-${slug}`,
-        agent,
-      );
-
-      try {
-        await Effect.runPromise(
-          runFlowWithLifecycle(ctx, async () =>
-            toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
-          ),
+    it.effect(label, () =>
+      Effect.gen(function* () {
+        const fake = yield* Effect.promise(() =>
+          initLifecycleTestPlatform(false),
+        );
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          `lifecycle-${slug}`,
+          agent,
         );
 
+        try {
+          yield* runFlowWithLifecycle(ctx, async () =>
+            toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
+          );
+
+          expect(
+            fake.globalState.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE),
+          ).toBe(expectedDone);
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+    );
+  }
+
+  it.effect('persists terminal state before updating onboarding state', () =>
+    Effect.gen(function* () {
+      const fake = yield* Effect.promise(() =>
+        initLifecycleTestPlatform(false),
+      );
+      const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+        'terminal-before-onboarding',
+        'assistant',
+      );
+      const updateOnboarding = vi.spyOn(fake.globalState, 'update');
+
+      try {
+        yield* runFlowWithLifecycle(ctx, async () =>
+          toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
+        );
+
+        expect(storageMocks.finalizeRun).toHaveBeenCalledOnce();
+        expect(updateOnboarding).toHaveBeenCalledWith(
+          GlobalStateKey.ONBOARDING_FIRST_RUN_DONE,
+          true,
+        );
         expect(
-          fake.globalState.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE),
-        ).toBe(expectedDone);
+          storageMocks.finalizeRun.mock.invocationCallOrder[0],
+        ).toBeLessThan(
+          updateOnboarding.mock.invocationCallOrder[0] ??
+            Number.POSITIVE_INFINITY,
+        );
       } finally {
         clearStreamStatusForTest(streamStatus, streamId);
       }
-    });
-  }
+    }),
+  );
 
-  it('persists terminal state before updating onboarding state', async () => {
-    const fake = await initLifecycleTestPlatform(false);
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'terminal-before-onboarding',
-      'assistant',
-    );
-    const updateOnboarding = vi.spyOn(fake.globalState, 'update');
+  it.effect('finalizes the status machine owned by the run session', () =>
+    Effect.gen(function* () {
+      const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+        'lifecycle-status-owner',
+      );
 
-    try {
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () =>
+      try {
+        // The lifecycle owns the whole transition (RUNNING on entry, terminal
+        // on exit) against the run session's one status machine.
+        expect(streamStatus).toBe(ctx.runScope.session.status);
+        yield* runFlowWithLifecycle(ctx, async () =>
           toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
-        ),
-      );
+        );
 
-      expect(storageMocks.finalizeRun).toHaveBeenCalledOnce();
-      expect(updateOnboarding).toHaveBeenCalledWith(
-        GlobalStateKey.ONBOARDING_FIRST_RUN_DONE,
-        true,
-      );
-      expect(storageMocks.finalizeRun.mock.invocationCallOrder[0]).toBeLessThan(
-        updateOnboarding.mock.invocationCallOrder[0] ??
-          Number.POSITIVE_INFINITY,
-      );
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+        expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
+      } finally {
+        clearStreamStatusForTest(streamStatus, streamId);
+      }
+    }),
+  );
 
-  it('finalizes the status machine owned by the run session', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-status-owner',
-    );
+  it.effect('projects run config before the RUNNING status projection', () =>
+    Effect.gen(function* () {
+      const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+        'lifecycle-run-config-before-running',
+      );
+      publishTestRunStart(ctx.runScope.session, streamId, executionId);
+      const trace = new TraceEmitter();
+      const detachTrace = ctx.runScope.session.attachRunTrace(trace, streamId);
+      // One plane in commit order: run.config and the status fact both land
+      // on it, so the ordering assertion reads one log.
+      const recorded = recordSessionEvents(ctx.runScope.session);
+      ctx.logger = trace;
+      ctx.disposeTrace = detachTrace;
 
-    try {
-      // The lifecycle owns the whole transition (RUNNING on entry, terminal
-      // on exit) against the run session's one status machine.
-      expect(streamStatus).toBe(ctx.runScope.session.status);
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () =>
+      try {
+        yield* runFlowWithLifecycle(ctx, async () =>
           toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
-        ),
+        );
+
+        const runConfigIndex = (yield* Effect.promise(() =>
+          recorded.read(),
+        )).findIndex((event) => event.type === 'run.config');
+        const runningIndex = (yield* Effect.promise(() =>
+          recorded.read(),
+        )).findIndex(
+          (event) =>
+            event.type === 'status' &&
+            event.aggregateId === qualifyAggregateId('stream', streamId) &&
+            event.phase === STREAM_PHASE.RUNNING,
+        );
+
+        expect(runConfigIndex).toBeGreaterThanOrEqual(0);
+        expect(runningIndex).toBeGreaterThanOrEqual(0);
+        expect(runConfigIndex).toBeLessThan(runningIndex);
+      } finally {
+        detachTrace();
+        clearStreamStatusForTest(streamStatus, streamId);
+      }
+    }),
+  );
+
+  it.effect(
+    'admits run start from a stale terminal phase via resume semantics',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-stale-terminal-start',
+        );
+
+        try {
+          seedStreamStatusForTest(streamStatus, streamId, {
+            phase: STREAM_PHASE.FAILED,
+          });
+
+          yield* runFlowWithLifecycle(ctx, async () => {
+            expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+            return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
+          });
+
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
+
+  it.effect('clears a stale resuming substate when a resumed run starts', () =>
+    Effect.gen(function* () {
+      const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+        'lifecycle-resuming-substate-start',
       );
 
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+      try {
+        seedStreamStatusForTest(streamStatus, streamId, {
+          phase: STREAM_PHASE.RUNNING,
+          substate: STREAM_SUBSTATE.RESUMING,
+        });
 
-  it('projects run config before the RUNNING status projection', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-run-config-before-running',
-    );
-    publishTestRunStart(ctx.runScope.session, streamId, executionId);
-    const trace = new TraceEmitter();
-    const detachTrace = ctx.runScope.session.attachRunTrace(trace, streamId);
-    // One plane in commit order: run.config and the status fact both land
-    // on it, so the ordering assertion reads one log.
-    const recorded = recordSessionEvents(ctx.runScope.session);
-    ctx.logger = trace;
-    ctx.disposeTrace = detachTrace;
-
-    try {
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () =>
-          toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
-        ),
-      );
-
-      const runConfigIndex = (await recorded.read()).findIndex(
-        (event) => event.type === 'run.config',
-      );
-      const runningIndex = (await recorded.read()).findIndex(
-        (event) =>
-          event.type === 'status' &&
-          event.aggregateId === qualifyAggregateId('stream', streamId) &&
-          event.phase === STREAM_PHASE.RUNNING,
-      );
-
-      expect(runConfigIndex).toBeGreaterThanOrEqual(0);
-      expect(runningIndex).toBeGreaterThanOrEqual(0);
-      expect(runConfigIndex).toBeLessThan(runningIndex);
-    } finally {
-      detachTrace();
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
-
-  it('admits run start from a stale terminal phase via resume semantics', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-stale-terminal-start',
-    );
-
-    try {
-      seedStreamStatusForTest(streamStatus, streamId, {
-        phase: STREAM_PHASE.FAILED,
-      });
-
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => {
-          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
-          return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
-        }),
-      );
-
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
-
-  it('clears a stale resuming substate when a resumed run starts', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-resuming-substate-start',
-    );
-
-    try {
-      seedStreamStatusForTest(streamStatus, streamId, {
-        phase: STREAM_PHASE.RUNNING,
-        substate: STREAM_SUBSTATE.RESUMING,
-      });
-
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => {
+        yield* runFlowWithLifecycle(ctx, async () => {
           expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
           expect(streamStatus.getSubstate(streamId)).toBeUndefined();
           return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
-        }),
+        });
+
+        expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
+      } finally {
+        clearStreamStatusForTest(streamStatus, streamId);
+      }
+    }),
+  );
+
+  it.effect(
+    'does not emit a status event when starting an already-running stream with no substate',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-steady-running-no-substate',
+        );
+
+        const recorded = recordSessionEvents(ctx.runScope.session);
+        try {
+          seedStreamStatusForTest(streamStatus, streamId, {
+            phase: STREAM_PHASE.RUNNING,
+          });
+
+          yield* runFlowWithLifecycle(ctx, async () => {
+            expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+            expect(streamStatus.getSubstate(streamId)).toBeUndefined();
+            expect(eventsOfType(await recorded.read(), 'status')).toEqual([]);
+            return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
+          });
+
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
+
+  it.effect('delivers subagent aborts through the terminal callback', () =>
+    Effect.gen(function* () {
+      const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+        'lifecycle-subagent-abort',
       );
+      ctx.attachedMemoryMisses = [
+        { path: '/memories/missing.md', reason: 'not found' },
+      ];
+      const onError = vi.fn();
 
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
-
-  it('does not emit a status event when starting an already-running stream with no substate', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-steady-running-no-substate',
-    );
-
-    const recorded = recordSessionEvents(ctx.runScope.session);
-    try {
-      seedStreamStatusForTest(streamStatus, streamId, {
-        phase: STREAM_PHASE.RUNNING,
-      });
-
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => {
-          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
-          expect(streamStatus.getSubstate(streamId)).toBeUndefined();
-          expect(eventsOfType(await recorded.read(), 'status')).toEqual([]);
-          return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
-        }),
-      );
-
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
-
-  it('delivers subagent aborts through the terminal callback', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-subagent-abort',
-    );
-    ctx.attachedMemoryMisses = [
-      { path: '/memories/missing.md', reason: 'not found' },
-    ];
-    const onError = vi.fn();
-
-    try {
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(
+      try {
+        const result = yield* runFlowWithLifecycle(
           ctx,
           async () => {
             throw new DOMException('Request aborted', 'AbortError');
           },
           { isSubagent: true, onError },
-        ),
-      );
+        );
 
-      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-      expect(result.memoryMisses).toEqual(ctx.attachedMemoryMisses);
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
-      expect(onError).toHaveBeenCalledOnce();
-      expect(onError.mock.calls[0][1]).toEqual(result);
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+        expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+        expect(result.memoryMisses).toEqual(ctx.attachedMemoryMisses);
+        expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+        expect(onError).toHaveBeenCalledOnce();
+        expect(onError.mock.calls[0][1]).toEqual(result);
+      } finally {
+        clearStreamStatusForTest(streamStatus, streamId);
+      }
+    }),
+  );
 
-  it('keeps subagent errors registered until terminal delivery runs', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-subagent-error-registered',
-    );
-    const onError = vi.fn(() => {
-      expect(defaultSession().executions.getHandle(executionId)).toBeDefined();
-    });
+  it.effect(
+    'keeps subagent errors registered until terminal delivery runs',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-subagent-error-registered',
+        );
+        const onError = vi.fn(() => {
+          expect(
+            defaultSession().executions.getHandle(executionId),
+          ).toBeDefined();
+        });
 
-    try {
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(
-          ctx,
-          async () => {
-            throw new Error('subagent failed');
-          },
-          { isSubagent: true, onError },
-        ),
-      );
+        try {
+          const result = yield* runFlowWithLifecycle(
+            ctx,
+            async () => {
+              throw new Error('subagent failed');
+            },
+            { isSubagent: true, onError },
+          );
 
-      expect(result.outcome).toBe(RUN_OUTCOME.FAILED);
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
-      expect(onError).toHaveBeenCalledOnce();
-      expect(
-        defaultSession().executions.getHandle(executionId),
-      ).toBeUndefined();
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          expect(result.outcome).toBe(RUN_OUTCOME.FAILED);
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+          expect(onError).toHaveBeenCalledOnce();
+          expect(
+            defaultSession().executions.getHandle(executionId),
+          ).toBeUndefined();
+        } finally {
+          defaultSession().executions.untrack(executionId);
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
-  it('keeps native subagent WAITING results registered and nonterminal', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-subagent-waiting',
-    );
-    const onError = vi.fn();
-    await acquireResumedExecutionLease(executionId);
+  it.effect(
+    'keeps native subagent WAITING results registered and nonterminal',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-subagent-waiting',
+        );
+        const onError = vi.fn();
+        yield* Effect.promise(() => acquireResumedExecutionLease(executionId));
 
-    try {
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(
-          ctx,
-          async () => {
-            expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
-            expect(
-              streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait'),
-            ).toBe(true);
-            return waitingResult(executionId, streamId);
-          },
-          { isSubagent: true, onError },
-        ),
-      );
+        try {
+          const result = yield* runFlowWithLifecycle(
+            ctx,
+            async () => {
+              expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+              expect(
+                streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait'),
+              ).toBe(true);
+              return waitingResult(executionId, streamId);
+            },
+            { isSubagent: true, onError },
+          );
 
-      expect(result.outcome).toBe(STREAM_PHASE.WAITING);
-      expect(storageMocks.finalizeRun).not.toHaveBeenCalled();
-      expect(onError).not.toHaveBeenCalled();
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
-      expect(defaultSession().executions.getHandle(executionId)).toBeDefined();
-      await expect(inspectExecutionLease(executionId)).resolves.toMatchObject({
-        status: 'owned',
-      });
-    } finally {
-      await releaseOwnedExecutionLease(executionId);
-      defaultSession().executions.untrack(executionId);
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+          expect(storageMocks.finalizeRun).not.toHaveBeenCalled();
+          expect(onError).not.toHaveBeenCalled();
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
+          expect(
+            defaultSession().executions.getHandle(executionId),
+          ).toBeDefined();
+          expect(
+            yield* Effect.promise(() => inspectExecutionLease(executionId)),
+          ).toMatchObject({
+            status: 'owned',
+          });
+        } finally {
+          yield* Effect.promise(() => releaseOwnedExecutionLease(executionId));
+          defaultSession().executions.untrack(executionId);
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
   it('does not let a stop abandon a run that completes without suspending', async () => {
     // The window a stop could once fall into: the run has returned, its live
@@ -654,19 +683,19 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
-  it('carries workflowPhase on the first child roster emission', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-workflow-phase',
-    );
-    const parentStreamId = 'parent-lifecycle-workflow-phase' as StreamTabId;
-    const rosters = recordChildRosters(ctx.runScope.session.executions);
-    // `track()` emits the roster synchronously, so onRun — which fires after
-    // tracking — is structurally too late to stamp a display field.
-    let rosterEmissionsBeforeOnRun = -1;
+  it.effect('carries workflowPhase on the first child roster emission', () =>
+    Effect.gen(function* () {
+      const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+        'lifecycle-workflow-phase',
+      );
+      const parentStreamId = 'parent-lifecycle-workflow-phase' as StreamTabId;
+      const rosters = recordChildRosters(ctx.runScope.session.executions);
+      // `track()` emits the roster synchronously, so onRun — which fires after
+      // tracking — is structurally too late to stamp a display field.
+      let rosterEmissionsBeforeOnRun = -1;
 
-    try {
-      await Effect.runPromise(
-        runFlowWithLifecycle(
+      try {
+        yield* runFlowWithLifecycle(
           ctx,
           async () =>
             toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
@@ -678,31 +707,31 @@ describe('runFlowWithLifecycle', () => {
               rosterEmissionsBeforeOnRun = rosters.rosters.length;
             },
           },
-        ),
+        );
+
+        const [firstRoster] = rosters.rosters;
+        expect(firstRoster?.items).toEqual([
+          expect.objectContaining({
+            executionId,
+            childStreamId: streamId,
+            workflowPhase: 'Reduce',
+          }),
+        ]);
+        expect(rosterEmissionsBeforeOnRun).toBeGreaterThan(0);
+      } finally {
+        defaultSession().executions.untrack(executionId);
+        clearStreamStatusForTest(streamStatus, streamId);
+      }
+    }),
+  );
+
+  it.effect('carries a stop requested by onRun on the run signal', () =>
+    Effect.gen(function* () {
+      const { executionId, streamId, ctx } = lifecycleFixture(
+        'lifecycle-early-stop',
       );
 
-      const [firstRoster] = rosters.rosters;
-      expect(firstRoster?.items).toEqual([
-        expect.objectContaining({
-          executionId,
-          childStreamId: streamId,
-          workflowPhase: 'Reduce',
-        }),
-      ]);
-      expect(rosterEmissionsBeforeOnRun).toBeGreaterThan(0);
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
-
-  it('carries a stop requested by onRun on the run signal', async () => {
-    const { executionId, streamId, ctx } = lifecycleFixture(
-      'lifecycle-early-stop',
-    );
-
-    const result = await Effect.runPromise(
-      runFlowWithLifecycle(
+      const result = yield* runFlowWithLifecycle(
         ctx,
         async () => {
           expect(defaultSession().status.get(streamId)).toBe(
@@ -720,63 +749,65 @@ describe('runFlowWithLifecycle', () => {
             await Effect.runPromise(stop.settlement);
           },
         },
-      ),
-    );
+      );
 
-    expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-  });
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+    }),
+  );
 
   // The stream is reused across runs, so a run that never claims it inherits
   // whatever the last one left. A stop landing in the track()-to-start window
   // is refused by the phase table while that leftover is terminal, so without
   // the start-time claim this run would adopt the previous run's COMPLETED as
   // its own verdict and drop its abort facts.
-  it('does not adopt a previous run terminal phase when a stop lands before start', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-stale-phase-early-stop',
-    );
-    let terminalResult: AgentRunHandle['result'] | undefined;
+  it.effect(
+    'does not adopt a previous run terminal phase when a stop lands before start',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-stale-phase-early-stop',
+        );
+        let terminalResult: AgentRunHandle['result'] | undefined;
 
-    try {
-      seedStreamStatusForTest(streamStatus, streamId, {
-        phase: STREAM_PHASE.COMPLETED,
-      });
+        try {
+          seedStreamStatusForTest(streamStatus, streamId, {
+            phase: STREAM_PHASE.COMPLETED,
+          });
 
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(
-          ctx,
-          async (handle) => {
-            expect(ctx.runScope.signal.aborted).toBe(true);
-            throw new DOMException('Request aborted', 'AbortError');
-          },
-          {
-            onRun: async (handle) => {
-              terminalResult = handle.result;
-              const stop = defaultSession().executions.kill(executionId);
-              expect(stop.accepted).toBe(true);
-              await Effect.runPromise(stop.settlement);
+          const result = yield* runFlowWithLifecycle(
+            ctx,
+            async (handle) => {
+              expect(ctx.runScope.signal.aborted).toBe(true);
+              throw new DOMException('Request aborted', 'AbortError');
             },
-          },
-        ),
-      );
+            {
+              onRun: async (handle) => {
+                terminalResult = handle.result;
+                const stop = defaultSession().executions.kill(executionId);
+                expect(stop.accepted).toBe(true);
+                await Effect.runPromise(stop.settlement);
+              },
+            },
+          );
 
-      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
-      expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
-        defaultSession(),
-        expect.objectContaining({
-          outcome: RUN_OUTCOME.CANCELLED,
-          flowRecord: 'preserve',
-        }),
-      );
-      await expect(Effect.runPromise(terminalResult!)).resolves.toMatchObject({
-        outcome: RUN_OUTCOME.CANCELLED,
-        error: { kind: 'abort' },
-      });
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+          expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
+            defaultSession(),
+            expect.objectContaining({
+              outcome: RUN_OUTCOME.CANCELLED,
+              flowRecord: 'preserve',
+            }),
+          );
+          expect(yield* terminalResult!).toMatchObject({
+            outcome: RUN_OUTCOME.CANCELLED,
+            error: { kind: 'abort' },
+          });
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
   // The claim above is a repair for an inherited phase, not a second start: a
   // stop that already reads CANCELLED on the stream is this run's outcome too,
@@ -822,74 +853,78 @@ describe('runFlowWithLifecycle', () => {
   // Outcome and flow-record disposition are one decision: a run the phase says
   // was interrupted keeps the record that makes it resumable, even when its own
   // report reached completion first.
-  it('keeps the flow record of a stopped run whose report says completed', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-stop-during-completion',
-    );
+  it.effect(
+    'keeps the flow record of a stopped run whose report says completed',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-stop-during-completion',
+        );
 
-    try {
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => {
-          const stop = defaultSession().executions.kill(executionId);
-          expect(stop.accepted).toBe(true);
-          await Effect.runPromise(stop.settlement);
-          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
-          return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
-        }),
-      );
-
-      // The caller receives the same verdict persistence carries: the stop
-      // won on the stream, so the flow's COMPLETED report is relabeled.
-      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-      expect(storageMocks.finalizeRun).toHaveBeenCalledExactlyOnceWith(
-        defaultSession(),
-        expect.objectContaining({
-          outcome: RUN_OUTCOME.CANCELLED,
-          flowRecord: 'preserve',
-        }),
-      );
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
-
-  // The parent's delivery is a projection of the same terminal fact as the
-  // persisted history, so a stopped child never arrives formatted as a failure.
-  it('delivers a stopped subagent as cancelled when its flow reports a failure', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-subagent-stop-then-failure',
-    );
-    const onError = vi.fn();
-
-    try {
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(
-          ctx,
-          async () => {
+        try {
+          const result = yield* runFlowWithLifecycle(ctx, async () => {
             const stop = defaultSession().executions.kill(executionId);
             expect(stop.accepted).toBe(true);
             await Effect.runPromise(stop.settlement);
-            throw new Error('child exited with code 143');
-          },
-          { isSubagent: true, onError },
-        ),
-      );
+            expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+            return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
+          });
 
-      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
-      expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
-        defaultSession(),
-        expect.objectContaining({
-          outcome: RUN_OUTCOME.CANCELLED,
-        }),
-      );
-      expect(onError).toHaveBeenCalledOnce();
-      expect(onError.mock.calls[0][1]).toEqual(result);
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          // The caller receives the same verdict persistence carries: the stop
+          // won on the stream, so the flow's COMPLETED report is relabeled.
+          expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+          expect(storageMocks.finalizeRun).toHaveBeenCalledExactlyOnceWith(
+            defaultSession(),
+            expect.objectContaining({
+              outcome: RUN_OUTCOME.CANCELLED,
+              flowRecord: 'preserve',
+            }),
+          );
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
+
+  // The parent's delivery is a projection of the same terminal fact as the
+  // persisted history, so a stopped child never arrives formatted as a failure.
+  it.effect(
+    'delivers a stopped subagent as cancelled when its flow reports a failure',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-subagent-stop-then-failure',
+        );
+        const onError = vi.fn();
+
+        try {
+          const result = yield* runFlowWithLifecycle(
+            ctx,
+            async () => {
+              const stop = defaultSession().executions.kill(executionId);
+              expect(stop.accepted).toBe(true);
+              await Effect.runPromise(stop.settlement);
+              throw new Error('child exited with code 143');
+            },
+            { isSubagent: true, onError },
+          );
+
+          expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+          expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
+            defaultSession(),
+            expect.objectContaining({
+              outcome: RUN_OUTCOME.CANCELLED,
+            }),
+          );
+          expect(onError).toHaveBeenCalledOnce();
+          expect(onError.mock.calls[0][1]).toEqual(result);
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
   it('lets a stop/kill tear down a subagent suspended at WAITING (issue #7287)', async () => {
     const { executionId, streamId, ctx } = lifecycleFixture(
@@ -1017,125 +1052,141 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
-  it('projects returned outcomes to terminal status, stage end, and stream status', async () => {
-    const cases = [
-      {
-        outcome: RUN_OUTCOME.COMPLETED,
-        stream: STREAM_PHASE.COMPLETED,
-      },
-      {
-        outcome: RUN_OUTCOME.CANCELLED,
-        stream: STREAM_PHASE.CANCELLED,
-      },
-      {
-        outcome: RUN_OUTCOME.FAILED,
-        stream: STREAM_PHASE.FAILED,
-      },
-    ] as const;
-
-    for (const expected of cases) {
-      const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-        `outcome-${expected.outcome}`,
-      );
-      const stageEnd = vi.spyOn(ctx.parentStage, 'end');
-
-      try {
-        const result = await Effect.runPromise(
-          runFlowWithLifecycle(ctx, async () =>
-            toolUseResult(executionId, streamId, expected.outcome),
-          ),
-        );
-
-        expect(result.outcome).toBe(expected.outcome);
-        expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
-          defaultSession(),
+  it.effect(
+    'projects returned outcomes to terminal status, stage end, and stream status',
+    () =>
+      Effect.gen(function* () {
+        const cases = [
           {
-            executionId,
-            outcome: expected.outcome,
-            flowRecord:
-              expected.outcome === RUN_OUTCOME.COMPLETED
-                ? 'delete'
-                : 'preserve',
+            outcome: RUN_OUTCOME.COMPLETED,
+            stream: STREAM_PHASE.COMPLETED,
           },
+          {
+            outcome: RUN_OUTCOME.CANCELLED,
+            stream: STREAM_PHASE.CANCELLED,
+          },
+          {
+            outcome: RUN_OUTCOME.FAILED,
+            stream: STREAM_PHASE.FAILED,
+          },
+        ] as const;
+
+        for (const expected of cases) {
+          const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+            `outcome-${expected.outcome}`,
+          );
+          const stageEnd = vi.spyOn(ctx.parentStage, 'end');
+
+          try {
+            const result = yield* runFlowWithLifecycle(ctx, async () =>
+              toolUseResult(executionId, streamId, expected.outcome),
+            );
+
+            expect(result.outcome).toBe(expected.outcome);
+            expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
+              defaultSession(),
+              {
+                executionId,
+                outcome: expected.outcome,
+                flowRecord:
+                  expected.outcome === RUN_OUTCOME.COMPLETED
+                    ? 'delete'
+                    : 'preserve',
+              },
+            );
+            expect(stageEnd).toHaveBeenCalledWith(expected.outcome);
+            expect(streamStatus.get(streamId)).toBe(expected.stream);
+          } finally {
+            clearStreamStatusForTest(streamStatus, streamId);
+          }
+        }
+      }),
+  );
+
+  it.effect(
+    'finalizes an outcome-only failure without fabricating provider error facts',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'outcome-only-failure',
         );
-        expect(stageEnd).toHaveBeenCalledWith(expected.outcome);
-        expect(streamStatus.get(streamId)).toBe(expected.stream);
-      } finally {
-        clearStreamStatusForTest(streamStatus, streamId);
-      }
-    }
-  });
+        const stageEnd = vi.spyOn(ctx.parentStage, 'end');
+        const emit = vi.spyOn(ctx.logger, 'emit');
+        const onError = vi.fn();
 
-  it('finalizes an outcome-only failure without fabricating provider error facts', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'outcome-only-failure',
-    );
-    const stageEnd = vi.spyOn(ctx.parentStage, 'end');
-    const emit = vi.spyOn(ctx.logger, 'emit');
-    const onError = vi.fn();
+        try {
+          const carriedResult = toolUseResult(
+            executionId,
+            streamId,
+            RUN_OUTCOME.FAILED,
+          );
+          const result = yield* runFlowWithLifecycle(
+            ctx,
+            async () => carriedResult,
+            {
+              isSubagent: true,
+              onError,
+            },
+          );
 
-    try {
-      const carriedResult = toolUseResult(
-        executionId,
-        streamId,
-        RUN_OUTCOME.FAILED,
-      );
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => carriedResult, {
-          isSubagent: true,
-          onError,
-        }),
-      );
+          expect(result).toEqual(carriedResult);
+          expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
+            defaultSession(),
+            {
+              executionId,
+              outcome: RUN_OUTCOME.FAILED,
+              flowRecord: 'preserve',
+            },
+          );
+          expect(stageEnd).toHaveBeenCalledWith(RUN_OUTCOME.FAILED);
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+          const resultEvent = emit.mock.calls
+            .map(([event]) => event)
+            .find((event) => event.type === 'result');
+          expect(resultEvent).toMatchObject({
+            type: 'result',
+            outcome: RUN_OUTCOME.FAILED,
+          });
+          expect(resultEvent).not.toHaveProperty('error');
+          expect(onError).not.toHaveBeenCalled();
+        } finally {
+          emit.mockRestore();
+          defaultSession().executions.untrack(executionId);
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
-      expect(result).toEqual(carriedResult);
-      expect(storageMocks.finalizeRun).toHaveBeenCalledWith(defaultSession(), {
-        executionId,
-        outcome: RUN_OUTCOME.FAILED,
-        flowRecord: 'preserve',
-      });
-      expect(stageEnd).toHaveBeenCalledWith(RUN_OUTCOME.FAILED);
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
-      const resultEvent = emit.mock.calls
-        .map(([event]) => event)
-        .find((event) => event.type === 'result');
-      expect(resultEvent).toMatchObject({
-        type: 'result',
-        outcome: RUN_OUTCOME.FAILED,
-      });
-      expect(resultEvent).not.toHaveProperty('error');
-      expect(onError).not.toHaveBeenCalled();
-    } finally {
-      emit.mockRestore();
-      defaultSession().executions.untrack(executionId);
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+  it.effect(
+    'projects a thrown abort as cancelled on its own stage outcome',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'outcome-thrown-abort',
+        );
+        const stageEnd = vi.spyOn(ctx.parentStage, 'end');
 
-  it('projects a thrown abort as cancelled on its own stage outcome', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'outcome-thrown-abort',
-    );
-    const stageEnd = vi.spyOn(ctx.parentStage, 'end');
+        try {
+          const result = yield* runFlowWithLifecycle(ctx, async () => {
+            throw new DOMException('Request aborted', 'AbortError');
+          });
 
-    try {
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => {
-          throw new DOMException('Request aborted', 'AbortError');
-        }),
-      );
-
-      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-      expect(storageMocks.finalizeRun).toHaveBeenCalledWith(defaultSession(), {
-        executionId,
-        outcome: RUN_OUTCOME.CANCELLED,
-        flowRecord: 'preserve',
-      });
-      expect(stageEnd).toHaveBeenCalledWith(RUN_OUTCOME.CANCELLED);
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+          expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
+            defaultSession(),
+            {
+              executionId,
+              outcome: RUN_OUTCOME.CANCELLED,
+              flowRecord: 'preserve',
+            },
+          );
+          expect(stageEnd).toHaveBeenCalledWith(RUN_OUTCOME.CANCELLED);
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
   it('projects an unexpected throw as failed', async () => {
     const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
@@ -1187,42 +1238,48 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
-  it('passes flow-carried terminal results to subagent error delivery', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-subagent-flow-error',
-    );
-    const carriedResult = {
-      category: 'toolUse' as const,
-      outcome: RUN_OUTCOME.FAILED,
-      executionId,
-      streamId,
-      totalCostUsd: 0.73,
-      error: { message: 'subagent failed', userRetryable: false },
-    };
-    const onError = vi.fn();
+  it.effect(
+    'passes flow-carried terminal results to subagent error delivery',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+          'lifecycle-subagent-flow-error',
+        );
+        const carriedResult = {
+          category: 'toolUse' as const,
+          outcome: RUN_OUTCOME.FAILED,
+          executionId,
+          streamId,
+          totalCostUsd: 0.73,
+          error: { message: 'subagent failed', userRetryable: false },
+        };
+        const onError = vi.fn();
 
-    try {
-      seedStreamStatusForTest(streamStatus, streamId, {
-        phase: STREAM_PHASE.RUNNING,
-      });
+        try {
+          seedStreamStatusForTest(streamStatus, streamId, {
+            phase: STREAM_PHASE.RUNNING,
+          });
 
-      const result = await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => carriedResult, {
-          isSubagent: true,
-          onError,
-        }),
-      );
+          const result = yield* runFlowWithLifecycle(
+            ctx,
+            async () => carriedResult,
+            {
+              isSubagent: true,
+              onError,
+            },
+          );
 
-      expect(result).toEqual(carriedResult);
-      expect(onError).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'subagent failed' }),
-        carriedResult,
-      );
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          expect(result).toEqual(carriedResult);
+          expect(onError).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'subagent failed' }),
+            carriedResult,
+          );
+        } finally {
+          defaultSession().executions.untrack(executionId);
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
   it('publishes the structured error facts a flow carried out on its result', async () => {
     const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
@@ -1456,156 +1513,160 @@ describe('finalizeRunTerminal', () => {
     }
   });
 
-  it('settles and untracks once while reporting terminal metadata failure', async () => {
-    const { executionId, streamId, streamStatus, handle, untrack } =
-      finalizeFixture('finalize-metadata-failure');
-    const durabilityError = new Error('metadata disk write failed');
-    storageMocks.finalizeRun.mockReturnValueOnce(
-      Effect.succeed({
-        ok: false,
-        outcomePersisted: false,
-        error: durabilityError,
-      }),
-    );
-
-    try {
-      seedStreamStatusForTest(streamStatus, streamId, {
-        phase: STREAM_PHASE.RUNNING,
-      });
-
-      const event = await Effect.runPromise(
-        finalizeRunTerminal({
-          session: defaultSession(),
-          handle,
-          executions: { untrack },
-          streamStatus,
-          outcome: RUN_OUTCOME.FAILED,
-          isSubagent: false,
-          trace: noopTrace,
-          persistence: { kind: 'finalize', flowRecord: 'preserve' },
-        }),
-      );
-
-      expect(event).toMatchObject({
-        event: {
-          type: 'result',
-          outcome: RUN_OUTCOME.FAILED,
-          executionId,
-        },
-      });
-      await expect(Effect.runPromise(handle.result)).resolves.toBe(
-        event?.event,
-      );
-      expect(untrack).toHaveBeenCalledExactlyOnceWith(executionId);
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
-      expect(channelTraceMocks.warn).toHaveBeenCalledExactlyOnceWith(
-        'Failed to finalize durable execution state',
-        {
-          data: {
-            agentIdentifier: 'test-agent',
-            executionId,
+  it.effect(
+    'settles and untracks once while reporting terminal metadata failure',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, handle, untrack } =
+          finalizeFixture('finalize-metadata-failure');
+        const durabilityError = new Error('metadata disk write failed');
+        storageMocks.finalizeRun.mockReturnValueOnce(
+          Effect.succeed({
+            ok: false,
             outcomePersisted: false,
             error: durabilityError,
-          },
-        },
-      );
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          }),
+        );
+
+        try {
+          seedStreamStatusForTest(streamStatus, streamId, {
+            phase: STREAM_PHASE.RUNNING,
+          });
+
+          const event = yield* finalizeRunTerminal({
+            session: defaultSession(),
+            handle,
+            executions: { untrack },
+            streamStatus,
+            outcome: RUN_OUTCOME.FAILED,
+            isSubagent: false,
+            trace: noopTrace,
+            persistence: { kind: 'finalize', flowRecord: 'preserve' },
+          });
+
+          expect(event).toMatchObject({
+            event: {
+              type: 'result',
+              outcome: RUN_OUTCOME.FAILED,
+              executionId,
+            },
+          });
+          expect(yield* handle.result).toBe(event?.event);
+          expect(untrack).toHaveBeenCalledExactlyOnceWith(executionId);
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+          expect(channelTraceMocks.warn).toHaveBeenCalledExactlyOnceWith(
+            'Failed to finalize durable execution state',
+            {
+              data: {
+                agentIdentifier: 'test-agent',
+                executionId,
+                outcomePersisted: false,
+                error: durabilityError,
+              },
+            },
+          );
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
   // The stream phase is the single owner of a run's terminal outcome. A
   // stop/kill transitions the phase behind the run's back, and the run it
   // killed then reports its own non-zero exit as a failure — so the phase, not
   // the report, has to decide, and no caller may cross-check it for itself.
-  it('resolves the terminal outcome from an already-cancelled stream phase', async () => {
-    const { executionId, streamId, streamStatus, handle, untrack } =
-      finalizeFixture('finalize-stopped');
-    const stage = { end: vi.fn() };
+  it.effect(
+    'resolves the terminal outcome from an already-cancelled stream phase',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, handle, untrack } =
+          finalizeFixture('finalize-stopped');
+        const stage = { end: vi.fn() };
 
-    try {
-      seedStreamStatusForTest(streamStatus, streamId, {
-        phase: STREAM_PHASE.CANCELLED,
-      });
+        try {
+          seedStreamStatusForTest(streamStatus, streamId, {
+            phase: STREAM_PHASE.CANCELLED,
+          });
 
-      const finalized = await Effect.runPromise(
-        finalizeRunTerminal({
-          session: defaultSession(),
-          handle,
-          executions: { untrack },
-          streamStatus,
-          outcome: RUN_OUTCOME.FAILED,
-          error: { kind: 'unexpected', message: 'exited with code 143' },
-          isSubagent: false,
-          stage,
-          trace: noopTrace,
-          persistence: { kind: 'finalize', flowRecord: 'delete' },
-        }),
-      );
+          const finalized = yield* finalizeRunTerminal({
+            session: defaultSession(),
+            handle,
+            executions: { untrack },
+            streamStatus,
+            outcome: RUN_OUTCOME.FAILED,
+            error: { kind: 'unexpected', message: 'exited with code 143' },
+            isSubagent: false,
+            stage,
+            trace: noopTrace,
+            persistence: { kind: 'finalize', flowRecord: 'delete' },
+          });
 
-      expect(finalized?.event).toMatchObject({
-        type: 'result',
-        outcome: RUN_OUTCOME.CANCELLED,
-        executionId,
-        streamId,
-      });
-      // Error facts classified for a failure that the phase says never
-      // happened must not ride the cancelled result.
-      expect(finalized?.event.error).toBeUndefined();
-      await expect(Effect.runPromise(handle.result)).resolves.toBe(
-        finalized?.event,
-      );
-      expect(stage.end).toHaveBeenCalledExactlyOnceWith(RUN_OUTCOME.CANCELLED);
-      expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
-        defaultSession(),
-        expect.objectContaining({
-          outcome: RUN_OUTCOME.CANCELLED,
-        }),
-      );
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
-      // The resolution is what keeps the terminal transition from being
-      // refused, so nothing is left to warn about.
-      expect(channelTraceMocks.warn).not.toHaveBeenCalled();
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          expect(finalized?.event).toMatchObject({
+            type: 'result',
+            outcome: RUN_OUTCOME.CANCELLED,
+            executionId,
+            streamId,
+          });
+          // Error facts classified for a failure that the phase says never
+          // happened must not ride the cancelled result.
+          expect(finalized?.event.error).toBeUndefined();
+          expect(yield* handle.result).toBe(finalized?.event);
+          expect(stage.end).toHaveBeenCalledExactlyOnceWith(
+            RUN_OUTCOME.CANCELLED,
+          );
+          expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
+            defaultSession(),
+            expect.objectContaining({
+              outcome: RUN_OUTCOME.CANCELLED,
+            }),
+          );
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+          // The resolution is what keeps the terminal transition from being
+          // refused, so nothing is left to warn about.
+          expect(channelTraceMocks.warn).not.toHaveBeenCalled();
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 
   // The same ownership rule in the other direction: a phase that already
   // published FAILED is a terminal fact a later stop cannot rewrite, so a
   // caller reporting `cancelled` does not get to relabel it.
-  it('keeps an already-failed stream phase over a later cancelled report', async () => {
-    const { executionId, streamId, streamStatus, handle, untrack } =
-      finalizeFixture('finalize-failed-then-stopped');
+  it.effect(
+    'keeps an already-failed stream phase over a later cancelled report',
+    () =>
+      Effect.gen(function* () {
+        const { executionId, streamId, streamStatus, handle, untrack } =
+          finalizeFixture('finalize-failed-then-stopped');
 
-    try {
-      seedStreamStatusForTest(streamStatus, streamId, {
-        phase: STREAM_PHASE.FAILED,
-      });
+        try {
+          seedStreamStatusForTest(streamStatus, streamId, {
+            phase: STREAM_PHASE.FAILED,
+          });
 
-      const finalized = await Effect.runPromise(
-        finalizeRunTerminal({
-          session: defaultSession(),
-          handle,
-          executions: { untrack },
-          streamStatus,
-          outcome: RUN_OUTCOME.CANCELLED,
-          isSubagent: false,
-          trace: noopTrace,
-          persistence: { kind: 'skip' },
-        }),
-      );
+          const finalized = yield* finalizeRunTerminal({
+            session: defaultSession(),
+            handle,
+            executions: { untrack },
+            streamStatus,
+            outcome: RUN_OUTCOME.CANCELLED,
+            isSubagent: false,
+            trace: noopTrace,
+            persistence: { kind: 'skip' },
+          });
 
-      expect(finalized?.event).toMatchObject({
-        type: 'result',
-        outcome: RUN_OUTCOME.FAILED,
-        executionId,
-        streamId,
-      });
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
-      expect(channelTraceMocks.warn).not.toHaveBeenCalled();
-    } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
+          expect(finalized?.event).toMatchObject({
+            type: 'result',
+            outcome: RUN_OUTCOME.FAILED,
+            executionId,
+            streamId,
+          });
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+          expect(channelTraceMocks.warn).not.toHaveBeenCalled();
+        } finally {
+          clearStreamStatusForTest(streamStatus, streamId);
+        }
+      }),
+  );
 });

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -1,6 +1,7 @@
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   buildAgentLaunchContext: vi.fn(),
@@ -142,9 +143,7 @@ function resumeToolUseFromResumeData(
   resume: Parameters<typeof resumeOnLane>[0],
   options: ResumeToolUseFromResumeDataOptions = {},
 ) {
-  return Effect.runPromise(
-    resumeOnLane(resume, { session: LANE_SESSION, ...options }),
-  );
+  return resumeOnLane(resume, { session: LANE_SESSION, ...options });
 }
 
 /** Minimal launch context for a resumed tool-use run that reaches the flow. */
@@ -201,241 +200,271 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
     );
   });
 
-  it('preserves persisted native follow-up support across resumed waiting turns', async () => {
-    const executionId = 'e9911-native-resume' as ExecutionId;
-    const streamId = 'stream-9911-native-resume' as StreamTabId;
-    const snapshot = createToolUseResumeData({ executionId, streamId });
-    mocks.getPersistedUserFollowUpSupport.mockResolvedValue(
-      USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
-    );
-    mocks.hasPersistedParent.mockResolvedValue(true);
-    mocks.buildAgentLaunchContext
-      .mockResolvedValueOnce(buildResumeContext(executionId, streamId))
-      .mockResolvedValueOnce(buildResumeContext(executionId, streamId));
-    mocks.runToolUseFlow.mockResolvedValue({
-      outcome: 'waiting',
-      response: 'ready for another follow-up',
-    });
+  it.effect(
+    'preserves persisted native follow-up support across resumed waiting turns',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'e9911-native-resume' as ExecutionId;
+        const streamId = 'stream-9911-native-resume' as StreamTabId;
+        const snapshot = createToolUseResumeData({ executionId, streamId });
+        mocks.getPersistedUserFollowUpSupport.mockResolvedValue(
+          USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+        );
+        mocks.hasPersistedParent.mockResolvedValue(true);
+        mocks.buildAgentLaunchContext
+          .mockResolvedValueOnce(buildResumeContext(executionId, streamId))
+          .mockResolvedValueOnce(buildResumeContext(executionId, streamId));
+        mocks.runToolUseFlow.mockResolvedValue({
+          outcome: 'waiting',
+          response: 'ready for another follow-up',
+        });
 
-    await resumeToolUseFromResumeData(snapshot);
-    await resumeToolUseFromResumeData(snapshot);
+        yield* resumeToolUseFromResumeData(snapshot);
+        yield* resumeToolUseFromResumeData(snapshot);
 
-    // The persisted support rides the launch input: `run.start` stamps it at
-    // the reservation commit point, before the lifecycle runs.
-    expect(mocks.buildAgentLaunchContext).toHaveBeenCalledTimes(2);
-    expect(
-      mocks.buildAgentLaunchContext.mock.calls.map(
-        (call) => call[0]?.userFollowUpSupport,
-      ),
-    ).toEqual([
-      USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
-      USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
-    ]);
-  });
-
-  it('resolves execution lineage before activating the resume stream', async () => {
-    const storageError = new Error('execution metadata unavailable');
-    const snapshot = createToolUseResumeData({
-      executionId: 'e8048' as ExecutionId,
-      streamId: 'stream-8048' as StreamTabId,
-    });
-    mocks.hasPersistedParent.mockRejectedValueOnce(storageError);
-
-    await expect(resumeToolUseFromResumeData(snapshot)).rejects.toBe(
-      storageError,
-    );
-
-    expect(mocks.buildAgentLaunchContext).not.toHaveBeenCalled();
-    expect(mocks.releaseOwnedExecutionLease).toHaveBeenCalledWith(
-      snapshot.executionId,
-    );
-    expect(mocks.releaseExecutionClaims).toHaveBeenCalledWith(
-      snapshot.executionId,
-    );
-    expect(mocks.releaseExecutionClaims).toHaveBeenCalledTimes(1);
-  });
-
-  it('reports a reloaded session that is no longer resumable distinctly', async () => {
-    const snapshot = createToolUseResumeData();
-    mocks.retrieveSessionResumeData.mockResolvedValueOnce(null);
-
-    await expect(resumeToolUseFromResumeData(snapshot)).rejects.toBeInstanceOf(
-      ResumeSessionUnavailableError,
-    );
-    expect(mocks.buildAgentLaunchContext).not.toHaveBeenCalled();
-  });
-
-  it('rejects a resumed launch that is not a tool-use agent', async () => {
-    const resume = createToolUseResumeData();
-    mocks.hasPersistedParent.mockResolvedValueOnce(false);
-    // The guard runs inside the lifecycle so its failure ends the started
-    // stream; the mocked lifecycle only has to run the body.
-    mocks.runFlowWithLifecycle.mockImplementationOnce(
-      (_context: unknown, runner: (...args: unknown[]) => unknown) =>
-        runner({}, {}),
-    );
-    mocks.buildAgentLaunchContext.mockResolvedValueOnce({
-      setting: { agentCategory: AgentCategory.Workflow },
-      runScope: {
-        executionId: resume.executionId,
-        streamId: resume.streamId,
-        session: {
-          flushArtifacts: vi.fn(),
-          releaseExecutionLease: vi.fn(async () => {}),
-        },
-      },
-    } as unknown as AgentLaunchContext);
-
-    await expect(resumeToolUseFromResumeData(resume)).rejects.toThrow(
-      'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
-    );
-  });
-
-  it('interrupts at flow attachment before substantive work starts', async () => {
-    const executionId = 'e8049' as ExecutionId;
-    const streamId = 'stream-8049' as StreamTabId;
-    const context = buildResumeContext(executionId, streamId);
-    const order: string[] = [];
-    const tools = [
-      {
-        definition: { name: 'run_scoped' },
-        call: vi.fn(),
-      },
-    ] as unknown as readonly ITool[];
-    let attachedContext: TestFlowContext | undefined;
-    const handle = {
-      attachToolUseFlow: vi.fn((flowContext: TestFlowContext) => {
-        order.push('attach');
-        attachedContext = flowContext;
+        // The persisted support rides the launch input: `run.start` stamps it
+        // at the reservation commit point, before the lifecycle runs.
+        expect(mocks.buildAgentLaunchContext).toHaveBeenCalledTimes(2);
+        expect(
+          mocks.buildAgentLaunchContext.mock.calls.map(
+            (call) => call[0]?.userFollowUpSupport,
+          ),
+        ).toEqual([
+          USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+          USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+        ]);
       }),
-      detachToolUseFlow: vi.fn((flowContext: TestFlowContext) => {
-        order.push('detach');
-        if (attachedContext === flowContext) attachedContext = undefined;
-      }),
-    };
+  );
 
-    mocks.buildAgentLaunchContext.mockResolvedValueOnce(context);
-    mocks.hasPersistedParent.mockResolvedValueOnce(false);
-    mocks.runFlowWithLifecycle.mockImplementationOnce(
-      async (
-        _context: unknown,
-        run: (liveHandle: typeof handle) => Promise<unknown>,
-      ) => run(handle),
-    );
-    mocks.runToolUseFlow.mockImplementationOnce(
-      async (
-        input: InterruptibleFlowInput,
-        _registry: unknown,
-        attachment: {
-          attach: (flowContext: TestFlowContext) => void;
-          detach: (flowContext: TestFlowContext) => void;
-        },
-      ) => {
-        expect(input.tools).toBe(tools);
-        const flowContext: TestFlowContext = {
-          interrupt: () => {
-            order.push('interrupt');
-            input.interrupt();
+  it.effect(
+    'resolves execution lineage before activating the resume stream',
+    () =>
+      Effect.gen(function* () {
+        const storageError = new Error('execution metadata unavailable');
+        const snapshot = createToolUseResumeData({
+          executionId: 'e8048' as ExecutionId,
+          streamId: 'stream-8048' as StreamTabId,
+        });
+        mocks.hasPersistedParent.mockRejectedValueOnce(storageError);
+
+        expect(yield* Effect.flip(resumeToolUseFromResumeData(snapshot))).toBe(
+          storageError,
+        );
+
+        expect(mocks.buildAgentLaunchContext).not.toHaveBeenCalled();
+        expect(mocks.releaseOwnedExecutionLease).toHaveBeenCalledWith(
+          snapshot.executionId,
+        );
+        expect(mocks.releaseExecutionClaims).toHaveBeenCalledWith(
+          snapshot.executionId,
+        );
+        expect(mocks.releaseExecutionClaims).toHaveBeenCalledTimes(1);
+      }),
+  );
+
+  it.effect(
+    'reports a reloaded session that is no longer resumable distinctly',
+    () =>
+      Effect.gen(function* () {
+        const snapshot = createToolUseResumeData();
+        mocks.retrieveSessionResumeData.mockResolvedValueOnce(null);
+
+        expect(
+          yield* Effect.flip(resumeToolUseFromResumeData(snapshot)),
+        ).toBeInstanceOf(ResumeSessionUnavailableError);
+        expect(mocks.buildAgentLaunchContext).not.toHaveBeenCalled();
+      }),
+  );
+
+  it.effect('rejects a resumed launch that is not a tool-use agent', () =>
+    Effect.gen(function* () {
+      const resume = createToolUseResumeData();
+      mocks.hasPersistedParent.mockResolvedValueOnce(false);
+      // The guard runs inside the lifecycle so its failure ends the started
+      // stream; the mocked lifecycle only has to run the body.
+      mocks.runFlowWithLifecycle.mockImplementationOnce(
+        (_context: unknown, runner: (...args: unknown[]) => unknown) =>
+          runner({}, {}),
+      );
+      mocks.buildAgentLaunchContext.mockResolvedValueOnce({
+        setting: { agentCategory: AgentCategory.Workflow },
+        runScope: {
+          executionId: resume.executionId,
+          streamId: resume.streamId,
+          session: {
+            flushArtifacts: vi.fn(),
+            releaseExecutionLease: vi.fn(async () => {}),
           },
+        },
+      } as unknown as AgentLaunchContext);
+
+      expect(
+        (yield* Effect.flip(resumeToolUseFromResumeData(resume))).message,
+      ).toContain(
+        'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
+      );
+    }),
+  );
+
+  it.effect(
+    'interrupts at flow attachment before substantive work starts',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'e8049' as ExecutionId;
+        const streamId = 'stream-8049' as StreamTabId;
+        const context = buildResumeContext(executionId, streamId);
+        const order: string[] = [];
+        const tools = [
+          {
+            definition: { name: 'run_scoped' },
+            call: vi.fn(),
+          },
+        ] as unknown as readonly ITool[];
+        let attachedContext: TestFlowContext | undefined;
+        const handle = {
+          attachToolUseFlow: vi.fn((flowContext: TestFlowContext) => {
+            order.push('attach');
+            attachedContext = flowContext;
+          }),
+          detachToolUseFlow: vi.fn((flowContext: TestFlowContext) => {
+            order.push('detach');
+            if (attachedContext === flowContext) attachedContext = undefined;
+          }),
         };
-        attachment.attach(flowContext);
-        input.takePendingFollowUps?.();
-        if (!input.runScope.signal.aborted) mocks.invokeModelOrTool();
-        attachment.detach(flowContext);
-        return {
-          outcome: input.runScope.signal.aborted
-            ? RUN_OUTCOME.CANCELLED
-            : RUN_OUTCOME.COMPLETED,
+
+        mocks.buildAgentLaunchContext.mockResolvedValueOnce(context);
+        mocks.hasPersistedParent.mockResolvedValueOnce(false);
+        mocks.runFlowWithLifecycle.mockImplementationOnce(
+          async (
+            _context: unknown,
+            run: (liveHandle: typeof handle) => Promise<unknown>,
+          ) => run(handle),
+        );
+        mocks.runToolUseFlow.mockImplementationOnce(
+          async (
+            input: InterruptibleFlowInput,
+            _registry: unknown,
+            attachment: {
+              attach: (flowContext: TestFlowContext) => void;
+              detach: (flowContext: TestFlowContext) => void;
+            },
+          ) => {
+            expect(input.tools).toBe(tools);
+            const flowContext: TestFlowContext = {
+              interrupt: () => {
+                order.push('interrupt');
+                input.interrupt();
+              },
+            };
+            attachment.attach(flowContext);
+            input.takePendingFollowUps?.();
+            if (!input.runScope.signal.aborted) mocks.invokeModelOrTool();
+            attachment.detach(flowContext);
+            return {
+              outcome: input.runScope.signal.aborted
+                ? RUN_OUTCOME.CANCELLED
+                : RUN_OUTCOME.COMPLETED,
+            };
+          },
+        );
+
+        const snapshot = createToolUseResumeData({
+          executionId,
+          streamId,
+        });
+
+        const result = yield* resumeToolUseFromResumeData(snapshot, {
+          tools,
+          takePendingFollowUps: () => {
+            order.push('take');
+            return [];
+          },
+          isCancellationRequested: () => {
+            order.push('query');
+            expect(attachedContext).toBeDefined();
+            return true;
+          },
+          onCancellationAtFlowAttachment: () => order.push('cancel'),
+        });
+
+        expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+        expect(mocks.releaseOwnedExecutionLease).toHaveBeenCalledWith(
+          executionId,
+        );
+        expect(mocks.invokeModelOrTool).not.toHaveBeenCalled();
+        expect(order).toEqual([
+          'attach',
+          'query',
+          'cancel',
+          'interrupt',
+          'take',
+          'detach',
+        ]);
+      }),
+  );
+
+  it.effect(
+    'mirrors a mid-run model switch onto the persisted config only',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'e9421-model' as ExecutionId;
+        const streamId = 'stream-9421-model' as StreamTabId;
+        const ctx = buildResumeContext(executionId, streamId);
+        mocks.buildAgentLaunchContext.mockResolvedValueOnce(ctx);
+        mocks.hasPersistedParent.mockResolvedValueOnce(false);
+        mocks.runToolUseFlow.mockImplementationOnce(
+          async (input: ModelSwitchingFlowInput) => {
+            input.onModelChanged('next-model');
+            return { outcome: RUN_OUTCOME.COMPLETED };
+          },
+        );
+
+        yield* resumeToolUseFromResumeData(
+          createToolUseResumeData({ executionId, streamId }),
+        );
+
+        // The cell is the live model: usage accounting and the prompt-side MODEL
+        // variable read it directly, so the only remaining mirror is the
+        // persisted AgentConfig schema field; the seeded transient stays as-is.
+        expect(ctx.config.model).toBe('next-model');
+        expect(ctx.userVarChannels.MODEL).toBe('test-model');
+      }),
+  );
+
+  it.effect(
+    'carries a failed resumed flow result, error included, to the lifecycle',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'e9421-error' as ExecutionId;
+        const streamId = 'stream-9421-error' as StreamTabId;
+        const flowError = {
+          message: 'provider failed mid-resume',
+          userRetryable: true,
         };
-      },
-    );
+        mocks.buildAgentLaunchContext.mockResolvedValueOnce(
+          buildResumeContext(executionId, streamId),
+        );
+        mocks.hasPersistedParent.mockResolvedValueOnce(true);
+        mocks.runToolUseFlow.mockResolvedValueOnce({
+          outcome: RUN_OUTCOME.FAILED,
+          response: 'partial answer',
+          totalCostUsd: 0.25,
+          error: flowError,
+        });
 
-    const snapshot = createToolUseResumeData({
-      executionId,
-      streamId,
-    });
+        const result = yield* resumeToolUseFromResumeData(
+          createToolUseResumeData({ executionId, streamId }),
+        );
 
-    const result = await resumeToolUseFromResumeData(snapshot, {
-      tools,
-      takePendingFollowUps: () => {
-        order.push('take');
-        return [];
-      },
-      isCancellationRequested: () => {
-        order.push('query');
-        expect(attachedContext).toBeDefined();
-        return true;
-      },
-      onCancellationAtFlowAttachment: () => order.push('cancel'),
-    });
-
-    expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-    expect(mocks.releaseOwnedExecutionLease).toHaveBeenCalledWith(executionId);
-    expect(mocks.invokeModelOrTool).not.toHaveBeenCalled();
-    expect(order).toEqual([
-      'attach',
-      'query',
-      'cancel',
-      'interrupt',
-      'take',
-      'detach',
-    ]);
-  });
-
-  it('mirrors a mid-run model switch onto the persisted config only', async () => {
-    const executionId = 'e9421-model' as ExecutionId;
-    const streamId = 'stream-9421-model' as StreamTabId;
-    const ctx = buildResumeContext(executionId, streamId);
-    mocks.buildAgentLaunchContext.mockResolvedValueOnce(ctx);
-    mocks.hasPersistedParent.mockResolvedValueOnce(false);
-    mocks.runToolUseFlow.mockImplementationOnce(
-      async (input: ModelSwitchingFlowInput) => {
-        input.onModelChanged('next-model');
-        return { outcome: RUN_OUTCOME.COMPLETED };
-      },
-    );
-
-    await resumeToolUseFromResumeData(
-      createToolUseResumeData({ executionId, streamId }),
-    );
-
-    // The cell is the live model: usage accounting and the prompt-side MODEL
-    // variable read it directly, so the only remaining mirror is the
-    // persisted AgentConfig schema field; the seeded transient stays as-is.
-    expect(ctx.config.model).toBe('next-model');
-    expect(ctx.userVarChannels.MODEL).toBe('test-model');
-  });
-
-  it('carries a failed resumed flow result, error included, to the lifecycle', async () => {
-    const executionId = 'e9421-error' as ExecutionId;
-    const streamId = 'stream-9421-error' as StreamTabId;
-    const flowError = {
-      message: 'provider failed mid-resume',
-      userRetryable: true,
-    };
-    mocks.buildAgentLaunchContext.mockResolvedValueOnce(
-      buildResumeContext(executionId, streamId),
-    );
-    mocks.hasPersistedParent.mockResolvedValueOnce(true);
-    mocks.runToolUseFlow.mockResolvedValueOnce({
-      outcome: RUN_OUTCOME.FAILED,
-      response: 'partial answer',
-      totalCostUsd: 0.25,
-      error: flowError,
-    });
-
-    const result = await resumeToolUseFromResumeData(
-      createToolUseResumeData({ executionId, streamId }),
-    );
-
-    expect(result).toMatchObject({
-      category: 'toolUse',
-      outcome: RUN_OUTCOME.FAILED,
-      response: 'partial answer',
-      totalCostUsd: 0.25,
-      executionId,
-      streamId,
-      error: flowError,
-    });
-  });
+        expect(result).toMatchObject({
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.FAILED,
+          response: 'partial answer',
+          totalCostUsd: 0.25,
+          executionId,
+          streamId,
+          error: flowError,
+        });
+      }),
+  );
 });

--- a/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
@@ -1,7 +1,8 @@
+import { it } from '@effect/vitest';
 import { Cause, Effect, Exit, Fiber } from 'effect';
 import '@test/support/defaultSessionTestSetup';
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
 import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
@@ -94,194 +95,215 @@ describe('run lifecycle host-interaction cancel', () => {
     globalState: { [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true },
   });
 
-  it('settles a pending approval when the run completes', async () => {
-    const { session, ctx, executionId, streamId } = lifecycleCase();
-    const pending = requestApproval(
-      session,
-      'approval:completed-run',
-      streamId,
-    );
+  it.effect('settles a pending approval when the run completes', () =>
+    Effect.gen(function* () {
+      const { session, ctx, executionId, streamId } = lifecycleCase();
+      const pending = requestApproval(
+        session,
+        'approval:completed-run',
+        streamId,
+      );
 
-    await Effect.runPromise(
-      runFlowWithLifecycle(ctx, async () =>
+      yield* runFlowWithLifecycle(ctx, async () =>
         toolUseRun(executionId, streamId, RUN_OUTCOME.COMPLETED),
-      ),
-    );
+      );
 
-    await expectRunEndedRejection(pending);
-    session.dispose();
-  });
+      yield* Effect.promise(() => expectRunEndedRejection(pending));
+      session.dispose();
+    }),
+  );
 
-  it('settles and untracks the run after native interruption joins the active flow', async () => {
-    const { session, ctx, executionId, streamId } = lifecycleCase();
-    const started = createDeferred<AgentExecutionHandle>();
-    const aborted = createDeferred();
-    const released = createDeferred();
-    const stopped = createDeferred();
-    const fiber = Effect.runFork(
-      runFlowWithLifecycle(ctx, async (handle) => {
-        started.resolve(handle);
-        ctx.runScope.signal.addEventListener('abort', () => aborted.resolve(), {
-          once: true,
+  it.effect(
+    'settles and untracks the run after native interruption joins the active flow',
+    () =>
+      Effect.gen(function* () {
+        const { session, ctx, executionId, streamId } = lifecycleCase();
+        const started = createDeferred<AgentExecutionHandle>();
+        const aborted = createDeferred();
+        const released = createDeferred();
+        const stopped = createDeferred();
+        const fiber = yield* Effect.forkChild(
+          runFlowWithLifecycle(ctx, async (handle) => {
+            started.resolve(handle);
+            ctx.runScope.signal.addEventListener(
+              'abort',
+              () => aborted.resolve(),
+              { once: true },
+            );
+            await aborted.promise;
+            await released.promise;
+            stopped.resolve();
+            return toolUseRun(executionId, streamId, RUN_OUTCOME.CANCELLED);
+          }),
+        );
+        const handle = yield* Effect.promise(() => started.promise);
+        const interrupted = yield* Effect.forkChild(Fiber.interrupt(fiber));
+        yield* Effect.promise(() => aborted.promise);
+        expect(ctx.disposeTrace).not.toHaveBeenCalled();
+        released.resolve();
+        yield* Fiber.join(interrupted);
+        const exit = yield* Fiber.await(fiber);
+        expect(Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)).toBe(
+          true,
+        );
+        yield* Effect.promise(() => stopped.promise);
+        expect(session.executions.getHandle(executionId)).toBeUndefined();
+        expect(yield* handle.result).toMatchObject({
+          outcome: RUN_OUTCOME.CANCELLED,
         });
-        await aborted.promise;
-        await released.promise;
-        stopped.resolve();
-        return toolUseRun(executionId, streamId, RUN_OUTCOME.CANCELLED);
+        expect(ctx.disposeTrace).toHaveBeenCalledOnce();
+        session.dispose();
       }),
-    );
-    const handle = await started.promise;
-    const interrupted = Effect.runPromise(Fiber.interrupt(fiber));
-    await aborted.promise;
-    expect(ctx.disposeTrace).not.toHaveBeenCalled();
-    released.resolve();
-    await interrupted;
-    const exit = await Effect.runPromise(Fiber.await(fiber));
-    expect(Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)).toBe(true);
-    await stopped.promise;
-    expect(session.executions.getHandle(executionId)).toBeUndefined();
-    await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-    expect(ctx.disposeTrace).toHaveBeenCalledOnce();
-    session.dispose();
-  });
+  );
 
-  it('settles a pending approval when the runner throws', async () => {
-    const { session, ctx, streamId } = lifecycleCase();
-    const pending = requestApproval(session, 'approval:failed-run', streamId);
+  it.effect('settles a pending approval when the runner throws', () =>
+    Effect.gen(function* () {
+      const { session, ctx, streamId } = lifecycleCase();
+      const pending = requestApproval(session, 'approval:failed-run', streamId);
 
-    await expect(
-      Effect.runPromise(
+      const failure = yield* Effect.flip(
         runFlowWithLifecycle(ctx, async () => {
           throw new Error('flow exploded');
         }),
-      ),
-    ).rejects.toThrow('flow exploded');
+      );
+      expect(failure.message).toContain('flow exploded');
 
-    await expectRunEndedRejection(pending);
-    session.dispose();
-  });
+      yield* Effect.promise(() => expectRunEndedRejection(pending));
+      session.dispose();
+    }),
+  );
 
-  it('settles a pending approval when the run parks at WAITING', async () => {
-    const { session, ctx, executionId, streamId } = lifecycleCase();
-    const pending = requestApproval(session, 'approval:waiting-run', streamId);
-
-    const result = await Effect.runPromise(
-      runFlowWithLifecycle(ctx, async () =>
-        toolUseRun(executionId, streamId, STREAM_PHASE.WAITING),
-      ),
-    );
-
-    expect(result.outcome).toBe(STREAM_PHASE.WAITING);
-    await expectRunEndedRejection(pending);
-    session.dispose();
-  });
-
-  it("leaves another stream's pending approval untouched", async () => {
-    const { session, ctx, executionId, streamId } = lifecycleCase();
-    const otherStreamId = `${streamId}:sibling` as StreamTabId;
-    const sibling = requestApproval(
-      session,
-      'approval:sibling-stream',
-      otherStreamId,
-    );
-    let settled = false;
-    void sibling.then(() => {
-      settled = true;
-    });
-
-    await Effect.runPromise(
-      runFlowWithLifecycle(ctx, async () =>
-        toolUseRun(executionId, streamId, RUN_OUTCOME.COMPLETED),
-      ),
-    );
-    await Promise.resolve();
-
-    expect(settled).toBe(false);
-    session.dispose();
-    await expect(sibling).resolves.toMatchObject({ action: 'reject' });
-  });
-
-  it('cancels after the runner finishes unwinding, so a flow releases its follow-up queue first', async () => {
-    const { session, ctx, executionId, streamId } = lifecycleCase();
-    const order: string[] = [];
-    const cancelSpy = vi
-      .spyOn(session.interactions, 'cancel')
-      .mockImplementation(() => {
-        order.push('cancel');
-      });
-
-    try {
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => {
-          try {
-            return toolUseRun(executionId, streamId, RUN_OUTCOME.COMPLETED);
-          } finally {
-            order.push('flow-teardown');
-          }
-        }),
+  it.effect('settles a pending approval when the run parks at WAITING', () =>
+    Effect.gen(function* () {
+      const { session, ctx, executionId, streamId } = lifecycleCase();
+      const pending = requestApproval(
+        session,
+        'approval:waiting-run',
+        streamId,
       );
 
-      expect(order).toEqual(['flow-teardown', 'cancel']);
-      expect(cancelSpy).toHaveBeenCalledExactlyOnceWith({
-        streamId,
-        cause: 'Run ended.',
+      const result = yield* runFlowWithLifecycle(ctx, async () =>
+        toolUseRun(executionId, streamId, STREAM_PHASE.WAITING),
+      );
+
+      expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+      yield* Effect.promise(() => expectRunEndedRejection(pending));
+      session.dispose();
+    }),
+  );
+
+  it.effect("leaves another stream's pending approval untouched", () =>
+    Effect.gen(function* () {
+      const { session, ctx, executionId, streamId } = lifecycleCase();
+      const otherStreamId = `${streamId}:sibling` as StreamTabId;
+      const sibling = requestApproval(
+        session,
+        'approval:sibling-stream',
+        otherStreamId,
+      );
+      let settled = false;
+      void sibling.then(() => {
+        settled = true;
       });
-    } finally {
-      cancelSpy.mockRestore();
+
+      yield* runFlowWithLifecycle(ctx, async () =>
+        toolUseRun(executionId, streamId, RUN_OUTCOME.COMPLETED),
+      );
+      yield* Effect.promise(() => Promise.resolve());
+
+      expect(settled).toBe(false);
       session.dispose();
-    }
-  });
+      expect(yield* Effect.promise(() => sibling)).toMatchObject({
+        action: 'reject',
+      });
+    }),
+  );
 
-  it('is harmless after an interrupt-time cancel already settled the approval', async () => {
-    const { session, ctx, executionId, streamId } = lifecycleCase();
-    const pending = requestApproval(
-      session,
-      'approval:interrupted-run',
-      streamId,
-    );
+  it.effect(
+    'cancels after the runner finishes unwinding, so a flow releases its follow-up queue first',
+    () =>
+      Effect.gen(function* () {
+        const { session, ctx, executionId, streamId } = lifecycleCase();
+        const order: string[] = [];
+        const cancelSpy = vi
+          .spyOn(session.interactions, 'cancel')
+          .mockImplementation(() => {
+            order.push('cancel');
+          });
 
-    const result = await Effect.runPromise(
-      runFlowWithLifecycle(ctx, async () => {
-        // What `flowContext.interrupt` does while the flow is still live.
-        session.interactions.cancel({ streamId, cause: 'Run interrupted.' });
-        return toolUseRun(executionId, streamId, RUN_OUTCOME.CANCELLED);
+        try {
+          yield* runFlowWithLifecycle(ctx, async () => {
+            try {
+              return toolUseRun(executionId, streamId, RUN_OUTCOME.COMPLETED);
+            } finally {
+              order.push('flow-teardown');
+            }
+          });
+
+          expect(order).toEqual(['flow-teardown', 'cancel']);
+          expect(cancelSpy).toHaveBeenCalledExactlyOnceWith({
+            streamId,
+            cause: 'Run ended.',
+          });
+        } finally {
+          cancelSpy.mockRestore();
+          session.dispose();
+        }
       }),
-    );
+  );
 
-    expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-    // The interrupt-time cancel wins; the lifecycle's second cancel matches no
-    // pending request and cannot overwrite the settled cause.
-    await expect(pending).resolves.toEqual({
-      action: 'reject',
-      cause: 'Run interrupted.',
-    });
-    session.dispose();
-  });
+  it.effect(
+    'is harmless after an interrupt-time cancel already settled the approval',
+    () =>
+      Effect.gen(function* () {
+        const { session, ctx, executionId, streamId } = lifecycleCase();
+        const pending = requestApproval(
+          session,
+          'approval:interrupted-run',
+          streamId,
+        );
 
-  it('keeps the published outcome when a host adapter throws on cancel', async () => {
-    const { session, ctx, executionId, streamId } = lifecycleCase();
-    const detach = session.interactions.use({
-      cancel: () => {
-        throw new Error('host cancel boom');
-      },
-    });
+        const result = yield* runFlowWithLifecycle(ctx, async () => {
+          // What `flowContext.interrupt` does while the flow is still live.
+          session.interactions.cancel({ streamId, cause: 'Run interrupted.' });
+          return toolUseRun(executionId, streamId, RUN_OUTCOME.CANCELLED);
+        });
 
-    try {
-      await expect(
-        Effect.runPromise(
-          runFlowWithLifecycle(ctx, async () =>
-            toolUseRun(executionId, streamId, RUN_OUTCOME.COMPLETED),
-          ),
-        ),
-      ).resolves.toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
-      expect(session.status.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
-      // The disposal below must not resurrect the throwing adapter's failure.
-      expect(ctx.modelCell.handler.dispose).toHaveBeenCalledTimes(1);
-    } finally {
-      detach();
-      session.dispose();
-    }
-  });
+        expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+        // The interrupt-time cancel wins; the lifecycle's second cancel matches
+        // no pending request and cannot overwrite the settled cause.
+        expect(yield* Effect.promise(() => pending)).toEqual({
+          action: 'reject',
+          cause: 'Run interrupted.',
+        });
+        session.dispose();
+      }),
+  );
+
+  it.effect(
+    'keeps the published outcome when a host adapter throws on cancel',
+    () =>
+      Effect.gen(function* () {
+        const { session, ctx, executionId, streamId } = lifecycleCase();
+        const detach = session.interactions.use({
+          cancel: () => {
+            throw new Error('host cancel boom');
+          },
+        });
+
+        try {
+          expect(
+            yield* runFlowWithLifecycle(ctx, async () =>
+              toolUseRun(executionId, streamId, RUN_OUTCOME.COMPLETED),
+            ),
+          ).toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
+          expect(session.status.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
+          // The disposal below must not resurrect the throwing adapter's failure.
+          expect(ctx.modelCell.handler.dispose).toHaveBeenCalledTimes(1);
+        } finally {
+          detach();
+          session.dispose();
+        }
+      }),
+  );
 });

--- a/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 import { getExecutionRecords } from '@agent/storage';
 
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
@@ -94,40 +95,47 @@ describe('session description helpers', () => {
     ).toBe('Summarize the paper.');
   });
 
-  it('uses the exact workflow-agent description carried by launch context', async () => {
-    const session = createTestSession();
-    publishTestRunStart(session, 'stream-workflow', 'a0b0c1' as ExecutionId);
-    await session.settlePublications();
-    const recorded = recordSessionEvents(session);
-    const handler = mockToolUseAnswer('Correcting derivation signs');
+  it.live(
+    'uses the exact workflow-agent description carried by launch context',
+    () =>
+      Effect.gen(function* () {
+        const session = createTestSession();
+        publishTestRunStart(
+          session,
+          'stream-workflow',
+          'a0b0c1' as ExecutionId,
+        );
+        yield* Effect.promise(() => session.settlePublications());
+        const recorded = recordSessionEvents(session);
+        const handler = mockToolUseAnswer('Correcting derivation signs');
 
-    await runDescription(
-      'a0b0c1',
-      'stream-workflow',
-      session,
-      AgentCategory.Workflow,
-      'Corrects a draft',
-    );
+        yield* Effect.promise(() =>
+          runDescription(
+            'a0b0c1',
+            'stream-workflow',
+            session,
+            AgentCategory.Workflow,
+            'Corrects a draft',
+          ),
+        );
 
-    expect(handler.initializeMessages.mock.calls[0]?.[1]).toContain(
-      '<agent-purpose>Corrects a draft</agent-purpose>',
-    );
-    expect(
-      (
-        await Effect.runPromise(
-          getExecutionRecords(session, 'a0b0c1').readMeta(),
-        )
-      )?.description,
-    ).toBe('Correcting derivation signs');
-    await session.settlePublications();
-    expect(await recorded.read()).toMatchObject([
-      {
-        type: 'updateStreamDescription',
-        aggregateId: qualifyAggregateId('stream', 'stream-workflow'),
-        description: 'Correcting derivation signs',
-      },
-    ]);
-  });
+        expect(handler.initializeMessages.mock.calls[0]?.[1]).toContain(
+          '<agent-purpose>Corrects a draft</agent-purpose>',
+        );
+        expect(
+          (yield* getExecutionRecords(session, 'a0b0c1').readMeta())
+            ?.description,
+        ).toBe('Correcting derivation signs');
+        yield* Effect.promise(() => session.settlePublications());
+        expect(yield* Effect.promise(() => recorded.read())).toMatchObject([
+          {
+            type: 'updateStreamDescription',
+            aggregateId: qualifyAggregateId('stream', 'stream-workflow'),
+            description: 'Correcting derivation signs',
+          },
+        ]);
+      }),
+  );
 
   it('logs helper-model failures without rejecting the fire-and-forget call', async () => {
     const session = createTestSession();
@@ -160,29 +168,29 @@ describe('session description helpers', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('keeps generating compact descriptions for tool-use runs', async () => {
-    const session = createTestSession();
-    publishTestRunStart(session, 'stream-tool', 'a0b0c2' as ExecutionId);
-    await session.settlePublications();
-    const recorded = recordSessionEvents(session);
-    mockToolUseAnswer('Fixing proof typos');
+  it.live('keeps generating compact descriptions for tool-use runs', () =>
+    Effect.gen(function* () {
+      const session = createTestSession();
+      publishTestRunStart(session, 'stream-tool', 'a0b0c2' as ExecutionId);
+      yield* Effect.promise(() => session.settlePublications());
+      const recorded = recordSessionEvents(session);
+      mockToolUseAnswer('Fixing proof typos');
 
-    await runDescription('a0b0c2', 'stream-tool', session);
+      yield* Effect.promise(() =>
+        runDescription('a0b0c2', 'stream-tool', session),
+      );
 
-    expect(
-      (
-        await Effect.runPromise(
-          getExecutionRecords(session, 'a0b0c2').readMeta(),
-        )
-      )?.description,
-    ).toBe('Fixing proof typos');
-    await session.settlePublications();
-    expect(await recorded.read()).toMatchObject([
-      {
-        type: 'updateStreamDescription',
-        aggregateId: qualifyAggregateId('stream', 'stream-tool'),
-        description: 'Fixing proof typos',
-      },
-    ]);
-  });
+      expect(
+        (yield* getExecutionRecords(session, 'a0b0c2').readMeta())?.description,
+      ).toBe('Fixing proof typos');
+      yield* Effect.promise(() => session.settlePublications());
+      expect(yield* Effect.promise(() => recorded.read())).toMatchObject([
+        {
+          type: 'updateStreamDescription',
+          aggregateId: qualifyAggregateId('stream', 'stream-tool'),
+          description: 'Fixing proof typos',
+        },
+      ]);
+    }),
+  );
 });

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -1,7 +1,8 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 import '@test/support/defaultSessionTestSetup';
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 
 import {
   createRunContext,
@@ -124,143 +125,156 @@ describe('session isolation', () => {
     }
   });
 
-  it('the host-exit drain settles each session under its own root, outside any scope', async () => {
-    const sessionA = createTestSession({
-      roots: createFakeWorkspaceRoots({
-        workspacePath: '/papers/a',
-        storagePath: '/storage/a',
+  it.effect(
+    'the host-exit drain settles each session under its own root, outside any scope',
+    () =>
+      Effect.gen(function* () {
+        const sessionA = createTestSession({
+          roots: createFakeWorkspaceRoots({
+            workspacePath: '/papers/a',
+            storagePath: '/storage/a',
+          }),
+        });
+        const sessionB = createTestSession({
+          roots: createFakeWorkspaceRoots({
+            workspacePath: '/papers/b',
+            storagePath: '/storage/b',
+          }),
+        });
+        const live = [
+          [sessionA, 'a0da01' as ExecutionId],
+          [sessionB, 'b0db01' as ExecutionId],
+        ] as const;
+        const closures = live.map(([session, executionId]) =>
+          vi.spyOn(session, 'publishRunEvent').mockImplementation(() => {
+            expect(
+              runInSession(session, () => ownsExecutionLease(executionId)),
+            ).toBe(true);
+          }),
+        );
+        try {
+          for (const [session, executionId] of live) {
+            const streamId = `stream:${executionId}` as StreamTabId;
+            publishTestRunStart(session, streamId, executionId);
+            session.publish([
+              {
+                type: 'stage.start',
+                aggregateId: aggregateId('stream', streamId),
+                id: `stage:${executionId}`,
+                label: 'Running stage',
+              },
+            ]);
+            yield* Effect.promise(() =>
+              runInSession(session, async () => {
+                await acquireFreshExecutionLease(executionId);
+                session.executions.track(
+                  testExecutionHandle({
+                    executionId,
+                    parentStreamId: `stream:${executionId}` as StreamTabId,
+                    agent: 'assistant',
+                  }),
+                );
+              }),
+            );
+          }
+          // A quit handler runs in no session scope; the process roots answer
+          // there, and neither paper's lease is keyed under them.
+          expect(ownsExecutionLease('a0da01' as ExecutionId)).toBe(false);
+          yield* settleLiveSessionExecutions(new AbortController().signal);
+          for (const [index, [, executionId]] of live.entries()) {
+            expect(closures[index]).toHaveBeenCalledWith(
+              `stream:${executionId}`,
+              {
+                type: 'stage.end',
+                id: `stage:${executionId}`,
+                status: RUN_OUTCOME.CANCELLED,
+              },
+            );
+          }
+          expect(storageMocks.settledUnder.get('a0da01')).toBe('/storage/a');
+          expect(storageMocks.settledUnder.get('b0db01')).toBe('/storage/b');
+          for (const [session, executionId] of live) {
+            expect(
+              runInSession(session, () => ownsExecutionLease(executionId)),
+            ).toBe(false);
+          }
+        } finally {
+          sessionA.dispose();
+          sessionB.dispose();
+        }
       }),
-    });
-    const sessionB = createTestSession({
-      roots: createFakeWorkspaceRoots({
-        workspacePath: '/papers/b',
-        storagePath: '/storage/b',
-      }),
-    });
-    const live = [
-      [sessionA, 'a0da01' as ExecutionId],
-      [sessionB, 'b0db01' as ExecutionId],
-    ] as const;
-    const closures = live.map(([session, executionId]) =>
-      vi.spyOn(session, 'publishRunEvent').mockImplementation(() => {
+  );
+
+  it.effect('a handle interrupt target lands in the run session only', () =>
+    Effect.gen(function* () {
+      const sessionB = createTestSession();
+      const executionId = 'exec:iso-interrupt' as ExecutionId;
+      const streamId = 'stream:iso-interrupt' as StreamTabId;
+      const interrupt = vi.fn();
+      try {
+        const handle = testExecutionHandle({
+          executionId,
+          parentStreamId: streamId,
+          agent: 'assistant',
+        });
+        handle.attachInterruptHandler({ interrupt });
+        sessionB.executions.track(handle);
+
+        const stop = sessionB.executions.kill(executionId);
+        expect(stop.accepted).toBe(true);
+        yield* stop.settlement;
+        expect(interrupt).toHaveBeenCalledOnce();
         expect(
-          runInSession(session, () => ownsExecutionLease(executionId)),
-        ).toBe(true);
-      }),
-    );
-    try {
-      for (const [session, executionId] of live) {
-        const streamId = `stream:${executionId}` as StreamTabId;
-        publishTestRunStart(session, streamId, executionId);
-        session.publish([
-          {
-            type: 'stage.start',
-            aggregateId: aggregateId('stream', streamId),
-            id: `stage:${executionId}`,
-            label: 'Running stage',
-          },
-        ]);
-        await runInSession(session, async () => {
-          await acquireFreshExecutionLease(executionId);
-          session.executions.track(
-            testExecutionHandle({
+          defaultSession().executions.getHandle(executionId),
+        ).toBeUndefined();
+      } finally {
+        sessionB.dispose();
+      }
+    }),
+  );
+
+  it.effect(
+    'runFlowWithLifecycle tracks the handle in the run session, not the default',
+    () =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() =>
+          installPlatform({
+            globalState: { [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true },
+          }),
+        );
+        const executionId = 'e15001' as ExecutionId;
+        const streamId = 'stream:iso-track' as StreamTabId;
+        const sessionB = createTestSession();
+        const ctx = createTestLaunchContext({
+          executionId,
+          streamId,
+          session: sessionB,
+        });
+
+        try {
+          yield* runFlowWithLifecycle(ctx, async () => {
+            // Mid-run: the handle is registered in session B's registry only.
+            expect(sessionB.executions.getHandle(executionId)).toBeDefined();
+            expect(
+              defaultSession().executions.getHandle(executionId),
+            ).toBeUndefined();
+            return {
+              category: 'toolUse',
+              outcome: RUN_OUTCOME.COMPLETED,
               executionId,
-              parentStreamId: `stream:${executionId}` as StreamTabId,
-              agent: 'assistant',
-            }),
-          );
-        });
-      }
-      // A quit handler runs in no session scope; the process roots answer
-      // there, and neither paper's lease is keyed under them.
-      expect(ownsExecutionLease('a0da01' as ExecutionId)).toBe(false);
-      await Effect.runPromise(
-        settleLiveSessionExecutions(new AbortController().signal),
-      );
-      for (const [index, [, executionId]] of live.entries()) {
-        expect(closures[index]).toHaveBeenCalledWith(`stream:${executionId}`, {
-          type: 'stage.end',
-          id: `stage:${executionId}`,
-          status: RUN_OUTCOME.CANCELLED,
-        });
-      }
-      expect(storageMocks.settledUnder.get('a0da01')).toBe('/storage/a');
-      expect(storageMocks.settledUnder.get('b0db01')).toBe('/storage/b');
-      for (const [session, executionId] of live) {
-        expect(
-          runInSession(session, () => ownsExecutionLease(executionId)),
-        ).toBe(false);
-      }
-    } finally {
-      sessionA.dispose();
-      sessionB.dispose();
-    }
-  });
+              streamId,
+            };
+          });
 
-  it('a handle interrupt target lands in the run session only', async () => {
-    const sessionB = createTestSession();
-    const executionId = 'exec:iso-interrupt' as ExecutionId;
-    const streamId = 'stream:iso-interrupt' as StreamTabId;
-    const interrupt = vi.fn();
-    try {
-      const handle = testExecutionHandle({
-        executionId,
-        parentStreamId: streamId,
-        agent: 'assistant',
-      });
-      handle.attachInterruptHandler({ interrupt });
-      sessionB.executions.track(handle);
-
-      const stop = sessionB.executions.kill(executionId);
-      expect(stop.accepted).toBe(true);
-      await Effect.runPromise(stop.settlement);
-      expect(interrupt).toHaveBeenCalledOnce();
-      expect(
-        defaultSession().executions.getHandle(executionId),
-      ).toBeUndefined();
-    } finally {
-      sessionB.dispose();
-    }
-  });
-
-  it('runFlowWithLifecycle tracks the handle in the run session, not the default', async () => {
-    await installPlatform({
-      globalState: { [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true },
-    });
-    const executionId = 'e15001' as ExecutionId;
-    const streamId = 'stream:iso-track' as StreamTabId;
-    const sessionB = createTestSession();
-    const ctx = createTestLaunchContext({
-      executionId,
-      streamId,
-      session: sessionB,
-    });
-
-    try {
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => {
-          // Mid-run: the handle is registered in session B's registry only.
-          expect(sessionB.executions.getHandle(executionId)).toBeDefined();
+          // After completion the run session untracked it; default never saw it.
+          expect(sessionB.executions.getHandle(executionId)).toBeUndefined();
           expect(
             defaultSession().executions.getHandle(executionId),
           ).toBeUndefined();
-          return {
-            category: 'toolUse',
-            outcome: RUN_OUTCOME.COMPLETED,
-            executionId,
-            streamId,
-          };
-        }),
-      );
-
-      // After completion the run session untracked it; default never saw it.
-      expect(sessionB.executions.getHandle(executionId)).toBeUndefined();
-      expect(
-        defaultSession().executions.getHandle(executionId),
-      ).toBeUndefined();
-    } finally {
-      clearStreamStatusForTest(sessionB.status, streamId);
-      sessionB.dispose();
-    }
-  });
+        } finally {
+          clearStreamStatusForTest(sessionB.status, streamId);
+          sessionB.dispose();
+        }
+      }),
+  );
 });

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -1,7 +1,8 @@
 import { Effect } from 'effect';
 import '@test/support/defaultSessionTestSetup';
 
-import { describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { describe, expect, vi } from 'vitest';
 
 import { TraceEmitter, type ResultEvent } from '@agent/trace';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
@@ -91,71 +92,75 @@ describe('terminal result event', () => {
     globalState: { [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true },
   });
 
-  it('emits exactly one completed result on a successful run', async () => {
-    const { ctx, streamStatus, results } = setupResultCase();
-    try {
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => completedRun(ctx)),
-      );
-      expectSingleResult(results, ctx, {
-        outcome: 'completed',
-        category: 'toolUse',
-        isSubagent: false,
-      });
-      expect(results[0].error).toBeUndefined();
-      // One disposal owner for the run's model handler: the cell closes
-      // whichever handler is live when the run ends.
-      expect(ctx.modelCell.handler.dispose).toHaveBeenCalledTimes(1);
-    } finally {
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-    }
-  });
+  it.effect('emits exactly one completed result on a successful run', () =>
+    Effect.gen(function* () {
+      const { ctx, streamStatus, results } = setupResultCase();
+      try {
+        yield* runFlowWithLifecycle(ctx, async () => completedRun(ctx));
+        expectSingleResult(results, ctx, {
+          outcome: 'completed',
+          category: 'toolUse',
+          isSubagent: false,
+        });
+        expect(results[0].error).toBeUndefined();
+        // One disposal owner for the run's model handler: the cell closes
+        // whichever handler is live when the run ends.
+        expect(ctx.modelCell.handler.dispose).toHaveBeenCalledTimes(1);
+      } finally {
+        clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+      }
+    }),
+  );
 
-  it('emits the completed result even if ending the parent stage throws', async () => {
-    const { ctx, streamStatus, results } = setupResultCase();
-    vi.spyOn(ctx.parentStage, 'end').mockImplementation(() => {
-      throw new Error('stage listener boom');
-    });
+  it.effect(
+    'emits the completed result even if ending the parent stage throws',
+    () =>
+      Effect.gen(function* () {
+        const { ctx, streamStatus, results } = setupResultCase();
+        vi.spyOn(ctx.parentStage, 'end').mockImplementation(() => {
+          throw new Error('stage listener boom');
+        });
 
-    try {
-      await expect(
-        Effect.runPromise(
-          runFlowWithLifecycle(ctx, async () => completedRun(ctx)),
-        ),
-      ).resolves.toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
+        try {
+          expect(
+            yield* runFlowWithLifecycle(ctx, async () => completedRun(ctx)),
+          ).toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
 
-      expectSingleResult(results, ctx, { outcome: 'completed' });
-    } finally {
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-    }
-  });
+          expectSingleResult(results, ctx, { outcome: 'completed' });
+        } finally {
+          clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+        }
+      }),
+  );
 
-  it('exposes the per-run handle via onRun and settles handle.result', async () => {
-    const { logger, ctx, streamStatus } = setupResultCase();
-    let handle: AgentRunHandle | undefined;
-    try {
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => completedRun(ctx), {
-          onRun: (h) => {
-            handle = h;
-          },
-        }),
-      );
-      expect(handle).toBeDefined();
-      // The handle carries the run's trace channel for run-scoped subscribers.
-      expect(handle?.trace).toBe(logger);
-      // `result` settles with the same terminal event (always resolves).
-      await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
-        type: 'result',
-        outcome: 'completed',
-        executionId: ctx.runScope.executionId,
-      });
-    } finally {
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-    }
-  });
+  it.effect(
+    'exposes the per-run handle via onRun and settles handle.result',
+    () =>
+      Effect.gen(function* () {
+        const { logger, ctx, streamStatus } = setupResultCase();
+        let handle: AgentRunHandle | undefined;
+        try {
+          yield* runFlowWithLifecycle(ctx, async () => completedRun(ctx), {
+            onRun: (h) => {
+              handle = h;
+            },
+          });
+          expect(handle).toBeDefined();
+          // The handle carries the run's trace channel for run-scoped subscribers.
+          expect(handle?.trace).toBe(logger);
+          // `result` settles with the same terminal event (always resolves).
+          expect(yield* handle!.result).toMatchObject({
+            type: 'result',
+            outcome: 'completed',
+            executionId: ctx.runScope.executionId,
+          });
+        } finally {
+          clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+        }
+      }),
+  );
 
-  it.each([
+  it.effect.each([
     {
       name: 'throws synchronously',
       onRun: () => {
@@ -168,162 +173,184 @@ describe('terminal result event', () => {
         throw new Error('onRun async boom');
       },
     },
-  ])('keeps running when onRun $name', async ({ onRun }) => {
-    const { ctx, streamStatus, results } = setupResultCase();
-    try {
-      await expect(
-        Effect.runPromise(
-          runFlowWithLifecycle(ctx, async () => completedRun(ctx), { onRun }),
-        ),
-      ).resolves.toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
-      await Promise.resolve();
-
-      expectSingleResult(results, ctx, { outcome: 'completed' });
-    } finally {
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-    }
-  });
-
-  it('keeps the failed subagent result when the onError delivery hook throws', async () => {
-    const { ctx, streamStatus, results } = setupResultCase();
-    try {
-      await expect(
-        Effect.runPromise(
-          runFlowWithLifecycle(ctx, explodedRun, {
-            isSubagent: true,
-            onError: () => {
-              throw new Error('delivery hook boom');
-            },
+  ])('keeps running when onRun $name', ({ onRun }) =>
+    Effect.gen(function* () {
+      const { ctx, streamStatus, results } = setupResultCase();
+      try {
+        expect(
+          yield* runFlowWithLifecycle(ctx, async () => completedRun(ctx), {
+            onRun,
           }),
-        ),
-      ).resolves.toMatchObject({ outcome: RUN_OUTCOME.FAILED });
+        ).toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
+        yield* Effect.promise(() => Promise.resolve());
 
-      expectSingleResult(results, ctx, { outcome: 'failed' });
-    } finally {
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-    }
-  });
+        expectSingleResult(results, ctx, { outcome: 'completed' });
+      } finally {
+        clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+      }
+    }),
+  );
 
-  it('emits the failed result even if ending the parent stage throws', async () => {
-    const { ctx, streamStatus, results } = setupResultCase();
-    vi.spyOn(ctx.parentStage, 'end').mockImplementation(() => {
-      throw new Error('stage listener boom');
-    });
-
-    try {
-      await expect(
-        Effect.runPromise(runFlowWithLifecycle(ctx, explodedRun)),
-      ).rejects.toThrow('model exploded');
-
-      expectSingleResult(results, ctx, { outcome: 'failed' });
-    } finally {
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-    }
-  });
-
-  it('settles handle.result as failed on a thrown run (always resolves)', async () => {
-    const { ctx, streamStatus } = setupResultCase();
-    let handle: AgentRunHandle | undefined;
-    try {
-      await expect(
-        Effect.runPromise(
-          runFlowWithLifecycle(
-            ctx,
-            async () => {
-              throw new Error('boom');
-            },
-            {
-              onRun: (h) => {
-                handle = h;
+  it.effect(
+    'keeps the failed subagent result when the onError delivery hook throws',
+    () =>
+      Effect.gen(function* () {
+        const { ctx, streamStatus, results } = setupResultCase();
+        try {
+          expect(
+            yield* runFlowWithLifecycle(ctx, explodedRun, {
+              isSubagent: true,
+              onError: () => {
+                throw new Error('delivery hook boom');
               },
-            },
-          ),
-        ),
-      ).rejects.toThrow('boom');
-      await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
-        type: 'result',
-        outcome: 'failed',
-      });
-    } finally {
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-    }
-  });
+            }),
+          ).toMatchObject({ outcome: RUN_OUTCOME.FAILED });
 
-  it('maps a returned cancellation to a cancelled result (sibling of failed)', async () => {
-    const { ctx, streamStatus, results } = setupResultCase();
-    try {
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => ({
-          category: 'toolUse',
-          outcome: RUN_OUTCOME.CANCELLED,
-          executionId: ctx.runScope.executionId,
-          streamId: ctx.runScope.streamId,
-        })),
-      );
-      expectSingleResult(results, ctx, { outcome: 'cancelled' });
-    } finally {
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-    }
-  });
+          expectSingleResult(results, ctx, { outcome: 'failed' });
+        } finally {
+          clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+        }
+      }),
+  );
 
-  it('emits a cancelled result with kind=abort on a thrown abort', async () => {
-    const { ctx, streamStatus, results } = setupResultCase();
-    try {
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => {
+  it.effect(
+    'emits the failed result even if ending the parent stage throws',
+    () =>
+      Effect.gen(function* () {
+        const { ctx, streamStatus, results } = setupResultCase();
+        vi.spyOn(ctx.parentStage, 'end').mockImplementation(() => {
+          throw new Error('stage listener boom');
+        });
+
+        try {
+          expect(
+            (yield* Effect.flip(runFlowWithLifecycle(ctx, explodedRun)))
+              .message,
+          ).toContain('model exploded');
+
+          expectSingleResult(results, ctx, { outcome: 'failed' });
+        } finally {
+          clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+        }
+      }),
+  );
+
+  it.effect(
+    'settles handle.result as failed on a thrown run (always resolves)',
+    () =>
+      Effect.gen(function* () {
+        const { ctx, streamStatus } = setupResultCase();
+        let handle: AgentRunHandle | undefined;
+        try {
+          expect(
+            (yield* Effect.flip(
+              runFlowWithLifecycle(
+                ctx,
+                async () => {
+                  throw new Error('boom');
+                },
+                {
+                  onRun: (h) => {
+                    handle = h;
+                  },
+                },
+              ),
+            )).message,
+          ).toContain('boom');
+          expect(yield* handle!.result).toMatchObject({
+            type: 'result',
+            outcome: 'failed',
+          });
+        } finally {
+          clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+        }
+      }),
+  );
+
+  it.effect(
+    'maps a returned cancellation to a cancelled result (sibling of failed)',
+    () =>
+      Effect.gen(function* () {
+        const { ctx, streamStatus, results } = setupResultCase();
+        try {
+          yield* runFlowWithLifecycle(ctx, async () => ({
+            category: 'toolUse',
+            outcome: RUN_OUTCOME.CANCELLED,
+            executionId: ctx.runScope.executionId,
+            streamId: ctx.runScope.streamId,
+          }));
+          expectSingleResult(results, ctx, { outcome: 'cancelled' });
+        } finally {
+          clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+        }
+      }),
+  );
+
+  it.effect('emits a cancelled result with kind=abort on a thrown abort', () =>
+    Effect.gen(function* () {
+      const { ctx, streamStatus, results } = setupResultCase();
+      try {
+        yield* runFlowWithLifecycle(ctx, async () => {
           throw new DOMException('Request aborted', 'AbortError');
-        }),
+        });
+        expectSingleResult(results, ctx, { outcome: 'cancelled' });
+        expect(results[0].error?.kind).toBe('abort');
+      } finally {
+        clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+      }
+    }),
+  );
+
+  it.effect(
+    'emits a failed result with usage on an unexpected throw after a round',
+    () =>
+      Effect.gen(function* () {
+        const { ctx, streamStatus, results } = setupResultCase();
+        // Record one round of usage so the failed result still carries totals.
+        yield* Effect.promise(() =>
+          ctx.usageMonitor.recordUsage(AgentRunStateSnapshotSchema.parse({})),
+        );
+        try {
+          expect(
+            (yield* Effect.flip(runFlowWithLifecycle(ctx, explodedRun)))
+              .message,
+          ).toContain('model exploded');
+          expectSingleResult(results, ctx, { outcome: 'failed' });
+          expect(results[0].error?.kind).toBeDefined();
+          expect(results[0].usage).toBeDefined();
+        } finally {
+          clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+        }
+      }),
+  );
+
+  it.effect('marks subagent runs and bridges results to session.onResult', () =>
+    Effect.gen(function* () {
+      const session = createTestSession();
+      const onResult = vi.fn();
+      const { logger, ctx, streamStatus } = setupResultCase(session);
+      publishTestRunStart(
+        session,
+        ctx.runScope.streamId,
+        ctx.runScope.executionId,
       );
-      expectSingleResult(results, ctx, { outcome: 'cancelled' });
-      expect(results[0].error?.kind).toBe('abort');
-    } finally {
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-    }
-  });
-
-  it('emits a failed result with usage on an unexpected throw after a round', async () => {
-    const { ctx, streamStatus, results } = setupResultCase();
-    // Record one round of usage so the failed result still carries totals.
-    await ctx.usageMonitor.recordUsage(AgentRunStateSnapshotSchema.parse({}));
-    try {
-      await expect(
-        Effect.runPromise(runFlowWithLifecycle(ctx, explodedRun)),
-      ).rejects.toThrow('model exploded');
-      expectSingleResult(results, ctx, { outcome: 'failed' });
-      expect(results[0].error?.kind).toBeDefined();
-      expect(results[0].usage).toBeDefined();
-    } finally {
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-    }
-  });
-
-  it('marks subagent runs and bridges results to session.onResult', async () => {
-    const session = createTestSession();
-    const onResult = vi.fn();
-    const { logger, ctx, streamStatus } = setupResultCase(session);
-    publishTestRunStart(
-      session,
-      ctx.runScope.streamId,
-      ctx.runScope.executionId,
-    );
-    const detach = session.attachRunTrace(logger, ctx.runScope.streamId);
-    session.onResult(onResult);
-    try {
-      await Effect.runPromise(
-        runFlowWithLifecycle(ctx, async () => completedRun(ctx), {
+      const detach = session.attachRunTrace(logger, ctx.runScope.streamId);
+      session.onResult(onResult);
+      try {
+        yield* runFlowWithLifecycle(ctx, async () => completedRun(ctx), {
           isSubagent: true,
-        }),
-      );
-      await session.settlePublications();
-      expect(onResult).toHaveBeenCalledOnce();
-      expect(onResult.mock.calls[0][0]).toMatchObject({
-        type: 'result',
-        isSubagent: true,
-      });
-    } finally {
-      detach();
-      clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
-      session.dispose();
-    }
-  });
+        });
+        yield* Effect.promise(() => session.settlePublications());
+        expect(onResult).toHaveBeenCalledOnce();
+        expect(onResult.mock.calls[0][0]).toMatchObject({
+          type: 'result',
+          isSubagent: true,
+        });
+      } finally {
+        detach();
+        clearStreamStatusForTest(streamStatus, ctx.runScope.streamId);
+        session.dispose();
+      }
+    }),
+  );
 });

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -1,6 +1,7 @@
 import '@test/support/defaultSessionTestSetup';
 
-import { describe, expect, it } from 'vitest';
+import { it } from '@effect/vitest';
+import { describe, expect } from 'vitest';
 import { Effect } from 'effect';
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
@@ -22,77 +23,87 @@ import { createRecordingHost } from '../progressTestUtils';
 const plan: Plan = { objective: 'Scope session-owned state.' };
 
 describe('session-owned transcripts and follow-up queues', () => {
-  it("writes run trace entries to the launching session's transcript store only", async () => {
-    const launching = createTestSession();
-    const sibling = createTestSession();
-    const streamId = 'stream:session-transcript-owner' as StreamTabId;
+  it.effect(
+    "writes run trace entries to the launching session's transcript store only",
+    () =>
+      Effect.gen(function* () {
+        const launching = createTestSession();
+        const sibling = createTestSession();
+        const streamId = 'stream:session-transcript-owner' as StreamTabId;
 
-    try {
-      publishTestRunStart(launching, streamId);
-      await launching.settlePublications();
-      const lease = await Effect.runPromise(
-        launching.transcripts.acquireRunResidency(streamId, streamId),
+        try {
+          publishTestRunStart(launching, streamId);
+          yield* Effect.promise(() => launching.settlePublications());
+          const lease = yield* launching.transcripts.acquireRunResidency(
+            streamId,
+            streamId,
+          );
+          const handle = createRunTrace(lease);
+          const detach = launching.attachRunTrace(handle.trace, streamId);
+          try {
+            const output = handle.trace.openStream(
+              MESSAGE_TYPES.MODEL_RESPONSE,
+            );
+            output.append('owned by launching session');
+            output.finalize();
+            yield* Effect.promise(() => launching.settlePublications());
+
+            expect(
+              launching.transcripts
+                .get(streamId)
+                ?.getRange(0)
+                .map((entry) => entry.text),
+            ).toEqual(['owned by launching session']);
+            expect(sibling.transcripts.get(streamId)).toBeUndefined();
+            expect(defaultSession().transcripts.get(streamId)).toBeUndefined();
+          } finally {
+            detach();
+            handle.dispose();
+          }
+        } finally {
+          launching.dispose();
+          sibling.dispose();
+        }
+      }),
+  );
+
+  it.effect('commits partial streaming text when status closes the run', () =>
+    Effect.gen(function* () {
+      const session = createTestSession();
+      const streamId = 'stream:partial-status-close' as StreamTabId;
+      publishTestRunStart(session, streamId);
+      yield* Effect.promise(() => session.settlePublications());
+      const lease = yield* session.transcripts.acquireRunResidency(
+        streamId,
+        streamId,
       );
       const handle = createRunTrace(lease);
-      const detach = launching.attachRunTrace(handle.trace, streamId);
+      const detach = session.attachRunTrace(handle.trace, streamId);
       try {
         const output = handle.trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
-        output.append('owned by launching session');
-        output.finalize();
-        await launching.settlePublications();
-
+        output.append('partial text');
+        session.publishStatus({
+          type: 'status',
+          streamId,
+          phase: STREAM_PHASE.WAITING,
+          cause: 'wait',
+        });
+        yield* Effect.promise(() => session.settlePublications());
+        const entries = yield* session.transcripts.readEntries(streamId);
         expect(
-          launching.transcripts
-            .get(streamId)
-            ?.getRange(0)
+          entries
+            .filter(
+              (entry) => entry.messageType === MESSAGE_TYPES.MODEL_RESPONSE,
+            )
             .map((entry) => entry.text),
-        ).toEqual(['owned by launching session']);
-        expect(sibling.transcripts.get(streamId)).toBeUndefined();
-        expect(defaultSession().transcripts.get(streamId)).toBeUndefined();
+        ).toEqual(['partial text']);
       } finally {
         detach();
         handle.dispose();
+        session.dispose();
       }
-    } finally {
-      launching.dispose();
-      sibling.dispose();
-    }
-  });
-
-  it('commits partial streaming text when status closes the run', async () => {
-    const session = createTestSession();
-    const streamId = 'stream:partial-status-close' as StreamTabId;
-    publishTestRunStart(session, streamId);
-    await session.settlePublications();
-    const lease = await Effect.runPromise(
-      session.transcripts.acquireRunResidency(streamId, streamId),
-    );
-    const handle = createRunTrace(lease);
-    const detach = session.attachRunTrace(handle.trace, streamId);
-    try {
-      const output = handle.trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
-      output.append('partial text');
-      session.publishStatus({
-        type: 'status',
-        streamId,
-        phase: STREAM_PHASE.WAITING,
-        cause: 'wait',
-      });
-      await session.settlePublications();
-      const entries = await Effect.runPromise(
-        session.transcripts.readEntries(streamId),
-      );
-      expect(
-        entries
-          .filter((entry) => entry.messageType === MESSAGE_TYPES.MODEL_RESPONSE)
-          .map((entry) => entry.text),
-      ).toEqual(['partial text']);
-    } finally {
-      detach();
-      handle.dispose();
-      session.dispose();
-    }
-  });
+    }),
+  );
 
   it('keeps same-stream follow-up queues isolated by session', () => {
     const a = createTestSession();
@@ -155,48 +166,48 @@ describe('approval reset scope', () => {
 });
 
 describe('sendFollowUp host-path session routing', () => {
-  it('resolves the follow-up target against the passed session, not the process default', async () => {
-    const processSession = createTestSession();
-    const parentStream = 'stream:fu-parent' as StreamTabId;
+  it.effect(
+    'resolves the follow-up target against the passed session, not the process default',
+    () =>
+      Effect.gen(function* () {
+        const processSession = createTestSession();
+        const parentStream = 'stream:fu-parent' as StreamTabId;
 
-    try {
-      // A child run is tracked in the explicit process session, as desktop
-      // composition does instead of using the module default.
-      processSession.executions.track(
-        testExecutionHandle({
-          executionId: 'exec:fu-child',
-          parentStreamId: parentStream,
-          childStreamId: 'stream:fu-child' as StreamTabId,
-          agent: 'orchestrator',
-        }),
-      );
+        try {
+          // A child run is tracked in the explicit process session, as desktop
+          // composition does instead of using the module default.
+          processSession.executions.track(
+            testExecutionHandle({
+              executionId: 'exec:fu-child',
+              parentStreamId: parentStream,
+              childStreamId: 'stream:fu-child' as StreamTabId,
+              agent: 'orchestrator',
+            }),
+          );
 
-      // A host-path caller (outside any run ALS, like the desktop IPC handler)
-      // that passes its process session sees the live child and queues.
-      await expect(
-        Effect.runPromise(
-          submitFollowUp(parentStream, 'continue', {
-            session: processSession,
-            resumePort: { tryResumeStream: async () => false },
-          }),
-        ),
-      ).resolves.toEqual({ status: 'queued', wake: 'failed' });
+          // A host-path caller (outside any run ALS, like the desktop IPC handler)
+          // that passes its process session sees the live child and queues.
+          expect(
+            yield* submitFollowUp(parentStream, 'continue', {
+              session: processSession,
+              resumePort: { tryResumeStream: async () => false },
+            }),
+          ).toEqual({ status: 'queued', wake: 'failed' });
 
-      // The default session does not own this run; selecting the actual
-      // session is required for desktop follow-up delivery.
-      await expect(
-        Effect.runPromise(
-          submitFollowUp(parentStream, 'continue', {
-            session: defaultSession(),
-          }),
-        ),
-      ).resolves.toEqual({
-        status: 'failed',
-        reason: 'not_resumable',
-      });
-    } finally {
-      processSession.followUps.terminalize(parentStream);
-      processSession.dispose();
-    }
-  });
+          // The default session does not own this run; selecting the actual
+          // session is required for desktop follow-up delivery.
+          expect(
+            yield* submitFollowUp(parentStream, 'continue', {
+              session: defaultSession(),
+            }),
+          ).toEqual({
+            status: 'failed',
+            reason: 'not_resumable',
+          });
+        } finally {
+          processSession.followUps.terminalize(parentStream);
+          processSession.dispose();
+        }
+      }),
+  );
 });

--- a/src/test-kernel/agent/runtime/agentLoad.vitest.ts
+++ b/src/test-kernel/agent/runtime/agentLoad.vitest.ts
@@ -1,12 +1,12 @@
 import { strict as assert } from 'node:assert';
 import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 import {
   afterAll,
   beforeAll,
   describe,
-  it,
   beforeEach,
   afterEach,
   vi,
@@ -290,10 +290,12 @@ describe('inline agent definitions', () => {
     }
   });
 
-  it('survives a catalog refresh that rebuilds the cache', async () => {
-    await Effect.runPromise(refresh({ includeRemote: false }));
-    assert.strictEqual(getAgent('inline:scratchpad')?.source, 'inline');
-  });
+  it.live('survives a catalog refresh that rebuilds the cache', () =>
+    Effect.gen(function* () {
+      yield* refresh({ includeRemote: false });
+      assert.strictEqual(getAgent('inline:scratchpad')?.source, 'inline');
+    }),
+  );
 
   it('accepts a registration made after the initial load', () => {
     registerInlineAgents([
@@ -403,30 +405,32 @@ describe('inline agent definitions', () => {
     );
   });
 
-  it('does not expose stored entry arrays through the live registry', async () => {
-    registerInlineAgents([
-      {
-        name: 'immutableEntry',
-        settings: {
-          agentCategory: AgentCategory.ToolUse,
-          tools: ['grep'],
-          defaultOutputFiles: ['report.md'],
+  it.live('does not expose stored entry arrays through the live registry', () =>
+    Effect.gen(function* () {
+      registerInlineAgents([
+        {
+          name: 'immutableEntry',
+          settings: {
+            agentCategory: AgentCategory.ToolUse,
+            tools: ['grep'],
+            defaultOutputFiles: ['report.md'],
+          },
+          prompts: {},
         },
-        prompts: {},
-      },
-    ]);
+      ]);
 
-    const first = getAgent('inline:immutableEntry');
-    assert.ok(first?.tools);
-    assert.ok(first.defaultOutputFiles);
-    first.tools.push('bash');
-    first.defaultOutputFiles.push('mutated.md');
+      const first = getAgent('inline:immutableEntry');
+      assert.ok(first?.tools);
+      assert.ok(first.defaultOutputFiles);
+      first.tools.push('bash');
+      first.defaultOutputFiles.push('mutated.md');
 
-    await Effect.runPromise(refresh({ includeRemote: false }));
-    const restored = getAgent('inline:immutableEntry');
-    assert.deepStrictEqual(restored?.tools, ['grep']);
-    assert.deepStrictEqual(restored?.defaultOutputFiles, ['report.md']);
-  });
+      yield* refresh({ includeRemote: false });
+      const restored = getAgent('inline:immutableEntry');
+      assert.deepStrictEqual(restored?.tools, ['grep']);
+      assert.deepStrictEqual(restored?.defaultOutputFiles, ['report.md']);
+    }),
+  );
 
   it('preserves runtime schemas in object-form tool definitions', async () => {
     const runtimeSchema = z.strictObject({ query: z.string() });

--- a/src/test-kernel/agent/storage/ChildRunOutput.vitest.ts
+++ b/src/test-kernel/agent/storage/ChildRunOutput.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { beforeEach, afterEach, describe, expect } from 'vitest';
 
 import {
   clearStoreCache,
@@ -57,17 +58,17 @@ function completedWorkflowResult(absolutePath: string): ResultMeta {
   };
 }
 
-async function persistCompletedChild(
+function persistCompletedChild(
   parentId: ExecutionId = parentExecutionId,
-): Promise<string> {
-  const absolutePath = StorageFS.fullPath(
-    `executions/${childExecutionId}/${relativePath}`,
-  );
-  const parentStreamId = `stream-${parentId}` as StreamTabId;
-  publishTestRunStart(session, parentStreamId, parentId);
-  await session.settlePublications();
-  await Effect.runPromise(
-    session.commit([
+): Effect.Effect<string, Error> {
+  return Effect.gen(function* () {
+    const absolutePath = StorageFS.fullPath(
+      `executions/${childExecutionId}/${relativePath}`,
+    );
+    const parentStreamId = `stream-${parentId}` as StreamTabId;
+    publishTestRunStart(session, parentStreamId, parentId);
+    yield* Effect.promise(() => session.settlePublications());
+    yield* session.commit([
       {
         type: 'run.start',
         aggregateId: aggregateId('stream', `stream-${childExecutionId}`),
@@ -78,84 +79,102 @@ async function persistCompletedChild(
         isRemote: false,
         userFollowUpSupport: 'unsupported',
       },
-    ]),
-  );
-  await Effect.runPromise(
-    getExecutionRecords(session, childExecutionId).writeResultMeta(
+    ]);
+    yield* getExecutionRecords(session, childExecutionId).writeResultMeta(
       completedWorkflowResult(absolutePath),
-    ),
-  );
-  await StorageFS.ensureDir(`executions/${childExecutionId}/r1`);
-  await StorageFS.write(
-    `executions/${childExecutionId}/${relativePath}`,
-    'draft',
-  );
-  return absolutePath;
+    );
+    yield* Effect.promise(() =>
+      StorageFS.ensureDir(`executions/${childExecutionId}/r1`),
+    );
+    yield* Effect.promise(() =>
+      StorageFS.write(
+        `executions/${childExecutionId}/${relativePath}`,
+        'draft',
+      ),
+    );
+    return absolutePath;
+  });
 }
 
 describe('resolveChildRunOutput', () => {
   afterEach(() => clearStoreCache());
 
-  it('resolves a declared regular output of a completed direct child', async () => {
-    const absolutePath = await persistCompletedChild();
+  it.effect(
+    'resolves a declared regular output of a completed direct child',
+    () =>
+      Effect.gen(function* () {
+        const absolutePath = yield* persistCompletedChild();
 
-    await expect(
-      Effect.runPromise(
+        expect(
+          yield* resolveChildRunOutput(
+            parentExecutionId,
+            absolutePath,
+            session,
+          ),
+        ).toEqual({
+          kind: 'runStorage',
+          absolutePath,
+          relativePath,
+          executionId: childExecutionId,
+        });
+      }),
+  );
+
+  it.effect('rejects output references from an unrelated execution tree', () =>
+    Effect.gen(function* () {
+      const absolutePath = yield* persistCompletedChild(otherParentExecutionId);
+
+      const failure = yield* Effect.flip(
         resolveChildRunOutput(parentExecutionId, absolutePath, session),
-      ),
-    ).resolves.toEqual({
-      kind: 'runStorage',
-      absolutePath,
-      relativePath,
-      executionId: childExecutionId,
-    });
-  });
+      );
+      expect(failure.message).toContain('is not a direct child');
+    }),
+  );
 
-  it('rejects output references from an unrelated execution tree', async () => {
-    const absolutePath = await persistCompletedChild(otherParentExecutionId);
+  it.effect(
+    'rejects files that are present but absent from the result manifest',
+    () =>
+      Effect.gen(function* () {
+        const absolutePath = yield* persistCompletedChild();
+        const undeclaredPath = absolutePath.replace('draft.tex', 'notes.tex');
+        yield* Effect.promise(() =>
+          StorageFS.write(
+            `executions/${childExecutionId}/r1/notes.tex`,
+            'notes',
+          ),
+        );
 
-    await expect(
-      Effect.runPromise(
+        const failure = yield* Effect.flip(
+          resolveChildRunOutput(parentExecutionId, undeclaredPath, session),
+        );
+        expect(failure.message).toContain('is not a declared output');
+      }),
+  );
+
+  it.effect('fails loudly when a declared output has disappeared', () =>
+    Effect.gen(function* () {
+      const absolutePath = yield* persistCompletedChild();
+      yield* Effect.promise(() =>
+        StorageFS.delete(`executions/${childExecutionId}/${relativePath}`),
+      );
+
+      const failure = yield* Effect.flip(
         resolveChildRunOutput(parentExecutionId, absolutePath, session),
-      ),
-    ).rejects.toThrow('is not a direct child');
-  });
+      );
+      expect(failure.message).toContain('is missing');
+    }),
+  );
 
-  it('rejects files that are present but absent from the result manifest', async () => {
-    const absolutePath = await persistCompletedChild();
-    const undeclaredPath = absolutePath.replace('draft.tex', 'notes.tex');
-    await StorageFS.write(
-      `executions/${childExecutionId}/r1/notes.tex`,
-      'notes',
-    );
-
-    await expect(
-      Effect.runPromise(
-        resolveChildRunOutput(parentExecutionId, undeclaredPath, session),
-      ),
-    ).rejects.toThrow('is not a declared output');
-  });
-
-  it('fails loudly when a declared output has disappeared', async () => {
-    const absolutePath = await persistCompletedChild();
-    await StorageFS.delete(`executions/${childExecutionId}/${relativePath}`);
-
-    await expect(
-      Effect.runPromise(
-        resolveChildRunOutput(parentExecutionId, absolutePath, session),
-      ),
-    ).rejects.toThrow('is missing');
-  });
-
-  it('rejects paths outside run storage', async () => {
-    await expect(
-      Effect.runPromise(
+  it.effect('rejects paths outside run storage', () =>
+    Effect.gen(function* () {
+      const failure = yield* Effect.flip(
         resolveChildRunOutput(
           parentExecutionId,
           '/workspace/draft.tex',
           session,
         ),
-      ),
-    ).rejects.toThrow('not inside task-run storage');
-  });
+      );
+      expect(failure.message).toContain('not inside task-run storage');
+    }),
+  );
 });

--- a/src/test-kernel/agent/storage/ExecutionChildLineage.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionChildLineage.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect } from 'vitest';
 import { hasPersistedParent } from '@agent/storage/executionLifecycle';
 import { aggregateId } from '@shared/schemas';
 import {
@@ -15,43 +16,39 @@ beforeEach(() => {
 });
 
 describe('hasPersistedParent', () => {
-  it('returns false for roots and absent executions', async () => {
-    publishTestRunStart(session, 'root', 'aaa001');
-    await session.settlePublications();
-    expect(await Effect.runPromise(hasPersistedParent('aaa001', session))).toBe(
-      false,
-    );
-    expect(await Effect.runPromise(hasPersistedParent('aaa002', session))).toBe(
-      false,
-    );
-  });
-  it('retains parent identity in the child creation even when reads exclude parent history', async () => {
-    publishTestRunStart(session, 'parent', 'aaa0ff');
-    await session.settlePublications();
-    const rows = await Effect.runPromise(
-      session.commit([
-        {
-          type: 'run.start',
-          aggregateId: aggregateId('stream', 'child'),
-          executionId: 'aaa010',
-          parentStreamId: 'parent',
-          identity: { kind: 'agent', agent: 'assistant' },
-          category: 'toolUse',
-          isRemote: false,
-          userFollowUpSupport: 'unsupported',
-        },
-      ]),
-    );
-    expect(rows[0]).toMatchObject({
-      parentExecutionId: 'aaa0ff',
-      parentStartCommit: 1,
-    });
-    const ownRows = await Effect.runPromise(
-      session.readExecutionRecords('aaa010'),
-    );
-    expect(ownRows).toHaveLength(1);
-    expect(await Effect.runPromise(hasPersistedParent('aaa010', session))).toBe(
-      true,
-    );
-  });
+  it.effect('returns false for roots and absent executions', () =>
+    Effect.gen(function* () {
+      publishTestRunStart(session, 'root', 'aaa001');
+      yield* Effect.promise(() => session.settlePublications());
+      expect(yield* hasPersistedParent('aaa001', session)).toBe(false);
+      expect(yield* hasPersistedParent('aaa002', session)).toBe(false);
+    }),
+  );
+  it.effect(
+    'retains parent identity in the child creation even when reads exclude parent history',
+    () =>
+      Effect.gen(function* () {
+        publishTestRunStart(session, 'parent', 'aaa0ff');
+        yield* Effect.promise(() => session.settlePublications());
+        const rows = yield* session.commit([
+          {
+            type: 'run.start',
+            aggregateId: aggregateId('stream', 'child'),
+            executionId: 'aaa010',
+            parentStreamId: 'parent',
+            identity: { kind: 'agent', agent: 'assistant' },
+            category: 'toolUse',
+            isRemote: false,
+            userFollowUpSupport: 'unsupported',
+          },
+        ]);
+        expect(rows[0]).toMatchObject({
+          parentExecutionId: 'aaa0ff',
+          parentStartCommit: 1,
+        });
+        const ownRows = yield* session.readExecutionRecords('aaa010');
+        expect(ownRows).toHaveLength(1);
+        expect(yield* hasPersistedParent('aaa010', session)).toBe(true);
+      }),
+  );
 });

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 import {
   clearStoreCache,
@@ -40,25 +41,29 @@ function config(
 }
 
 let session: SessionHandle;
-async function writeMetadata(
+const writeMetadata = (
   id: ExecutionId,
   meta: Omit<ExecutionMeta, 'schemaVersion' | 'streamId'> & {
     streamId?: StreamTabId;
   },
-): Promise<void> {
-  const existing = await Effect.runPromise(
-    getExecutionRecords(session, id).readMeta(),
-  );
-  const streamId = (meta.streamId ??
-    existing?.streamId ??
-    `stream-${id}`) as StreamTabId;
-  if (!existing) {
-    const clock = vi
-      .spyOn(Date, 'now')
-      .mockReturnValue(Date.parse(meta.timestamp));
-    try {
-      await Effect.runPromise(
-        session.commit([
+) =>
+  Effect.gen(function* () {
+    const existing = yield* getExecutionRecords(session, id).readMeta();
+    const streamId = (meta.streamId ??
+      existing?.streamId ??
+      `stream-${id}`) as StreamTabId;
+    if (!existing) {
+      const clock = vi
+        .spyOn(Date, 'now')
+        .mockReturnValue(Date.parse(meta.timestamp));
+      yield* Effect.gen(function* () {
+        const parentStreamId = meta.parentExecutionId
+          ? (yield* getExecutionRecords(
+              session,
+              meta.parentExecutionId,
+            ).readMeta())?.streamId
+          : undefined;
+        yield* session.commit([
           {
             type: 'run.start',
             aggregateId: aggregateId('stream', streamId),
@@ -67,61 +72,44 @@ async function writeMetadata(
             category: 'toolUse',
             isRemote: false,
             userFollowUpSupport: 'unsupported',
-            parentStreamId: meta.parentExecutionId
-              ? (
-                  await Effect.runPromise(
-                    getExecutionRecords(
-                      session,
-                      meta.parentExecutionId,
-                    ).readMeta(),
-                  )
-                )?.streamId
-              : undefined,
+            parentStreamId,
           },
-        ]),
-      );
-    } finally {
-      clock.mockRestore();
+        ]);
+      }).pipe(Effect.ensuring(Effect.sync(() => clock.mockRestore())));
     }
-  }
-  if (meta.description)
-    await Effect.runPromise(
-      session.commit([
+    if (meta.description)
+      yield* session.commit([
         {
           type: 'execution.description',
           aggregateId: aggregateId('execution', id),
           description: meta.description,
         },
-      ]),
-    );
-  if (meta.outcome)
-    await Effect.runPromise(
-      session.commit([
+      ]);
+    if (meta.outcome)
+      yield* session.commit([
         {
           type: 'status',
           aggregateId: aggregateId('stream', streamId),
           phase: meta.outcome,
           cause: 'test outcome',
         },
-      ]),
-    );
-}
-async function writeExecution(
+      ]);
+  });
+const writeExecution = (
   id: ExecutionId,
   timestamp: string,
   agentConfig?: AgentConfig,
   parentExecutionId?: ExecutionId,
-): Promise<void> {
-  await writeMetadata(id, {
-    timestamp,
-    parentExecutionId,
-    identity: { kind: 'agent', agent: agentConfig?.agent ?? 'assistant' },
+) =>
+  Effect.gen(function* () {
+    yield* writeMetadata(id, {
+      timestamp,
+      parentExecutionId,
+      identity: { kind: 'agent', agent: agentConfig?.agent ?? 'assistant' },
+    });
+    if (agentConfig)
+      yield* getExecutionRecords(session, id).writeRunRecord(agentConfig);
   });
-  if (agentConfig)
-    await Effect.runPromise(
-      getExecutionRecords(session, id).writeRunRecord(agentConfig),
-    );
-}
 
 describe('execution listing normalization', () => {
   setupPlatform({ workspacePath: '/workspace' });
@@ -131,233 +119,277 @@ describe('execution listing normalization', () => {
     session = createProcessSession();
   });
 
-  it('sees executions written by another host after an earlier listing', async () => {
-    expect(await Effect.runPromise(listExecutions(session))).toEqual([]);
+  // `it.live`, not `it.effect`: these rows pin their timestamps through
+  // `vi.spyOn(Date, 'now')`, which the TestClock would override with 0.
 
-    const id = 'eee555' as ExecutionId;
-    await writeExecution(id, '2026-07-15T11:00:00.000Z', config('assistant'));
+  it.live(
+    'sees executions written by another host after an earlier listing',
+    () =>
+      Effect.gen(function* () {
+        expect(yield* listExecutions(session)).toEqual([]);
 
-    expect(await Effect.runPromise(listExecutions(session))).toEqual([
-      expect.objectContaining({
-        id,
-        kind: 'run',
-        identity: { kind: 'agent', agent: 'assistant' },
+        const id = 'eee555' as ExecutionId;
+        yield* writeExecution(
+          id,
+          '2026-07-15T11:00:00.000Z',
+          config('assistant'),
+        );
+
+        expect(yield* listExecutions(session)).toEqual([
+          expect.objectContaining({
+            id,
+            kind: 'run',
+            identity: { kind: 'agent', agent: 'assistant' },
+          }),
+        ]);
       }),
-    ]);
-  });
+  );
 
   // A row is dropped only when the facts it is built from are unreadable. The
   // checkpoint probe is not one of them: it decides an advertisement, so a
   // failing `stat` costs the row its Resume affordance, never its place in
   // history.
-  it('keeps a row whose checkpoint probe fails, without a checkpoint', async () => {
-    const id = 'eee556' as ExecutionId;
-    await writeExecution(id, '2026-07-15T11:00:00.000Z', config('assistant'));
-    vi.spyOn(getExecutionStore(id), 'exists').mockRejectedValue(
-      new Error('stat failed'),
-    );
+  it.live(
+    'keeps a row whose checkpoint probe fails, without a checkpoint',
+    () =>
+      Effect.gen(function* () {
+        const id = 'eee556' as ExecutionId;
+        yield* writeExecution(
+          id,
+          '2026-07-15T11:00:00.000Z',
+          config('assistant'),
+        );
+        vi.spyOn(getExecutionStore(id), 'exists').mockRejectedValue(
+          new Error('stat failed'),
+        );
 
-    expect(await Effect.runPromise(listExecutions(session))).toEqual([
-      expect.objectContaining({ id, kind: 'run', checkpointPresent: false }),
-    ]);
-  });
-
-  it('sees metadata replaced by another host after an earlier listing', async () => {
-    const id = 'fff666' as ExecutionId;
-    await writeExecution(id, '2026-07-15T12:00:00.000Z', config('assistant'));
-    expect(await Effect.runPromise(listExecutions(session))).toEqual([
-      expect.not.objectContaining({ description: expect.any(String) }),
-    ]);
-
-    await writeMetadata(id, {
-      timestamp: '2026-07-15T12:00:00.000Z',
-      identity: { kind: 'agent', agent: 'assistant' },
-      description: 'Updated by another host',
-      outcome: 'completed',
-    });
-
-    expect(await Effect.runPromise(listExecutions(session))).toEqual([
-      expect.objectContaining({
-        id,
-        description: 'Updated by another host',
-        outcome: 'completed',
+        expect(yield* listExecutions(session)).toEqual([
+          expect.objectContaining({
+            id,
+            kind: 'run',
+            checkpointPresent: false,
+          }),
+        ]);
       }),
-    ]);
-  });
+  );
 
-  it('uses the config as the canonical source for visible agent fields', async () => {
-    const id = 'aaa111' as ExecutionId;
-    const agentConfig = config('assistant');
-    await writeExecution(id, '2026-07-15T10:00:00.000Z', agentConfig);
+  it.live(
+    'sees metadata replaced by another host after an earlier listing',
+    () =>
+      Effect.gen(function* () {
+        const id = 'fff666' as ExecutionId;
+        yield* writeExecution(
+          id,
+          '2026-07-15T12:00:00.000Z',
+          config('assistant'),
+        );
+        expect(yield* listExecutions(session)).toEqual([
+          expect.not.objectContaining({ description: expect.any(String) }),
+        ]);
 
-    const entries = await Effect.runPromise(listExecutions(session));
+        yield* writeMetadata(id, {
+          timestamp: '2026-07-15T12:00:00.000Z',
+          identity: { kind: 'agent', agent: 'assistant' },
+          description: 'Updated by another host',
+          outcome: 'completed',
+        });
 
-    expect(entries).toEqual([
-      {
-        kind: 'run',
-        id,
-        timestamp: '2026-07-15T10:00:00.000Z',
-        identity: { kind: 'agent', agent: 'assistant' },
-        record: agentConfig,
-        checkpointPresent: false,
-        streamId: `stream-${id}`,
-      },
-    ]);
-    expect(entries.filter(isUserVisibleExecution)).toHaveLength(1);
-    expect(entries[0]).not.toHaveProperty('agent');
-    expect(entries[0]).not.toHaveProperty('model');
-    expect(entries[0]).not.toHaveProperty('category');
-  });
+        expect(yield* listExecutions(session)).toEqual([
+          expect.objectContaining({
+            id,
+            description: 'Updated by another host',
+            outcome: 'completed',
+          }),
+        ]);
+      }),
+  );
 
-  it('classifies process and incomplete storage rows explicitly', async () => {
-    const processId = 'bbb222' as ExecutionId;
-    const customBashAgentId = 'ccc333' as ExecutionId;
-    const incompleteId = 'ddd444' as ExecutionId;
-    const processStore = getExecutionRecords(session, processId);
-    await writeMetadata(processId, {
-      timestamp: '2026-07-15T09:00:00.000Z',
-      identity: { kind: 'process', tool: 'assistant' },
-    });
-    await Effect.runPromise(processStore.writeRunRecord(config('assistant')));
-    await writeExecution(
-      customBashAgentId,
-      '2026-07-15T08:00:00.000Z',
-      config('bash'),
-    );
-    await writeExecution(incompleteId, '2026-07-15T07:00:00.000Z');
+  it.live(
+    'uses the config as the canonical source for visible agent fields',
+    () =>
+      Effect.gen(function* () {
+        const id = 'aaa111' as ExecutionId;
+        const agentConfig = config('assistant');
+        yield* writeExecution(id, '2026-07-15T10:00:00.000Z', agentConfig);
 
-    const entries = await Effect.runPromise(listExecutions(session));
+        const entries = yield* listExecutions(session);
 
-    expect(entries.map(({ kind }) => kind)).toEqual([
-      'run',
-      'run',
-      'incomplete',
-    ]);
-    expect(entries[0]).toMatchObject({
-      kind: 'run',
-      identity: { kind: 'process', tool: 'assistant' },
-      record: { agent: 'assistant' },
-    });
-    expect(entries[1]).toMatchObject({
-      kind: 'run',
-      identity: { kind: 'agent', agent: 'bash' },
-      record: { agent: 'bash' },
-    });
-    expect(entries[2]).toEqual({
-      kind: 'incomplete',
-      id: incompleteId,
-      streamId: `stream-${incompleteId}`,
-      timestamp: '2026-07-15T07:00:00.000Z',
-      checkpointPresent: false,
-    });
-    expect(entries.filter(isUserVisibleExecution)).toEqual([entries[1]]);
-  });
+        expect(entries).toEqual([
+          {
+            kind: 'run',
+            id,
+            timestamp: '2026-07-15T10:00:00.000Z',
+            identity: { kind: 'agent', agent: 'assistant' },
+            record: agentConfig,
+            checkpointPresent: false,
+            streamId: `stream-${id}`,
+          },
+        ]);
+        expect(entries.filter(isUserVisibleExecution)).toHaveLength(1);
+        expect(entries[0]).not.toHaveProperty('agent');
+        expect(entries[0]).not.toHaveProperty('model');
+        expect(entries[0]).not.toHaveProperty('category');
+      }),
+  );
 
-  it('lists an honest non-agent record as kind run without fabricated fields', async () => {
-    const id = 'abe001' as ExecutionId;
-    const store = getExecutionRecords(session, id);
-    await writeMetadata(id, {
-      timestamp: '2026-07-15T04:00:00.000Z',
-      identity: { kind: 'process', tool: 'bash' },
-    });
-    await Effect.runPromise(
-      store.writeRunRecord({ name: 'bash', instruction: 'ls -la' }),
-    );
-
-    const entries = await Effect.runPromise(listExecutions(session));
-    const entry = entries.find((candidate) => candidate.id === id);
-    expect(entry).toMatchObject({
-      kind: 'run',
-      identity: { kind: 'process', tool: 'bash' },
-      record: { name: 'bash', instruction: 'ls -la' },
-    });
-    expect(entry && 'record' in entry && entry.record).not.toHaveProperty(
-      'agentCategory',
-    );
-    expect(entry && 'record' in entry && entry.record).not.toHaveProperty(
-      'model',
-    );
-    expect(entries.filter(isUserVisibleExecution)).toHaveLength(0);
-  });
-
-  it('keeps agent-spawned child runs out of history listings', async () => {
-    const rootId = 'eee111' as ExecutionId;
-    const childId = 'fff222' as ExecutionId;
-    await writeExecution(
-      rootId,
-      '2026-07-15T10:00:00.000Z',
-      config('orchestrator'),
-    );
-    await writeExecution(
-      childId,
-      '2026-07-15T10:05:00.000Z',
-      config('search'),
-      rootId,
-    );
-
-    const entries = await Effect.runPromise(listExecutions(session));
-
-    // The raw listing still carries the child so tool-facing callers can walk
-    // the lineage; only the history-listing filter drops it.
-    expect(entries.map(({ id }) => id)).toEqual([childId, rootId]);
-    expect(entries.filter(isUserVisibleExecution).map(({ id }) => id)).toEqual([
-      rootId,
-    ]);
-  });
-
-  it('projects agent runs and stream ids for latexdiff execution discovery', async () => {
-    const rootId = 'ab1001' as ExecutionId;
-    const childId = 'ab1002' as ExecutionId;
-    const processId = 'ab1003' as ExecutionId;
-    const rootStore = getExecutionRecords(session, rootId);
-    await writeMetadata(rootId, {
-      timestamp: '2026-07-15T10:00:00.000Z',
-      identity: { kind: 'agent', agent: 'assistant' },
-      streamId: 'assistant@deepseekT#ab1001',
-    });
-    await Effect.runPromise(
-      rootStore.writeRunRecord(config('assistant', ['main.tex'])),
-    );
-    await writeExecution(
-      childId,
-      '2026-07-15T09:00:00.000Z',
-      config('delegated', ['child.tex']),
-      rootId,
-    );
-    const processStore = getExecutionRecords(session, processId);
-    await writeMetadata(processId, {
-      timestamp: '2026-07-15T08:00:00.000Z',
-      identity: { kind: 'process', tool: 'bash' },
-    });
-    await Effect.runPromise(
-      processStore.writeRunRecord({ name: 'bash', instruction: 'ls -la' }),
-    );
-
-    const discovery = createLatexExecutionDiscovery(session);
-
-    // Unlike a history listing, latexdiff discovery keeps delegated children
-    // and drops non-agent rows.
-    expect(await Effect.runPromise(discovery.listAgentRuns())).toEqual([
-      {
-        id: rootId,
-        timestamp: '2026-07-15T10:00:00.000Z',
-        agent: 'assistant',
-        model: 'deepseekT',
-        inputFiles: ['main.tex'],
-      },
-      {
-        id: childId,
+  it.live('classifies process and incomplete storage rows explicitly', () =>
+    Effect.gen(function* () {
+      const processId = 'bbb222' as ExecutionId;
+      const customBashAgentId = 'ccc333' as ExecutionId;
+      const incompleteId = 'ddd444' as ExecutionId;
+      const processStore = getExecutionRecords(session, processId);
+      yield* writeMetadata(processId, {
         timestamp: '2026-07-15T09:00:00.000Z',
-        agent: 'delegated',
-        model: 'deepseekT',
-        inputFiles: ['child.tex'],
-      },
-    ]);
-    expect(await Effect.runPromise(discovery.readStreamId(rootId))).toBe(
-      'assistant@deepseekT#ab1001',
-    );
-    expect(await Effect.runPromise(discovery.readStreamId(childId))).toBe(
-      `stream-${childId}`,
-    );
-  });
+        identity: { kind: 'process', tool: 'assistant' },
+      });
+      yield* processStore.writeRunRecord(config('assistant'));
+      yield* writeExecution(
+        customBashAgentId,
+        '2026-07-15T08:00:00.000Z',
+        config('bash'),
+      );
+      yield* writeExecution(incompleteId, '2026-07-15T07:00:00.000Z');
+
+      const entries = yield* listExecutions(session);
+
+      expect(entries.map(({ kind }) => kind)).toEqual([
+        'run',
+        'run',
+        'incomplete',
+      ]);
+      expect(entries[0]).toMatchObject({
+        kind: 'run',
+        identity: { kind: 'process', tool: 'assistant' },
+        record: { agent: 'assistant' },
+      });
+      expect(entries[1]).toMatchObject({
+        kind: 'run',
+        identity: { kind: 'agent', agent: 'bash' },
+        record: { agent: 'bash' },
+      });
+      expect(entries[2]).toEqual({
+        kind: 'incomplete',
+        id: incompleteId,
+        streamId: `stream-${incompleteId}`,
+        timestamp: '2026-07-15T07:00:00.000Z',
+        checkpointPresent: false,
+      });
+      expect(entries.filter(isUserVisibleExecution)).toEqual([entries[1]]);
+    }),
+  );
+
+  it.live(
+    'lists an honest non-agent record as kind run without fabricated fields',
+    () =>
+      Effect.gen(function* () {
+        const id = 'abe001' as ExecutionId;
+        const store = getExecutionRecords(session, id);
+        yield* writeMetadata(id, {
+          timestamp: '2026-07-15T04:00:00.000Z',
+          identity: { kind: 'process', tool: 'bash' },
+        });
+        yield* store.writeRunRecord({ name: 'bash', instruction: 'ls -la' });
+
+        const entries = yield* listExecutions(session);
+        const entry = entries.find((candidate) => candidate.id === id);
+        expect(entry).toMatchObject({
+          kind: 'run',
+          identity: { kind: 'process', tool: 'bash' },
+          record: { name: 'bash', instruction: 'ls -la' },
+        });
+        expect(entry && 'record' in entry && entry.record).not.toHaveProperty(
+          'agentCategory',
+        );
+        expect(entry && 'record' in entry && entry.record).not.toHaveProperty(
+          'model',
+        );
+        expect(entries.filter(isUserVisibleExecution)).toHaveLength(0);
+      }),
+  );
+
+  it.live('keeps agent-spawned child runs out of history listings', () =>
+    Effect.gen(function* () {
+      const rootId = 'eee111' as ExecutionId;
+      const childId = 'fff222' as ExecutionId;
+      yield* writeExecution(
+        rootId,
+        '2026-07-15T10:00:00.000Z',
+        config('orchestrator'),
+      );
+      yield* writeExecution(
+        childId,
+        '2026-07-15T10:05:00.000Z',
+        config('search'),
+        rootId,
+      );
+
+      const entries = yield* listExecutions(session);
+
+      // The raw listing still carries the child so tool-facing callers can walk
+      // the lineage; only the history-listing filter drops it.
+      expect(entries.map(({ id }) => id)).toEqual([childId, rootId]);
+      expect(
+        entries.filter(isUserVisibleExecution).map(({ id }) => id),
+      ).toEqual([rootId]);
+    }),
+  );
+
+  it.live(
+    'projects agent runs and stream ids for latexdiff execution discovery',
+    () =>
+      Effect.gen(function* () {
+        const rootId = 'ab1001' as ExecutionId;
+        const childId = 'ab1002' as ExecutionId;
+        const processId = 'ab1003' as ExecutionId;
+        const rootStore = getExecutionRecords(session, rootId);
+        yield* writeMetadata(rootId, {
+          timestamp: '2026-07-15T10:00:00.000Z',
+          identity: { kind: 'agent', agent: 'assistant' },
+          streamId: 'assistant@deepseekT#ab1001',
+        });
+        yield* rootStore.writeRunRecord(config('assistant', ['main.tex']));
+        yield* writeExecution(
+          childId,
+          '2026-07-15T09:00:00.000Z',
+          config('delegated', ['child.tex']),
+          rootId,
+        );
+        const processStore = getExecutionRecords(session, processId);
+        yield* writeMetadata(processId, {
+          timestamp: '2026-07-15T08:00:00.000Z',
+          identity: { kind: 'process', tool: 'bash' },
+        });
+        yield* processStore.writeRunRecord({
+          name: 'bash',
+          instruction: 'ls -la',
+        });
+
+        const discovery = createLatexExecutionDiscovery(session);
+
+        // Unlike a history listing, latexdiff discovery keeps delegated children
+        // and drops non-agent rows.
+        expect(yield* discovery.listAgentRuns()).toEqual([
+          {
+            id: rootId,
+            timestamp: '2026-07-15T10:00:00.000Z',
+            agent: 'assistant',
+            model: 'deepseekT',
+            inputFiles: ['main.tex'],
+          },
+          {
+            id: childId,
+            timestamp: '2026-07-15T09:00:00.000Z',
+            agent: 'delegated',
+            model: 'deepseekT',
+            inputFiles: ['child.tex'],
+          },
+        ]);
+        expect(yield* discovery.readStreamId(rootId)).toBe(
+          'assistant@deepseekT#ab1001',
+        );
+        expect(yield* discovery.readStreamId(childId)).toBe(
+          `stream-${childId}`,
+        );
+      }),
+  );
 });

--- a/src/test-kernel/agent/storage/ExecutionMetaWrites.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionMetaWrites.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect } from 'vitest';
 import { finalizeRun, getExecutionRecords } from '@agent/storage';
 import { aggregateId } from '@shared/schemas';
 import {
@@ -18,51 +19,51 @@ beforeEach(async () => {
 });
 
 describe('execution metadata updates', () => {
-  it('preserves description and outcome when independent facts overlap', async () => {
-    await Effect.runPromise(
-      Effect.all(
-        [
-          session.commit([
-            {
-              type: 'execution.description',
-              aggregateId: aggregateId('execution', id),
-              description: 'A described session',
-            },
-          ]),
-          finalizeRun(session, {
-            executionId: id,
-            outcome: 'completed',
-            flowRecord: 'preserve',
-          }),
-        ],
-        { concurrency: 'unbounded' },
-      ),
-    );
-    expect(
-      await Effect.runPromise(getExecutionRecords(session, id).readMeta()),
-    ).toMatchObject({
-      description: 'A described session',
-      outcome: 'completed',
-    });
-  });
-  it('keeps a driver outcome when host-exit finalization follows', async () => {
-    await Effect.runPromise(
-      finalizeRun(session, {
+  it.effect(
+    'preserves description and outcome when independent facts overlap',
+    () =>
+      Effect.gen(function* () {
+        yield* Effect.all(
+          [
+            session.commit([
+              {
+                type: 'execution.description',
+                aggregateId: aggregateId('execution', id),
+                description: 'A described session',
+              },
+            ]),
+            finalizeRun(session, {
+              executionId: id,
+              outcome: 'completed',
+              flowRecord: 'preserve',
+            }),
+          ],
+          { concurrency: 'unbounded' },
+        );
+        expect(
+          yield* getExecutionRecords(session, id).readMeta(),
+        ).toMatchObject({
+          description: 'A described session',
+          outcome: 'completed',
+        });
+      }),
+  );
+  it.effect('keeps a driver outcome when host-exit finalization follows', () =>
+    Effect.gen(function* () {
+      yield* finalizeRun(session, {
         executionId: id,
         outcome: 'completed',
         flowRecord: 'preserve',
-      }),
-    );
-    await Effect.runPromise(
-      finalizeRun(session, {
+      });
+      yield* finalizeRun(session, {
         executionId: id,
         outcome: 'cancelled',
         flowRecord: 'preserve',
         keepExistingOutcome: true,
-      }),
-    );
-    expect(
-      await Effect.runPromise(getExecutionRecords(session, id).readMeta()),
-    ).toMatchObject({ outcome: 'completed' });
-  });
+      });
+      expect(yield* getExecutionRecords(session, id).readMeta()).toMatchObject({
+        outcome: 'completed',
+      });
+    }),
+  );
 });

--- a/src/test-kernel/agent/storage/Resumability.vitest.ts
+++ b/src/test-kernel/agent/storage/Resumability.vitest.ts
@@ -1,6 +1,7 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 import { z } from 'zod';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 import {
   clearStoreCache,
@@ -42,193 +43,209 @@ describe('deriveResumability', () => {
     session = createProcessSession();
   });
 
-  async function writeFlow(executionId: ExecutionId): Promise<void> {
-    await getExecutionStore(executionId).write(
-      flowKey(executionId),
-      BASE_FLOW_RECORD,
+  function writeFlow(executionId: ExecutionId) {
+    return Effect.promise(() =>
+      getExecutionStore(executionId).write(
+        flowKey(executionId),
+        BASE_FLOW_RECORD,
+      ),
     );
   }
 
-  async function writeMeta(
+  function writeMeta(
     executionId: ExecutionId,
     { outcome }: { outcome?: RunOutcome },
-  ): Promise<void> {
-    const streamId = `stream-${executionId}` as StreamTabId;
-    publishTestRunStart(session, streamId, executionId);
-    await session.settlePublications();
-    if (outcome) {
-      await Effect.runPromise(
-        session.commit([
+  ) {
+    return Effect.gen(function* () {
+      const streamId = `stream-${executionId}` as StreamTabId;
+      publishTestRunStart(session, streamId, executionId);
+      yield* Effect.promise(() => session.settlePublications());
+      if (outcome) {
+        yield* session.commit([
           {
             type: 'status',
             aggregateId: aggregateId('stream', streamId),
             phase: outcome,
             cause: 'test outcome',
           },
-        ]),
-      );
-    }
+        ]);
+      }
+    });
   }
 
-  it('keeps a failed execution resumable while its checkpoint exists', async () => {
-    const executionId = 'ac0000' as ExecutionId;
-    await writeMeta(executionId, { outcome: RUN_OUTCOME.FAILED });
-    await writeFlow(executionId);
+  it.effect(
+    'keeps a failed execution resumable while its checkpoint exists',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'ac0000' as ExecutionId;
+        yield* writeMeta(executionId, { outcome: RUN_OUTCOME.FAILED });
+        yield* writeFlow(executionId);
 
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toMatchObject({
-      kind: 'checkpoint',
-      outcome: RUN_OUTCOME.FAILED,
-      flowRecord: BASE_FLOW_RECORD,
-    });
-  });
-
-  it('stays resumable when terminal metadata persists but flow deletion fails', async () => {
-    const executionId = 'ac0001' as ExecutionId;
-    await writeMeta(executionId, {});
-    await writeFlow(executionId);
-    const store = getExecutionStore(executionId);
-    vi.spyOn(store, 'delete').mockRejectedValueOnce(
-      new Error('flow delete failed'),
-    );
-
-    await expect(
-      Effect.runPromise(
-        finalizeRun(session, {
-          executionId,
-          outcome: RUN_OUTCOME.COMPLETED,
-          flowRecord: 'delete',
-        }),
-      ),
-    ).resolves.toMatchObject({
-      ok: false,
-      outcomePersisted: true,
-    });
-
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toMatchObject({
-      kind: 'checkpoint',
-      outcome: RUN_OUTCOME.COMPLETED,
-    });
-  });
-
-  it('does not treat a spent cursor as a checkpoint', async () => {
-    const executionId = 'ac0002' as ExecutionId;
-    await writeMeta(executionId, { outcome: RUN_OUTCOME.COMPLETED });
-    await getExecutionStore(executionId).write(flowKey(executionId), {
-      ...BASE_FLOW_RECORD,
-      cursor: { ...BASE_FLOW_RECORD.cursor, nextNodeId: null },
-    });
-
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toMatchObject({
-      kind: 'unreadable',
-      cause: 'checkpoint is malformed',
-    });
-  });
-
-  it('keeps a preserved checkpoint when terminal metadata fails for a failed execution', async () => {
-    const executionId = 'ac0003' as ExecutionId;
-    await writeMeta(executionId, {});
-    await writeFlow(executionId);
-    vi.spyOn(session, 'updateRecordFacts').mockReturnValueOnce(
-      Effect.die(new Error('metadata disk full')),
-    );
-
-    await expect(
-      Effect.runPromise(
-        finalizeRun(session, {
-          executionId,
+        expect(yield* deriveResumability(executionId, session)).toMatchObject({
+          kind: 'checkpoint',
           outcome: RUN_OUTCOME.FAILED,
-          flowRecord: 'preserve',
+          flowRecord: BASE_FLOW_RECORD,
+        });
+      }),
+  );
+
+  it.effect(
+    'stays resumable when terminal metadata persists but flow deletion fails',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'ac0001' as ExecutionId;
+        yield* writeMeta(executionId, {});
+        yield* writeFlow(executionId);
+        const store = getExecutionStore(executionId);
+        vi.spyOn(store, 'delete').mockRejectedValueOnce(
+          new Error('flow delete failed'),
+        );
+
+        expect(
+          yield* finalizeRun(session, {
+            executionId,
+            outcome: RUN_OUTCOME.COMPLETED,
+            flowRecord: 'delete',
+          }),
+        ).toMatchObject({
+          ok: false,
+          outcomePersisted: true,
+        });
+
+        expect(yield* deriveResumability(executionId, session)).toMatchObject({
+          kind: 'checkpoint',
+          outcome: RUN_OUTCOME.COMPLETED,
+        });
+      }),
+  );
+
+  it.effect('does not treat a spent cursor as a checkpoint', () =>
+    Effect.gen(function* () {
+      const executionId = 'ac0002' as ExecutionId;
+      yield* writeMeta(executionId, { outcome: RUN_OUTCOME.COMPLETED });
+      yield* Effect.promise(() =>
+        getExecutionStore(executionId).write(flowKey(executionId), {
+          ...BASE_FLOW_RECORD,
+          cursor: { ...BASE_FLOW_RECORD.cursor, nextNodeId: null },
         }),
-      ),
-    ).resolves.toMatchObject({
-      ok: false,
-      outcomePersisted: false,
-    });
+      );
 
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toMatchObject({
-      kind: 'checkpoint',
-    });
-  });
+      expect(yield* deriveResumability(executionId, session)).toMatchObject({
+        kind: 'unreadable',
+        cause: 'checkpoint is malformed',
+      });
+    }),
+  );
 
-  it('marks cancelled executions with a valid flow record as resumable', async () => {
-    const executionId = 'ac0004' as ExecutionId;
-    await writeMeta(executionId, { outcome: RUN_OUTCOME.CANCELLED });
-    await writeFlow(executionId);
+  it.effect(
+    'keeps a preserved checkpoint when terminal metadata fails for a failed execution',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'ac0003' as ExecutionId;
+        yield* writeMeta(executionId, {});
+        yield* writeFlow(executionId);
+        vi.spyOn(session, 'updateRecordFacts').mockReturnValueOnce(
+          Effect.die(new Error('metadata disk full')),
+        );
 
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toMatchObject({
-      kind: 'checkpoint',
-      outcome: RUN_OUTCOME.CANCELLED,
-      flowRecord: BASE_FLOW_RECORD,
-    });
-  });
+        expect(
+          yield* finalizeRun(session, {
+            executionId,
+            outcome: RUN_OUTCOME.FAILED,
+            flowRecord: 'preserve',
+          }),
+        ).toMatchObject({
+          ok: false,
+          outcomePersisted: false,
+        });
 
-  it('does not mark cancelled executions resumable without a flow record', async () => {
-    const executionId = 'ac0005' as ExecutionId;
-    await writeMeta(executionId, { outcome: RUN_OUTCOME.CANCELLED });
+        expect(yield* deriveResumability(executionId, session)).toMatchObject({
+          kind: 'checkpoint',
+        });
+      }),
+  );
 
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toMatchObject({
-      kind: 'none',
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-  });
+  it.effect(
+    'marks cancelled executions with a valid flow record as resumable',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'ac0004' as ExecutionId;
+        yield* writeMeta(executionId, { outcome: RUN_OUTCOME.CANCELLED });
+        yield* writeFlow(executionId);
 
-  it('marks missing-terminal executions with a valid flow record as resumable', async () => {
-    const executionId = 'ac0006' as ExecutionId;
-    await writeFlow(executionId);
+        expect(yield* deriveResumability(executionId, session)).toMatchObject({
+          kind: 'checkpoint',
+          outcome: RUN_OUTCOME.CANCELLED,
+          flowRecord: BASE_FLOW_RECORD,
+        });
+      }),
+  );
 
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toMatchObject({
-      kind: 'checkpoint',
-      flowRecord: BASE_FLOW_RECORD,
-    });
-  });
+  it.effect(
+    'does not mark cancelled executions resumable without a flow record',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'ac0005' as ExecutionId;
+        yield* writeMeta(executionId, { outcome: RUN_OUTCOME.CANCELLED });
 
-  it('accepts an unstamped legacy envelope and preserves extra fields', async () => {
-    const executionId = 'ac0007' as ExecutionId;
-    const legacyRecord = {
-      ...BASE_FLOW_RECORD,
-      legacyOwner: { host: 'extension' },
-    };
-    await getExecutionStore(executionId).write(
-      flowKey(executionId),
-      legacyRecord,
-    );
+        expect(yield* deriveResumability(executionId, session)).toMatchObject({
+          kind: 'none',
+          outcome: RUN_OUTCOME.CANCELLED,
+        });
+      }),
+  );
 
-    const decision = await Effect.runPromise(
-      deriveResumability(executionId, session),
-    );
+  it.effect(
+    'marks missing-terminal executions with a valid flow record as resumable',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'ac0006' as ExecutionId;
+        yield* writeFlow(executionId);
 
-    expect(decision).toMatchObject({ kind: 'checkpoint' });
-    if (decision.kind !== 'checkpoint') return;
-    expect(decision.flowRecord).toEqual(legacyRecord);
-    expect(Object.hasOwn(decision.flowRecord, 'schemaVersion')).toBe(false);
-  });
+        expect(yield* deriveResumability(executionId, session)).toMatchObject({
+          kind: 'checkpoint',
+          flowRecord: BASE_FLOW_RECORD,
+        });
+      }),
+  );
 
-  it('reports missing flow records as not resumable', async () => {
-    const executionId = 'ac0008' as ExecutionId;
+  it.effect(
+    'accepts an unstamped legacy envelope and preserves extra fields',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'ac0007' as ExecutionId;
+        const legacyRecord = {
+          ...BASE_FLOW_RECORD,
+          legacyOwner: { host: 'extension' },
+        };
+        yield* Effect.promise(() =>
+          getExecutionStore(executionId).write(
+            flowKey(executionId),
+            legacyRecord,
+          ),
+        );
 
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toEqual({
-      kind: 'none',
-      outcome: undefined,
-    });
-  });
+        const decision = yield* deriveResumability(executionId, session);
 
-  it.each([
+        expect(decision).toMatchObject({ kind: 'checkpoint' });
+        if (decision.kind !== 'checkpoint') return;
+        expect(decision.flowRecord).toEqual(legacyRecord);
+        expect(Object.hasOwn(decision.flowRecord, 'schemaVersion')).toBe(false);
+      }),
+  );
+
+  it.effect('reports missing flow records as not resumable', () =>
+    Effect.gen(function* () {
+      const executionId = 'ac0008' as ExecutionId;
+
+      expect(yield* deriveResumability(executionId, session)).toEqual({
+        kind: 'none',
+        outcome: undefined,
+      });
+    }),
+  );
+
+  it.effect.each([
     {
       name: 'reports invalid flow records as not resumable',
       record: { ...BASE_FLOW_RECORD, shared: null },
@@ -244,57 +261,65 @@ describe('deriveResumability', () => {
         schemaVersion: FLOW_RECORD_SCHEMA_VERSION + 1,
       },
     },
-  ])('$name', async ({ record }) => {
-    const executionId = 'ac0009' as ExecutionId;
-    await getExecutionStore(executionId).write(flowKey(executionId), record);
+  ])('$name', ({ record }) =>
+    Effect.gen(function* () {
+      const executionId = 'ac0009' as ExecutionId;
+      yield* Effect.promise(() =>
+        getExecutionStore(executionId).write(flowKey(executionId), record),
+      );
 
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toEqual({
-      kind: 'unreadable',
-      // The one fault that names the record itself: callers refuse this
-      // cohort as unusable saved state, and every other fault operationally.
-      fault: 'checkpoint-malformed',
-      cause: 'checkpoint is malformed',
-    });
-  });
+      expect(yield* deriveResumability(executionId, session)).toEqual({
+        kind: 'unreadable',
+        // The one fault that names the record itself: callers refuse this
+        // cohort as unusable saved state, and every other fault operationally.
+        fault: 'checkpoint-malformed',
+        cause: 'checkpoint is malformed',
+      });
+    }),
+  );
 
-  it('reports invalid metadata as not resumable even with a valid flow record', async () => {
-    const executionId = 'ac000a' as ExecutionId;
-    vi.spyOn(session, 'readExecutionRecords').mockReturnValue(
-      Effect.die(
-        new z.ZodError([
-          { code: 'custom', path: [], message: 'corrupt execution metadata' },
-        ]),
-      ),
-    );
-    await writeFlow(executionId);
+  it.effect(
+    'reports invalid metadata as not resumable even with a valid flow record',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'ac000a' as ExecutionId;
+        vi.spyOn(session, 'readExecutionRecords').mockReturnValue(
+          Effect.die(
+            new z.ZodError([
+              {
+                code: 'custom',
+                path: [],
+                message: 'corrupt execution metadata',
+              },
+            ]),
+          ),
+        );
+        yield* writeFlow(executionId);
 
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toMatchObject({
-      kind: 'unreadable',
-      cause: 'execution metadata is malformed',
-    });
-  });
+        expect(yield* deriveResumability(executionId, session)).toMatchObject({
+          kind: 'unreadable',
+          cause: 'execution metadata is malformed',
+        });
+      }),
+  );
 
-  it('reports unreadable flow records as not resumable', async () => {
-    const executionId = 'ac000b' as ExecutionId;
-    const store = getExecutionStore(executionId);
-    await writeFlow(executionId);
-    const originalRead = store.read.bind(store);
-    vi.spyOn(store, 'read').mockImplementation(async (key) => {
-      if (key === flowKey(executionId)) {
-        throw new Error('disk offline');
-      }
-      return originalRead(key);
-    });
+  it.effect('reports unreadable flow records as not resumable', () =>
+    Effect.gen(function* () {
+      const executionId = 'ac000b' as ExecutionId;
+      const store = getExecutionStore(executionId);
+      yield* writeFlow(executionId);
+      const originalRead = store.read.bind(store);
+      vi.spyOn(store, 'read').mockImplementation(async (key) => {
+        if (key === flowKey(executionId)) {
+          throw new Error('disk offline');
+        }
+        return originalRead(key);
+      });
 
-    await expect(
-      Effect.runPromise(deriveResumability(executionId, session)),
-    ).resolves.toMatchObject({
-      kind: 'unreadable',
-      cause: 'checkpoint could not be read (disk offline)',
-    });
-  });
+      expect(yield* deriveResumability(executionId, session)).toMatchObject({
+        kind: 'unreadable',
+        cause: 'checkpoint could not be read (disk offline)',
+      });
+    }),
+  );
 });

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.ts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 // Shared mock registrations must evaluate before anything that loads
 // the mocked modules — keep these imports immediately after the vitest
@@ -10,6 +10,7 @@ import { cliInitPlatformMock } from '@test/support/cliInitPlatformMock';
 import { cliLogSinksMock } from '@test/support/cliLogSinksMock';
 import { cliOutputMock } from '@test/support/cliOutputMock';
 
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 import { ensureError } from '@utils/errors/errorMessage';
 
@@ -112,131 +113,143 @@ describe('CLI agents run command', () => {
     });
   });
 
-  it('anchors headless tool-use runs on provided files without polluting display text', async () => {
-    const exitCode = await runToolUseAgent(createRunCommandCliContext(), {
-      agent: 'chat',
-      inputFiles: ['problem.md'],
-      contextFiles: ['notes.md'],
-      model: 'gpt54',
-      instruction: 'Assess the proof concisely.',
-    });
+  it.effect(
+    'anchors headless tool-use runs on provided files without polluting display text',
+    () =>
+      Effect.gen(function* () {
+        const exitCode = yield* nativeRun(createRunCommandCliContext(), {
+          agent: 'chat',
+          inputFiles: ['problem.md'],
+          contextFiles: ['notes.md'],
+          model: 'gpt54',
+          instruction: 'Assess the proof concisely.',
+        });
 
-    expect(exitCode).toBe(0);
-    expect(cliInitPlatformMock.initLocalCliPlatform).toHaveBeenCalledWith(
-      expect.objectContaining({ cwd: '/tmp/project' }),
-    );
-    expect(
-      cliInitPlatformMock.initLocalCliPlatform.mock.invocationCallOrder[0],
-    ).toBeLessThan(mocks.resolveCliLaunchAgent.mock.invocationCallOrder[0]);
-    expect(mocks.resolveCliLaunchAgent).toHaveBeenCalledWith(
-      'chat',
-      'agentsRun',
-    );
-    expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
-      ['problem.md'],
-      ['notes.md'],
-      '/tmp/project',
-      {
-        allowEmptyInput: true,
-        requireWorkspaceFiles: true,
-        readStdinText: expect.any(Function),
-      },
-      expect.any(Function),
-    );
-    const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
-    expect(config?.inputFiles).toEqual(['problem.md']);
-    expect(config?.contextFiles).toEqual(['notes.md']);
-    expect(config?.displayInstruction).toBe('Assess the proof concisely.');
-    expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
-      recoveryInputIsDurable: true,
-    });
-    expect(config?.instruction).toContain('Primary user input files:');
-    expect(config?.instruction).toContain('- "problem.md"');
-    expect(config?.instruction).toContain('Read-only context files:');
-    expect(config?.instruction).toContain('- "notes.md"');
-    expect(config?.instruction).toContain('Additional user instruction:');
-    expect(config?.instruction).toContain('Assess the proof concisely.');
-    const emission = cliOutputMock.emitCliResult.mock.calls[0]?.[1];
-    expect(emission?.json).toEqual({
-      category: AgentCategory.ToolUse,
-      executionId: 'exec-1',
-      streamId: 'stream-1',
-      outcome: RUN_OUTCOME.COMPLETED,
-      response: 'Correct.',
-      workingDirectory: '/tmp/project',
-    });
-    // `outcome` is the only terminal fact the headless JSON publishes.
-    expect(Object.keys(emission?.json ?? {})).toEqual([
-      'category',
-      'executionId',
-      'streamId',
-      'outcome',
-      'response',
-      'workingDirectory',
-    ]);
-    expect(emission?.ndjson).toEqual({
-      kind: 'agent-result',
-      result: emission.json,
-    });
-    expect(emission?.text).toBe('Correct.');
-  });
+        expect(exitCode).toBe(0);
+        expect(cliInitPlatformMock.initLocalCliPlatform).toHaveBeenCalledWith(
+          expect.objectContaining({ cwd: '/tmp/project' }),
+        );
+        expect(
+          cliInitPlatformMock.initLocalCliPlatform.mock.invocationCallOrder[0],
+        ).toBeLessThan(mocks.resolveCliLaunchAgent.mock.invocationCallOrder[0]);
+        expect(mocks.resolveCliLaunchAgent).toHaveBeenCalledWith(
+          'chat',
+          'agentsRun',
+        );
+        expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
+          ['problem.md'],
+          ['notes.md'],
+          '/tmp/project',
+          {
+            allowEmptyInput: true,
+            requireWorkspaceFiles: true,
+            readStdinText: expect.any(Function),
+          },
+          expect.any(Function),
+        );
+        const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
+        expect(config?.inputFiles).toEqual(['problem.md']);
+        expect(config?.contextFiles).toEqual(['notes.md']);
+        expect(config?.displayInstruction).toBe('Assess the proof concisely.');
+        expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
+          recoveryInputIsDurable: true,
+        });
+        expect(config?.instruction).toContain('Primary user input files:');
+        expect(config?.instruction).toContain('- "problem.md"');
+        expect(config?.instruction).toContain('Read-only context files:');
+        expect(config?.instruction).toContain('- "notes.md"');
+        expect(config?.instruction).toContain('Additional user instruction:');
+        expect(config?.instruction).toContain('Assess the proof concisely.');
+        const emission = cliOutputMock.emitCliResult.mock.calls[0]?.[1];
+        expect(emission?.json).toEqual({
+          category: AgentCategory.ToolUse,
+          executionId: 'exec-1',
+          streamId: 'stream-1',
+          outcome: RUN_OUTCOME.COMPLETED,
+          response: 'Correct.',
+          workingDirectory: '/tmp/project',
+        });
+        // `outcome` is the only terminal fact the headless JSON publishes.
+        expect(Object.keys(emission?.json ?? {})).toEqual([
+          'category',
+          'executionId',
+          'streamId',
+          'outcome',
+          'response',
+          'workingDirectory',
+        ]);
+        expect(emission?.ndjson).toEqual({
+          kind: 'agent-result',
+          result: emission.json,
+        });
+        expect(emission?.text).toBe('Correct.');
+      }),
+  );
 
-  it('marks materialized stdin as unavailable for recovery advertising', async () => {
-    mocks.withExpandedRunInputs.mockImplementationOnce(
-      async (
-        _inputSpecs: readonly string[],
-        _contextSpecs: readonly string[],
-        _cwd: string,
-        _options: unknown,
-        run: (inputs: {
-          readonly inputFiles: string[];
-          readonly contextFiles: string[];
-          readonly stdinInputPath?: string;
-        }) => Promise<unknown>,
-      ) =>
-        run({
-          inputFiles: ['.texra-tmp/stdin.tex'],
+  it.effect(
+    'marks materialized stdin as unavailable for recovery advertising',
+    () =>
+      Effect.gen(function* () {
+        mocks.withExpandedRunInputs.mockImplementationOnce(
+          async (
+            _inputSpecs: readonly string[],
+            _contextSpecs: readonly string[],
+            _cwd: string,
+            _options: unknown,
+            run: (inputs: {
+              readonly inputFiles: string[];
+              readonly contextFiles: string[];
+              readonly stdinInputPath?: string;
+            }) => Promise<unknown>,
+          ) =>
+            run({
+              inputFiles: ['.texra-tmp/stdin.tex'],
+              contextFiles: [],
+              stdinInputPath: '.texra-tmp/stdin.tex',
+            }),
+        );
+        yield* nativeRun(createRunCommandCliContext(), {
+          agent: 'chat',
+          inputFiles: ['-'],
           contextFiles: [],
-          stdinInputPath: '.texra-tmp/stdin.tex',
-        }),
-    );
-    await runToolUseAgent(createRunCommandCliContext(), {
-      agent: 'chat',
-      inputFiles: ['-'],
-      contextFiles: [],
-      model: 'gpt54',
-      instruction: 'Assess the proof.',
-    });
+          model: 'gpt54',
+          instruction: 'Assess the proof.',
+        });
 
-    expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
-      recoveryInputIsDurable: false,
-    });
-  });
+        expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
+          recoveryInputIsDurable: false,
+        });
+      }),
+  );
 
-  it('publishes the canonical outcome for a shutdown cancellation', async () => {
-    mocks.executeCliToolUseConfig.mockResolvedValueOnce({
-      ok: true,
-      result: {
-        category: AgentCategory.ToolUse,
-        executionId: 'exec-interrupted',
-        streamId: 'stream-interrupted',
-        outcome: RUN_OUTCOME.CANCELLED,
-        workingDirectory: '/tmp/project',
-      },
-      exitCode: CliExitCode.Interrupted,
-    });
-    const exitCode = await runToolUseAgent(createRunCommandCliContext(), {
-      agent: 'chat',
-      inputFiles: ['problem.md'],
-      contextFiles: [],
-      instruction: 'Assess the proof.',
-    });
+  it.effect('publishes the canonical outcome for a shutdown cancellation', () =>
+    Effect.gen(function* () {
+      mocks.executeCliToolUseConfig.mockResolvedValueOnce({
+        ok: true,
+        result: {
+          category: AgentCategory.ToolUse,
+          executionId: 'exec-interrupted',
+          streamId: 'stream-interrupted',
+          outcome: RUN_OUTCOME.CANCELLED,
+          workingDirectory: '/tmp/project',
+        },
+        exitCode: CliExitCode.Interrupted,
+      });
+      const exitCode = yield* nativeRun(createRunCommandCliContext(), {
+        agent: 'chat',
+        inputFiles: ['problem.md'],
+        contextFiles: [],
+        instruction: 'Assess the proof.',
+      });
 
-    expect(exitCode).toBe(CliExitCode.Interrupted);
-    expect(cliOutputMock.emitCliResult.mock.calls[0]?.[1].json).toMatchObject({
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-  });
+      expect(exitCode).toBe(CliExitCode.Interrupted);
+      expect(cliOutputMock.emitCliResult.mock.calls[0]?.[1].json).toMatchObject(
+        {
+          outcome: RUN_OUTCOME.CANCELLED,
+        },
+      );
+    }),
+  );
 
   it('reports missing instruction before resolving the model', async () => {
     await expect(

--- a/src/test-kernel/cli/CliContext.vitest.ts
+++ b/src/test-kernel/cli/CliContext.vitest.ts
@@ -2,7 +2,8 @@ import { mkdir, realpath, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { it } from '@effect/vitest';
+import { describe, expect } from 'vitest';
 
 import { Effect } from 'effect';
 import {
@@ -202,60 +203,76 @@ describe('CLI context config defaults', () => {
     expect(context.configWarnings).toEqual([]);
   });
 
-  it('reports unknown and invalid workspace config fields without failing', async () => {
-    const workspace = await workspaceWithConfig(
-      JSON.stringify({
-        unknown: true,
-        'texra.model': 'claude-opus-4-7',
-        'texra.chat': { other: true, model: 'deepseekT' },
+  it.effect(
+    'reports unknown and invalid workspace config fields without failing',
+    () =>
+      Effect.gen(function* () {
+        const workspace = yield* Effect.promise(() =>
+          workspaceWithConfig(
+            JSON.stringify({
+              unknown: true,
+              'texra.model': 'claude-opus-4-7',
+              'texra.chat': { other: true, model: 'deepseekT' },
+            }),
+          ),
+        );
+
+        const loaded = yield* loadWorkspaceCliConfig(workspace);
+
+        expect(loaded.values.chat?.model).toBe('deepseekT');
+        expect(loaded.values.model).toBeUndefined();
+        expect(loaded.warnings.join('\n')).toContain('unknown');
+        expect(loaded.warnings.join('\n')).toContain('model');
+        expect(loaded.warnings.join('\n')).toContain('chat.other');
       }),
-    );
+  );
 
-    const loaded = await Effect.runPromise(loadWorkspaceCliConfig(workspace));
+  it.effect('accepts the CLI-only ChatGPT Codex preference key', () =>
+    Effect.gen(function* () {
+      const workspace = yield* Effect.promise(() =>
+        workspaceWithConfig(
+          JSON.stringify({
+            'texra.chatgptCodex.preferSubscription': true,
+          }),
+        ),
+      );
 
-    expect(loaded.values.chat?.model).toBe('deepseekT');
-    expect(loaded.values.model).toBeUndefined();
-    expect(loaded.warnings.join('\n')).toContain('unknown');
-    expect(loaded.warnings.join('\n')).toContain('model');
-    expect(loaded.warnings.join('\n')).toContain('chat.other');
-  });
+      const loaded = yield* loadWorkspaceCliConfig(workspace);
 
-  it('accepts the CLI-only ChatGPT Codex preference key', async () => {
-    const workspace = await workspaceWithConfig(
-      JSON.stringify({
-        'texra.chatgptCodex.preferSubscription': true,
+      expect(loaded.warnings).toEqual([]);
+    }),
+  );
+
+  it.effect(
+    'accepts prefixed command sections from unified workspace config',
+    () =>
+      Effect.gen(function* () {
+        const workspace = yield* Effect.promise(() =>
+          workspaceWithConfig(
+            JSON.stringify({
+              'texra.agent': 'generic',
+              'texra.model': 'gpt55',
+              'texra.chat': { agent: 'chat', model: 'deepseekT' },
+              'texra.run': { agent: 'criticize', model: 'sonnet46T' },
+            }),
+          ),
+        );
+
+        const loaded = yield* loadWorkspaceCliConfig(workspace);
+
+        expect(loaded.values.agent).toBe('generic');
+        expect(loaded.values.model).toBe('gpt55');
+        expect(loaded.values.chat).toEqual({
+          agent: 'chat',
+          model: 'deepseekT',
+        });
+        expect(loaded.values.run).toEqual({
+          agent: 'criticize',
+          model: 'sonnet46T',
+        });
+        expect(loaded.warnings).toEqual([]);
       }),
-    );
-
-    const loaded = await Effect.runPromise(loadWorkspaceCliConfig(workspace));
-
-    expect(loaded.warnings).toEqual([]);
-  });
-
-  it('accepts prefixed command sections from unified workspace config', async () => {
-    const workspace = await workspaceWithConfig(
-      JSON.stringify({
-        'texra.agent': 'generic',
-        'texra.model': 'gpt55',
-        'texra.chat': { agent: 'chat', model: 'deepseekT' },
-        'texra.run': { agent: 'criticize', model: 'sonnet46T' },
-      }),
-    );
-
-    const loaded = await Effect.runPromise(loadWorkspaceCliConfig(workspace));
-
-    expect(loaded.values.agent).toBe('generic');
-    expect(loaded.values.model).toBe('gpt55');
-    expect(loaded.values.chat).toEqual({
-      agent: 'chat',
-      model: 'deepseekT',
-    });
-    expect(loaded.values.run).toEqual({
-      agent: 'criticize',
-      model: 'sonnet46T',
-    });
-    expect(loaded.warnings).toEqual([]);
-  });
+  );
 
   it('canonicalizes existing workspace paths before reading config', async () => {
     const root = await makeTempDir('texra-cli-context-link-', tempDirs);
@@ -278,28 +295,38 @@ describe('CLI context config defaults', () => {
     expect(context.outputFormat).toBe('json');
   });
 
-  it('reports malformed workspace config files without failing', async () => {
-    const workspace = await workspaceWithConfig('{');
+  it.effect('reports malformed workspace config files without failing', () =>
+    Effect.gen(function* () {
+      const workspace = yield* Effect.promise(() => workspaceWithConfig('{'));
 
-    const loaded = await Effect.runPromise(loadWorkspaceCliConfig(workspace));
+      const loaded = yield* loadWorkspaceCliConfig(workspace);
 
-    expect(loaded.values).toEqual({});
-    expect(loaded.path).toContain(join('.texra', 'config.json'));
-    expect(loaded.warnings.join('\n')).toContain('Could not parse');
-  });
+      expect(loaded.values).toEqual({});
+      expect(loaded.path).toContain(join('.texra', 'config.json'));
+      expect(loaded.warnings.join('\n')).toContain('Could not parse');
+    }),
+  );
 
-  it('reports unreadable workspace config files without treating them as absent', async () => {
-    const workspace = await makeTempDir('texra-cli-context-', tempDirs);
-    await mkdir(join(workspace, '.texra', 'config.json'), {
-      recursive: true,
-    });
+  it.effect(
+    'reports unreadable workspace config files without treating them as absent',
+    () =>
+      Effect.gen(function* () {
+        const workspace = yield* Effect.promise(() =>
+          makeTempDir('texra-cli-context-', tempDirs),
+        );
+        yield* Effect.promise(() =>
+          mkdir(join(workspace, '.texra', 'config.json'), {
+            recursive: true,
+          }),
+        );
 
-    const loaded = await Effect.runPromise(loadWorkspaceCliConfig(workspace));
+        const loaded = yield* loadWorkspaceCliConfig(workspace);
 
-    expect(loaded.values).toEqual({});
-    expect(loaded.path).toContain(join('.texra', 'config.json'));
-    expect(loaded.warnings.join('\n')).toContain('Could not read');
-  });
+        expect(loaded.values).toEqual({});
+        expect(loaded.path).toContain(join('.texra', 'config.json'));
+        expect(loaded.warnings.join('\n')).toContain('Could not read');
+      }),
+  );
 
   it('ignores unknown TEXRA_MODEL values before they reach runtime', async () => {
     const context = await cliContext({

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 import {
   readCliModelAccessStatus,
@@ -13,9 +14,15 @@ import {
   resolveCliModelAccessRoute,
   shortCliModelAccessRoute,
 } from '@cli/runtime/modelAccessRoute';
-import { effectRuntime } from '@platform/processRuntime';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
+import { testHttpClientLayer } from '@test/support/fetchTestUtils';
+
+/**
+ * The HTTP client these programs took from the process runtime before the
+ * suite ran them natively: the same layer `installFakeHost` merges in.
+ */
+const withHttpClient = Effect.provide(testHttpClientLayer);
 
 const mocks = vi.hoisted(() => ({
   getCodexStatus: vi.fn(),
@@ -302,41 +309,45 @@ describe('CLI model access routes', () => {
     });
   });
 
-  it('enables Kimi Code routing on a personal fallback when a key exists', async () => {
-    mocks.hasUsableApiKey.mockResolvedValue(true);
+  it.effect(
+    'enables Kimi Code routing on a personal fallback when a key exists',
+    () =>
+      Effect.gen(function* () {
+        mocks.hasUsableApiKey.mockResolvedValue(true);
 
-    const result = await effectRuntime().runPromise(
-      await updateCliModelAccess(
-        context,
-        subscriptionPreference('kimi-code', 'on'),
-        { writeProgress: vi.fn() },
-      ),
-    );
+        const result = yield* updateCliModelAccess(
+          context,
+          subscriptionPreference('kimi-code', 'on'),
+          { writeProgress: vi.fn() },
+        );
 
-    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
-    expect(mocks.writePlatformSetting).toHaveBeenCalledWith(
-      GlobalStateKey.KIMI_CODE_PREFER,
-      true,
-    );
-    expect(result).toEqual({
-      message:
-        'Prefer Kimi Code subscription enabled for Kimi models · other models still use your own API keys.',
-    });
-  });
+        expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+        expect(mocks.writePlatformSetting).toHaveBeenCalledWith(
+          GlobalStateKey.KIMI_CODE_PREFER,
+          true,
+        );
+        expect(result).toEqual({
+          message:
+            'Prefer Kimi Code subscription enabled for Kimi models · other models still use your own API keys.',
+        });
+      }).pipe(withHttpClient),
+  );
 
-  it('guides to key entry when Kimi Code is selected without a key', async () => {
-    const result = await effectRuntime().runPromise(
-      await updateCliModelAccess(
-        context,
-        subscriptionPreference('kimi-code', 'on'),
-        { writeProgress: vi.fn() },
-      ),
-    );
+  it.effect(
+    'guides to key entry when Kimi Code is selected without a key',
+    () =>
+      Effect.gen(function* () {
+        const result = yield* updateCliModelAccess(
+          context,
+          subscriptionPreference('kimi-code', 'on'),
+          { writeProgress: vi.fn() },
+        );
 
-    expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
-    expect(result.message).toContain('No Kimi Code API key configured');
-    expect(result.message).toContain('https://www.kimi.com/code/console');
-  });
+        expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
+        expect(result.message).toContain('No Kimi Code API key configured');
+        expect(result.message).toContain('https://www.kimi.com/code/console');
+      }).pipe(withHttpClient),
+  );
 
   it('reports the GLM Coding Plan preference independently of key', async () => {
     mocks.hasUsableApiKey.mockImplementation(
@@ -357,243 +368,247 @@ describe('CLI model access routes', () => {
     );
   });
 
-  it('enables GLM Coding Plan routing on a personal fallback when a key exists', async () => {
-    mocks.hasUsableApiKey.mockResolvedValue(true);
+  it.effect(
+    'enables GLM Coding Plan routing on a personal fallback when a key exists',
+    () =>
+      Effect.gen(function* () {
+        mocks.hasUsableApiKey.mockResolvedValue(true);
 
-    const result = await effectRuntime().runPromise(
-      await updateCliModelAccess(
-        context,
-        subscriptionPreference('glm-code', 'on'),
-        { writeProgress: vi.fn() },
-      ),
-    );
+        const result = yield* updateCliModelAccess(
+          context,
+          subscriptionPreference('glm-code', 'on'),
+          { writeProgress: vi.fn() },
+        );
 
-    expect(mocks.setGLMCodingPlan).toHaveBeenCalledWith(true);
-    expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
-    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
-    expect(mocks.setPreferXaiSubscription).not.toHaveBeenCalled();
-    expect(mocks.updateGlobalState).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      message:
-        'Prefer GLM Coding Plan enabled for GLM models · other models still use your own API keys.',
-    });
-  });
+        expect(mocks.setGLMCodingPlan).toHaveBeenCalledWith(true);
+        expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
+        expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+        expect(mocks.setPreferXaiSubscription).not.toHaveBeenCalled();
+        expect(mocks.updateGlobalState).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          message:
+            'Prefer GLM Coding Plan enabled for GLM models · other models still use your own API keys.',
+        });
+      }).pipe(withHttpClient),
+  );
 
-  it('guides to key entry when GLM Coding Plan is selected without a key', async () => {
-    const result = await effectRuntime().runPromise(
-      await updateCliModelAccess(
-        context,
-        subscriptionPreference('glm-code', 'on'),
-        { writeProgress: vi.fn() },
-      ),
-    );
+  it.effect(
+    'guides to key entry when GLM Coding Plan is selected without a key',
+    () =>
+      Effect.gen(function* () {
+        const result = yield* updateCliModelAccess(
+          context,
+          subscriptionPreference('glm-code', 'on'),
+          { writeProgress: vi.fn() },
+        );
 
-    expect(mocks.setGLMCodingPlan).not.toHaveBeenCalled();
-    expect(result.message).toContain('No GLM API key configured');
-    expect(result.message).toContain('https://open.bigmodel.cn');
-  });
+        expect(mocks.setGLMCodingPlan).not.toHaveBeenCalled();
+        expect(result.message).toContain('No GLM API key configured');
+        expect(result.message).toContain('https://open.bigmodel.cn');
+      }).pipe(withHttpClient),
+  );
 
-  it('turns off GLM Coding Plan without requiring a key', async () => {
-    const result = await effectRuntime().runPromise(
-      await updateCliModelAccess(
+  it.effect('turns off GLM Coding Plan without requiring a key', () =>
+    Effect.gen(function* () {
+      const result = yield* updateCliModelAccess(
         context,
         subscriptionPreference('glm-code', 'off'),
         { writeProgress: vi.fn() },
-      ),
-    );
+      );
 
-    expect(mocks.hasUsableApiKey).not.toHaveBeenCalled();
-    expect(mocks.setGLMCodingPlan).toHaveBeenCalledWith(false);
-    expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
-    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      message: 'Prefer GLM Coding Plan disabled for GLM models.',
-    });
-  });
+      expect(mocks.hasUsableApiKey).not.toHaveBeenCalled();
+      expect(mocks.setGLMCodingPlan).toHaveBeenCalledWith(false);
+      expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
+      expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        message: 'Prefer GLM Coding Plan disabled for GLM models.',
+      });
+    }).pipe(withHttpClient),
+  );
 
-  it('signs in when needed and enables ChatGPT without an API key', async () => {
-    mocks.signInCliSubscription.mockReturnValue(
-      Effect.succeed({
-        signedIn: true,
-        email: 'user@example.com',
-        label: 'user@example.com',
-      }),
-    );
-    mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: true,
-      target: 'global',
-    });
-    const writeProgress = vi.fn();
+  it.effect('signs in when needed and enables ChatGPT without an API key', () =>
+    Effect.gen(function* () {
+      mocks.signInCliSubscription.mockReturnValue(
+        Effect.succeed({
+          signedIn: true,
+          email: 'user@example.com',
+          label: 'user@example.com',
+        }),
+      );
+      mocks.setPreferCodexSubscription.mockResolvedValue({
+        effective: true,
+        target: 'global',
+      });
+      const writeProgress = vi.fn();
 
-    const result = await effectRuntime().runPromise(
-      await updateCliModelAccess(
+      const result = yield* updateCliModelAccess(
         context,
         subscriptionPreference('chatgpt', 'on'),
         { writeProgress },
-      ),
-    );
+      );
 
-    expect(mocks.signInCliSubscription).toHaveBeenCalledWith(
-      'chatgpt',
-      { device: false, noBrowser: false },
-      { writeProgress },
-    );
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(true);
-    expect(mocks.updateGlobalState).toHaveBeenCalledWith(
-      'texra.useOpenRouter',
-      false,
-    );
-    expect(result.message).toBe(
-      'Prefer ChatGPT subscription enabled for Codex models (user@example.com).',
-    );
-  });
+      expect(mocks.signInCliSubscription).toHaveBeenCalledWith(
+        'chatgpt',
+        { device: false, noBrowser: false },
+        { writeProgress },
+      );
+      expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(true);
+      expect(mocks.updateGlobalState).toHaveBeenCalledWith(
+        'texra.useOpenRouter',
+        false,
+      );
+      expect(result.message).toBe(
+        'Prefer ChatGPT subscription enabled for Codex models (user@example.com).',
+      );
+    }).pipe(withHttpClient),
+  );
 
-  it('turns off ChatGPT without changing the Kimi preference', async () => {
-    mocks.getCodexStatus.mockResolvedValue({
-      signedIn: true,
-      email: 'user@example.com',
-    });
-    mocks.isPreferCodexSubscription.mockReturnValue(true);
-    mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: false,
-      target: 'global',
-    });
+  it.effect('turns off ChatGPT without changing the Kimi preference', () =>
+    Effect.gen(function* () {
+      mocks.getCodexStatus.mockResolvedValue({
+        signedIn: true,
+        email: 'user@example.com',
+      });
+      mocks.isPreferCodexSubscription.mockReturnValue(true);
+      mocks.setPreferCodexSubscription.mockResolvedValue({
+        effective: false,
+        target: 'global',
+      });
 
-    const result = await effectRuntime().runPromise(
-      await updateCliModelAccess(
+      const result = yield* updateCliModelAccess(
         context,
         subscriptionPreference('chatgpt', 'off'),
         { writeProgress: vi.fn() },
-      ),
-    );
+      );
 
-    expect(mocks.signInCliSubscription).not.toHaveBeenCalled();
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
-    expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      message: 'Prefer ChatGPT subscription disabled for Codex models.',
-    });
-  });
+      expect(mocks.signInCliSubscription).not.toHaveBeenCalled();
+      expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+      expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        message: 'Prefer ChatGPT subscription disabled for Codex models.',
+      });
+    }).pipe(withHttpClient),
+  );
 
-  it('represents preferences independently and toggles each without side effects', async () => {
-    mocks.getCodexStatus.mockResolvedValue({
-      signedIn: true,
-      email: 'user@example.com',
-    });
-    mocks.isPreferCodexSubscription.mockReturnValue(true);
-    mocks.getPreferKimiCode.mockReturnValue(true);
-    mocks.hasUsableApiKey.mockResolvedValue(true);
+  it.effect(
+    'represents preferences independently and toggles each without side effects',
+    () =>
+      Effect.gen(function* () {
+        mocks.getCodexStatus.mockResolvedValue({
+          signedIn: true,
+          email: 'user@example.com',
+        });
+        mocks.isPreferCodexSubscription.mockReturnValue(true);
+        mocks.getPreferKimiCode.mockReturnValue(true);
+        mocks.hasUsableApiKey.mockResolvedValue(true);
 
-    const status = await readCliModelAccessStatus();
-    expect(status.preferences).toEqual({
-      chatGpt: 'on',
-      grok: 'off',
-    });
-    const descriptions = Object.fromEntries(
-      buildCliModelAccessItems({ kind: 'loaded', access: status })
-        .filter((item) => item.value.kind === 'subscription-preference')
-        .map((item) => {
-          if (item.value.kind !== 'subscription-preference') {
-            throw new Error('expected subscription preference');
-          }
-          return [item.value.provider, item.description];
-        }),
-    );
-    expect(descriptions).toEqual({
-      chatgpt: 'On · user@example.com',
-      grok: 'Off · sign in required to enable',
-      'kimi-code': 'On · key configured',
-      'glm-code': 'Off · key configured',
-    });
+        const status = yield* Effect.promise(() => readCliModelAccessStatus());
+        expect(status.preferences).toEqual({
+          chatGpt: 'on',
+          grok: 'off',
+        });
+        const descriptions = Object.fromEntries(
+          buildCliModelAccessItems({ kind: 'loaded', access: status })
+            .filter((item) => item.value.kind === 'subscription-preference')
+            .map((item) => {
+              if (item.value.kind !== 'subscription-preference') {
+                throw new Error('expected subscription preference');
+              }
+              return [item.value.provider, item.description];
+            }),
+        );
+        expect(descriptions).toEqual({
+          chatgpt: 'On · user@example.com',
+          grok: 'Off · sign in required to enable',
+          'kimi-code': 'On · key configured',
+          'glm-code': 'Off · key configured',
+        });
 
-    await effectRuntime().runPromise(
-      await updateCliModelAccess(
-        context,
-        subscriptionPreference('kimi-code', 'off'),
-        { writeProgress: vi.fn() },
-      ),
-    );
-    expect(mocks.writePlatformSetting).toHaveBeenCalledWith(
-      GlobalStateKey.KIMI_CODE_PREFER,
-      false,
-    );
-    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
-    expect(mocks.setPreferXaiSubscription).not.toHaveBeenCalled();
+        yield* updateCliModelAccess(
+          context,
+          subscriptionPreference('kimi-code', 'off'),
+          { writeProgress: vi.fn() },
+        );
+        expect(mocks.writePlatformSetting).toHaveBeenCalledWith(
+          GlobalStateKey.KIMI_CODE_PREFER,
+          false,
+        );
+        expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+        expect(mocks.setPreferXaiSubscription).not.toHaveBeenCalled();
 
-    vi.clearAllMocks();
-    mocks.getCodexStatus.mockResolvedValue({
-      signedIn: true,
-      email: 'user@example.com',
-    });
-    mocks.isPreferCodexSubscription.mockReturnValue(true);
-    mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: false,
-      target: 'global',
-    });
-    await effectRuntime().runPromise(
-      await updateCliModelAccess(
-        context,
-        subscriptionPreference('chatgpt', 'off'),
-        { writeProgress: vi.fn() },
-      ),
-    );
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
-    expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
-    expect(mocks.setPreferXaiSubscription).not.toHaveBeenCalled();
-  });
+        vi.clearAllMocks();
+        mocks.getCodexStatus.mockResolvedValue({
+          signedIn: true,
+          email: 'user@example.com',
+        });
+        mocks.isPreferCodexSubscription.mockReturnValue(true);
+        mocks.setPreferCodexSubscription.mockResolvedValue({
+          effective: false,
+          target: 'global',
+        });
+        yield* updateCliModelAccess(
+          context,
+          subscriptionPreference('chatgpt', 'off'),
+          { writeProgress: vi.fn() },
+        );
+        expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+        expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
+        expect(mocks.setPreferXaiSubscription).not.toHaveBeenCalled();
+      }).pipe(withHttpClient),
+  );
 
-  it('turns off a stale signed-out preference without signing in', async () => {
-    mocks.isPreferCodexSubscription.mockReturnValue(true);
-    mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: false,
-      target: 'global',
-    });
+  it.effect('turns off a stale signed-out preference without signing in', () =>
+    Effect.gen(function* () {
+      mocks.isPreferCodexSubscription.mockReturnValue(true);
+      mocks.setPreferCodexSubscription.mockResolvedValue({
+        effective: false,
+        target: 'global',
+      });
 
-    const status = await readCliModelAccessStatus();
-    const selection = buildCliModelAccessItems({
-      kind: 'loaded',
-      access: status,
-    }).find(
-      (item) =>
-        item.value.kind === 'subscription-preference' &&
-        item.value.provider === 'chatgpt',
-    );
-    expect(selection?.description).toBe('On · sign in required');
-    if (!selection) throw new Error('Expected ChatGPT preference item');
-    await effectRuntime().runPromise(
-      await updateCliModelAccess(context, selection.value, {
+      const status = yield* Effect.promise(() => readCliModelAccessStatus());
+      const selection = buildCliModelAccessItems({
+        kind: 'loaded',
+        access: status,
+      }).find(
+        (item) =>
+          item.value.kind === 'subscription-preference' &&
+          item.value.provider === 'chatgpt',
+      );
+      expect(selection?.description).toBe('On · sign in required');
+      if (!selection) throw new Error('Expected ChatGPT preference item');
+      yield* updateCliModelAccess(context, selection.value, {
         writeProgress: vi.fn(),
-      }),
-    );
+      });
 
-    expect(mocks.signInCliSubscription).not.toHaveBeenCalled();
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
-  });
+      expect(mocks.signInCliSubscription).not.toHaveBeenCalled();
+      expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    }).pipe(withHttpClient),
+  );
 
-  it('turns off a stale Kimi preference without requiring a key', async () => {
-    mocks.getPreferKimiCode.mockReturnValue(true);
-    const status = await readCliModelAccessStatus();
-    const selection = buildCliModelAccessItems({
-      kind: 'loaded',
-      access: status,
-    }).find(
-      (item) =>
-        item.value.kind === 'subscription-preference' &&
-        item.value.provider === 'kimi-code',
-    );
-    expect(selection?.description).toBe('On · key required');
-    if (!selection) throw new Error('Expected Kimi preference item');
+  it.effect('turns off a stale Kimi preference without requiring a key', () =>
+    Effect.gen(function* () {
+      mocks.getPreferKimiCode.mockReturnValue(true);
+      const status = yield* Effect.promise(() => readCliModelAccessStatus());
+      const selection = buildCliModelAccessItems({
+        kind: 'loaded',
+        access: status,
+      }).find(
+        (item) =>
+          item.value.kind === 'subscription-preference' &&
+          item.value.provider === 'kimi-code',
+      );
+      expect(selection?.description).toBe('On · key required');
+      if (!selection) throw new Error('Expected Kimi preference item');
 
-    vi.clearAllMocks();
-    await effectRuntime().runPromise(
-      await updateCliModelAccess(context, selection.value),
-    );
+      vi.clearAllMocks();
+      yield* updateCliModelAccess(context, selection.value);
 
-    expect(mocks.hasUsableApiKey).not.toHaveBeenCalled();
-    expect(mocks.writePlatformSetting).toHaveBeenCalledWith(
-      GlobalStateKey.KIMI_CODE_PREFER,
-      false,
-    );
-    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
-  });
+      expect(mocks.hasUsableApiKey).not.toHaveBeenCalled();
+      expect(mocks.writePlatformSetting).toHaveBeenCalledWith(
+        GlobalStateKey.KIMI_CODE_PREFER,
+        false,
+      );
+      expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+    }).pipe(withHttpClient),
+  );
 });

--- a/src/test-kernel/cli/ToolUseResumeData.vitest.ts
+++ b/src/test-kernel/cli/ToolUseResumeData.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect } from 'vitest';
 
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import type { AgentConfig } from '@agent/runtime';
@@ -19,10 +20,10 @@ import { StorageFS } from '@utils/files/storageFS';
 
 setupPlatform({ workspacePath: '/workspace/cli-resume-listing' });
 
-function isCliRunResumable(facts: CliRunResumabilityFacts): Promise<boolean> {
-  return Effect.runPromise(
-    isCliRunResumableEffect(facts, createProcessSession()),
-  );
+function isCliRunResumable(
+  facts: CliRunResumabilityFacts,
+): Effect.Effect<boolean> {
+  return isCliRunResumableEffect(facts, createProcessSession());
 }
 
 const config = {
@@ -70,46 +71,52 @@ afterEach(async () => {
 });
 
 describe('CLI listing resumability', () => {
-  it.each([
+  it.effect.each([
     ['no checkpoint file', { checkpointPresent: false }],
     ['no stamped stream id', { streamId: undefined }],
-  ])(
+  ] as const)(
     'does not advertise a row with %s, without reading its state',
-    async (description, overrides) => {
-      const executionId =
-        `gate-${description.replaceAll(' ', '-')}` as ExecutionId;
-      // A continuable record is on disk, so reading it would answer `true`.
-      // Only the two free facts can produce the `false` asserted below.
-      await writeFlowRecord(executionId, { currentRound: 0, totalRounds: 4 });
+    ([description, overrides]) =>
+      Effect.gen(function* () {
+        const executionId =
+          `gate-${description.replaceAll(' ', '-')}` as ExecutionId;
+        // A continuable record is on disk, so reading it would answer `true`.
+        // Only the two free facts can produce the `false` asserted below.
+        yield* Effect.promise(() =>
+          writeFlowRecord(executionId, { currentRound: 0, totalRounds: 4 }),
+        );
 
-      await expect(
-        isCliRunResumable(listingFacts(executionId, overrides)),
-      ).resolves.toBe(false);
-    },
+        expect(
+          yield* isCliRunResumable(listingFacts(executionId, overrides)),
+        ).toBe(false);
+      }),
   );
 
-  it.each([
+  it.effect.each([
     [
       'a tool-use row',
       { agentCategory: 'toolUse' as AgentConfig['agentCategory'] },
     ],
     ['a workflow row that did not fail', { outcome: RUN_OUTCOME.CANCELLED }],
-  ])(
+  ] as const)(
     'advertises %s without parsing its checkpoint',
-    async (description, overrides) => {
-      const executionId =
-        `free-${description.replaceAll(' ', '-')}` as ExecutionId;
-      // A terminal rejection is on disk, so a parse would answer `false`.
-      // Only the short-circuit can produce the `true` asserted below.
-      await writeFlowRecord(executionId, TERMINAL_REJECTION);
+    ([description, overrides]) =>
+      Effect.gen(function* () {
+        const executionId =
+          `free-${description.replaceAll(' ', '-')}` as ExecutionId;
+        // A terminal rejection is on disk, so a parse would answer `false`.
+        // Only the short-circuit can produce the `true` asserted below.
+        yield* Effect.promise(() =>
+          writeFlowRecord(executionId, TERMINAL_REJECTION),
+        );
 
-      await expect(
-        isCliRunResumable(listingFacts(executionId, overrides)),
-      ).resolves.toBe(true);
-    },
+        expect(
+          yield* isCliRunResumable(listingFacts(executionId, overrides)),
+        ).toBe(true);
+      }),
   );
 
-  it.each([
+  it.effect.each([
     ['the unresolved rejection marker', TERMINAL_REJECTION],
     [
       'legacy compile failure context',
@@ -119,16 +126,15 @@ describe('CLI listing resumability', () => {
         compileFailureContext: 'The generated document did not compile.',
       },
     ],
-  ])(
+  ] as const)(
     'does not advertise a failed workflow with terminal %s as resumable',
-    async (description, shared) => {
-      const executionId =
-        `workflow-terminal-${description.replaceAll(' ', '-')}` as ExecutionId;
-      await writeFlowRecord(executionId, shared);
+    ([description, shared]) =>
+      Effect.gen(function* () {
+        const executionId =
+          `workflow-terminal-${description.replaceAll(' ', '-')}` as ExecutionId;
+        yield* Effect.promise(() => writeFlowRecord(executionId, shared));
 
-      await expect(isCliRunResumable(listingFacts(executionId))).resolves.toBe(
-        false,
-      );
-    },
+        expect(yield* isCliRunResumable(listingFacts(executionId))).toBe(false);
+      }),
   );
 });

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -4,10 +4,11 @@
 // registry, event hub, stream status, host interactions) are the real
 // runtime objects wherever a test asserts through them.
 
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 import PQueue from 'p-queue';
 import pDefer from 'p-defer';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   executeAgent: vi.fn(),
@@ -508,59 +509,63 @@ describe('CLI terminal outcome resolution', () => {
     mocks.getExecutionRecords.mockReset();
   });
 
-  it('prefers the persisted post-shutdown outcome', async () => {
-    mocks.getExecutionRecords.mockReturnValue({
-      readMeta: vi.fn().mockResolvedValue({
-        outcome: RUN_OUTCOME.CANCELLED,
-      }),
-    });
+  it.effect('prefers the persisted post-shutdown outcome', () =>
+    Effect.gen(function* () {
+      mocks.getExecutionRecords.mockReturnValue({
+        readMeta: vi.fn().mockResolvedValue({
+          outcome: RUN_OUTCOME.CANCELLED,
+        }),
+      });
 
-    await expect(
-      Effect.runPromise(
-        readCliRunOutcomeState(mocks.defaultSession(), {
+      expect(
+        yield* readCliRunOutcomeState(mocks.defaultSession(), {
           category: 'toolUse',
           executionId: 'shutdown-race',
           outcome: RUN_OUTCOME.COMPLETED,
           streamId: 'shutdown-race',
         } as Parameters<typeof readCliRunOutcomeState>[1]),
-      ),
-    ).resolves.toEqual({
-      outcome: RUN_OUTCOME.CANCELLED,
-      outcomePersisted: true,
-    });
-  });
+      ).toEqual({
+        outcome: RUN_OUTCOME.CANCELLED,
+        outcomePersisted: true,
+      });
+    }),
+  );
 
-  it('reports an outcome read failure and retains the completed run', async () => {
-    const reportReadFailure = vi.fn();
-    mocks.getExecutionRecords.mockReturnValue({
-      readMeta: vi.fn().mockRejectedValue(new Error('metadata read failed')),
-    });
+  it.effect(
+    'reports an outcome read failure and retains the completed run',
+    () =>
+      Effect.gen(function* () {
+        const reportReadFailure = vi.fn();
+        mocks.getExecutionRecords.mockReturnValue({
+          readMeta: vi
+            .fn()
+            .mockRejectedValue(new Error('metadata read failed')),
+        });
 
-    await expect(
-      Effect.runPromise(
-        readCliRunOutcomeState(
-          mocks.defaultSession(),
-          {
-            category: 'toolUse',
-            executionId: 'broken-storage',
-            outcome: RUN_OUTCOME.COMPLETED,
-            streamId: 'broken-storage',
-          } as Parameters<typeof readCliRunOutcomeState>[1],
-          reportReadFailure,
-        ),
-      ),
-    ).resolves.toEqual({
-      outcome: RUN_OUTCOME.COMPLETED,
-      outcomePersisted: false,
-    });
-    expect(reportReadFailure).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({
-        message:
-          'Could not verify the persisted outcome for execution broken-storage; using the current run outcome: metadata read failed',
-        cause: expect.any(Error),
+        expect(
+          yield* readCliRunOutcomeState(
+            mocks.defaultSession(),
+            {
+              category: 'toolUse',
+              executionId: 'broken-storage',
+              outcome: RUN_OUTCOME.COMPLETED,
+              streamId: 'broken-storage',
+            } as Parameters<typeof readCliRunOutcomeState>[1],
+            reportReadFailure,
+          ),
+        ).toEqual({
+          outcome: RUN_OUTCOME.COMPLETED,
+          outcomePersisted: false,
+        });
+        expect(reportReadFailure).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            message:
+              'Could not verify the persisted outcome for execution broken-storage; using the current run outcome: metadata read failed',
+            cause: expect.any(Error),
+          }),
+        );
       }),
-    );
-  });
+  );
 });
 
 describe('createChatSessionController', () => {

--- a/src/test-kernel/common/teams/TeamAvailabilityPreflight.vitest.ts
+++ b/src/test-kernel/common/teams/TeamAvailabilityPreflight.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 
 import { preflightTeamAvailability } from '@common/teams/TeamAvailabilityPreflight';
 
@@ -47,118 +48,129 @@ function options(overrides: {
 }
 
 describe('team availability preflight', () => {
-  it('does not prompt or refresh a local-only team', async () => {
-    const deps = options({ initial: { unresolvedNames: ['local-plugin'] } });
-    await expect(
-      Effect.runPromise(preflightTeamAvailability(deps.input)),
-    ).resolves.toEqual({
-      status: 'proceed',
-      value: { unresolvedNames: ['local-plugin'] },
-      partial: false,
-    });
-    expect(deps.choose).not.toHaveBeenCalled();
-    expect(deps.refresh).not.toHaveBeenCalled();
-  });
+  it.effect('does not prompt or refresh a local-only team', () =>
+    Effect.gen(function* () {
+      const deps = options({ initial: { unresolvedNames: ['local-plugin'] } });
+      expect(yield* preflightTeamAvailability(deps.input)).toEqual({
+        status: 'proceed',
+        value: { unresolvedNames: ['local-plugin'] },
+        partial: false,
+      });
+      expect(deps.choose).not.toHaveBeenCalled();
+      expect(deps.refresh).not.toHaveBeenCalled();
+    }),
+  );
 
-  it('continues only after an explicit partial-team choice', async () => {
-    const deps = options({ choice: 'continue' });
-    await expect(
-      Effect.runPromise(preflightTeamAvailability(deps.input)),
-    ).resolves.toMatchObject({
-      status: 'proceed',
-      partial: true,
-    });
-    expect(deps.signIn).not.toHaveBeenCalled();
-    expect(deps.refresh).not.toHaveBeenCalled();
-  });
+  it.effect('continues only after an explicit partial-team choice', () =>
+    Effect.gen(function* () {
+      const deps = options({ choice: 'continue' });
+      expect(yield* preflightTeamAvailability(deps.input)).toMatchObject({
+        status: 'proceed',
+        partial: true,
+      });
+      expect(deps.signIn).not.toHaveBeenCalled();
+      expect(deps.refresh).not.toHaveBeenCalled();
+    }),
+  );
 
-  it('cancels without signing in or refreshing', async () => {
-    const deps = options({ choice: 'cancel' });
-    await expect(
-      Effect.runPromise(preflightTeamAvailability(deps.input)),
-    ).resolves.toMatchObject({
-      status: 'cancelled',
-    });
-    expect(deps.signIn).not.toHaveBeenCalled();
-    expect(deps.refresh).not.toHaveBeenCalled();
-  });
+  it.effect('cancels without signing in or refreshing', () =>
+    Effect.gen(function* () {
+      const deps = options({ choice: 'cancel' });
+      expect(yield* preflightTeamAvailability(deps.input)).toMatchObject({
+        status: 'cancelled',
+      });
+      expect(deps.signIn).not.toHaveBeenCalled();
+      expect(deps.refresh).not.toHaveBeenCalled();
+    }),
+  );
 
-  it('honors a supplied partial-team choice before authenticated refresh', async () => {
-    const deps = options({ authenticated: true, providedChoice: 'continue' });
-    await expect(
-      Effect.runPromise(preflightTeamAvailability(deps.input)),
-    ).resolves.toMatchObject({
-      status: 'proceed',
-      partial: true,
-    });
-    expect(deps.choose).not.toHaveBeenCalled();
-    expect(deps.refresh).not.toHaveBeenCalled();
-  });
+  it.effect(
+    'honors a supplied partial-team choice before authenticated refresh',
+    () =>
+      Effect.gen(function* () {
+        const deps = options({
+          authenticated: true,
+          providedChoice: 'continue',
+        });
+        expect(yield* preflightTeamAvailability(deps.input)).toMatchObject({
+          status: 'proceed',
+          partial: true,
+        });
+        expect(deps.choose).not.toHaveBeenCalled();
+        expect(deps.refresh).not.toHaveBeenCalled();
+      }),
+  );
 
-  it('honors a supplied cancellation before authenticated refresh', async () => {
-    const deps = options({ authenticated: true, providedChoice: 'cancel' });
-    await expect(
-      Effect.runPromise(preflightTeamAvailability(deps.input)),
-    ).resolves.toMatchObject({
-      status: 'cancelled',
-    });
-    expect(deps.choose).not.toHaveBeenCalled();
-    expect(deps.refresh).not.toHaveBeenCalled();
-  });
+  it.effect('honors a supplied cancellation before authenticated refresh', () =>
+    Effect.gen(function* () {
+      const deps = options({ authenticated: true, providedChoice: 'cancel' });
+      expect(yield* preflightTeamAvailability(deps.input)).toMatchObject({
+        status: 'cancelled',
+      });
+      expect(deps.choose).not.toHaveBeenCalled();
+      expect(deps.refresh).not.toHaveBeenCalled();
+    }),
+  );
 
-  it('returns an actionable choice-required result without side effects', async () => {
-    const deps = options({ choiceRequired: true });
+  it.effect(
+    'returns an actionable choice-required result without side effects',
+    () =>
+      Effect.gen(function* () {
+        const deps = options({ choiceRequired: true });
 
-    await expect(
-      Effect.runPromise(preflightTeamAvailability(deps.input)),
-    ).resolves.toMatchObject({
-      status: 'choice-required',
-      unavailableNames: ['orchestrator'],
-    });
-    expect(deps.signIn).not.toHaveBeenCalled();
-    expect(deps.refresh).not.toHaveBeenCalled();
-  });
+        expect(yield* preflightTeamAvailability(deps.input)).toMatchObject({
+          status: 'choice-required',
+          unavailableNames: ['orchestrator'],
+        });
+        expect(deps.signIn).not.toHaveBeenCalled();
+        expect(deps.refresh).not.toHaveBeenCalled();
+      }),
+  );
 
-  it('refreshes and retries exactly once after successful sign-in', async () => {
-    const deps = options({ choice: 'sign-in', signedIn: true });
-    await expect(
-      Effect.runPromise(preflightTeamAvailability(deps.input)),
-    ).resolves.toMatchObject({
-      status: 'proceed',
-      partial: false,
-    });
-    expect(deps.signIn).toHaveBeenCalledOnce();
-    expect(deps.refresh).toHaveBeenCalledOnce();
-  });
+  it.effect('refreshes and retries exactly once after successful sign-in', () =>
+    Effect.gen(function* () {
+      const deps = options({ choice: 'sign-in', signedIn: true });
+      expect(yield* preflightTeamAvailability(deps.input)).toMatchObject({
+        status: 'proceed',
+        partial: false,
+      });
+      expect(deps.signIn).toHaveBeenCalledOnce();
+      expect(deps.refresh).toHaveBeenCalledOnce();
+    }),
+  );
 
-  it('reports the real availability failure after authenticated refresh', async () => {
-    const deps = options({
-      authenticated: true,
-      refreshed: { unresolvedNames: ['orchestrator'] },
-    });
-    await expect(
-      Effect.runPromise(preflightTeamAvailability(deps.input)),
-    ).resolves.toEqual({
-      status: 'unavailable',
-      value: { unresolvedNames: ['orchestrator'] },
-      unavailableNames: ['orchestrator'],
-    });
-    expect(deps.choose).not.toHaveBeenCalled();
-    expect(deps.signIn).not.toHaveBeenCalled();
-    expect(deps.refresh).toHaveBeenCalledOnce();
-  });
+  it.effect(
+    'reports the real availability failure after authenticated refresh',
+    () =>
+      Effect.gen(function* () {
+        const deps = options({
+          authenticated: true,
+          refreshed: { unresolvedNames: ['orchestrator'] },
+        });
+        expect(yield* preflightTeamAvailability(deps.input)).toEqual({
+          status: 'unavailable',
+          value: { unresolvedNames: ['orchestrator'] },
+          unavailableNames: ['orchestrator'],
+        });
+        expect(deps.choose).not.toHaveBeenCalled();
+        expect(deps.signIn).not.toHaveBeenCalled();
+        expect(deps.refresh).toHaveBeenCalledOnce();
+      }),
+  );
 
-  it('does not repeat an authenticated refresh already performed by the caller', async () => {
-    const deps = options({
-      authenticated: true,
-      remoteCatalogRefreshAttempted: true,
-    });
-    await expect(
-      Effect.runPromise(preflightTeamAvailability(deps.input)),
-    ).resolves.toMatchObject({
-      status: 'unavailable',
-      unavailableNames: ['orchestrator'],
-    });
-    expect(deps.refresh).not.toHaveBeenCalled();
-  });
+  it.effect(
+    'does not repeat an authenticated refresh already performed by the caller',
+    () =>
+      Effect.gen(function* () {
+        const deps = options({
+          authenticated: true,
+          remoteCatalogRefreshAttempted: true,
+        });
+        expect(yield* preflightTeamAvailability(deps.input)).toMatchObject({
+          status: 'unavailable',
+          unavailableNames: ['orchestrator'],
+        });
+        expect(deps.refresh).not.toHaveBeenCalled();
+      }),
+  );
 });

--- a/src/test-kernel/common/teams/TeamPlan.vitest.ts
+++ b/src/test-kernel/common/teams/TeamPlan.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 
 import {
   buildTeamOptions,
@@ -378,45 +379,49 @@ describe('buildTeamOptions', () => {
 });
 
 describe('loadTeamOptions', () => {
-  it('refreshes a gapped plan when remote access exists and builds final options', async () => {
-    let ensured = false;
-    let refreshed = false;
-    const custom = preset();
+  it.effect(
+    'refreshes a gapped plan when remote access exists and builds final options',
+    () =>
+      Effect.gen(function* () {
+        let ensured = false;
+        let refreshed = false;
+        const custom = preset();
 
-    const options = await Effect.runPromise(
-      loadTeamOptions({
-        customPresetsRaw: [custom],
-        ensureCatalogLoaded: () =>
-          Effect.sync(() => {
-            ensured = true;
-          }),
-        getAgents: (category) => {
-          if (!refreshed) return [];
-          return category === 'workflow'
-            ? [agent('writer', { source: 'builtInWorkflow' })]
-            : [agent('lead', { tools: delegateTools }), agent('member')];
-        },
-        canAccessRemoteCatalog: async () => true,
-        refreshRemote: () =>
-          Effect.sync(() => {
-            refreshed = true;
-          }),
+        const options = yield* loadTeamOptions({
+          customPresetsRaw: [custom],
+          ensureCatalogLoaded: () =>
+            Effect.sync(() => {
+              ensured = true;
+            }),
+          getAgents: (category) => {
+            if (!refreshed) return [];
+            return category === 'workflow'
+              ? [agent('writer', { source: 'builtInWorkflow' })]
+              : [agent('lead', { tools: delegateTools }), agent('member')];
+          },
+          canAccessRemoteCatalog: async () => true,
+          refreshRemote: () =>
+            Effect.sync(() => {
+              refreshed = true;
+            }),
+        });
+
+        expect(ensured).toBe(true);
+        expect(refreshed).toBe(true);
+        expect(
+          options.find((option) => option.value === custom.id),
+        ).toMatchObject({
+          disabled: undefined,
+          unavailableMembers: [],
+        });
       }),
-    );
+  );
 
-    expect(ensured).toBe(true);
-    expect(refreshed).toBe(true);
-    expect(options.find((option) => option.value === custom.id)).toMatchObject({
-      disabled: undefined,
-      unavailableMembers: [],
-    });
-  });
+  it.effect('does not refresh gapped plans without remote catalog access', () =>
+    Effect.gen(function* () {
+      let refreshed = false;
 
-  it('does not refresh gapped plans without remote catalog access', async () => {
-    let refreshed = false;
-
-    await Effect.runPromise(
-      loadTeamOptions({
+      yield* loadTeamOptions({
         customPresetsRaw: [preset()],
         ensureCatalogLoaded: () => Effect.void,
         getAgents: () => [],
@@ -425,21 +430,21 @@ describe('loadTeamOptions', () => {
           Effect.sync(() => {
             refreshed = true;
           }),
-      }),
-    );
+      });
 
-    expect(refreshed).toBe(false);
-  });
+      expect(refreshed).toBe(false);
+    }),
+  );
 
-  it('loads the catalog before planning team options', async () => {
-    let loaded = false;
-    const getAgents = vi.fn(() => {
-      expect(loaded).toBe(true);
-      return [];
-    });
+  it.effect('loads the catalog before planning team options', () =>
+    Effect.gen(function* () {
+      let loaded = false;
+      const getAgents = vi.fn(() => {
+        expect(loaded).toBe(true);
+        return [];
+      });
 
-    await Effect.runPromise(
-      loadTeamOptions({
+      yield* loadTeamOptions({
         customPresetsRaw: [],
         ensureCatalogLoaded: () =>
           Effect.sync(() => {
@@ -448,11 +453,11 @@ describe('loadTeamOptions', () => {
         getAgents,
         canAccessRemoteCatalog: async () => false,
         refreshRemote: () => Effect.void,
-      }),
-    );
+      });
 
-    expect(getAgents).toHaveBeenCalled();
-  });
+      expect(getAgents).toHaveBeenCalled();
+    }),
+  );
 });
 
 describe('resolveTeamLaunch', () => {
@@ -486,36 +491,36 @@ describe('resolveTeamLaunch', () => {
     });
   }
 
-  it('returns execution-scoped fields for a ready team', async () => {
-    await expect(
-      Effect.runPromise(resolveTeamLaunch(launchArgs())),
-    ).resolves.toEqual({
-      status: 'ready',
-      fields: {
-        agent: 'builtInToolUse:lead',
-        delegationAgentScope: {
-          workflow: ['builtInWorkflow:writer'],
-          toolUse: ['builtInToolUse:lead', 'builtInToolUse:member'],
+  it.effect('returns execution-scoped fields for a ready team', () =>
+    Effect.gen(function* () {
+      expect(yield* resolveTeamLaunch(launchArgs())).toEqual({
+        status: 'ready',
+        fields: {
+          agent: 'builtInToolUse:lead',
+          delegationAgentScope: {
+            workflow: ['builtInWorkflow:writer'],
+            toolUse: ['builtInToolUse:lead', 'builtInToolUse:member'],
+          },
+          cli: { multiAgentPresetId: 'custom-team' },
         },
-        cli: { multiAgentPresetId: 'custom-team' },
-      },
-      partial: false,
-      missingNames: [],
-    });
-  });
+        partial: false,
+        missingNames: [],
+      });
+    }),
+  );
 
-  it('loads the catalog before planning a team launch', async () => {
-    let loaded = false;
-    const getAgents = vi.fn((category: string) => {
-      expect(loaded).toBe(true);
-      return category === 'workflow'
-        ? [agent('writer', { source: 'builtInWorkflow' })]
-        : [agent('lead', { tools: delegateTools }), agent('member')];
-    });
+  it.effect('loads the catalog before planning a team launch', () =>
+    Effect.gen(function* () {
+      let loaded = false;
+      const getAgents = vi.fn((category: string) => {
+        expect(loaded).toBe(true);
+        return category === 'workflow'
+          ? [agent('writer', { source: 'builtInWorkflow' })]
+          : [agent('lead', { tools: delegateTools }), agent('member')];
+      });
 
-    await expect(
-      Effect.runPromise(
-        resolveTeamLaunch(
+      expect(
+        yield* resolveTeamLaunch(
           launchArgs({
             ensureCatalogLoaded: () =>
               Effect.sync(() => {
@@ -524,110 +529,112 @@ describe('resolveTeamLaunch', () => {
             getAgents,
           }),
         ),
-      ),
-    ).resolves.toMatchObject({ status: 'ready' });
-    expect(getAgents).toHaveBeenCalled();
-  });
+      ).toMatchObject({ status: 'ready' });
+      expect(getAgents).toHaveBeenCalled();
+    }),
+  );
 
-  it('continues with available members and reports a partial team', async () => {
-    const hostedPreset = preset({
-      agents: {
-        workflow: ['writer', 'hosted-writer'],
-        toolUse: ['lead', 'member'],
-      },
-      texraHostedAgents: ['hosted-writer'],
-    });
+  it.effect('continues with available members and reports a partial team', () =>
+    Effect.gen(function* () {
+      const hostedPreset = preset({
+        agents: {
+          workflow: ['writer', 'hosted-writer'],
+          toolUse: ['lead', 'member'],
+        },
+        texraHostedAgents: ['hosted-writer'],
+      });
 
-    await expect(
-      Effect.runPromise(
-        resolveTeamLaunch(
+      expect(
+        yield* resolveTeamLaunch(
           launchArgs({
             customPresetsRaw: [hostedPreset],
             choose: async () => 'continue' as const,
           }),
         ),
-      ),
-    ).resolves.toMatchObject({
-      status: 'ready',
-      partial: true,
-      missingNames: ['hosted-writer'],
-    });
-  });
+      ).toMatchObject({
+        status: 'ready',
+        partial: true,
+        missingNames: ['hosted-writer'],
+      });
+    }),
+  );
 
-  it('uses a provided continue choice without invoking the interactive port', async () => {
-    const choose = vi.fn(async () => undefined);
-    await expect(
-      Effect.runPromise(
-        resolveTeamLaunch(
+  it.effect(
+    'uses a provided continue choice without invoking the interactive port',
+    () =>
+      Effect.gen(function* () {
+        const choose = vi.fn(async () => undefined);
+        expect(
+          yield* resolveTeamLaunch(
+            launchArgs({
+              customPresetsRaw: [hostedWriterPreset()],
+              providedChoice: 'continue',
+              choose,
+            }),
+          ),
+        ).toMatchObject({ status: 'ready', partial: true });
+        expect(choose).not.toHaveBeenCalled();
+      }),
+  );
+
+  it.effect('treats an explicit cancel or dismissed choice as cancelled', () =>
+    Effect.gen(function* () {
+      expect(
+        yield* resolveTeamLaunch(
           launchArgs({
             customPresetsRaw: [hostedWriterPreset()],
-            providedChoice: 'continue',
-            choose,
           }),
         ),
-      ),
-    ).resolves.toMatchObject({ status: 'ready', partial: true });
-    expect(choose).not.toHaveBeenCalled();
-  });
-
-  it('treats an explicit cancel or dismissed choice as cancelled', async () => {
-    await expect(
-      Effect.runPromise(
-        resolveTeamLaunch(
-          launchArgs({
-            customPresetsRaw: [hostedWriterPreset()],
-          }),
-        ),
-      ),
-    ).resolves.toEqual({ status: 'cancelled' });
-    await expect(
-      Effect.runPromise(
-        resolveTeamLaunch(
+      ).toEqual({ status: 'cancelled' });
+      expect(
+        yield* resolveTeamLaunch(
           launchArgs({
             customPresetsRaw: [hostedWriterPreset()],
             choose: async () => undefined,
           }),
         ),
-      ),
-    ).resolves.toEqual({ status: 'cancelled' });
-  });
+      ).toEqual({ status: 'cancelled' });
+    }),
+  );
 
-  it('reports hosted members still unavailable after remote refresh', async () => {
-    let refreshed = false;
-    await expect(
-      Effect.runPromise(
-        resolveTeamLaunch(
-          launchArgs({
-            customPresetsRaw: [hostedWriterPreset()],
-            canAccessRemoteCatalog: async () => true,
-            refreshRemote: () =>
-              Effect.sync(() => {
-                refreshed = true;
-              }),
-          }),
-        ),
-      ),
-    ).resolves.toEqual({
-      status: 'unavailable',
-      unavailableNames: ['hosted-writer'],
-    });
-    expect(refreshed).toBe(true);
-  });
+  it.effect(
+    'reports hosted members still unavailable after remote refresh',
+    () =>
+      Effect.gen(function* () {
+        let refreshed = false;
+        expect(
+          yield* resolveTeamLaunch(
+            launchArgs({
+              customPresetsRaw: [hostedWriterPreset()],
+              canAccessRemoteCatalog: async () => true,
+              refreshRemote: () =>
+                Effect.sync(() => {
+                  refreshed = true;
+                }),
+            }),
+          ),
+        ).toEqual({
+          status: 'unavailable',
+          unavailableNames: ['hosted-writer'],
+        });
+        expect(refreshed).toBe(true);
+      }),
+  );
 
-  it('reports an unknown team without consulting catalog ports', async () => {
-    const getAgents = vi.fn(() => []);
-    await expect(
-      Effect.runPromise(
-        resolveTeamLaunch(launchArgs({ teamId: 'missing', getAgents })),
-      ),
-    ).resolves.toEqual({ status: 'unknown-team' });
-    expect(getAgents).not.toHaveBeenCalled();
-  });
+  it.effect('reports an unknown team without consulting catalog ports', () =>
+    Effect.gen(function* () {
+      const getAgents = vi.fn(() => []);
+      expect(
+        yield* resolveTeamLaunch(launchArgs({ teamId: 'missing', getAgents })),
+      ).toEqual({ status: 'unknown-team' });
+      expect(getAgents).not.toHaveBeenCalled();
+    }),
+  );
 
-  it('blocks a planned team with no delegation-capable root', async () => {
-    await expect(
-      Effect.runPromise(
-        resolveTeamLaunch(
+  it.effect('blocks a planned team with no delegation-capable root', () =>
+    Effect.gen(function* () {
+      expect(
+        yield* resolveTeamLaunch(
           launchArgs({
             customPresetsRaw: [
               preset({ agents: { workflow: ['writer'], toolUse: ['plain'] } }),
@@ -638,39 +645,46 @@ describe('resolveTeamLaunch', () => {
                 : [agent('plain')],
           }),
         ),
-      ),
-    ).resolves.toEqual({
-      status: 'blocked',
-      reason: 'no runnable team root',
-    });
-  });
+      ).toEqual({
+        status: 'blocked',
+        reason: 'no runnable team root',
+      });
+    }),
+  );
 });
 
 describe('refreshRemoteCatalogForGaps', () => {
-  it('refreshes and returns the replanned value only when gaps and access exist', async () => {
-    let refreshed = false;
-    const replan = vi.fn(() => 'remote');
-    const canAccessRemoteCatalog = vi.fn(async () => true);
+  it.effect(
+    'refreshes and returns the replanned value only when gaps and access exist',
+    () =>
+      Effect.gen(function* () {
+        let refreshed = false;
+        const replan = vi.fn(() => 'remote');
+        const canAccessRemoteCatalog = vi.fn(async () => true);
 
-    const result = await Effect.runPromise(
-      refreshRemoteCatalogForGaps('local', () => true, replan, {
-        canAccessRemoteCatalog,
-        refreshRemote: () =>
-          Effect.sync(() => {
-            refreshed = true;
-          }),
+        const result = yield* refreshRemoteCatalogForGaps(
+          'local',
+          () => true,
+          replan,
+          {
+            canAccessRemoteCatalog,
+            refreshRemote: () =>
+              Effect.sync(() => {
+                refreshed = true;
+              }),
+          },
+        );
+
+        expect(result).toEqual({
+          value: 'remote',
+          remoteCatalogRefreshAttempted: true,
+        });
+        expect(refreshed).toBe(true);
+        expect(replan).toHaveBeenCalledOnce();
       }),
-    );
+  );
 
-    expect(result).toEqual({
-      value: 'remote',
-      remoteCatalogRefreshAttempted: true,
-    });
-    expect(refreshed).toBe(true);
-    expect(replan).toHaveBeenCalledOnce();
-  });
-
-  it.each([
+  it.effect.each([
     {
       name: 'without gaps',
       hasGaps: false,
@@ -685,28 +699,32 @@ describe('refreshRemoteCatalogForGaps', () => {
     },
   ])(
     'returns the local plan $name without refreshing or replanning',
-    async ({ hasGaps, canAccess, accessChecks }) => {
-      const canAccessRemoteCatalog = vi.fn(async () => canAccess);
-      let refreshed = false;
-      const replan = vi.fn(() => 'remote');
+    ({ hasGaps, canAccess, accessChecks }) =>
+      Effect.gen(function* () {
+        const canAccessRemoteCatalog = vi.fn(async () => canAccess);
+        let refreshed = false;
+        const replan = vi.fn(() => 'remote');
 
-      const result = await Effect.runPromise(
-        refreshRemoteCatalogForGaps('local', () => hasGaps, replan, {
-          canAccessRemoteCatalog,
-          refreshRemote: () =>
-            Effect.sync(() => {
-              refreshed = true;
-            }),
-        }),
-      );
+        const result = yield* refreshRemoteCatalogForGaps(
+          'local',
+          () => hasGaps,
+          replan,
+          {
+            canAccessRemoteCatalog,
+            refreshRemote: () =>
+              Effect.sync(() => {
+                refreshed = true;
+              }),
+          },
+        );
 
-      expect(result).toEqual({
-        value: 'local',
-        remoteCatalogRefreshAttempted: false,
-      });
-      expect(canAccessRemoteCatalog).toHaveBeenCalledTimes(accessChecks);
-      expect(refreshed).toBe(false);
-      expect(replan).not.toHaveBeenCalled();
-    },
+        expect(result).toEqual({
+          value: 'local',
+          remoteCatalogRefreshAttempted: false,
+        });
+        expect(canAccessRemoteCatalog).toHaveBeenCalledTimes(accessChecks);
+        expect(refreshed).toBe(false);
+        expect(replan).not.toHaveBeenCalled();
+      }),
   );
 });

--- a/src/test-kernel/controllers/MainViewExecutionLaunchController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewExecutionLaunchController.vitest.ts
@@ -1,6 +1,7 @@
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 // Local imports
 import type { MainViewExecuteMessage } from '@shared/schemas';
@@ -50,9 +51,7 @@ function teamMessage(teamId = 'physicist'): MainViewExecuteMessage {
 }
 
 function launchTeam(host: ReturnType<typeof createHost>, teamId = 'physicist') {
-  return Effect.runPromise(
-    prepareMainViewExecutionLaunch(teamMessage(teamId), host),
-  );
+  return prepareMainViewExecutionLaunch(teamMessage(teamId), host);
 }
 
 describe('main-view execution launch controller', () => {
@@ -60,31 +59,35 @@ describe('main-view execution launch controller', () => {
     vi.clearAllMocks();
   });
 
-  it('prepares ordinary launches without loading the team catalog', async () => {
-    const message: MainViewExecuteMessage = {};
-    const request = { agentName: 'ordinary' };
-    mocks.prepareMainViewExecutionRequest.mockReturnValue({
-      valid: true,
-      request,
-    });
+  it.effect('prepares ordinary launches without loading the team catalog', () =>
+    Effect.gen(function* () {
+      const message: MainViewExecuteMessage = {};
+      const request = { agentName: 'ordinary' };
+      mocks.prepareMainViewExecutionRequest.mockReturnValue({
+        valid: true,
+        request,
+      });
 
-    await expect(
-      Effect.runPromise(prepareMainViewExecutionLaunch(message, createHost())),
-    ).resolves.toEqual(request);
-    expect(mocks.resolveTeamLaunch).not.toHaveBeenCalled();
-  });
+      expect(
+        yield* prepareMainViewExecutionLaunch(message, createHost()),
+      ).toEqual(request);
+      expect(mocks.resolveTeamLaunch).not.toHaveBeenCalled();
+    }),
+  );
 
-  it('rejects a team launch without a selected team', async () => {
-    const host = createHost();
+  it.effect('rejects a team launch without a selected team', () =>
+    Effect.gen(function* () {
+      const host = createHost();
 
-    await expect(launchTeam(host, '')).rejects.toMatchObject({
-      _tag: 'Rejected',
-      reason: 'Select a team',
-    });
-    expect(mocks.resolveTeamLaunch).not.toHaveBeenCalled();
-  });
+      expect(yield* Effect.flip(launchTeam(host, ''))).toMatchObject({
+        _tag: 'Rejected',
+        reason: 'Select a team',
+      });
+      expect(mocks.resolveTeamLaunch).not.toHaveBeenCalled();
+    }),
+  );
 
-  it.each([
+  it.effect.each([
     {
       resolution: { status: 'unknown-team' },
       expected: 'Unknown physicist',
@@ -100,86 +103,99 @@ describe('main-view execution launch controller', () => {
       },
       expected: 'Unavailable physicist: critic, writer',
     },
-  ])(
-    'returns $resolution.status team failures',
-    async ({ resolution, expected }) => {
+  ])('returns $resolution.status team failures', ({ resolution, expected }) =>
+    Effect.gen(function* () {
       const host = createHost();
       mocks.resolveTeamLaunch.mockReturnValue(Effect.succeed(resolution));
 
-      await expect(launchTeam(host)).rejects.toMatchObject({
+      expect(yield* Effect.flip(launchTeam(host))).toMatchObject({
         _tag: 'Rejected',
         reason: expected,
       });
       expect(mocks.prepareMainViewTeamExecutionRequest).not.toHaveBeenCalled();
-    },
+    }),
   );
 
-  it('returns without presenting an error when team launch is cancelled', async () => {
-    const host = createHost();
-    mocks.resolveTeamLaunch.mockReturnValue(
-      Effect.succeed({ status: 'cancelled' }),
-    );
+  it.effect(
+    'returns without presenting an error when team launch is cancelled',
+    () =>
+      Effect.gen(function* () {
+        const host = createHost();
+        mocks.resolveTeamLaunch.mockReturnValue(
+          Effect.succeed({ status: 'cancelled' }),
+        );
 
-    await expect(launchTeam(host)).rejects.toMatchObject({ _tag: 'Cancelled' });
-  });
-
-  it('returns partial membership and prepares the resolved team fields', async () => {
-    const host = createHost();
-    const fields = {
-      agent: 'team-root',
-      delegationAgentScope: {
-        workflowAgentKeys: ['workflow:critic'],
-        toolUseAgentKeys: ['toolUse:team-root'],
-      },
-      cli: { multiAgentPresetId: 'physicist' },
-    };
-    const request = { agentName: 'team-root' };
-    mocks.resolveTeamLaunch.mockReturnValue(
-      Effect.succeed({
-        status: 'ready',
-        fields,
-        partial: true,
-        missingNames: ['writer'],
+        expect(yield* Effect.flip(launchTeam(host))).toMatchObject({
+          _tag: 'Cancelled',
+        });
       }),
-    );
-    mocks.prepareMainViewTeamExecutionRequest.mockReturnValue({
-      valid: true,
-      request,
-    });
-    const message = teamMessage();
+  );
 
-    await expect(
-      Effect.runPromise(prepareMainViewExecutionLaunch(message, host)),
-    ).resolves.toEqual(request);
-    expect(host.showInfoMessage).toHaveBeenCalledWith('Partial: writer');
-    expect(mocks.prepareMainViewTeamExecutionRequest).toHaveBeenCalledWith(
-      message,
-      fields,
-    );
-    expect(mocks.resolveTeamLaunch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        teamId: 'physicist',
-        catalog: true,
-        choose: expect.any(Function),
-        signIn: expect.any(Function),
+  it.effect(
+    'returns partial membership and prepares the resolved team fields',
+    () =>
+      Effect.gen(function* () {
+        const host = createHost();
+        const fields = {
+          agent: 'team-root',
+          delegationAgentScope: {
+            workflowAgentKeys: ['workflow:critic'],
+            toolUseAgentKeys: ['toolUse:team-root'],
+          },
+          cli: { multiAgentPresetId: 'physicist' },
+        };
+        const request = { agentName: 'team-root' };
+        mocks.resolveTeamLaunch.mockReturnValue(
+          Effect.succeed({
+            status: 'ready',
+            fields,
+            partial: true,
+            missingNames: ['writer'],
+          }),
+        );
+        mocks.prepareMainViewTeamExecutionRequest.mockReturnValue({
+          valid: true,
+          request,
+        });
+        const message = teamMessage();
+
+        expect(yield* prepareMainViewExecutionLaunch(message, host)).toEqual(
+          request,
+        );
+        expect(host.showInfoMessage).toHaveBeenCalledWith('Partial: writer');
+        expect(mocks.prepareMainViewTeamExecutionRequest).toHaveBeenCalledWith(
+          message,
+          fields,
+        );
+        expect(mocks.resolveTeamLaunch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            teamId: 'physicist',
+            catalog: true,
+            choose: expect.any(Function),
+            signIn: expect.any(Function),
+          }),
+        );
+        const launchPorts = mocks.resolveTeamLaunch.mock.calls[0]![0];
+        expect(
+          yield* Effect.promise(() => launchPorts.choose(['writer'])),
+        ).toBe('continue');
+        expect(yield* Effect.promise(() => launchPorts.signIn())).toBe(true);
+        expect(host.chooseTeamAvailability).toHaveBeenCalledWith(['writer']);
+        expect(host.signInForRemoteAgentCatalog).toHaveBeenCalledOnce();
       }),
-    );
-    const launchPorts = mocks.resolveTeamLaunch.mock.calls[0]![0];
-    await expect(launchPorts.choose(['writer'])).resolves.toBe('continue');
-    await expect(launchPorts.signIn()).resolves.toBe(true);
-    expect(host.chooseTeamAvailability).toHaveBeenCalledWith(['writer']);
-    expect(host.signInForRemoteAgentCatalog).toHaveBeenCalledOnce();
-  });
+  );
 
-  it('surfaces catalog errors as a launch error', async () => {
-    const host = createHost();
-    mocks.resolveTeamLaunch.mockReturnValue(
-      Effect.fail(new Error('catalog unavailable')),
-    );
+  it.effect('surfaces catalog errors as a launch error', () =>
+    Effect.gen(function* () {
+      const host = createHost();
+      mocks.resolveTeamLaunch.mockReturnValue(
+        Effect.fail(new Error('catalog unavailable')),
+      );
 
-    await expect(launchTeam(host)).rejects.toMatchObject({
-      _tag: 'Rejected',
-      reason: 'Team launch failed: catalog unavailable',
-    });
-  });
+      expect(yield* Effect.flip(launchTeam(host))).toMatchObject({
+        _tag: 'Rejected',
+        reason: 'Team launch failed: catalog unavailable',
+      });
+    }),
+  );
 });

--- a/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
+++ b/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { it as effectIt } from '@effect/vitest';
 import { Cause, Effect, Exit, Fiber, Scope, Stream } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -485,32 +486,37 @@ describe('native editor model', () => {
     mocks.canSendRequest.mockReturnValue(true);
   });
 
-  it('captures the exact model and preserves ordered text, images and complete tool exchanges without invented metadata', async () => {
-    const sendRequest = vi
-      .fn()
-      .mockResolvedValueOnce(
-        nativeResponse([
-          new LanguageModelTextPart(''),
-          new LanguageModelTextPart('be'),
-          new LanguageModelTextPart('fore'),
-          new LanguageModelToolCallPart('original-0', 'search', { q: 'a' }),
-          new LanguageModelTextPart('between'),
-          new LanguageModelToolCallPart('original-1', 'search', { q: 'b' }),
-          new LanguageModelTextPart('af'),
-          new LanguageModelTextPart('ter'),
-        ]),
-      )
-      .mockResolvedValueOnce(
-        nativeResponse([new LanguageModelTextPart('done')]),
-      );
-    const selected = fakeModel({ sendRequest });
-    mocks.selectChatModels.mockResolvedValue([
-      fakeModel({ vendor: 'other' }),
-      selected,
-    ]);
-    await Effect.runPromise(
+  effectIt.effect(
+    'captures the exact model and preserves ordered text, images and complete tool exchanges without invented metadata',
+    () =>
       Effect.scoped(
         Effect.gen(function* () {
+          const sendRequest = vi
+            .fn()
+            .mockResolvedValueOnce(
+              nativeResponse([
+                new LanguageModelTextPart(''),
+                new LanguageModelTextPart('be'),
+                new LanguageModelTextPart('fore'),
+                new LanguageModelToolCallPart('original-0', 'search', {
+                  q: 'a',
+                }),
+                new LanguageModelTextPart('between'),
+                new LanguageModelToolCallPart('original-1', 'search', {
+                  q: 'b',
+                }),
+                new LanguageModelTextPart('af'),
+                new LanguageModelTextPart('ter'),
+              ]),
+            )
+            .mockResolvedValueOnce(
+              nativeResponse([new LanguageModelTextPart('done')]),
+            );
+          const selected = fakeModel({ sendRequest });
+          mocks.selectChatModels.mockResolvedValue([
+            fakeModel({ vendor: 'other' }),
+            selected,
+          ]);
           const model = yield* acquireVscodeLanguageModel(
             nativeContext,
             nativeConfiguration(),
@@ -658,10 +664,9 @@ describe('native editor model', () => {
           ).toBe(true);
         }),
       ),
-    );
-  });
+  );
 
-  it.each([
+  effectIt.effect.each([
     [false, false, 'require-granted', false],
     [false, false, 'request-on-send', false],
     [undefined, undefined, 'require-granted', false],
@@ -672,79 +677,75 @@ describe('native editor model', () => {
     [true, undefined, 'request-on-send', true],
   ] as const)(
     'requires explicit consent authority for access %s then %s and mode %s',
-    async (initialAccess, sendAccess, mode, permitted) => {
-      mocks.canSendRequest.mockReturnValue(initialAccess);
-      const selected = fakeModel({
-        sendRequest: vi.fn(async () => nativeResponse([])),
-      });
-      mocks.selectChatModels.mockResolvedValue([selected]);
-      const exit = await Effect.runPromise(
-        Effect.scoped(
-          Effect.gen(function* () {
-            const model = yield* acquireVscodeLanguageModel(
-              nativeContext,
-              nativeConfiguration(),
-              mode,
-            );
-            const turn = yield* model.prepareTurn(nativeRequest);
-            if (turn.mode !== 'foreground')
-              throw new Error('Expected foreground input.');
-            mocks.canSendRequest.mockReturnValue(sendAccess);
-            return yield* model.generateTurn(turn);
-          }),
-        ).pipe(Effect.exit),
-      );
-      expect(Exit.isSuccess(exit)).toBe(permitted);
-      if (Exit.isFailure(exit)) {
-        const failure = exit.cause.reasons.find(Cause.isFailReason);
-        expect(failure?.error).toMatchObject({ kind: 'authentication' });
-        expect(failure?.error).not.toHaveProperty('providerEvidence');
-      }
-      expect(selected.sendRequest).toHaveBeenCalledTimes(Number(permitted));
-      expect(mocks.selectChatModels).toHaveBeenCalledOnce();
-      expect(mocks.canSendRequest).toHaveBeenLastCalledWith(selected);
-    },
+    ([initialAccess, sendAccess, mode, permitted]) =>
+      Effect.gen(function* () {
+        mocks.canSendRequest.mockReturnValue(initialAccess);
+        const selected = fakeModel({
+          sendRequest: vi.fn(async () => nativeResponse([])),
+        });
+        mocks.selectChatModels.mockResolvedValue([selected]);
+        const exit = yield* Effect.exit(
+          Effect.scoped(
+            Effect.gen(function* () {
+              const model = yield* acquireVscodeLanguageModel(
+                nativeContext,
+                nativeConfiguration(),
+                mode,
+              );
+              const turn = yield* model.prepareTurn(nativeRequest);
+              if (turn.mode !== 'foreground')
+                throw new Error('Expected foreground input.');
+              mocks.canSendRequest.mockReturnValue(sendAccess);
+              return yield* model.generateTurn(turn);
+            }),
+          ),
+        );
+        expect(Exit.isSuccess(exit)).toBe(permitted);
+        if (Exit.isFailure(exit)) {
+          const failure = exit.cause.reasons.find(Cause.isFailReason);
+          expect(failure?.error).toMatchObject({ kind: 'authentication' });
+          expect(failure?.error).not.toHaveProperty('providerEvidence');
+        }
+        expect(selected.sendRequest).toHaveBeenCalledTimes(Number(permitted));
+        expect(mocks.selectChatModels).toHaveBeenCalledOnce();
+        expect(mocks.canSendRequest).toHaveBeenLastCalledWith(selected);
+      }),
   );
 
-  it('rejects foreign and retired acquisitions without reselecting or sending', async () => {
-    const selected = fakeModel();
-    mocks.selectChatModels.mockResolvedValue([selected]);
-    const scope = Effect.runSync(Scope.make());
-    const model = await Effect.runPromise(
-      acquireVscodeLanguageModel(nativeContext, nativeConfiguration()).pipe(
-        Scope.provide(scope),
-      ),
-    );
-    const turn = await Effect.runPromise(model.prepareTurn(nativeRequest));
-    if (turn.mode !== 'foreground' || turn.protocol !== 'vscode-lm')
-      throw new Error('Expected editor input.');
-    const foreign = await Effect.runPromise(
-      model
-        .generateTurn({
-          ...turn,
-          acquisitionId: '11111111-1111-4111-8111-111111111111',
-        })
-        .pipe(Effect.exit),
-    );
-    expect(Exit.isFailure(foreign)).toBe(true);
-    await Effect.runPromise(Scope.close(scope, Exit.void));
-    expect(
-      Exit.isFailure(
-        await Effect.runPromise(model.generateTurn(turn).pipe(Effect.exit)),
-      ),
-    ).toBe(true);
-    expect(
-      Exit.isFailure(
-        await Effect.runPromise(
-          model.prepareTurn(nativeRequest).pipe(Effect.exit),
-        ),
-      ),
-    ).toBe(true);
-    expect(mocks.selectChatModels).toHaveBeenCalledOnce();
-    expect(selected.sendRequest).not.toHaveBeenCalled();
-  });
+  effectIt.effect(
+    'rejects foreign and retired acquisitions without reselecting or sending',
+    () =>
+      Effect.gen(function* () {
+        const selected = fakeModel();
+        mocks.selectChatModels.mockResolvedValue([selected]);
+        const scope = yield* Scope.make();
+        const model = yield* acquireVscodeLanguageModel(
+          nativeContext,
+          nativeConfiguration(),
+        ).pipe(Scope.provide(scope));
+        const turn = yield* model.prepareTurn(nativeRequest);
+        if (turn.mode !== 'foreground' || turn.protocol !== 'vscode-lm')
+          throw new Error('Expected editor input.');
+        const foreign = yield* Effect.exit(
+          model.generateTurn({
+            ...turn,
+            acquisitionId: '11111111-1111-4111-8111-111111111111',
+          }),
+        );
+        expect(Exit.isFailure(foreign)).toBe(true);
+        yield* Scope.close(scope, Exit.void);
+        expect(
+          Exit.isFailure(yield* Effect.exit(model.generateTurn(turn))),
+        ).toBe(true);
+        expect(
+          Exit.isFailure(yield* Effect.exit(model.prepareTurn(nativeRequest))),
+        ).toBe(true);
+        expect(mocks.selectChatModels).toHaveBeenCalledOnce();
+        expect(selected.sendRequest).not.toHaveBeenCalled();
+      }),
+  );
 
-  it.each([
+  effectIt.effect.each([
     { ...nativeRequest, temperature: 0.2 },
     {
       messages: [
@@ -774,178 +775,191 @@ describe('native editor model', () => {
     { ...nativeRequest, toolChoice: { name: 'search' } },
   ] satisfies TurnRequest[])(
     'rejects unsupported prepared input before generation: %j',
-    async (request) => {
-      const selected = fakeModel();
-      mocks.selectChatModels.mockResolvedValue([selected]);
-      const exit = await Effect.runPromise(
-        Effect.scoped(
-          Effect.gen(function* () {
-            const model = yield* acquireVscodeLanguageModel(
-              nativeContext,
-              nativeConfiguration(),
-            );
-            return yield* model.prepareTurn(request);
-          }),
-        ).pipe(Effect.exit),
-      );
-      expect(Exit.isFailure(exit)).toBe(true);
-      expect(selected.sendRequest).not.toHaveBeenCalled();
-    },
-  );
-
-  it.each(['NoPermissions', 'Blocked', 'NotFound'] as const)(
-    'retains actual native %s evidence without a synthetic HTTP status',
-    async (code) => {
-      const cause = Object.assign(new Error('native rejection'), { code });
-      mocks.selectChatModels.mockResolvedValue([
-        fakeModel({
-          sendRequest: vi.fn(async () => {
-            throw cause;
-          }),
-        }),
-      ]);
-      const exit = await Effect.runPromise(
-        Effect.scoped(
-          Effect.gen(function* () {
-            const model = yield* acquireVscodeLanguageModel(
-              nativeContext,
-              nativeConfiguration(),
-            );
-            const turn = yield* model.prepareTurn(nativeRequest);
-            if (turn.mode !== 'foreground')
-              throw new Error('Expected foreground input.');
-            return yield* model.generateTurn(turn);
-          }),
-        ).pipe(Effect.exit),
-      );
-      if (!Exit.isFailure(exit)) throw new Error('Expected native failure.');
-      expect(exit.cause.reasons).toHaveLength(1);
-      const failure = exit.cause.reasons.find(Cause.isFailReason);
-      expect(failure?.error).toMatchObject({
-        message: 'native rejection',
-        cause,
-        providerEvidence: { kind: 'vscode-lm', code },
-      });
-      expect(failure?.error).not.toHaveProperty('status');
-      expect(cancellationSources[0].dispose).toHaveBeenCalledOnce();
-    },
-  );
-
-  it.each(['headers', 'body'] as const)(
-    'cancels before joining the exposed pending %s operation',
-    async (stage) => {
-      let entered!: () => void;
-      const ready = new Promise<void>((resolve) => {
-        entered = resolve;
-      });
-      let finish!: () => void;
-      const order: string[] = [];
-      const sendRequest = vi.fn(
-        async (
-          _messages,
-          _options,
-          token: CancellationTokenSource['token'],
-        ) => {
-          token.onCancellationRequested(() => {
-            order.push('cancel');
-          });
-          const pending = new Promise<never>((_resolve, reject) => {
-            finish = () => {
-              order.push('joined');
-              reject(new CancellationError());
-            };
-          });
-          if (stage === 'headers') {
-            entered();
-            return pending;
-          }
-          return {
-            stream: {
-              [Symbol.asyncIterator]: () => ({
-                next: () => {
-                  entered();
-                  return pending;
-                },
-                return: async () => {
-                  order.push('return');
-                  return { done: true, value: undefined };
-                },
-              }),
-            },
-          };
-        },
-      );
-      mocks.selectChatModels.mockResolvedValue([fakeModel({ sendRequest })]);
-      const fiber = Effect.runFork(
-        Effect.scoped(
-          Effect.gen(function* () {
-            const model = yield* acquireVscodeLanguageModel(
-              nativeContext,
-              nativeConfiguration(),
-            );
-            const turn = yield* model.prepareTurn(nativeRequest);
-            if (turn.mode !== 'foreground')
-              throw new Error('Expected foreground input.');
-            return yield* model.generateTurn(turn);
-          }),
-        ),
-      );
-      await ready;
-      const cancellation = Effect.runFork(Fiber.interrupt(fiber));
-      await vi.waitFor(() => expect(order).toEqual(['cancel']));
-      expect(cancellation.pollUnsafe()).toBeUndefined();
-      finish();
-      await Effect.runPromise(Fiber.join(cancellation));
-      expect(order).toEqual(
-        stage === 'headers'
-          ? ['cancel', 'joined']
-          : ['cancel', 'joined', 'return'],
-      );
-      expect(cancellationSources[0].dispose).toHaveBeenCalledOnce();
-      expect(sendRequest).toHaveBeenCalledOnce();
-    },
-  );
-
-  it('preserves a primary malformed response and a distinct iterator cleanup defect', async () => {
-    const cleanup = new Error('return failed');
-    mocks.selectChatModels.mockResolvedValue([
-      fakeModel({
-        sendRequest: vi.fn(async () => ({
-          stream: {
-            [Symbol.asyncIterator]: () => ({
-              next: async () => ({
-                done: false,
-                value: new LanguageModelToolCallPart('', 'search', {}),
-              }),
-              return: async () => {
-                throw cleanup;
-              },
+    (request) =>
+      Effect.gen(function* () {
+        const selected = fakeModel();
+        mocks.selectChatModels.mockResolvedValue([selected]);
+        const exit = yield* Effect.exit(
+          Effect.scoped(
+            Effect.gen(function* () {
+              const model = yield* acquireVscodeLanguageModel(
+                nativeContext,
+                nativeConfiguration(),
+              );
+              return yield* model.prepareTurn(request);
             }),
-          },
-        })),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(selected.sendRequest).not.toHaveBeenCalled();
       }),
-    ]);
-    const exit = await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const model = yield* acquireVscodeLanguageModel(
-            nativeContext,
-            nativeConfiguration(),
-          );
-          const turn = yield* model.prepareTurn(nativeRequest);
-          if (turn.mode !== 'foreground')
-            throw new Error('Expected foreground input.');
-          return yield* model.generateTurn(turn);
-        }),
-      ).pipe(Effect.exit),
-    );
-    if (!Exit.isFailure(exit)) throw new Error('Expected failure.');
-    expect(exit.cause.reasons.find(Cause.isFailReason)?.error).toMatchObject({
-      kind: 'malformed-output',
-    });
-    expect(exit.cause.reasons.find(Cause.isDieReason)?.defect).toMatchObject({
-      cause: cleanup,
-    });
-    expect(cancellationSources[0].dispose).toHaveBeenCalledOnce();
-  });
+  );
+
+  effectIt.effect.each(['NoPermissions', 'Blocked', 'NotFound'] as const)(
+    'retains actual native %s evidence without a synthetic HTTP status',
+    (code) =>
+      Effect.gen(function* () {
+        const cause = Object.assign(new Error('native rejection'), { code });
+        mocks.selectChatModels.mockResolvedValue([
+          fakeModel({
+            sendRequest: vi.fn(async () => {
+              throw cause;
+            }),
+          }),
+        ]);
+        const exit = yield* Effect.exit(
+          Effect.scoped(
+            Effect.gen(function* () {
+              const model = yield* acquireVscodeLanguageModel(
+                nativeContext,
+                nativeConfiguration(),
+              );
+              const turn = yield* model.prepareTurn(nativeRequest);
+              if (turn.mode !== 'foreground')
+                throw new Error('Expected foreground input.');
+              return yield* model.generateTurn(turn);
+            }),
+          ),
+        );
+        if (!Exit.isFailure(exit)) throw new Error('Expected native failure.');
+        expect(exit.cause.reasons).toHaveLength(1);
+        const failure = exit.cause.reasons.find(Cause.isFailReason);
+        expect(failure?.error).toMatchObject({
+          message: 'native rejection',
+          cause,
+          providerEvidence: { kind: 'vscode-lm', code },
+        });
+        expect(failure?.error).not.toHaveProperty('status');
+        expect(cancellationSources[0].dispose).toHaveBeenCalledOnce();
+      }),
+  );
+
+  effectIt.effect.each(['headers', 'body'] as const)(
+    'cancels before joining the exposed pending %s operation',
+    (stage) =>
+      Effect.gen(function* () {
+        let entered!: () => void;
+        const ready = new Promise<void>((resolve) => {
+          entered = resolve;
+        });
+        let finish!: () => void;
+        const order: string[] = [];
+        const sendRequest = vi.fn(
+          async (
+            _messages,
+            _options,
+            token: CancellationTokenSource['token'],
+          ) => {
+            token.onCancellationRequested(() => {
+              order.push('cancel');
+            });
+            const pending = new Promise<never>((_resolve, reject) => {
+              finish = () => {
+                order.push('joined');
+                reject(new CancellationError());
+              };
+            });
+            if (stage === 'headers') {
+              entered();
+              return pending;
+            }
+            return {
+              stream: {
+                [Symbol.asyncIterator]: () => ({
+                  next: () => {
+                    entered();
+                    return pending;
+                  },
+                  return: async () => {
+                    order.push('return');
+                    return { done: true, value: undefined };
+                  },
+                }),
+              },
+            };
+          },
+        );
+        mocks.selectChatModels.mockResolvedValue([fakeModel({ sendRequest })]);
+        const fiber = yield* Effect.forkChild(
+          Effect.scoped(
+            Effect.gen(function* () {
+              const model = yield* acquireVscodeLanguageModel(
+                nativeContext,
+                nativeConfiguration(),
+              );
+              const turn = yield* model.prepareTurn(nativeRequest);
+              if (turn.mode !== 'foreground')
+                throw new Error('Expected foreground input.');
+              return yield* model.generateTurn(turn);
+            }),
+          ),
+        );
+        yield* Effect.promise(() => ready);
+        const cancellation = yield* Effect.forkChild(Fiber.interrupt(fiber));
+        yield* Effect.promise(() =>
+          vi.waitFor(() => expect(order).toEqual(['cancel'])),
+        );
+        expect(cancellation.pollUnsafe()).toBeUndefined();
+        finish();
+        yield* Fiber.join(cancellation);
+        expect(order).toEqual(
+          stage === 'headers'
+            ? ['cancel', 'joined']
+            : ['cancel', 'joined', 'return'],
+        );
+        expect(cancellationSources[0].dispose).toHaveBeenCalledOnce();
+        expect(sendRequest).toHaveBeenCalledOnce();
+      }),
+  );
+
+  effectIt.effect(
+    'preserves a primary malformed response and a distinct iterator cleanup defect',
+    () =>
+      Effect.gen(function* () {
+        const cleanup = new Error('return failed');
+        mocks.selectChatModels.mockResolvedValue([
+          fakeModel({
+            sendRequest: vi.fn(async () => ({
+              stream: {
+                [Symbol.asyncIterator]: () => ({
+                  next: async () => ({
+                    done: false,
+                    value: new LanguageModelToolCallPart('', 'search', {}),
+                  }),
+                  return: async () => {
+                    throw cleanup;
+                  },
+                }),
+              },
+            })),
+          }),
+        ]);
+        const exit = yield* Effect.exit(
+          Effect.scoped(
+            Effect.gen(function* () {
+              const model = yield* acquireVscodeLanguageModel(
+                nativeContext,
+                nativeConfiguration(),
+              );
+              const turn = yield* model.prepareTurn(nativeRequest);
+              if (turn.mode !== 'foreground')
+                throw new Error('Expected foreground input.');
+              return yield* model.generateTurn(turn);
+            }),
+          ),
+        );
+        if (!Exit.isFailure(exit)) throw new Error('Expected failure.');
+        expect(
+          exit.cause.reasons.find(Cause.isFailReason)?.error,
+        ).toMatchObject({
+          kind: 'malformed-output',
+        });
+        expect(
+          exit.cause.reasons.find(Cause.isDieReason)?.defect,
+        ).toMatchObject({
+          cause: cleanup,
+        });
+        expect(cancellationSources[0].dispose).toHaveBeenCalledOnce();
+      }),
+  );
 });

--- a/src/test-kernel/llm/OpenrouterChat.vitest.ts
+++ b/src/test-kernel/llm/OpenrouterChat.vitest.ts
@@ -10,8 +10,9 @@ import {
   type TurnEvent,
   type TurnRequest,
 } from '@texra-ai/llm/turn';
+import { it } from '@effect/vitest';
 import { Cause, Effect, Exit, Fiber, Stream } from 'effect';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 
 const CONFIG = {
   protocol: 'openrouter-chat',
@@ -156,13 +157,11 @@ function call(index: number, args: string, metadata = true): object {
   };
 }
 function run(model: Model, request: TurnRequest = REQUEST) {
-  return Effect.runPromise(
-    Effect.gen(function* () {
-      const turn = yield* model.prepareTurn(request);
-      assert.equal(turn.mode, 'foreground');
-      return yield* model.generateTurn(turn);
-    }),
-  );
+  return Effect.gen(function* () {
+    const turn = yield* model.prepareTurn(request);
+    assert.equal(turn.mode, 'foreground');
+    return yield* model.generateTurn(turn);
+  });
 }
 function errors(exit: Exit.Exit<unknown, ModelError>) {
   assert(Exit.isFailure(exit));
@@ -172,234 +171,251 @@ function errors(exit: Exit.Exit<unknown, ModelError>) {
 }
 
 describe('native OpenRouter Chat', () => {
-  it('preserves ordered media, complete reasoning, annotations, receipt and tool settlement through rehydrated replay', async () => {
-    const sent: Record<string, any>[] = [];
-    const fetch = vi.fn<typeof globalThis.fetch>(async (url, init) => {
-      expect(url).toBe('https://synthetic.invalid/api/v1/chat/completions');
-      expect(new Headers(init?.headers).get('Authorization')).toBe(
-        'Bearer selected-key',
-      );
-      sent.push(JSON.parse(String(init?.body)));
-      if (sent.length === 2)
-        return response(sse(frame({ content: 'Done.' }, 'stop')));
-      return response(
-        sse(
-          frame({ reasoning: null, reasoning_details: null }),
-          frame({ reasoning: '', reasoning_details: [] }),
-          frame({ reasoning: 'plain', reasoning_details: DETAILS.slice(0, 2) }),
-          frame({ reasoning: null, reasoning_details: DETAILS.slice(2) }),
-          frame({ content: 'Search now.', annotations: [FILE, CITATION] }),
-          frame({ tool_calls: [call(1, '{"q":'), call(0, '{')] }),
-          frame({
-            tool_calls: [call(0, '"q":"a"}', false), call(1, '"b"}', false)],
-          }),
-          {
-            choices: [
-              {
-                index: 0,
-                finish_reason: 'tool_calls',
-                native_finish_reason: 'tool_use',
-              },
-            ],
-          },
-          {
-            choices: [
-              {
-                index: 0,
-                delta: {},
-                finish_reason: 'tool_calls',
-                native_finish_reason: 'tool_use',
-              },
-            ],
-            usage: USAGE,
-            service_tier: 'standard',
-          },
-          { choices: [], usage: USAGE },
-        ),
-      );
-    });
-    const model = openrouterChatModel(CONFIG, {
-      apiKey: 'selected-key',
-      fetch,
-    });
-    const request: TurnRequest = {
-      system: '',
-      tools: TOOLS,
-      toolChoice: { name: 'search' },
-      effort: 'minimal',
-      stopSequences: ['END'],
-      messages: [
-        {
-          role: 'user',
-          content: [
-            { kind: 'text', text: 'image label' },
-            {
-              kind: 'image',
-              mimeType: 'IMAGE/PNG',
-              base64: '',
-              detail: 'high',
-            },
-            { kind: 'text', text: 'audio label' },
-            { kind: 'audio', mimeType: 'audio/mpeg', base64: 'AA==' },
-            { kind: 'text', text: 'PDF label' },
-            { kind: 'document', mimeType: 'application/pdf', base64: '' },
-          ],
-        },
-      ],
-    };
-    const events = await Effect.runPromise(
+  it.effect(
+    'preserves ordered media, complete reasoning, annotations, receipt and tool settlement through rehydrated replay',
+    () =>
       Effect.gen(function* () {
+        const sent: Record<string, any>[] = [];
+        const fetch = vi.fn<typeof globalThis.fetch>(async (url, init) => {
+          expect(url).toBe('https://synthetic.invalid/api/v1/chat/completions');
+          expect(new Headers(init?.headers).get('Authorization')).toBe(
+            'Bearer selected-key',
+          );
+          sent.push(JSON.parse(String(init?.body)));
+          if (sent.length === 2)
+            return response(sse(frame({ content: 'Done.' }, 'stop')));
+          return response(
+            sse(
+              frame({ reasoning: null, reasoning_details: null }),
+              frame({ reasoning: '', reasoning_details: [] }),
+              frame({
+                reasoning: 'plain',
+                reasoning_details: DETAILS.slice(0, 2),
+              }),
+              frame({ reasoning: null, reasoning_details: DETAILS.slice(2) }),
+              frame({ content: 'Search now.', annotations: [FILE, CITATION] }),
+              frame({ tool_calls: [call(1, '{"q":'), call(0, '{')] }),
+              frame({
+                tool_calls: [
+                  call(0, '"q":"a"}', false),
+                  call(1, '"b"}', false),
+                ],
+              }),
+              {
+                choices: [
+                  {
+                    index: 0,
+                    finish_reason: 'tool_calls',
+                    native_finish_reason: 'tool_use',
+                  },
+                ],
+              },
+              {
+                choices: [
+                  {
+                    index: 0,
+                    delta: {},
+                    finish_reason: 'tool_calls',
+                    native_finish_reason: 'tool_use',
+                  },
+                ],
+                usage: USAGE,
+                service_tier: 'standard',
+              },
+              { choices: [], usage: USAGE },
+            ),
+          );
+        });
+        const model = openrouterChatModel(CONFIG, {
+          apiKey: 'selected-key',
+          fetch,
+        });
+        const request: TurnRequest = {
+          system: '',
+          tools: TOOLS,
+          toolChoice: { name: 'search' },
+          effort: 'minimal',
+          stopSequences: ['END'],
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { kind: 'text', text: 'image label' },
+                {
+                  kind: 'image',
+                  mimeType: 'IMAGE/PNG',
+                  base64: '',
+                  detail: 'high',
+                },
+                { kind: 'text', text: 'audio label' },
+                { kind: 'audio', mimeType: 'audio/mpeg', base64: 'AA==' },
+                { kind: 'text', text: 'PDF label' },
+                { kind: 'document', mimeType: 'application/pdf', base64: '' },
+              ],
+            },
+          ],
+        };
         const turn = yield* model.prepareTurn(request);
         assert.equal(turn.mode, 'foreground');
-        return yield* Stream.runCollect(model.streamTurn(turn));
-      }),
-    );
-    expect(events[0].kind).toBe('identified');
-    expect(
-      events
-        .map((event) =>
-          event.kind === 'delta' && event.part === 'reasoning'
-            ? event.text
-            : '',
-        )
-        .join(''),
-    ).toBe('plansummary');
-    const completed = events.findLast((event) => event.kind === 'completed');
-    assert(completed?.kind === 'completed');
-    const result = completed.result;
-    expect(result).toMatchObject({
-      providerResponseId: 'generation-1',
-      returnedModel: 'returned-model',
-      finishReason: 'tool-calls',
-      finishEvidence: { kind: 'openrouter', nativeFinishReason: 'tool_use' },
-      usage: {
-        inputTokens: 11,
-        cachedInputTokens: 3,
-        reasoningTokens: 5,
-        providerUsage: {
-          kind: 'openrouter',
-          cost: 0,
-          isByok: false,
-          costDetails: { upstreamInferenceCost: 0.125 },
-          inputDetails: { cacheWriteTokens: 4 },
-          outputDetails: { acceptedPredictionTokens: 0 },
-          serviceTier: 'standard',
-        },
-      },
-    });
-    expect(result.content.map((part) => part.kind)).toEqual([
-      'reasoning',
-      'message',
-      'local-call',
-      'local-call',
-      'file-annotation',
-      'url-citation',
-    ]);
-    expect(result.content[0]).toMatchObject({
-      kind: 'reasoning',
-      summary: [],
-      evidence: {
-        kind: 'openrouter-reasoning',
-        plain: 'plain',
-        details: [
-          { kind: 'text', text: '', signature: null },
-          { kind: 'text', text: 'plan', signature: 'signature' },
-          { kind: 'summary', summary: 'summary' },
-          { kind: 'encrypted', data: 'opaque==' },
-          {
-            kind: 'server-tool-call',
-            arguments: '{ "q": "x" }',
-            result: ' raw hosted result ',
+        const events = yield* Stream.runCollect(model.streamTurn(turn));
+        expect(events[0].kind).toBe('identified');
+        expect(
+          events
+            .map((event) =>
+              event.kind === 'delta' && event.part === 'reasoning'
+                ? event.text
+                : '',
+            )
+            .join(''),
+        ).toBe('plansummary');
+        const completed = events.findLast(
+          (event) => event.kind === 'completed',
+        );
+        assert(completed?.kind === 'completed');
+        const result = completed.result;
+        expect(result).toMatchObject({
+          providerResponseId: 'generation-1',
+          returnedModel: 'returned-model',
+          finishReason: 'tool-calls',
+          finishEvidence: {
+            kind: 'openrouter',
+            nativeFinishReason: 'tool_use',
           },
-        ],
-      },
-    });
-    expect('content' in result.content[0]).toBe(false);
-    const restored = JSON.parse(JSON.stringify(result));
-    const followUp: TurnRequest = {
-      ...request,
-      messages: [
-        ...request.messages,
-        {
-          role: 'assistant',
-          origin: restored.requestedOrigin,
-          content: restored.content,
-        },
-        {
-          role: 'tool',
-          results: [
+          usage: {
+            inputTokens: 11,
+            cachedInputTokens: 3,
+            reasoningTokens: 5,
+            providerUsage: {
+              kind: 'openrouter',
+              cost: 0,
+              isByok: false,
+              costDetails: { upstreamInferenceCost: 0.125 },
+              inputDetails: { cacheWriteTokens: 4 },
+              outputDetails: { acceptedPredictionTokens: 0 },
+              serviceTier: 'standard',
+            },
+          },
+        });
+        expect(result.content.map((part) => part.kind)).toEqual([
+          'reasoning',
+          'message',
+          'local-call',
+          'local-call',
+          'file-annotation',
+          'url-citation',
+        ]);
+        expect(result.content[0]).toMatchObject({
+          kind: 'reasoning',
+          summary: [],
+          evidence: {
+            kind: 'openrouter-reasoning',
+            plain: 'plain',
+            details: [
+              { kind: 'text', text: '', signature: null },
+              { kind: 'text', text: 'plan', signature: 'signature' },
+              { kind: 'summary', summary: 'summary' },
+              { kind: 'encrypted', data: 'opaque==' },
+              {
+                kind: 'server-tool-call',
+                arguments: '{ "q": "x" }',
+                result: ' raw hosted result ',
+              },
+            ],
+          },
+        });
+        expect('content' in result.content[0]).toBe(false);
+        const restored = JSON.parse(JSON.stringify(result));
+        const followUp: TurnRequest = {
+          ...request,
+          messages: [
+            ...request.messages,
             {
-              callOrdinal: 0,
-              status: 'success',
-              content: [{ kind: 'text', text: 'A' }],
+              role: 'assistant',
+              origin: restored.requestedOrigin,
+              content: restored.content,
             },
             {
-              callOrdinal: 1,
-              status: 'error',
-              content: [{ kind: 'text', text: 'B' }],
+              role: 'tool',
+              results: [
+                {
+                  callOrdinal: 0,
+                  status: 'success',
+                  content: [{ kind: 'text', text: 'A' }],
+                },
+                {
+                  callOrdinal: 1,
+                  status: 'error',
+                  content: [{ kind: 'text', text: 'B' }],
+                },
+              ],
             },
           ],
-        },
-      ],
-    };
-    await run(model, followUp);
-    expect(sent[0]).toMatchObject({
-      stream: true,
-      max_completion_tokens: 100,
-      reasoning: { effort: 'minimal' },
-      stop: ['END'],
-      tool_choice: { type: 'function', function: { name: 'search' } },
-    });
-    expect(sent[0].messages[1].content).toEqual([
-      { type: 'text', text: 'image label' },
-      {
-        type: 'image_url',
-        image_url: { url: 'data:IMAGE/PNG;base64,', detail: 'high' },
-      },
-      { type: 'text', text: 'audio label' },
-      { type: 'input_audio', input_audio: { data: 'AA==', format: 'mp3' } },
-      { type: 'text', text: 'PDF label' },
-      { type: 'file', file: { file_data: 'data:application/pdf;base64,' } },
-    ]);
-    expect(sent[1].messages[2]).toMatchObject({
-      role: 'assistant',
-      content: 'Search now.',
-      reasoning: 'plain',
-      reasoning_details: DETAILS,
-      annotations: [FILE, CITATION],
-      tool_calls: [
-        { id: 'call-0', function: { name: 'search', arguments: '{"q":"a"}' } },
-        { id: 'call-1', function: { name: 'fetch', arguments: '{"q":"b"}' } },
-      ],
-    });
-    expect(sent[1].messages.slice(-2)).toEqual([
-      { role: 'tool', tool_call_id: 'call-0', content: 'A' },
-      { role: 'tool', tool_call_id: 'call-1', content: 'Error: B' },
-    ]);
-    for (const order of [
-      [1, 0, 2, 3, 4, 5],
-      [0, 2, 1, 3, 4, 5],
-      [0, 1, 4, 2, 3, 5],
-    ]) {
-      const exit = await Effect.runPromiseExit(
-        model.prepareTurn({
-          ...followUp,
-          messages: followUp.messages.map((message) =>
-            message.role === 'assistant'
-              ? {
-                  ...message,
-                  content: order.map((index) => result.content[index]),
-                }
-              : message,
-          ),
-        }),
-      );
-      expect(errors(exit)[0].kind).toBe('unsupported');
-    }
-    expect(fetch).toHaveBeenCalledTimes(2);
-  });
+        };
+        yield* run(model, followUp);
+        expect(sent[0]).toMatchObject({
+          stream: true,
+          max_completion_tokens: 100,
+          reasoning: { effort: 'minimal' },
+          stop: ['END'],
+          tool_choice: { type: 'function', function: { name: 'search' } },
+        });
+        expect(sent[0].messages[1].content).toEqual([
+          { type: 'text', text: 'image label' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:IMAGE/PNG;base64,', detail: 'high' },
+          },
+          { type: 'text', text: 'audio label' },
+          { type: 'input_audio', input_audio: { data: 'AA==', format: 'mp3' } },
+          { type: 'text', text: 'PDF label' },
+          { type: 'file', file: { file_data: 'data:application/pdf;base64,' } },
+        ]);
+        expect(sent[1].messages[2]).toMatchObject({
+          role: 'assistant',
+          content: 'Search now.',
+          reasoning: 'plain',
+          reasoning_details: DETAILS,
+          annotations: [FILE, CITATION],
+          tool_calls: [
+            {
+              id: 'call-0',
+              function: { name: 'search', arguments: '{"q":"a"}' },
+            },
+            {
+              id: 'call-1',
+              function: { name: 'fetch', arguments: '{"q":"b"}' },
+            },
+          ],
+        });
+        expect(sent[1].messages.slice(-2)).toEqual([
+          { role: 'tool', tool_call_id: 'call-0', content: 'A' },
+          { role: 'tool', tool_call_id: 'call-1', content: 'Error: B' },
+        ]);
+        for (const order of [
+          [1, 0, 2, 3, 4, 5],
+          [0, 2, 1, 3, 4, 5],
+          [0, 1, 4, 2, 3, 5],
+        ]) {
+          const exit = yield* Effect.exit(
+            model.prepareTurn({
+              ...followUp,
+              messages: followUp.messages.map((message) =>
+                message.role === 'assistant'
+                  ? {
+                      ...message,
+                      content: order.map((index) => result.content[index]),
+                    }
+                  : message,
+              ),
+            }),
+          );
+          expect(errors(exit)[0].kind).toBe('unsupported');
+        }
+        expect(fetch).toHaveBeenCalledTimes(2);
+      }),
+  );
 
-  it.each([
+  it.effect.each([
     ['absent', {}, {}],
     ['null plain', { reasoning: null }, { reasoning: null }],
     ['empty plain', { reasoning: '' }, { reasoning: '' }],
@@ -410,88 +426,97 @@ describe('native OpenRouter Chat', () => {
       { reasoning: '', reasoning_details: [] },
       { reasoning: '', reasoning_details: [] },
     ],
-  ])(
+  ] as const)(
     'retains %s reasoning-field presence through a subsequent request',
-    async (_, delta, expected) => {
-      const bodies: any[] = [];
-      const fetch = vi.fn<typeof globalThis.fetch>(async (_url, init) => {
-        bodies.push(JSON.parse(String(init?.body)));
-        return response(sse(frame(delta), frame({}, 'stop')));
-      });
-      const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
-      const result = await run(model);
-      await run(model, {
-        messages: [
-          ...REQUEST.messages,
-          {
-            role: 'assistant',
-            origin: result.requestedOrigin,
-            content: result.content,
-          },
-          { role: 'user', content: [{ kind: 'text', text: 'Continue.' }] },
-        ],
-      });
-      const assistant = bodies[1].messages[1];
-      expect(
-        Object.fromEntries(
-          Object.entries(assistant).filter(([key]) =>
-            key.startsWith('reasoning'),
+    ([_, delta, expected]) =>
+      Effect.gen(function* () {
+        const bodies: any[] = [];
+        const fetch = vi.fn<typeof globalThis.fetch>(async (_url, init) => {
+          bodies.push(JSON.parse(String(init?.body)));
+          return response(sse(frame(delta), frame({}, 'stop')));
+        });
+        const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
+        const result = yield* run(model);
+        yield* run(model, {
+          messages: [
+            ...REQUEST.messages,
+            {
+              role: 'assistant',
+              origin: result.requestedOrigin,
+              content: result.content,
+            },
+            { role: 'user', content: [{ kind: 'text', text: 'Continue.' }] },
+          ],
+        });
+        const assistant = bodies[1].messages[1];
+        expect(
+          Object.fromEntries(
+            Object.entries(assistant).filter(([key]) =>
+              key.startsWith('reasoning'),
+            ),
           ),
-        ),
-      ).toEqual(expected);
-    },
+        ).toEqual(expected);
+      }),
   );
 
-  it('accepts identity-free terminal accounting, repeated terminal reasons and a DONE sharing its byte chunk with later data', async () => {
-    const wire =
-      ': keep-alive\r\nretry: 1\r\n\r\n' +
-      sse(
-        frame({ content: 'α\nβ' }),
-        { choices: [{ finish_reason: 'stop', native_finish_reason: null }] },
-        {
-          choices: [{ finish_reason: 'stop' }],
-          usage: {
-            prompt_tokens: 0,
-            completion_tokens: 0,
-            total_tokens: 0,
-            cost: 0,
-            is_byok: true,
+  it.effect(
+    'accepts identity-free terminal accounting, repeated terminal reasons and a DONE sharing its byte chunk with later data',
+    () =>
+      Effect.gen(function* () {
+        const wire =
+          ': keep-alive\r\nretry: 1\r\n\r\n' +
+          sse(
+            frame({ content: 'α\nβ' }),
+            {
+              choices: [{ finish_reason: 'stop', native_finish_reason: null }],
+            },
+            {
+              choices: [{ finish_reason: 'stop' }],
+              usage: {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+                cost: 0,
+                is_byok: true,
+              },
+            },
+          ) +
+          'data: {"error":{"message":"must not be consumed"}}\n\n';
+        const encoded = new TextEncoder().encode(wire);
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            for (const byte of encoded.slice(0, -100))
+              controller.enqueue(new Uint8Array([byte]));
+            controller.enqueue(encoded.slice(-100));
+            controller.close();
           },
-        },
-      ) +
-      'data: {"error":{"message":"must not be consumed"}}\n\n';
-    const encoded = new TextEncoder().encode(wire);
-    const body = new ReadableStream<Uint8Array>({
-      start(controller) {
-        for (const byte of encoded.slice(0, -100))
-          controller.enqueue(new Uint8Array([byte]));
-        controller.enqueue(encoded.slice(-100));
-        controller.close();
-      },
-    });
-    const fetch = vi.fn<typeof globalThis.fetch>(async () => response(body));
-    const result = await run(
-      openrouterChatModel(CONFIG, { apiKey: 'key', fetch }),
-    );
-    expect(result.content).toEqual([
-      { kind: 'message', content: [{ kind: 'text', text: 'α\nβ' }] },
-    ]);
-    expect(result.usage).toMatchObject({
-      inputTokens: 0,
-      outputTokens: 0,
-      totalTokens: 0,
-      providerUsage: { cost: 0, isByok: true },
-    });
-    assert(result.providerResponseId !== null);
-    expect(result.finishEvidence).toEqual({
-      kind: 'openrouter',
-      nativeFinishReason: null,
-    });
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(body.locked).toBe(false);
-  });
+        });
+        const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+          response(body),
+        );
+        const result = yield* run(
+          openrouterChatModel(CONFIG, { apiKey: 'key', fetch }),
+        );
+        expect(result.content).toEqual([
+          { kind: 'message', content: [{ kind: 'text', text: 'α\nβ' }] },
+        ]);
+        expect(result.usage).toMatchObject({
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          providerUsage: { cost: 0, isByok: true },
+        });
+        assert(result.providerResponseId !== null);
+        expect(result.finishEvidence).toEqual({
+          kind: 'openrouter',
+          nativeFinishReason: null,
+        });
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(body.locked).toBe(false);
+      }),
+  );
 
-  it.each([
+  it.effect.each([
     [
       'image disabled',
       { ...CONFIG, supportsImageInput: false },
@@ -515,17 +540,19 @@ describe('native OpenRouter Chat', () => {
     ['raw audio', CONFIG, { kind: 'audio', mimeType: 'audio/L16', base64: '' }],
     ['video', CONFIG, { kind: 'video', mimeType: 'video/mp4', base64: '' }],
     ['non-PDF', CONFIG, { kind: 'document', mimeType: 'text/csv', base64: '' }],
-  ] as const)('rejects %s before I/O', async (_, config, part) => {
-    const fetch = vi.fn<typeof globalThis.fetch>();
-    const model = openrouterChatModel(config, { apiKey: 'key', fetch });
-    const exit = await Effect.runPromiseExit(
-      model.prepareTurn({ messages: [{ role: 'user', content: [part] }] }),
-    );
-    expect(errors(exit)[0].kind).toBe('unsupported');
-    expect(fetch).not.toHaveBeenCalled();
-  });
+  ] as const)('rejects %s before I/O', ([_, config, part]) =>
+    Effect.gen(function* () {
+      const fetch = vi.fn<typeof globalThis.fetch>();
+      const model = openrouterChatModel(config, { apiKey: 'key', fetch });
+      const exit = yield* Effect.exit(
+        model.prepareTurn({ messages: [{ role: 'user', content: [part] }] }),
+      );
+      expect(errors(exit)[0].kind).toBe('unsupported');
+      expect(fetch).not.toHaveBeenCalled();
+    }),
+  );
 
-  it.each([
+  it.effect.each([
     ['unsupported effort', { effort: 'medium' }],
     ['parallel', { parallelToolCalls: false }],
     ['background', { mode: 'background' }],
@@ -534,18 +561,19 @@ describe('native OpenRouter Chat', () => {
     ['unknown named tool', { toolChoice: { name: 'missing' } }],
   ] as const)(
     'rejects %s and does not issue an automatic request',
-    async (_, controls) => {
-      const fetch = vi.fn<typeof globalThis.fetch>();
-      const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
-      const exit = await Effect.runPromiseExit(
-        model.prepareTurn({ ...REQUEST, ...controls }),
-      );
-      expect(errors(exit)[0].kind).toBe('unsupported');
-      expect(fetch).not.toHaveBeenCalled();
-    },
+    ([_, controls]) =>
+      Effect.gen(function* () {
+        const fetch = vi.fn<typeof globalThis.fetch>();
+        const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
+        const exit = yield* Effect.exit(
+          model.prepareTurn({ ...REQUEST, ...controls }),
+        );
+        expect(errors(exit)[0].kind).toBe('unsupported');
+        expect(fetch).not.toHaveBeenCalled();
+      }),
   );
 
-  it.each([
+  it.effect.each([
     [
       'missing index',
       [
@@ -659,97 +687,101 @@ describe('native OpenRouter Chat', () => {
       ],
     ],
     ['missing finish', [frame({ content: 'partial' })]],
-  ])('fails %s without producing a completed result', async (_, frames) => {
-    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-      response(sse(...frames)),
-    );
-    const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
-    const exit = await Effect.runPromiseExit(
-      Effect.gen(function* () {
-        const turn = yield* model.prepareTurn({ ...REQUEST, tools: TOOLS });
-        assert.equal(turn.mode, 'foreground');
-        return yield* Stream.runCollect(model.streamTurn(turn));
-      }),
-    );
-    expect(errors(exit)[0].kind).toBe('malformed-output');
-    expect(fetch).toHaveBeenCalledTimes(1);
-  });
-
-  it.each([401, 429, 200])(
-    'preserves HTTP %s or in-band failure, original code and PDF evidence',
-    async (status) => {
-      const error = {
-        code: status === 200 ? 'server_error' : status,
-        message: 'Provider failed',
-        metadata: { file_annotations: [FILE] },
-      };
-      const wire =
-        status === 200
-          ? sse(frame({ content: 'partial' }), {
-              ...IDENTITY,
-              error,
-              choices: [{ finish_reason: 'error' }],
-            })
-          : JSON.stringify({ error });
+  ] as const)('fails %s without producing a completed result', ([_, frames]) =>
+    Effect.gen(function* () {
       const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-        response(wire, status),
+        response(sse(...frames)),
       );
       const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
-      const exit = await Effect.runPromiseExit(
+      const exit = yield* Effect.exit(
         Effect.gen(function* () {
-          const turn = yield* model.prepareTurn(REQUEST);
+          const turn = yield* model.prepareTurn({ ...REQUEST, tools: TOOLS });
           assert.equal(turn.mode, 'foreground');
-          return yield* model.generateTurn(turn);
+          return yield* Stream.runCollect(model.streamTurn(turn));
         }),
       );
-      const failure = errors(exit)[0];
-      expect(failure).toMatchObject({
-        kind: status === 401 ? 'authentication' : 'provider-rejection',
-        message: 'Provider failed',
-        requestId: 'request-1',
-        cause: error,
-        providerEvidence: {
-          kind: 'openrouter',
-          origin: { protocol: 'openrouter-chat' },
-          fileAnnotations: [{ kind: 'file-annotation', hash: 'file-hash' }],
-        },
-      });
-      if (status === 200) expect(failure.responseId).toBe('generation-1');
-      expect(failure.providerEvidence?.origin).toEqual({
-        protocol: 'openrouter-chat',
-        codecVersion: 1,
-        requestedModel: CONFIG.requestedModel,
-        deployment: CONFIG.deployment,
-      });
+      expect(errors(exit)[0].kind).toBe('malformed-output');
       expect(fetch).toHaveBeenCalledTimes(1);
-    },
+    }),
   );
 
-  it.each(['missing DONE', 'invalid JSON', 'connection'] as const)(
-    'classifies %s without retry',
-    async (variant) => {
-      const cause = new Error('Disconnected');
-      const fetch = vi.fn<typeof globalThis.fetch>(async () => {
-        if (variant === 'connection') throw cause;
-        return response(
-          variant === 'invalid JSON'
-            ? 'data: {broken}\n\n'
-            : `data: ${JSON.stringify(frame({ content: 'partial' }, 'stop'))}\n\n`,
+  it.effect.each([401, 429, 200])(
+    'preserves HTTP %s or in-band failure, original code and PDF evidence',
+    (status) =>
+      Effect.gen(function* () {
+        const error = {
+          code: status === 200 ? 'server_error' : status,
+          message: 'Provider failed',
+          metadata: { file_annotations: [FILE] },
+        };
+        const wire =
+          status === 200
+            ? sse(frame({ content: 'partial' }), {
+                ...IDENTITY,
+                error,
+                choices: [{ finish_reason: 'error' }],
+              })
+            : JSON.stringify({ error });
+        const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+          response(wire, status),
         );
-      });
-      const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
-      const exit = await Effect.runPromiseExit(
-        Effect.gen(function* () {
-          const turn = yield* model.prepareTurn(REQUEST);
-          assert.equal(turn.mode, 'foreground');
-          return yield* model.generateTurn(turn);
-        }),
-      );
-      expect(errors(exit)[0].kind).toBe(
-        variant === 'connection' ? 'transport' : 'malformed-output',
-      );
-      expect(fetch).toHaveBeenCalledTimes(1);
-    },
+        const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
+        const exit = yield* Effect.exit(
+          Effect.gen(function* () {
+            const turn = yield* model.prepareTurn(REQUEST);
+            assert.equal(turn.mode, 'foreground');
+            return yield* model.generateTurn(turn);
+          }),
+        );
+        const failure = errors(exit)[0];
+        expect(failure).toMatchObject({
+          kind: status === 401 ? 'authentication' : 'provider-rejection',
+          message: 'Provider failed',
+          requestId: 'request-1',
+          cause: error,
+          providerEvidence: {
+            kind: 'openrouter',
+            origin: { protocol: 'openrouter-chat' },
+            fileAnnotations: [{ kind: 'file-annotation', hash: 'file-hash' }],
+          },
+        });
+        if (status === 200) expect(failure.responseId).toBe('generation-1');
+        expect(failure.providerEvidence?.origin).toEqual({
+          protocol: 'openrouter-chat',
+          codecVersion: 1,
+          requestedModel: CONFIG.requestedModel,
+          deployment: CONFIG.deployment,
+        });
+        expect(fetch).toHaveBeenCalledTimes(1);
+      }),
+  );
+
+  it.effect.each(['missing DONE', 'invalid JSON', 'connection'] as const)(
+    'classifies %s without retry',
+    (variant) =>
+      Effect.gen(function* () {
+        const cause = new Error('Disconnected');
+        const fetch = vi.fn<typeof globalThis.fetch>(async () => {
+          if (variant === 'connection') throw cause;
+          return response(
+            variant === 'invalid JSON'
+              ? 'data: {broken}\n\n'
+              : `data: ${JSON.stringify(frame({ content: 'partial' }, 'stop'))}\n\n`,
+          );
+        });
+        const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
+        const exit = yield* Effect.exit(
+          Effect.gen(function* () {
+            const turn = yield* model.prepareTurn(REQUEST);
+            assert.equal(turn.mode, 'foreground');
+            return yield* model.generateTurn(turn);
+          }),
+        );
+        expect(errors(exit)[0].kind).toBe(
+          variant === 'connection' ? 'transport' : 'malformed-output',
+        );
+        expect(fetch).toHaveBeenCalledTimes(1);
+      }),
   );
 
   it.each(['headers', 'body', 'body with distinct cleanup'] as const)(
@@ -839,40 +871,46 @@ describe('native OpenRouter Chat', () => {
     },
   );
 
-  it('preserves the original malformed frame and a distinct reader cleanup defect', async () => {
-    const cleanup = new Error('Cancellation failed');
-    const body = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(
-          new TextEncoder().encode(
-            `data: ${JSON.stringify(frame({ content: 'partial' }))}\n\ndata: {bad}\n\n`,
-          ),
-        );
-      },
-      cancel() {
-        throw cleanup;
-      },
-    });
-    const fetch = vi.fn<typeof globalThis.fetch>(async () => response(body));
-    const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
-    const exit = await Effect.runPromiseExit(
+  it.effect(
+    'preserves the original malformed frame and a distinct reader cleanup defect',
+    () =>
       Effect.gen(function* () {
-        const turn = yield* model.prepareTurn(REQUEST);
-        assert.equal(turn.mode, 'foreground');
-        return yield* Stream.runDrain(model.streamTurn(turn));
+        const cleanup = new Error('Cancellation failed');
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                `data: ${JSON.stringify(frame({ content: 'partial' }))}\n\ndata: {bad}\n\n`,
+              ),
+            );
+          },
+          cancel() {
+            throw cleanup;
+          },
+        });
+        const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+          response(body),
+        );
+        const model = openrouterChatModel(CONFIG, { apiKey: 'key', fetch });
+        const exit = yield* Effect.exit(
+          Effect.gen(function* () {
+            const turn = yield* model.prepareTurn(REQUEST);
+            assert.equal(turn.mode, 'foreground');
+            return yield* Stream.runDrain(model.streamTurn(turn));
+          }),
+        );
+        expect(errors(exit)[0]).toMatchObject({
+          kind: 'malformed-output',
+          responseId: 'generation-1',
+          requestId: 'request-1',
+        });
+        assert(Exit.isFailure(exit));
+        expect(
+          exit.cause.reasons.some(
+            (reason) => Cause.isDieReason(reason) && reason.defect === cleanup,
+          ),
+        ).toBe(true);
+        expect(body.locked).toBe(false);
       }),
-    );
-    expect(errors(exit)[0]).toMatchObject({
-      kind: 'malformed-output',
-      responseId: 'generation-1',
-      requestId: 'request-1',
-    });
-    assert(Exit.isFailure(exit));
-    expect(
-      exit.cause.reasons.some(
-        (reason) => Cause.isDieReason(reason) && reason.defect === cleanup,
-      ),
-    ).toBe(true);
-    expect(body.locked).toBe(false);
-  });
+  );
 });

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, vi } from 'vitest';
 
 import { effectDiagnosticsLayer } from '@logger/effectDiagnostics';
 import { setLogSink, type LogEntry } from '@logger/logSink';
@@ -128,39 +129,45 @@ describe('logUtils', () => {
     );
   });
 
-  it('routes native Effect logs and nested spans through the redacting sink', () => {
-    enableDebugLogging();
-    const entries = captureEntries();
-    const operation = Effect.fn('model.request')(function* () {
-      yield* Effect.annotateCurrentSpan('executionId', 'run-42');
-      yield* Effect.annotateCurrentSpan('authorization', `Bearer ${SECRET}`);
-      yield* Effect.logWarning('provider warning').pipe(
-        Effect.annotateLogs({ executionId: 'run-42', apiKey: SECRET }),
-      );
-    });
+  it.effect(
+    'routes native Effect logs and nested spans through the redacting sink',
+    () =>
+      Effect.gen(function* () {
+        enableDebugLogging();
+        const entries = captureEntries();
+        const operation = Effect.fn('model.request')(function* () {
+          yield* Effect.annotateCurrentSpan('executionId', 'run-42');
+          yield* Effect.annotateCurrentSpan(
+            'authorization',
+            `Bearer ${SECRET}`,
+          );
+          yield* Effect.logWarning('provider warning').pipe(
+            Effect.annotateLogs({ executionId: 'run-42', apiKey: SECRET }),
+          );
+        });
 
-    Effect.runSync(
-      operation().pipe(
-        Effect.withSpan('session.run'),
-        Effect.provide(effectDiagnosticsLayer),
-      ),
-    );
+        yield* operation().pipe(
+          Effect.withSpan('session.run'),
+          Effect.provide(effectDiagnosticsLayer),
+        );
 
-    const warning = entries.find((entry) => entry.level === 'WARN');
-    expect(warning?.message).toBe('provider warning');
-    // Identity rides the entry's annotations, not a channel argument. A tracer
-    // span does not attribute a log entry: `spans` reads `CurrentLogSpans`.
-    expect(warning?.annotations['executionId']).toBe('run-42');
-    const output = JSON.stringify(entries);
-    expect(output).toContain('[redacted]');
-    expect(output).not.toContain(SECRET);
+        const warning = entries.find((entry) => entry.level === 'WARN');
+        expect(warning?.message).toBe('provider warning');
+        // Identity rides the entry's annotations, not a channel argument. A
+        // tracer span does not attribute a log entry: `spans` reads
+        // `CurrentLogSpans`.
+        expect(warning?.annotations['executionId']).toBe('run-42');
+        const output = JSON.stringify(entries);
+        expect(output).toContain('[redacted]');
+        expect(output).not.toContain(SECRET);
 
-    vi.spyOn(rootsAccess, 'tryWorkspaceRoots').mockReturnValue(undefined);
-    entries.length = 0;
-    Effect.runSync(operation().pipe(Effect.provide(effectDiagnosticsLayer)));
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.message).toBe('provider warning');
-  });
+        vi.spyOn(rootsAccess, 'tryWorkspaceRoots').mockReturnValue(undefined);
+        entries.length = 0;
+        yield* operation().pipe(Effect.provide(effectDiagnosticsLayer));
+        expect(entries).toHaveLength(1);
+        expect(entries[0]?.message).toBe('provider warning');
+      }),
+  );
 
   it('disposes a replaced sink exactly once', () => {
     const dispose = vi.fn();

--- a/src/test-kernel/progressView/ChatExportController.vitest.ts
+++ b/src/test-kernel/progressView/ChatExportController.vitest.ts
@@ -1,8 +1,9 @@
 import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect } from 'vitest';
 
 import { getExecutionRecords } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -81,13 +82,13 @@ function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
   };
 }
 
-async function persistTranscriptEntry(
+function persistTranscriptEntry(
   executionId: ExecutionId,
   agent: string,
-): Promise<StreamTabId> {
-  const streamId = getStreamTabId(agent, { executionId });
-  await Effect.runPromise(
-    session.commit([
+): Effect.Effect<StreamTabId> {
+  return Effect.gen(function* () {
+    const streamId = getStreamTabId(agent, { executionId });
+    yield* session.commit([
       {
         type: 'log',
         aggregateId: aggregateId('stream', streamId),
@@ -95,10 +96,10 @@ async function persistTranscriptEntry(
         messageType: MESSAGE_TYPES.USER_MESSAGE,
         message: 'hello',
       },
-    ]),
-  );
+    ]);
 
-  return streamId;
+    return streamId;
+  });
 }
 
 describe('ChatExportController.exportAsHtml', () => {
@@ -113,69 +114,78 @@ describe('ChatExportController.exportAsHtml', () => {
     });
   });
 
-  it('returns config_missing when nothing is stored', async () => {
-    const templatePath = await writeTemplate();
+  it.live('returns config_missing when nothing is stored', () =>
+    Effect.gen(function* () {
+      const templatePath = yield* Effect.promise(() => writeTemplate());
 
-    const outcome = await Effect.runPromise(
-      controller.exportAsHtml('missing', templatePath),
-    );
+      const outcome = yield* controller.exportAsHtml('missing', templatePath);
 
-    expect(outcome).toEqual({ status: 'config_missing' });
-  });
+      expect(outcome).toEqual({ status: 'config_missing' });
+    }),
+  );
 
-  it('writes a self-contained HTML file with the trace embedded, when everything is present', async () => {
-    const templatePath = await writeTemplate();
-    const executionId = 'eec001' as ExecutionId;
-    const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
-    publishTestRunStart(
-      session,
-      getStreamTabId(executionConfig.agent, { executionId }),
-      executionId,
-    );
-    await session.settlePublications();
-    await Effect.runPromise(
-      getExecutionRecords(session, executionId).writeRunRecord(executionConfig),
-    );
-    const streamId = await persistTranscriptEntry(executionId, 'review');
+  it.live(
+    'writes a self-contained HTML file with the trace embedded, when everything is present',
+    () =>
+      Effect.gen(function* () {
+        const templatePath = yield* Effect.promise(() => writeTemplate());
+        const executionId = 'eec001' as ExecutionId;
+        const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
+        publishTestRunStart(
+          session,
+          getStreamTabId(executionConfig.agent, { executionId }),
+          executionId,
+        );
+        yield* Effect.promise(() => session.settlePublications());
+        yield* getExecutionRecords(session, executionId).writeRunRecord(
+          executionConfig,
+        );
+        const streamId = yield* persistTranscriptEntry(executionId, 'review');
 
-    const outcome = await Effect.runPromise(
-      controller.exportAsHtml(executionId, templatePath),
-    );
+        const outcome = yield* controller.exportAsHtml(
+          executionId,
+          templatePath,
+        );
 
-    expect(outcome.status).toBe('ok');
-    if (outcome.status !== 'ok') return;
-    expect(outcome.result.storagePath).toMatch(
-      /^executions\/eec001\/texra-chat-.*\.html$/,
-    );
+        expect(outcome.status).toBe('ok');
+        if (outcome.status !== 'ok') return;
+        expect(outcome.result.storagePath).toMatch(
+          /^executions\/eec001\/texra-chat-.*\.html$/,
+        );
 
-    const written = await nodeFilesystem.readFile(outcome.result.absolutePath);
-    const html = new TextDecoder().decode(written);
-    expect(html).toContain('<script>window.__TEXRA_TRACE__');
-    expect(html).toContain('"text":"hello"');
-    expect(html).toContain(
-      '<script type="module" crossorigin src="./index.js">',
-    );
-  });
+        const written = yield* Effect.promise(() =>
+          nodeFilesystem.readFile(outcome.result.absolutePath),
+        );
+        const html = new TextDecoder().decode(written);
+        expect(html).toContain('<script>window.__TEXRA_TRACE__');
+        expect(html).toContain('"text":"hello"');
+        expect(html).toContain(
+          '<script type="module" crossorigin src="./index.js">',
+        );
+      }),
+  );
 
-  it('throws when the standalone template bundle is missing', async () => {
-    const executionId = 'eec002' as ExecutionId;
-    publishTestRunStart(
-      session,
-      getStreamTabId(config().agent, { executionId }),
-      executionId,
-    );
-    await session.settlePublications();
-    await Effect.runPromise(
-      getExecutionRecords(session, executionId).writeRunRecord(config()),
-    );
-    const streamId = await persistTranscriptEntry(executionId, 'orchestrator');
+  it.live('throws when the standalone template bundle is missing', () =>
+    Effect.gen(function* () {
+      const executionId = 'eec002' as ExecutionId;
+      publishTestRunStart(
+        session,
+        getStreamTabId(config().agent, { executionId }),
+        executionId,
+      );
+      yield* Effect.promise(() => session.settlePublications());
+      yield* getExecutionRecords(session, executionId).writeRunRecord(config());
+      const streamId = yield* persistTranscriptEntry(
+        executionId,
+        'orchestrator',
+      );
 
-    await expect(
-      Effect.runPromise(
+      const failure = yield* Effect.flip(
         controller.exportAsHtml(executionId, '/nonexistent/index.html'),
-      ),
-    ).rejects.toThrow(/Trace-viewer standalone bundle missing/);
-  });
+      );
+      expect(failure.message).toMatch(/Trace-viewer standalone bundle missing/);
+    }),
+  );
 });
 
 describe('ChatExportController.buildExportInput', () => {
@@ -190,50 +200,53 @@ describe('ChatExportController.buildExportInput', () => {
     });
   });
 
-  it('reports config_missing when nothing is stored', async () => {
-    await expect(
-      Effect.runPromise(controller.buildExportInput('missing')),
-    ).resolves.toEqual({
-      status: 'config_missing',
-    });
-  });
+  it.live('reports config_missing when nothing is stored', () =>
+    Effect.gen(function* () {
+      expect(yield* controller.buildExportInput('missing')).toEqual({
+        status: 'config_missing',
+      });
+    }),
+  );
 
-  it('returns ok when config and transcript are stored', async () => {
-    const executionId = 'eec001' as ExecutionId;
-    publishTestRunStart(
-      session,
-      getStreamTabId(config().agent, { executionId }),
-      executionId,
-    );
-    await session.settlePublications();
-    await Effect.runPromise(
-      getExecutionRecords(session, executionId).writeRunRecord(config()),
-    );
-    const streamId = await persistTranscriptEntry(executionId, 'orchestrator');
+  it.live('returns ok when config and transcript are stored', () =>
+    Effect.gen(function* () {
+      const executionId = 'eec001' as ExecutionId;
+      publishTestRunStart(
+        session,
+        getStreamTabId(config().agent, { executionId }),
+        executionId,
+      );
+      yield* Effect.promise(() => session.settlePublications());
+      yield* getExecutionRecords(session, executionId).writeRunRecord(config());
+      const streamId = yield* persistTranscriptEntry(
+        executionId,
+        'orchestrator',
+      );
 
-    await expect(
-      Effect.runPromise(controller.buildExportInput(executionId)),
-    ).resolves.toMatchObject({
-      status: 'ok',
-    });
-  });
+      expect(yield* controller.buildExportInput(executionId)).toMatchObject({
+        status: 'ok',
+      });
+    }),
+  );
 
-  it('reports conversation_missing when a config is stored but no transcript exists', async () => {
-    const executionId = 'eec003' as ExecutionId;
-    publishTestRunStart(
-      session,
-      getStreamTabId(config().agent, { executionId }),
-      executionId,
-    );
-    await session.settlePublications();
-    await Effect.runPromise(
-      getExecutionRecords(session, executionId).writeRunRecord(config()),
-    );
+  it.live(
+    'reports conversation_missing when a config is stored but no transcript exists',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'eec003' as ExecutionId;
+        publishTestRunStart(
+          session,
+          getStreamTabId(config().agent, { executionId }),
+          executionId,
+        );
+        yield* Effect.promise(() => session.settlePublications());
+        yield* getExecutionRecords(session, executionId).writeRunRecord(
+          config(),
+        );
 
-    await expect(
-      Effect.runPromise(controller.buildExportInput(executionId)),
-    ).resolves.toEqual({
-      status: 'conversation_missing',
-    });
-  });
+        expect(yield* controller.buildExportInput(executionId)).toEqual({
+          status: 'conversation_missing',
+        });
+      }),
+  );
 });

--- a/src/test-kernel/settings/TeamRosterApplication.vitest.ts
+++ b/src/test-kernel/settings/TeamRosterApplication.vitest.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { describe, expect, vi } from 'vitest';
 
 import { Effect } from 'effect';
 import {
@@ -66,15 +67,15 @@ function makeDeps(
 }
 
 describe('team roster application', () => {
-  it('signs in, forces one refresh, and commits exactly once', async () => {
-    const calls: string[] = [];
-    let refreshed = false;
-    const commitPreset = vi.fn(async () => {
-      calls.push('commit');
-    });
+  it.effect('signs in, forces one refresh, and commits exactly once', () =>
+    Effect.gen(function* () {
+      const calls: string[] = [];
+      let refreshed = false;
+      const commitPreset = vi.fn(async () => {
+        calls.push('commit');
+      });
 
-    const result = await Effect.runPromise(
-      applyTeamRosterWithPreflight(
+      const result = yield* applyTeamRosterWithPreflight(
         'research',
         makeDeps({
           catalog: {
@@ -103,32 +104,32 @@ describe('team roster application', () => {
               refreshed = true;
             }),
         }),
-      ),
-    );
+      );
 
-    expect(result).toEqual({
-      status: 'applied',
-      preset,
-      resolution: resolved,
-    });
-    expect(calls).toEqual([
-      'local-load',
-      'choose',
-      'sign-in',
-      'forced-refresh',
-      'commit',
-    ]);
-    expect(commitPreset).toHaveBeenCalledOnce();
-    expect(commitPreset).toHaveBeenCalledWith(preset);
-  });
+      expect(result).toEqual({
+        status: 'applied',
+        preset,
+        resolution: resolved,
+      });
+      expect(calls).toEqual([
+        'local-load',
+        'choose',
+        'sign-in',
+        'forced-refresh',
+        'commit',
+      ]);
+      expect(commitPreset).toHaveBeenCalledOnce();
+      expect(commitPreset).toHaveBeenCalledWith(preset);
+    }),
+  );
 
-  it('cancels before refresh or roster writes', async () => {
-    const commitPreset = vi.fn();
-    let forcedRefresh = false;
-    const signIn = vi.fn();
+  it.effect('cancels before refresh or roster writes', () =>
+    Effect.gen(function* () {
+      const commitPreset = vi.fn();
+      let forcedRefresh = false;
+      const signIn = vi.fn();
 
-    const result = await Effect.runPromise(
-      applyTeamRosterWithPreflight(
+      const result = yield* applyTeamRosterWithPreflight(
         'research',
         makeDeps({
           catalog: { commitPreset },
@@ -138,155 +139,161 @@ describe('team roster application', () => {
               forcedRefresh = true;
             }),
         }),
-      ),
-    );
+      );
 
-    expect(result).toEqual({ status: 'cancelled', preset });
-    expect(signIn).not.toHaveBeenCalled();
-    expect(forcedRefresh).toBe(false);
-    expect(commitPreset).not.toHaveBeenCalled();
-  });
+      expect(result).toEqual({ status: 'cancelled', preset });
+      expect(signIn).not.toHaveBeenCalled();
+      expect(forcedRefresh).toBe(false);
+      expect(commitPreset).not.toHaveBeenCalled();
+    }),
+  );
 
-  it('preflights an arbitrary unresolved member in a legacy custom team', async () => {
-    const legacyPreset: AgentModePreset = {
-      id: 'legacy',
-      name: 'Legacy',
-      description: 'Saved before hosted provenance',
-      icon: 'bookmark',
-      agents: {
-        workflow: [],
-        toolUse: ['review', 'remoteSpecialist'],
-      },
-    };
-    const choose = vi.fn(
-      async (_names: readonly string[]) => 'cancel' as const,
-    );
-    const commitPreset = vi.fn();
-
-    const result = await Effect.runPromise(
-      applyTeamRosterWithPreflight(
-        'legacy',
-        makeDeps({
-          catalog: {
-            resolvePreset: () => ({
-              ok: true,
-              preset: legacyPreset,
-              resolution: {
-                keys: {
-                  workflow: [],
-                  toolUse: ['builtInToolUse:review'],
-                },
-                nameSlots: {
-                  workflow: [],
-                  toolUse: ['remoteSpecialist'],
-                },
-                unresolvedNames: ['remoteSpecialist'],
-              },
-            }),
-            commitPreset,
+  it.effect(
+    'preflights an arbitrary unresolved member in a legacy custom team',
+    () =>
+      Effect.gen(function* () {
+        const legacyPreset: AgentModePreset = {
+          id: 'legacy',
+          name: 'Legacy',
+          description: 'Saved before hosted provenance',
+          icon: 'bookmark',
+          agents: {
+            workflow: [],
+            toolUse: ['review', 'remoteSpecialist'],
           },
-          choose: async (_preset, names) => choose(names),
-        }),
-      ),
-    );
+        };
+        const choose = vi.fn(
+          async (_names: readonly string[]) => 'cancel' as const,
+        );
+        const commitPreset = vi.fn();
 
-    expect(result.status).toBe('cancelled');
-    expect(choose).toHaveBeenCalledWith(['remoteSpecialist']);
-    expect(commitPreset).not.toHaveBeenCalled();
-  });
-
-  it('preflights recognized and arbitrary unresolved members in a mixed legacy team', async () => {
-    const legacyPreset: AgentModePreset = {
-      id: 'mixed-legacy',
-      name: 'Mixed legacy',
-      description: 'Contains local and remote members without provenance',
-      icon: 'bookmark',
-      agents: {
-        workflow: ['generic'],
-        toolUse: ['review', 'remoteSpecialist'],
-      },
-    };
-    const choose = vi.fn(
-      async (_names: readonly string[]) => 'cancel' as const,
-    );
-
-    await Effect.runPromise(
-      applyTeamRosterWithPreflight(
-        'mixed-legacy',
-        makeDeps({
-          catalog: {
-            resolvePreset: () => ({
-              ok: true,
-              preset: legacyPreset,
-              resolution: {
-                keys: {
-                  workflow: [],
-                  toolUse: ['builtInToolUse:review'],
+        const result = yield* applyTeamRosterWithPreflight(
+          'legacy',
+          makeDeps({
+            catalog: {
+              resolvePreset: () => ({
+                ok: true,
+                preset: legacyPreset,
+                resolution: {
+                  keys: {
+                    workflow: [],
+                    toolUse: ['builtInToolUse:review'],
+                  },
+                  nameSlots: {
+                    workflow: [],
+                    toolUse: ['remoteSpecialist'],
+                  },
+                  unresolvedNames: ['remoteSpecialist'],
                 },
-                nameSlots: {
-                  workflow: ['generic'],
-                  toolUse: ['remoteSpecialist'],
-                },
-                unresolvedNames: ['generic', 'remoteSpecialist'],
-              },
-            }),
-          },
-          choose: async (_preset, names) => choose(names),
-        }),
-      ),
-    );
+              }),
+              commitPreset,
+            },
+            choose: async (_preset, names) => choose(names),
+          }),
+        );
 
-    expect(choose).toHaveBeenCalledWith(['generic', 'remoteSpecialist']);
-    expect(legacyPreset).not.toHaveProperty('texraHostedAgents');
-  });
-
-  it('refreshes the host before presenting a successful settings application', async () => {
-    const calls: string[] = [];
-    const getPresetToolUseRoot = vi.fn(() => 'orchestrator');
-
-    await Effect.runPromise(
-      applySettingsTeamRoster('research', {
-        catalog: {
-          resolvePreset: () => ({ ok: true, preset, resolution: resolved }),
-          commitPreset: async () => {
-            calls.push('apply');
-          },
-          getPresetToolUseRoot,
-        },
-        loadLocalCatalog: () => Effect.void,
-        canAccessRemoteCatalog: async () => false,
-        signIn: async () => false,
-        forceRefreshRemoteCatalog: () => Effect.void,
-        presentation: {
-          chooseTeamAvailability: async () => 'cancel',
-          showErrorMessage: async () => {},
-          showInfoMessage: async (message) => {
-            calls.push(`info:${message}`);
-          },
-        },
-        refreshAfterApply: async (selectedToolUseAgent) => {
-          calls.push(`refresh:${selectedToolUseAgent}`);
-        },
+        expect(result.status).toBe('cancelled');
+        expect(choose).toHaveBeenCalledWith(['remoteSpecialist']);
+        expect(commitPreset).not.toHaveBeenCalled();
       }),
-    );
+  );
 
-    expect(getPresetToolUseRoot).toHaveBeenCalledWith(
-      ['orchestrator'],
-      'research',
-    );
-    expect(calls).toEqual([
-      'apply',
-      'refresh:orchestrator',
-      'info:Applied "Research" team',
-    ]);
-  });
+  it.effect(
+    'preflights recognized and arbitrary unresolved members in a mixed legacy team',
+    () =>
+      Effect.gen(function* () {
+        const legacyPreset: AgentModePreset = {
+          id: 'mixed-legacy',
+          name: 'Mixed legacy',
+          description: 'Contains local and remote members without provenance',
+          icon: 'bookmark',
+          agents: {
+            workflow: ['generic'],
+            toolUse: ['review', 'remoteSpecialist'],
+          },
+        };
+        const choose = vi.fn(
+          async (_names: readonly string[]) => 'cancel' as const,
+        );
 
-  it('presents canonical unavailable-member choices and errors', async () => {
-    const prompts: unknown[] = [];
-    const errors: string[] = [];
+        yield* applyTeamRosterWithPreflight(
+          'mixed-legacy',
+          makeDeps({
+            catalog: {
+              resolvePreset: () => ({
+                ok: true,
+                preset: legacyPreset,
+                resolution: {
+                  keys: {
+                    workflow: [],
+                    toolUse: ['builtInToolUse:review'],
+                  },
+                  nameSlots: {
+                    workflow: ['generic'],
+                    toolUse: ['remoteSpecialist'],
+                  },
+                  unresolvedNames: ['generic', 'remoteSpecialist'],
+                },
+              }),
+            },
+            choose: async (_preset, names) => choose(names),
+          }),
+        );
 
-    await Effect.runPromise(
-      applySettingsTeamRoster('research', {
+        expect(choose).toHaveBeenCalledWith(['generic', 'remoteSpecialist']);
+        expect(legacyPreset).not.toHaveProperty('texraHostedAgents');
+      }),
+  );
+
+  it.effect(
+    'refreshes the host before presenting a successful settings application',
+    () =>
+      Effect.gen(function* () {
+        const calls: string[] = [];
+        const getPresetToolUseRoot = vi.fn(() => 'orchestrator');
+
+        yield* applySettingsTeamRoster('research', {
+          catalog: {
+            resolvePreset: () => ({ ok: true, preset, resolution: resolved }),
+            commitPreset: async () => {
+              calls.push('apply');
+            },
+            getPresetToolUseRoot,
+          },
+          loadLocalCatalog: () => Effect.void,
+          canAccessRemoteCatalog: async () => false,
+          signIn: async () => false,
+          forceRefreshRemoteCatalog: () => Effect.void,
+          presentation: {
+            chooseTeamAvailability: async () => 'cancel',
+            showErrorMessage: async () => {},
+            showInfoMessage: async (message) => {
+              calls.push(`info:${message}`);
+            },
+          },
+          refreshAfterApply: async (selectedToolUseAgent) => {
+            calls.push(`refresh:${selectedToolUseAgent}`);
+          },
+        });
+
+        expect(getPresetToolUseRoot).toHaveBeenCalledWith(
+          ['orchestrator'],
+          'research',
+        );
+        expect(calls).toEqual([
+          'apply',
+          'refresh:orchestrator',
+          'info:Applied "Research" team',
+        ]);
+      }),
+  );
+
+  it.effect('presents canonical unavailable-member choices and errors', () =>
+    Effect.gen(function* () {
+      const prompts: unknown[] = [];
+      const errors: string[] = [];
+
+      yield* applySettingsTeamRoster('research', {
         catalog: {
           resolvePreset: () => ({ ok: true, preset, resolution: unresolved }),
           commitPreset: vi.fn(),
@@ -307,51 +314,53 @@ describe('team roster application', () => {
           showInfoMessage: async () => {},
         },
         refreshAfterApply: async () => {},
+      });
+
+      expect(prompts).toEqual([
+        {
+          severity: 'warning',
+          message:
+            'Team "Research" has unavailable TeXRA-hosted members: orchestrator.',
+          actions: [
+            { choice: 'sign-in', label: 'Sign In to TeXRA' },
+            {
+              choice: 'continue',
+              label: 'Continue with Available Members',
+            },
+            { choice: 'cancel', label: 'Cancel' },
+          ],
+        },
+      ]);
+      expect(errors).toEqual(['Team "Research" is unavailable: orchestrator.']);
+    }),
+  );
+
+  it.effect(
+    'proceeds on a provided "continue" choice without prompting or signing in',
+    () =>
+      Effect.gen(function* () {
+        const choose = vi.fn();
+        const signIn = vi.fn();
+        const commitPreset = vi.fn();
+
+        const result = yield* applyTeamRosterWithPreflight(
+          'research',
+          makeDeps({
+            catalog: { commitPreset },
+            providedChoice: 'continue',
+            choose,
+            signIn,
+          }),
+        );
+
+        expect(result).toEqual({
+          status: 'applied',
+          preset,
+          resolution: unresolved,
+        });
+        expect(choose).not.toHaveBeenCalled();
+        expect(signIn).not.toHaveBeenCalled();
+        expect(commitPreset).toHaveBeenCalledWith(preset);
       }),
-    );
-
-    expect(prompts).toEqual([
-      {
-        severity: 'warning',
-        message:
-          'Team "Research" has unavailable TeXRA-hosted members: orchestrator.',
-        actions: [
-          { choice: 'sign-in', label: 'Sign In to TeXRA' },
-          {
-            choice: 'continue',
-            label: 'Continue with Available Members',
-          },
-          { choice: 'cancel', label: 'Cancel' },
-        ],
-      },
-    ]);
-    expect(errors).toEqual(['Team "Research" is unavailable: orchestrator.']);
-  });
-
-  it('proceeds on a provided "continue" choice without prompting or signing in', async () => {
-    const choose = vi.fn();
-    const signIn = vi.fn();
-    const commitPreset = vi.fn();
-
-    const result = await Effect.runPromise(
-      applyTeamRosterWithPreflight(
-        'research',
-        makeDeps({
-          catalog: { commitPreset },
-          providedChoice: 'continue',
-          choose,
-          signIn,
-        }),
-      ),
-    );
-
-    expect(result).toEqual({
-      status: 'applied',
-      preset,
-      resolution: unresolved,
-    });
-    expect(choose).not.toHaveBeenCalled();
-    expect(signIn).not.toHaveBeenCalled();
-    expect(commitPreset).toHaveBeenCalledWith(preset);
-  });
+  );
 });

--- a/src/test-kernel/tools/Attachments.vitest.ts
+++ b/src/test-kernel/tools/Attachments.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { buildBytesAttachment } from '@tools/attachments';
 
@@ -18,38 +19,43 @@ function pngHeader(width: number, height: number): Buffer {
 }
 
 function buildImageAttachment(bytes: Buffer) {
-  return Effect.runSync(
-    buildBytesAttachment({
-      path: 'figure.png',
-      mimeType: 'image/png',
-      bytes,
-    }),
-  );
+  return buildBytesAttachment({
+    path: 'figure.png',
+    mimeType: 'image/png',
+    bytes,
+  });
 }
 
 describe('buildBytesAttachment oversized-image handling', () => {
-  it('strips binary data from images beyond the dimension limit', () => {
-    for (const bytes of [pngHeader(2001, 100), pngHeader(100, 2001)]) {
-      const attachment = buildImageAttachment(bytes);
-      expect(attachment.bytes).toBeUndefined();
-      expect(attachment.description).toBe(
-        'Image exceeds 2000px dimension limit; binary data stripped',
-      );
-    }
-  });
+  it.effect('strips binary data from images beyond the dimension limit', () =>
+    Effect.gen(function* () {
+      for (const bytes of [pngHeader(2001, 100), pngHeader(100, 2001)]) {
+        const attachment = yield* buildImageAttachment(bytes);
+        expect(attachment.bytes).toBeUndefined();
+        expect(attachment.description).toBe(
+          'Image exceeds 2000px dimension limit; binary data stripped',
+        );
+      }
+    }),
+  );
 
-  it('keeps the bytes of images within the limit', () => {
-    const attachment = buildImageAttachment(pngHeader(2000, 2000));
-    expect(attachment.bytes).toBeDefined();
-    expect(attachment.description).toBeUndefined();
-  });
+  it.effect('keeps the bytes of images within the limit', () =>
+    Effect.gen(function* () {
+      const attachment = yield* buildImageAttachment(pngHeader(2000, 2000));
+      expect(attachment.bytes).toBeDefined();
+      expect(attachment.description).toBeUndefined();
+    }),
+  );
 
-  it('treats unrecognized data as not oversized', () => {
-    for (const bytes of [
-      Buffer.from('plain text, not an image'),
-      Buffer.alloc(0),
-    ]) {
-      expect(buildImageAttachment(bytes).bytes).toBeDefined();
-    }
-  });
+  it.effect('treats unrecognized data as not oversized', () =>
+    Effect.gen(function* () {
+      for (const bytes of [
+        Buffer.from('plain text, not an image'),
+        Buffer.alloc(0),
+      ]) {
+        const attachment = yield* buildImageAttachment(bytes);
+        expect(attachment.bytes).toBeDefined();
+      }
+    }),
+  );
 });

--- a/src/test-kernel/tools/ChildRunDelivery.vitest.ts
+++ b/src/test-kernel/tools/ChildRunDelivery.vitest.ts
@@ -1,5 +1,6 @@
-import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { Cause, Effect, Exit } from 'effect';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 import type { ResultMeta } from '@agent/storage';
 
@@ -20,106 +21,116 @@ import type { ExecutionId, StreamTabId } from '@shared/schemas';
 describe('child run delivery', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('persists reports and result manifests', async () => {
-    const resultMeta = {
-      producer: 'subagent',
-      agentName: 'review',
-      wallTimeMs: 1,
-      result: {
-        category: 'toolUse',
-        outcome: 'completed',
-        response: 'done',
-        files: [],
-        cost: 0,
-      },
-    } satisfies ResultMeta;
+  it.effect('persists reports and result manifests', () =>
+    Effect.gen(function* () {
+      const resultMeta = {
+        producer: 'subagent',
+        agentName: 'review',
+        wallTimeMs: 1,
+        result: {
+          category: 'toolUse',
+          outcome: 'completed',
+          response: 'done',
+          files: [],
+          cost: 0,
+        },
+      } satisfies ResultMeta;
 
-    mocks.commit.mockReturnValue(Effect.succeed([]));
-    await Effect.runPromise(
-      persistChildRunDelivery(
+      mocks.commit.mockReturnValue(Effect.succeed([]));
+      yield* persistChildRunDelivery(
         { commit: mocks.commit } as unknown as SessionHandle,
         'exec-1' as ExecutionId,
         'payload',
         resultMeta,
-      ),
-    );
-    expect(mocks.commit).toHaveBeenCalledWith([
-      expect.objectContaining({ type: 'execution.report', report: 'payload' }),
-      expect.objectContaining({ type: 'execution.result', result: resultMeta }),
-    ]);
-  });
+      );
+      expect(mocks.commit).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'execution.report',
+          report: 'payload',
+        }),
+        expect.objectContaining({
+          type: 'execution.result',
+          result: resultMeta,
+        }),
+      ]);
+    }),
+  );
 
-  it('propagates persistence failures', async () => {
-    const err = new Error('disk full');
-    mocks.commit.mockReturnValue(Effect.die(err));
-    await expect(
-      Effect.runPromise(
+  it.effect('propagates persistence failures', () =>
+    Effect.gen(function* () {
+      const err = new Error('disk full');
+      mocks.commit.mockReturnValue(Effect.die(err));
+      const exit = yield* Effect.exit(
         persistChildRunDelivery(
           { commit: mocks.commit } as unknown as SessionHandle,
           'exec-1' as ExecutionId,
           'payload',
           undefined,
         ),
-      ),
-    ).rejects.toBe(err);
-  });
+      );
+      expect(Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined).toBe(
+        err,
+      );
+    }),
+  );
 
-  it('submits delivery and recovery as one operation', async () => {
-    const session = { tag: 'owner' };
-    mocks.submitFollowUp.mockReturnValue(Effect.succeed({ status: 'queued' }));
+  it.effect('submits delivery and recovery as one operation', () =>
+    Effect.gen(function* () {
+      const session = { tag: 'owner' };
+      mocks.submitFollowUp.mockReturnValue(
+        Effect.succeed({ status: 'queued' }),
+      );
 
-    await expect(
-      Effect.runPromise(
-        deliverChildRunFollowUp({
+      expect(
+        yield* deliverChildRunFollowUp({
           targetStreamId: 'parent' as StreamTabId,
           followUp: { text: 'done', origin: 'subagent_result' },
           session: session as never,
         }),
-      ),
-    ).resolves.toEqual({ kind: 'delivered' });
-    expect(mocks.submitFollowUp).toHaveBeenCalledWith(
-      'parent',
-      { text: 'done', origin: 'subagent_result' },
-      {
-        session,
-        mode: 'child_delivery',
-      },
-    );
-  });
-
-  it('carries the refusal reason for a parent that did not accept delivery', async () => {
-    function deliverToParent(followUp: {
-      text: string;
-    }): Promise<Effect.Success<ReturnType<typeof deliverChildRunFollowUp>>> {
-      return Effect.runPromise(
-        deliverChildRunFollowUp({
-          targetStreamId: 'parent' as StreamTabId,
-          followUp,
-          session: {} as never,
-        }),
+      ).toEqual({ kind: 'delivered' });
+      expect(mocks.submitFollowUp).toHaveBeenCalledWith(
+        'parent',
+        { text: 'done', origin: 'subagent_result' },
+        {
+          session,
+          mode: 'child_delivery',
+        },
       );
-    }
+    }),
+  );
 
-    mocks.submitFollowUp.mockReturnValueOnce(
-      Effect.succeed({
-        status: 'failed',
-        reason: 'finished',
-      }),
-    );
-    await expect(deliverToParent({ text: 'done' })).resolves.toEqual({
-      kind: 'failed',
-      reason: 'finished',
-    });
+  it.effect(
+    'carries the refusal reason for a parent that did not accept delivery',
+    () =>
+      Effect.gen(function* () {
+        const deliverToParent = (followUp: { text: string }) =>
+          deliverChildRunFollowUp({
+            targetStreamId: 'parent' as StreamTabId,
+            followUp,
+            session: {} as never,
+          });
 
-    mocks.submitFollowUp.mockReturnValueOnce(
-      Effect.succeed({
-        status: 'failed',
-        reason: 'not_resumable',
+        mocks.submitFollowUp.mockReturnValueOnce(
+          Effect.succeed({
+            status: 'failed',
+            reason: 'finished',
+          }),
+        );
+        expect(yield* deliverToParent({ text: 'done' })).toEqual({
+          kind: 'failed',
+          reason: 'finished',
+        });
+
+        mocks.submitFollowUp.mockReturnValueOnce(
+          Effect.succeed({
+            status: 'failed',
+            reason: 'not_resumable',
+          }),
+        );
+        expect(yield* deliverToParent({ text: 'late' })).toEqual({
+          kind: 'failed',
+          reason: 'not_resumable',
+        });
       }),
-    );
-    await expect(deliverToParent({ text: 'late' })).resolves.toEqual({
-      kind: 'failed',
-      reason: 'not_resumable',
-    });
-  });
+  );
 });

--- a/src/test-kernel/tools/DelegationAvailability.vitest.ts
+++ b/src/test-kernel/tools/DelegationAvailability.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 import type { ModelOptionData, ToolDefinition } from '@shared/schemas';
 
@@ -357,54 +358,58 @@ describe('delegation model availability', () => {
     expect(rewritten.description).not.toContain('loaded at runtime');
   });
 
-  it('rejects an explicitly requested model that is not currently available', async () => {
-    mocks.computeModelOptionsData.mockResolvedValue([
-      model('sonnet46T'),
-      model('deepseekT'),
-    ]);
+  it.effect(
+    'rejects an explicitly requested model that is not currently available',
+    () =>
+      Effect.gen(function* () {
+        mocks.computeModelOptionsData.mockResolvedValue([
+          model('sonnet46T'),
+          model('deepseekT'),
+        ]);
 
-    await expect(
-      Effect.runPromise(
-        selectAvailableDelegationModel({
-          requestedModel: 'opus48T',
-          parentModel: 'sonnet46T',
-        }),
-      ),
-    ).rejects.toThrow(
-      'Model "opus48T" is not currently available for delegation with the currently configured model access. Available models: sonnet46T, deepseekT.',
-    );
-  });
+        const failure = yield* Effect.flip(
+          selectAvailableDelegationModel({
+            requestedModel: 'opus48T',
+            parentModel: 'sonnet46T',
+          }),
+        );
 
-  it('uses the parent model only when it is available', async () => {
-    mocks.computeModelOptionsData.mockResolvedValue([
-      model('deepseekT'),
-      model('sonnet46T'),
-    ]);
+        expect(failure.message).toContain(
+          'Model "opus48T" is not currently available for delegation with the currently configured model access. Available models: sonnet46T, deepseekT.',
+        );
+      }),
+  );
 
-    await expect(
-      Effect.runPromise(
-        selectAvailableDelegationModel({ parentModel: 'sonnet46T' }),
-      ),
-    ).resolves.toBe('sonnet46T');
+  it.effect('uses the parent model only when it is available', () =>
+    Effect.gen(function* () {
+      mocks.computeModelOptionsData.mockResolvedValue([
+        model('deepseekT'),
+        model('sonnet46T'),
+      ]);
 
-    await expect(
-      Effect.runPromise(
+      expect(
+        yield* selectAvailableDelegationModel({ parentModel: 'sonnet46T' }),
+      ).toBe('sonnet46T');
+
+      expect(
+        yield* selectAvailableDelegationModel({ parentModel: 'opus48T' }),
+      ).toBe('deepseekT');
+    }),
+  );
+
+  it.effect('rejects delegation when no models are currently available', () =>
+    Effect.gen(function* () {
+      mocks.computeModelOptionsData.mockResolvedValue([]);
+
+      const failure = yield* Effect.flip(
         selectAvailableDelegationModel({ parentModel: 'opus48T' }),
-      ),
-    ).resolves.toBe('deepseekT');
-  });
+      );
 
-  it('rejects delegation when no models are currently available', async () => {
-    mocks.computeModelOptionsData.mockResolvedValue([]);
-
-    await expect(
-      Effect.runPromise(
-        selectAvailableDelegationModel({ parentModel: 'opus48T' }),
-      ),
-    ).rejects.toThrow(
-      'No models are currently available for delegation. Review or configure model access before delegating.',
-    );
-  });
+      expect(failure.message).toContain(
+        'No models are currently available for delegation. Review or configure model access before delegating.',
+      );
+    }),
+  );
 });
 
 describe('delegation worktree availability', () => {

--- a/src/test-kernel/tools/EmlParser.vitest.ts
+++ b/src/test-kernel/tools/EmlParser.vitest.ts
@@ -1,7 +1,8 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { describe, it } from 'vitest';
+import { describe } from 'vitest';
 
 // Local imports
 import { parseEml } from '@tools/emlParser';
@@ -21,17 +22,21 @@ Content-Type: text/html; charset=utf-8
 `;
 
 describe('parseEml', () => {
-  it('converts an HTML-only body to Markdown without leaking style/script content', async () => {
-    const { text } = await Effect.runPromise(parseEml(HTML_ONLY_EML));
+  it.effect(
+    'converts an HTML-only body to Markdown without leaking style/script content',
+    () =>
+      Effect.gen(function* () {
+        const { text } = yield* parseEml(HTML_ONLY_EML);
 
-    assert.match(text, /Hello \*\*world\*\*,/);
-    assert.match(text, /Item one/);
-    assert.match(text, /Item two/);
-    assert.match(text, /\[this link\]\(https:\/\/example\.com\)/);
-    // Numeric entity (&#8217;) decodes to a curly apostrophe.
-    assert.match(text, /it’s here/);
+        assert.match(text, /Hello \*\*world\*\*,/);
+        assert.match(text, /Item one/);
+        assert.match(text, /Item two/);
+        assert.match(text, /\[this link\]\(https:\/\/example\.com\)/);
+        // Numeric entity (&#8217;) decodes to a curly apostrophe.
+        assert.match(text, /it’s here/);
 
-    assert.doesNotMatch(text, /color:red/);
-    assert.doesNotMatch(text, /alert\(/);
-  });
+        assert.doesNotMatch(text, /color:red/);
+        assert.doesNotMatch(text, /alert\(/);
+      }),
+  );
 });

--- a/src/test-kernel/tools/ExecutionFormatters.vitest.ts
+++ b/src/test-kernel/tools/ExecutionFormatters.vitest.ts
@@ -1,6 +1,7 @@
 // Third-party imports
 import * as assert from 'node:assert';
-import { beforeEach, afterEach, describe, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { beforeEach, afterEach, describe, vi } from 'vitest';
 import { Effect } from 'effect';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { RunOutcome } from '@shared/schemas';
@@ -55,139 +56,148 @@ describe('getExecutionStatusInfo', () => {
     mocks.inspectExecutionLease.mockResolvedValue({ status: 'free' });
   });
 
-  it.each<{ outcome?: RunOutcome; expected: string }>([
+  it.effect.each<{ outcome?: RunOutcome; expected: string }>([
     { outcome: undefined, expected: 'unknown' },
     { outcome: 'cancelled', expected: 'cancelled' },
   ])(
     'reports $expected when the live handle is gone and nothing owns the run',
-    async ({ outcome, expected }) => {
-      persisted({ outcome }, 'no-checkpoint');
+    ({ outcome, expected }) =>
+      Effect.gen(function* () {
+        persisted({ outcome }, 'no-checkpoint');
 
-      const info = await Effect.runPromise(
-        getExecutionStatusInfo('exec-1', session),
-      );
+        const info = yield* getExecutionStatusInfo('exec-1', session);
 
-      assert.strictEqual(info.status, expected);
-    },
+        assert.strictEqual(info.status, expected);
+      }),
   );
 
-  it('reads no checkpoint and no lease for a row that recorded its outcome', async () => {
-    // The listing's whole budget: one metadata row (here the caller's own),
-    // and nothing else for a run that already said how it ended.
-    persisted(null, 'no-checkpoint');
+  it.effect(
+    'reads no checkpoint and no lease for a row that recorded its outcome',
+    () =>
+      Effect.gen(function* () {
+        // The listing's whole budget: one metadata row (here the caller's own),
+        // and nothing else for a run that already said how it ended.
+        persisted(null, 'no-checkpoint');
 
-    const info = await Effect.runPromise(
-      getExecutionStatusInfo('exec-1', session, {
-        outcome: 'completed',
+        const info = yield* getExecutionStatusInfo('exec-1', session, {
+          outcome: 'completed',
+        });
+
+        assert.strictEqual(info.status, 'completed');
+        assert.strictEqual(mocks.readMeta.mock.calls.length, 0);
+        assert.strictEqual(mocks.exists.mock.calls.length, 0);
+        assert.strictEqual(mocks.inspectExecutionLease.mock.calls.length, 0);
       }),
-    );
+  );
 
-    assert.strictEqual(info.status, 'completed');
-    assert.strictEqual(mocks.readMeta.mock.calls.length, 0);
-    assert.strictEqual(mocks.exists.mock.calls.length, 0);
-    assert.strictEqual(mocks.inspectExecutionLease.mock.calls.length, 0);
-  });
+  it.effect('costs one lease read and one stat for a settled row', () =>
+    Effect.gen(function* () {
+      persisted({}, 'no-checkpoint');
 
-  it('costs one lease read and one stat for a settled row', async () => {
-    persisted({}, 'no-checkpoint');
+      const info = yield* getExecutionStatusInfo('exec-1', session, {});
 
-    const info = await Effect.runPromise(
-      getExecutionStatusInfo('exec-1', session, {}),
-    );
+      assert.strictEqual(info.status, 'unknown');
+      assert.strictEqual(mocks.readMeta.mock.calls.length, 0);
+      assert.strictEqual(mocks.inspectExecutionLease.mock.calls.length, 1);
+      assert.strictEqual(mocks.exists.mock.calls.length, 1);
+    }),
+  );
 
-    assert.strictEqual(info.status, 'unknown');
-    assert.strictEqual(mocks.readMeta.mock.calls.length, 0);
-    assert.strictEqual(mocks.inspectExecutionLease.mock.calls.length, 1);
-    assert.strictEqual(mocks.exists.mock.calls.length, 1);
-  });
+  it.effect(
+    'reports a checkpointless run a live foreign owner holds as held',
+    () =>
+      Effect.gen(function* () {
+        // A background shell holds its execution lease for its whole lifetime and
+        // never writes a flow record, so the checkpoint stat cannot decide it.
+        persisted({}, 'no-checkpoint');
+        mocks.inspectExecutionLease.mockResolvedValue({
+          status: 'held',
+          owner: { pid: 5150, hostname: 'other-host' },
+        });
 
-  it('reports a checkpointless run a live foreign owner holds as held', async () => {
-    // A background shell holds its execution lease for its whole lifetime and
-    // never writes a flow record, so the checkpoint stat cannot decide it.
-    persisted({}, 'no-checkpoint');
-    mocks.inspectExecutionLease.mockResolvedValue({
-      status: 'held',
-      owner: { pid: 5150, hostname: 'other-host' },
-    });
+        const info = yield* getExecutionStatusInfo('exec-1', session, {});
 
-    const info = await Effect.runPromise(
-      getExecutionStatusInfo('exec-1', session, {}),
-    );
+        assert.strictEqual(info.status, 'unknown');
+        assert.match(info.detail ?? '', /pid 5150 on other-host/);
+        assert.strictEqual(mocks.exists.mock.calls.length, 0);
+      }),
+  );
 
-    assert.strictEqual(info.status, 'unknown');
-    assert.match(info.detail ?? '', /pid 5150 on other-host/);
-    assert.strictEqual(mocks.exists.mock.calls.length, 0);
-  });
+  it.effect('calls a checkpointed run nobody owns interrupted', () =>
+    Effect.gen(function* () {
+      persisted({}, 'checkpoint');
+      mocks.inspectExecutionLease.mockResolvedValue({ status: 'free' });
 
-  it('calls a checkpointed run nobody owns interrupted', async () => {
-    persisted({}, 'checkpoint');
-    mocks.inspectExecutionLease.mockResolvedValue({ status: 'free' });
+      const info = yield* getExecutionStatusInfo('exec-1', session);
 
-    const info = await Effect.runPromise(
-      getExecutionStatusInfo('exec-1', session),
-    );
+      assert.strictEqual(info.status, 'cancelled');
+      // Presence, not validity: a stat cannot promise the record can be resumed.
+      assert.match(
+        info.detail ?? '',
+        /interrupted; a flow record remains \(not validated here\)/,
+      );
+    }),
+  );
 
-    assert.strictEqual(info.status, 'cancelled');
-    // Presence, not validity: a stat cannot promise the record can be resumed.
-    assert.match(
-      info.detail ?? '',
-      /interrupted; a flow record remains \(not validated here\)/,
-    );
-  });
+  it.effect(
+    'does not call a run cancelled while another process holds it',
+    () =>
+      Effect.gen(function* () {
+        persisted({}, 'checkpoint');
+        mocks.inspectExecutionLease.mockResolvedValue({
+          status: 'held',
+          owner: { pid: 4242, hostname: 'other-host' },
+        });
 
-  it('does not call a run cancelled while another process holds it', async () => {
-    persisted({}, 'checkpoint');
-    mocks.inspectExecutionLease.mockResolvedValue({
-      status: 'held',
-      owner: { pid: 4242, hostname: 'other-host' },
-    });
+        const info = yield* getExecutionStatusInfo('exec-1', session);
 
-    const info = await Effect.runPromise(
-      getExecutionStatusInfo('exec-1', session),
-    );
+        assert.strictEqual(info.status, 'unknown');
+        assert.match(info.detail ?? '', /pid 4242 on other-host/);
+      }),
+  );
 
-    assert.strictEqual(info.status, 'unknown');
-    assert.match(info.detail ?? '', /pid 4242 on other-host/);
-  });
+  it.effect(
+    'does not settle a run whose lease this process holds with no run',
+    () =>
+      Effect.gen(function* () {
+        // Nothing durable behind the lease: no outcome ever written.
+        persisted({}, 'checkpoint');
+        mocks.inspectExecutionLease.mockResolvedValue({ status: 'owned' });
 
-  it('does not settle a run whose lease this process holds with no run', async () => {
-    // Nothing durable behind the lease: no outcome ever written.
-    persisted({}, 'checkpoint');
-    mocks.inspectExecutionLease.mockResolvedValue({ status: 'owned' });
+        const info = yield* getExecutionStatusInfo('exec-1', session);
 
-    const info = await Effect.runPromise(
-      getExecutionStatusInfo('exec-1', session),
-    );
+        assert.strictEqual(info.status, 'unknown');
+        assert.match(info.detail ?? '', /no live run/);
+      }),
+  );
 
-    assert.strictEqual(info.status, 'unknown');
-    assert.match(info.detail ?? '', /no live run/);
-  });
+  it.effect(
+    'still reports the outcome while this process lags releasing the lease',
+    () =>
+      Effect.gen(function* () {
+        // A finished child untracks its handle and writes the outcome long before
+        // its loop releases the execution lease (#8093), and the parent reads the
+        // run inside exactly that window.
+        persisted({ outcome: 'completed' }, 'checkpoint');
+        mocks.inspectExecutionLease.mockResolvedValue({ status: 'owned' });
 
-  it('still reports the outcome while this process lags releasing the lease', async () => {
-    // A finished child untracks its handle and writes the outcome long before
-    // its loop releases the execution lease (#8093), and the parent reads the
-    // run inside exactly that window.
-    persisted({ outcome: 'completed' }, 'checkpoint');
-    mocks.inspectExecutionLease.mockResolvedValue({ status: 'owned' });
+        const info = yield* getExecutionStatusInfo('exec-1', session);
 
-    const info = await Effect.runPromise(
-      getExecutionStatusInfo('exec-1', session),
-    );
+        assert.strictEqual(info.status, 'completed');
+      }),
+  );
 
-    assert.strictEqual(info.status, 'completed');
-  });
+  it.effect('reports an unreadable lease rather than a terminal reading', () =>
+    Effect.gen(function* () {
+      persisted({}, 'checkpoint');
+      mocks.inspectExecutionLease.mockRejectedValue(new Error('lease corrupt'));
 
-  it('reports an unreadable lease rather than a terminal reading', async () => {
-    persisted({}, 'checkpoint');
-    mocks.inspectExecutionLease.mockRejectedValue(new Error('lease corrupt'));
+      const info = yield* getExecutionStatusInfo('exec-1', session);
 
-    const info = await Effect.runPromise(
-      getExecutionStatusInfo('exec-1', session),
-    );
-
-    assert.strictEqual(info.status, 'unknown');
-    assert.match(info.detail ?? '', /cannot read \(lease corrupt\)/);
-  });
+      assert.strictEqual(info.status, 'unknown');
+      assert.match(info.detail ?? '', /cannot read \(lease corrupt\)/);
+    }),
+  );
 });
 
 describe('turnAttributionNote', () => {
@@ -195,27 +205,36 @@ describe('turnAttributionNote', () => {
     vi.clearAllMocks();
   });
 
-  it('does not call an accepted turn running once its stream is terminal', async () => {
-    // The handle outlives the stream's terminal phase, so handle presence
-    // alone must not word the note as "still running".
-    const handle = testExecutionHandle({
-      executionId: 'exec-1',
-      parentStreamId: 'stream-1',
-      agent: 'test',
-    });
-    session.executions.track(handle);
-    seedStreamStatusForTest(session.status, 'stream-1', { phase: 'completed' });
-    const store = {
-      getExecutionId: () => 'exec-1',
-      readTurnState: async () => ({
-        activeTurn: { token: 'turn-2' },
-        lastCompletedTurn: { token: 'turn-1' },
+  it.effect(
+    'does not call an accepted turn running once its stream is terminal',
+    () =>
+      Effect.gen(function* () {
+        // The handle outlives the stream's terminal phase, so handle presence
+        // alone must not word the note as "still running".
+        const handle = testExecutionHandle({
+          executionId: 'exec-1',
+          parentStreamId: 'stream-1',
+          agent: 'test',
+        });
+        session.executions.track(handle);
+        seedStreamStatusForTest(session.status, 'stream-1', {
+          phase: 'completed',
+        });
+        const store = {
+          getExecutionId: () => 'exec-1',
+          readTurnState: async () => ({
+            activeTurn: { token: 'turn-2' },
+            lastCompletedTurn: { token: 'turn-1' },
+          }),
+        } as unknown as Parameters<typeof turnAttributionNote>[0];
+
+        const note = yield* turnAttributionNote(store, session);
+
+        assert.match(
+          note ?? '',
+          /turn turn-2 ended with its run \(completed\)/,
+        );
+        assert.doesNotMatch(note ?? '', /still running/);
       }),
-    } as unknown as Parameters<typeof turnAttributionNote>[0];
-
-    const note = await Effect.runPromise(turnAttributionNote(store, session));
-
-    assert.match(note ?? '', /turn turn-2 ended with its run \(completed\)/);
-    assert.doesNotMatch(note ?? '', /still running/);
-  });
+  );
 });

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -5,8 +5,9 @@ import '@test/support/defaultSessionTestSetup';
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { beforeEach, afterEach, describe, it, vi } from 'vitest';
+import { beforeEach, afterEach, describe, vi } from 'vitest';
 
 // Local imports
 import {
@@ -446,326 +447,351 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     assert.ok(output.includes(`/executions/${executionId}/report`));
   });
 
-  it('points a non-process execution at /conversation instead of dumping its transcript', async () => {
-    const executionId = generateExecutionId();
-    await Effect.runPromise(
-      registerExecution(
-        defaultSession(),
-        executionId,
-        AgentConfigSchema.parse({
-          agent: 'chat',
-          instruction: 'Check the proof.',
-          agentCategory: AgentCategory.ToolUse,
-        }),
-        'chat',
-        {
-          streamId: `chat@model#${executionId}` as StreamTabId,
-          identity: { kind: 'agent', agent: 'chat' },
-        },
-      ),
-    );
-
-    const result = await readOutput(executionId);
-
-    assert.equal(result.status, 'executed');
-    assert.ok(
-      (result.output ?? '').includes(`/executions/${executionId}/conversation`),
-    );
-  });
-
-  it('exposes the canonical workflow aggregate without full instructions', async () => {
-    const executionId = await registerWorkflowExecution('observable');
-    const timestamp = new Date().toISOString();
-    const longStageId = `stage-${'s'.repeat(2_500)}-stage-tail`;
-    const longCallId = `call-${'i'.repeat(2_500)}-call-tail`;
-    const longTitle = `Draft ${'t'.repeat(3_000)}-title-tail`;
-    const longError = `Failure ${'e'.repeat(4_000)}-error-tail`;
-    const longFiles = Array.from(
-      { length: 513 },
-      (_, index) => `${'f'.repeat(600)}-${index}-file-tail.tex`,
-    );
-    await Effect.runPromise(
-      writeWorkflowExecutionSnapshot(defaultSession(), executionId, {
-        lifecycle: 'active',
-        currentStageId: longStageId,
-        stages: [
+  it.effect(
+    'points a non-process execution at /conversation instead of dumping its transcript',
+    () =>
+      Effect.gen(function* () {
+        const executionId = generateExecutionId();
+        yield* registerExecution(
+          defaultSession(),
+          executionId,
+          AgentConfigSchema.parse({
+            agent: 'chat',
+            instruction: 'Check the proof.',
+            agentCategory: AgentCategory.ToolUse,
+          }),
+          'chat',
           {
-            id: longStageId,
-            title: longTitle,
-            order: 0,
-            lifecycle: 'active',
-            startedAt: timestamp,
+            streamId: `chat@model#${executionId}` as StreamTabId,
+            identity: { kind: 'agent', agent: 'chat' },
           },
-        ],
-        calls: [
-          {
-            id: longCallId,
-            label: '   ',
-            stageId: longStageId,
-            agent: 'writer',
-            files: { input: longFiles, context: [], media: [] },
-            childExecutionId: 'abcdef123456',
-            attempts: [
-              {
-                number: 1,
-                id: '111111111111',
-                startedAt: timestamp,
-                completedAt: timestamp,
-              },
-              {
-                number: 2,
-                id: '222222222222',
-                childStreamId: 'writer#222222222222',
-                model: 'historical-model',
-                costUsd: 0.2,
-                startedAt: timestamp,
-                completedAt: timestamp,
-              },
-              {
-                number: 3,
-                id: 'abcdef123456',
-                childStreamId: 'writer#abcdef123456',
-                model: 'replacement-model',
-                costUsd: 0.3,
-                startedAt: timestamp,
-                completedAt: timestamp,
-              },
-            ],
-            status: 'failed',
-            error: longError,
-            timestamps: {
-              createdAt: timestamp,
+        );
+
+        const result = yield* Effect.promise(() => readOutput(executionId));
+
+        assert.equal(result.status, 'executed');
+        assert.ok(
+          (result.output ?? '').includes(
+            `/executions/${executionId}/conversation`,
+          ),
+        );
+      }),
+  );
+
+  it.effect(
+    'exposes the canonical workflow aggregate without full instructions',
+    () =>
+      Effect.gen(function* () {
+        const executionId = yield* Effect.promise(() =>
+          registerWorkflowExecution('observable'),
+        );
+        const timestamp = new Date().toISOString();
+        const longStageId = `stage-${'s'.repeat(2_500)}-stage-tail`;
+        const longCallId = `call-${'i'.repeat(2_500)}-call-tail`;
+        const longTitle = `Draft ${'t'.repeat(3_000)}-title-tail`;
+        const longError = `Failure ${'e'.repeat(4_000)}-error-tail`;
+        const longFiles = Array.from(
+          { length: 513 },
+          (_, index) => `${'f'.repeat(600)}-${index}-file-tail.tex`,
+        );
+        yield* writeWorkflowExecutionSnapshot(defaultSession(), executionId, {
+          lifecycle: 'active',
+          currentStageId: longStageId,
+          stages: [
+            {
+              id: longStageId,
+              title: longTitle,
+              order: 0,
+              lifecycle: 'active',
               startedAt: timestamp,
-              updatedAt: timestamp,
-              completedAt: timestamp,
             },
-          },
-        ],
-        timestamps: { createdAt: timestamp, updatedAt: timestamp },
-      }),
-    );
-
-    const result = await new ExecutionsTool().call({
-      path: `/executions/${executionId}`,
-    });
-    const output = result.output ?? '';
-    assert.equal(result.status, 'executed');
-    assert.ok(output.includes('"currentPhase"'));
-    assert.ok(output.includes('"calls"'));
-    assert.ok(output.includes('"stageBlocked": 0'));
-    assert.ok(output.includes('"childExecutionId": "abcdef123456"'));
-    assert.ok(output.includes('"number": 3'));
-    assert.ok(output.includes('"childStreamId": "writer#222222222222"'));
-    assert.ok(output.includes('"model": "historical-model"'));
-    assert.ok(output.includes('"costUsd": 0.2'));
-    assert.ok(output.includes('"error": "Failure '));
-    assert.ok(!output.includes('"number": 1'));
-    assert.ok(!output.includes('private full instruction'));
-    assert.ok(!output.includes('stage-tail'));
-    assert.ok(!output.includes('call-tail'));
-    assert.ok(!output.includes('title-tail'));
-    assert.ok(!output.includes('error-tail'));
-    assert.ok(!output.includes('file-tail'));
-    assert.ok(output.length < 20_000);
-    assert.ok(
-      (
-        await Effect.runPromise(
-          getExecutionRecords(defaultSession(), executionId).readMeta(),
-        )
-      )?.workflow,
-    );
-  });
-
-  it('keeps cancellation reasons on the aggregate and omits per-call error', async () => {
-    const executionId = await registerWorkflowExecution('cancelled-summary');
-    const timestamp = new Date().toISOString();
-    await Effect.runPromise(
-      writeWorkflowExecutionSnapshot(defaultSession(), executionId, {
-        lifecycle: 'cancelled',
-        stages: [],
-        calls: [
-          {
-            id: 'cancelled-call',
-            label: 'Cancelled call',
-            issued: true,
-            kind: 'document',
-            files: { input: [], context: [], media: [] },
-            attempts: [],
-            status: 'cancelled',
-            timestamps: {
-              createdAt: timestamp,
-              updatedAt: timestamp,
-              completedAt: timestamp,
-            },
-          },
-        ],
-        error: 'Workflow cancelled by user.',
-        timestamps: {
-          createdAt: timestamp,
-          updatedAt: timestamp,
-          completedAt: timestamp,
-        },
-      }),
-    );
-
-    const result = await new ExecutionsTool().call({
-      path: `/executions/${executionId}`,
-    });
-    const output = result.output ?? '';
-
-    assert.equal(result.status, 'executed');
-    assert.ok(output.includes('"error": "Workflow cancelled by user."'));
-    assert.ok(output.includes('"status": "cancelled"'));
-    assert.equal(output.match(/"error":/g)?.length, 1);
-  });
-
-  it('keeps a failed call ahead of newer completed current-stage calls when bounded', async () => {
-    const executionId = await registerWorkflowExecution('failed-rank');
-    const base = Date.parse('2026-04-01T00:00:00.000Z');
-    const completedCalls = Array.from({ length: 8 }, (_, index) => {
-      const updatedAt = new Date(base + (index + 1) * 1_000).toISOString();
-      return {
-        id: `completed-${index}`,
-        label: `Completed ${index}`,
-        stageId: 'stage-2',
-        files: { input: [], context: [], media: [] },
-        attempts: [],
-        status: 'completed' as const,
-        timestamps: {
-          createdAt: updatedAt,
-          updatedAt,
-          completedAt: updatedAt,
-        },
-      };
-    });
-    const failedAt = new Date(base).toISOString();
-    await Effect.runPromise(
-      writeWorkflowExecutionSnapshot(defaultSession(), executionId, {
-        lifecycle: 'active',
-        currentStageId: 'stage-2',
-        stages: [
-          {
-            id: 'stage-1',
-            title: 'Earlier stage',
-            order: 0,
-            lifecycle: 'failed',
-            startedAt: failedAt,
-            completedAt: failedAt,
-          },
-          {
-            id: 'stage-2',
-            title: 'Current stage',
-            order: 1,
-            lifecycle: 'active',
-            startedAt: failedAt,
-          },
-        ],
-        calls: [
-          {
-            id: 'older-failed',
-            label: 'Older failed',
-            stageId: 'stage-1',
-            files: { input: [], context: [], media: [] },
-            attempts: [
-              {
-                number: 1,
-                startedAt: failedAt,
-                completedAt: failedAt,
+          ],
+          calls: [
+            {
+              id: longCallId,
+              label: '   ',
+              stageId: longStageId,
+              agent: 'writer',
+              files: { input: longFiles, context: [], media: [] },
+              childExecutionId: 'abcdef123456',
+              attempts: [
+                {
+                  number: 1,
+                  id: '111111111111',
+                  startedAt: timestamp,
+                  completedAt: timestamp,
+                },
+                {
+                  number: 2,
+                  id: '222222222222',
+                  childStreamId: 'writer#222222222222',
+                  model: 'historical-model',
+                  costUsd: 0.2,
+                  startedAt: timestamp,
+                  completedAt: timestamp,
+                },
+                {
+                  number: 3,
+                  id: 'abcdef123456',
+                  childStreamId: 'writer#abcdef123456',
+                  model: 'replacement-model',
+                  costUsd: 0.3,
+                  startedAt: timestamp,
+                  completedAt: timestamp,
+                },
+              ],
+              status: 'failed',
+              error: longError,
+              timestamps: {
+                createdAt: timestamp,
+                startedAt: timestamp,
+                updatedAt: timestamp,
+                completedAt: timestamp,
               },
-            ],
-            status: 'failed',
-            error: 'expected failure',
-            timestamps: {
-              createdAt: failedAt,
-              startedAt: failedAt,
-              updatedAt: failedAt,
-              completedAt: failedAt,
             },
-          },
-          ...completedCalls,
-        ],
-        timestamps: { createdAt: failedAt, updatedAt: failedAt },
+          ],
+          timestamps: { createdAt: timestamp, updatedAt: timestamp },
+        });
+
+        const result = yield* Effect.promise(() =>
+          new ExecutionsTool().call({
+            path: `/executions/${executionId}`,
+          }),
+        );
+        const output = result.output ?? '';
+        assert.equal(result.status, 'executed');
+        assert.ok(output.includes('"currentPhase"'));
+        assert.ok(output.includes('"calls"'));
+        assert.ok(output.includes('"stageBlocked": 0'));
+        assert.ok(output.includes('"childExecutionId": "abcdef123456"'));
+        assert.ok(output.includes('"number": 3'));
+        assert.ok(output.includes('"childStreamId": "writer#222222222222"'));
+        assert.ok(output.includes('"model": "historical-model"'));
+        assert.ok(output.includes('"costUsd": 0.2'));
+        assert.ok(output.includes('"error": "Failure '));
+        assert.ok(!output.includes('"number": 1'));
+        assert.ok(!output.includes('private full instruction'));
+        assert.ok(!output.includes('stage-tail'));
+        assert.ok(!output.includes('call-tail'));
+        assert.ok(!output.includes('title-tail'));
+        assert.ok(!output.includes('error-tail'));
+        assert.ok(!output.includes('file-tail'));
+        assert.ok(output.length < 20_000);
+        assert.ok(
+          (yield* getExecutionRecords(defaultSession(), executionId).readMeta())
+            ?.workflow,
+        );
       }),
-    );
+  );
 
-    const result = await new ExecutionsTool().call({
-      path: `/executions/${executionId}`,
-    });
-    const output = result.output ?? '';
-
-    assert.equal(result.status, 'executed');
-    assert.ok(output.includes('"id": "older-failed"'));
-    assert.ok(output.includes('"omittedCalls": 1'));
-    assert.ok(!output.includes('"id": "completed-0"'));
-  });
-
-  it('keeps an earlier-stage live call ahead of current-stage terminal calls when bounded', async () => {
-    const executionId = await registerWorkflowExecution('ranked');
-    const timestamp = new Date().toISOString();
-    const terminalCalls = Array.from({ length: 8 }, (_, index) => ({
-      id: `current-terminal-${index}`,
-      label: `Current terminal ${index}`,
-      stageId: 'stage-2',
-      files: { input: [], context: [], media: [] },
-      attempts: [],
-      status: 'completed' as const,
-      timestamps: {
-        createdAt: timestamp,
-        updatedAt: timestamp,
-        completedAt: timestamp,
-      },
-    }));
-    await Effect.runPromise(
-      writeWorkflowExecutionSnapshot(defaultSession(), executionId, {
-        lifecycle: 'active',
-        currentStageId: 'stage-2',
-        stages: [
-          {
-            id: 'stage-1',
-            title: 'Earlier stage',
-            order: 0,
-            lifecycle: 'completed',
-            startedAt: timestamp,
+  it.effect(
+    'keeps cancellation reasons on the aggregate and omits per-call error',
+    () =>
+      Effect.gen(function* () {
+        const executionId = yield* Effect.promise(() =>
+          registerWorkflowExecution('cancelled-summary'),
+        );
+        const timestamp = new Date().toISOString();
+        yield* writeWorkflowExecutionSnapshot(defaultSession(), executionId, {
+          lifecycle: 'cancelled',
+          stages: [],
+          calls: [
+            {
+              id: 'cancelled-call',
+              label: 'Cancelled call',
+              issued: true,
+              kind: 'document',
+              files: { input: [], context: [], media: [] },
+              attempts: [],
+              status: 'cancelled',
+              timestamps: {
+                createdAt: timestamp,
+                updatedAt: timestamp,
+                completedAt: timestamp,
+              },
+            },
+          ],
+          error: 'Workflow cancelled by user.',
+          timestamps: {
+            createdAt: timestamp,
+            updatedAt: timestamp,
             completedAt: timestamp,
           },
-          {
-            id: 'stage-2',
-            title: 'Current stage',
-            order: 1,
-            lifecycle: 'active',
-            startedAt: timestamp,
-          },
-        ],
-        calls: [
-          ...terminalCalls,
-          {
-            id: 'earlier-live',
-            label: 'Earlier live',
-            stageId: 'stage-1',
-            files: { input: [], context: [], media: [] },
-            attempts: [{ number: 1, startedAt: timestamp }],
-            status: 'running',
-            timestamps: {
-              createdAt: timestamp,
-              startedAt: timestamp,
-              updatedAt: timestamp,
-            },
-          },
-        ],
-        timestamps: { createdAt: timestamp, updatedAt: timestamp },
+        });
+
+        const result = yield* Effect.promise(() =>
+          new ExecutionsTool().call({
+            path: `/executions/${executionId}`,
+          }),
+        );
+        const output = result.output ?? '';
+
+        assert.equal(result.status, 'executed');
+        assert.ok(output.includes('"error": "Workflow cancelled by user."'));
+        assert.ok(output.includes('"status": "cancelled"'));
+        assert.equal(output.match(/"error":/g)?.length, 1);
       }),
-    );
+  );
 
-    const result = await new ExecutionsTool().call({
-      path: `/executions/${executionId}`,
-    });
-    const output = result.output ?? '';
+  it.effect(
+    'keeps a failed call ahead of newer completed current-stage calls when bounded',
+    () =>
+      Effect.gen(function* () {
+        const executionId = yield* Effect.promise(() =>
+          registerWorkflowExecution('failed-rank'),
+        );
+        const base = Date.parse('2026-04-01T00:00:00.000Z');
+        const completedCalls = Array.from({ length: 8 }, (_, index) => {
+          const updatedAt = new Date(base + (index + 1) * 1_000).toISOString();
+          return {
+            id: `completed-${index}`,
+            label: `Completed ${index}`,
+            stageId: 'stage-2',
+            files: { input: [], context: [], media: [] },
+            attempts: [],
+            status: 'completed' as const,
+            timestamps: {
+              createdAt: updatedAt,
+              updatedAt,
+              completedAt: updatedAt,
+            },
+          };
+        });
+        const failedAt = new Date(base).toISOString();
+        yield* writeWorkflowExecutionSnapshot(defaultSession(), executionId, {
+          lifecycle: 'active',
+          currentStageId: 'stage-2',
+          stages: [
+            {
+              id: 'stage-1',
+              title: 'Earlier stage',
+              order: 0,
+              lifecycle: 'failed',
+              startedAt: failedAt,
+              completedAt: failedAt,
+            },
+            {
+              id: 'stage-2',
+              title: 'Current stage',
+              order: 1,
+              lifecycle: 'active',
+              startedAt: failedAt,
+            },
+          ],
+          calls: [
+            {
+              id: 'older-failed',
+              label: 'Older failed',
+              stageId: 'stage-1',
+              files: { input: [], context: [], media: [] },
+              attempts: [
+                {
+                  number: 1,
+                  startedAt: failedAt,
+                  completedAt: failedAt,
+                },
+              ],
+              status: 'failed',
+              error: 'expected failure',
+              timestamps: {
+                createdAt: failedAt,
+                startedAt: failedAt,
+                updatedAt: failedAt,
+                completedAt: failedAt,
+              },
+            },
+            ...completedCalls,
+          ],
+          timestamps: { createdAt: failedAt, updatedAt: failedAt },
+        });
 
-    assert.equal(result.status, 'executed');
-    assert.ok(output.includes('"id": "earlier-live"'));
-    assert.ok(output.includes('"omittedCalls": 1'));
-    assert.ok(!output.includes('"id": "current-terminal-7"'));
-  });
+        const result = yield* Effect.promise(() =>
+          new ExecutionsTool().call({
+            path: `/executions/${executionId}`,
+          }),
+        );
+        const output = result.output ?? '';
+
+        assert.equal(result.status, 'executed');
+        assert.ok(output.includes('"id": "older-failed"'));
+        assert.ok(output.includes('"omittedCalls": 1'));
+        assert.ok(!output.includes('"id": "completed-0"'));
+      }),
+  );
+
+  it.effect(
+    'keeps an earlier-stage live call ahead of current-stage terminal calls when bounded',
+    () =>
+      Effect.gen(function* () {
+        const executionId = yield* Effect.promise(() =>
+          registerWorkflowExecution('ranked'),
+        );
+        const timestamp = new Date().toISOString();
+        const terminalCalls = Array.from({ length: 8 }, (_, index) => ({
+          id: `current-terminal-${index}`,
+          label: `Current terminal ${index}`,
+          stageId: 'stage-2',
+          files: { input: [], context: [], media: [] },
+          attempts: [],
+          status: 'completed' as const,
+          timestamps: {
+            createdAt: timestamp,
+            updatedAt: timestamp,
+            completedAt: timestamp,
+          },
+        }));
+        yield* writeWorkflowExecutionSnapshot(defaultSession(), executionId, {
+          lifecycle: 'active',
+          currentStageId: 'stage-2',
+          stages: [
+            {
+              id: 'stage-1',
+              title: 'Earlier stage',
+              order: 0,
+              lifecycle: 'completed',
+              startedAt: timestamp,
+              completedAt: timestamp,
+            },
+            {
+              id: 'stage-2',
+              title: 'Current stage',
+              order: 1,
+              lifecycle: 'active',
+              startedAt: timestamp,
+            },
+          ],
+          calls: [
+            ...terminalCalls,
+            {
+              id: 'earlier-live',
+              label: 'Earlier live',
+              stageId: 'stage-1',
+              files: { input: [], context: [], media: [] },
+              attempts: [{ number: 1, startedAt: timestamp }],
+              status: 'running',
+              timestamps: {
+                createdAt: timestamp,
+                startedAt: timestamp,
+                updatedAt: timestamp,
+              },
+            },
+          ],
+          timestamps: { createdAt: timestamp, updatedAt: timestamp },
+        });
+
+        const result = yield* Effect.promise(() =>
+          new ExecutionsTool().call({
+            path: `/executions/${executionId}`,
+          }),
+        );
+        const output = result.output ?? '';
+
+        assert.equal(result.status, 'executed');
+        assert.ok(output.includes('"id": "earlier-live"'));
+        assert.ok(output.includes('"omittedCalls": 1'));
+        assert.ok(!output.includes('"id": "current-terminal-7"'));
+      }),
+  );
 
   it('shows one model for a workflow run in both the listing and its summary', async () => {
     const executionId = await registerWorkflowExecution(

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -2,8 +2,9 @@
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect, Fiber } from 'effect';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 import type { PreparedAgentDefinition } from '@agent/runtime/AgentLaunchContext';
 
 // Local imports
@@ -98,10 +99,8 @@ import {
 import { ensureError } from '@utils/errors/errorMessage';
 
 /** Drive and join the native child at the test entry point. */
-function startChildRunLoop<TTurn>(input: ChildRunLoopParams<TTurn>) {
-  return Effect.runPromise(
-    startNativeChildRunLoop(input).pipe(Effect.flatMap(Fiber.join)),
-  );
+function childRunLoop<TTurn>(input: ChildRunLoopParams<TTurn>) {
+  return startNativeChildRunLoop(input).pipe(Effect.flatMap(Fiber.join));
 }
 
 const ownedSessions = new Set<SessionHandle>();
@@ -224,277 +223,310 @@ describe('NativeSubagentStrategy', () => {
     ownedSessions.clear();
   });
 
-  it('resolveDeliveryTarget follows the live run handle, including after detach', async () => {
-    const params = baseParams();
-    const strategy = createNativeSubagentStrategy(params);
+  it.effect(
+    'resolveDeliveryTarget follows the live run handle, including after detach',
+    () =>
+      Effect.gen(function* () {
+        const params = baseParams();
+        const strategy = createNativeSubagentStrategy(params);
 
-    // Before any turn ran, falls back to the static orchestrator stream.
-    expect(strategy.resolveDeliveryTarget?.()).toBe(params.parentStreamId);
+        // Before any turn ran, falls back to the static orchestrator stream.
+        expect(strategy.resolveDeliveryTarget?.()).toBe(params.parentStreamId);
 
-    mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {
-      options.onRun?.({
-        childStreamId: CHILD_STREAM_ID,
-        deliveryTargetStreamId: params.parentStreamId,
-      });
-      return toolUseTurnResult(STREAM_PHASE.WAITING, params.executionId);
-    });
+        mocks.executeAgent.mockImplementationOnce(
+          async (_config, _id, options) => {
+            options.onRun?.({
+              childStreamId: CHILD_STREAM_ID,
+              deliveryTargetStreamId: params.parentStreamId,
+            });
+            return toolUseTurnResult(STREAM_PHASE.WAITING, params.executionId);
+          },
+        );
 
-    await Effect.runPromise(
-      strategy.launch(fakePorts(), new AbortController().signal),
-    );
-    expect(mocks.executeAgent).toHaveBeenLastCalledWith(
-      params.definition,
-      params.executionId,
-      expect.objectContaining({ isSubagent: true }),
-    );
-    expect(strategy.resolveDeliveryTarget?.()).toBe(params.parentStreamId);
+        yield* strategy.launch(fakePorts(), new AbortController().signal);
+        expect(mocks.executeAgent).toHaveBeenLastCalledWith(
+          params.definition,
+          params.executionId,
+          expect.objectContaining({ isSubagent: true }),
+        );
+        expect(strategy.resolveDeliveryTarget?.()).toBe(params.parentStreamId);
 
-    // Detach: the same handle object's deliveryTargetStreamId flips to
-    // undefined (AgentExecutionHandle.detach) — the strategy must track the
-    // LIVE handle, not a stale copy, so it observes this without a new turn.
-    const liveHandle = {
-      childStreamId: CHILD_STREAM_ID,
-      deliveryTargetStreamId: params.parentStreamId as StreamTabId | undefined,
-    };
-    mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {
-      options.onRun?.(liveHandle);
-      return toolUseTurnResult(STREAM_PHASE.WAITING, params.executionId);
-    });
-    await Effect.runPromise(
-      strategy.launch(fakePorts(), new AbortController().signal),
-    );
-    expect(strategy.resolveDeliveryTarget?.()).toBe(params.parentStreamId);
-    liveHandle.deliveryTargetStreamId = undefined;
-    expect(strategy.resolveDeliveryTarget?.()).toBeUndefined();
-  });
+        // Detach: the same handle object's deliveryTargetStreamId flips to
+        // undefined (AgentExecutionHandle.detach) — the strategy must track the
+        // LIVE handle, not a stale copy, so it observes this without a new turn.
+        const liveHandle = {
+          childStreamId: CHILD_STREAM_ID,
+          deliveryTargetStreamId: params.parentStreamId as
+            StreamTabId | undefined,
+        };
+        mocks.executeAgent.mockImplementationOnce(
+          async (_config, _id, options) => {
+            options.onRun?.(liveHandle);
+            return toolUseTurnResult(STREAM_PHASE.WAITING, params.executionId);
+          },
+        );
+        yield* strategy.launch(fakePorts(), new AbortController().signal);
+        expect(strategy.resolveDeliveryTarget?.()).toBe(params.parentStreamId);
+        liveHandle.deliveryTargetStreamId = undefined;
+        expect(strategy.resolveDeliveryTarget?.()).toBeUndefined();
+      }),
+  );
 
-  it('uses the same launch primitive in durable single-cycle mode', async () => {
-    const params = {
-      ...baseParams(),
-      executionMode: 'single-cycle' as const,
-      workflowPhase: 'review',
-    };
-    const strategy = createNativeSubagentStrategy(params);
-    const ports = fakePorts();
-    const progress = { message: 'Reading proof' };
-
-    mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {
-      options.onStreamResolved?.(CHILD_STREAM_ID);
-      options.onProgress?.(progress);
-      return toolUseTurnResult('completed', params.executionId, {
-        totalCostUsd: 0.17,
-      });
-    });
-
-    await Effect.runPromise(
-      strategy.launch(ports, new AbortController().signal),
-    );
-
-    expect(mocks.executeAgent).toHaveBeenCalledWith(
-      params.definition,
-      params.executionId,
-      expect.objectContaining({
-        isSubagent: true,
-        parentStreamId: params.parentStreamId,
-        stopAfterCycle: true,
+  it.effect('uses the same launch primitive in durable single-cycle mode', () =>
+    Effect.gen(function* () {
+      const params = {
+        ...baseParams(),
+        executionMode: 'single-cycle' as const,
         workflowPhase: 'review',
-      }),
-    );
-    expect(params.onStreamResolved).toHaveBeenCalledWith(CHILD_STREAM_ID);
-    expect(ports.notify).toHaveBeenCalledWith(progress);
-    expect(ports.recordCost).toHaveBeenCalledWith(0.17);
-  });
+      };
+      const strategy = createNativeSubagentStrategy(params);
+      const ports = fakePorts();
+      const progress = { message: 'Reading proof' };
 
-  it('records a failed turn cost once through interactive loop settlement', async () => {
-    const params = baseParams();
-    const recordCost = vi.fn();
-    mocks.executeAgent.mockResolvedValueOnce(
-      toolUseTurnResult('failed', params.executionId, {
-        totalCostUsd: 0.29,
-        error: { message: 'provider failed', userRetryable: false },
-      }),
-    );
+      mocks.executeAgent.mockImplementationOnce(
+        async (_config, _id, options) => {
+          options.onStreamResolved?.(CHILD_STREAM_ID);
+          options.onProgress?.(progress);
+          return toolUseTurnResult('completed', params.executionId, {
+            totalCostUsd: 0.17,
+          });
+        },
+      );
 
-    const completion = startChildRunLoop({
-      session: params.session,
-      childStreamId: CHILD_STREAM_ID,
-      parentStreamId: params.parentStreamId,
-      executionId: params.executionId,
-      agentName: params.agentName,
-      strategy: createNativeSubagentStrategy(params),
-      recordCost,
-    });
-    await completion;
+      yield* strategy.launch(ports, new AbortController().signal);
 
-    expect(recordCost).toHaveBeenCalledOnce();
-    expect(recordCost).toHaveBeenCalledWith(0.29);
-    expect(mocks.persistChildRunDelivery).toHaveBeenCalledWith(
-      params.session,
-      params.executionId,
-      expect.any(String),
-      expect.objectContaining({
-        result: expect.objectContaining({ cost: 0.29, outcome: 'failed' }),
-      }),
-    );
-  });
-
-  it('persists a typed result-only failure without formatting error prose', async () => {
-    const params = { ...baseParams(), resultOnly: true };
-    const failure = new Error('provider failed');
-    mocks.throwErrorFormatting = true;
-    mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {
-      options.onRunError?.(failure);
-      return toolUseTurnResult('failed', params.executionId, {
-        error: { message: failure.message, userRetryable: false },
-      });
-    });
-
-    const completion = startChildRunLoop({
-      session: params.session,
-      childStreamId: CHILD_STREAM_ID,
-      parentStreamId: params.parentStreamId,
-      executionId: params.executionId,
-      agentName: params.agentName,
-      strategy: createNativeSubagentStrategy(params),
-    });
-    await completion;
-
-    expect(mocks.persistChildRunDelivery).toHaveBeenCalledWith(
-      params.session,
-      params.executionId,
-      expect.any(String),
-      expect.objectContaining({
-        producer: 'subagent',
-        result: expect.objectContaining({
-          outcome: 'failed',
-          error: expect.objectContaining({ message: 'provider failed' }),
-        }),
-      }),
-    );
-  });
-
-  it('interrupts when the turn aborts before launch publishes its handle', async () => {
-    const turn = new AbortController();
-    turn.abort();
-    const interrupt = vi.fn();
-    const strategy = createNativeSubagentStrategy(baseParams());
-    mockLaunchPublishing({ interrupt }, 'cancelled');
-
-    await Effect.runPromise(strategy.launch(fakePorts(), turn.signal));
-
-    expect(interrupt).toHaveBeenCalledOnce();
-  });
-
-  it('interrupts once for an already-aborted external signal', async () => {
-    const external = new AbortController();
-    external.abort();
-    const interrupt = vi.fn();
-    const strategy = createNativeSubagentStrategy({
-      ...baseParams(),
-      signal: external.signal,
-    });
-    mockLaunchPublishing({ interrupt }, 'cancelled');
-
-    await Effect.runPromise(
-      strategy.launch(fakePorts(), new AbortController().signal),
-    );
-
-    expect(interrupt).toHaveBeenCalledOnce();
-  });
-
-  it('deduplicates the same external and per-turn abort signal', async () => {
-    const controller = new AbortController();
-    const interrupt = vi.fn();
-    const strategy = createNativeSubagentStrategy({
-      ...baseParams(),
-      signal: controller.signal,
-    });
-    mockLaunchPublishing({ interrupt }, 'cancelled', () => controller.abort());
-
-    await Effect.runPromise(strategy.launch(fakePorts(), controller.signal));
-
-    expect(interrupt).toHaveBeenCalledOnce();
-  });
-
-  it('detaches from the run signal after launch and ignores later aborts', async () => {
-    const controller = new AbortController();
-    const interrupt = vi.fn();
-    const strategy = createNativeSubagentStrategy(baseParams());
-    mockLaunchPublishing({ interrupt }, 'completed');
-
-    await Effect.runPromise(strategy.launch(fakePorts(), controller.signal));
-    controller.abort();
-
-    expect(interrupt).not.toHaveBeenCalled();
-  });
-
-  it('binds resumed-turn cancellation and policy options to the replacement run', async () => {
-    const params = {
-      ...baseParams(),
-      approvalPromptsUnavailable: true,
-      runtimeUnavailableTools: ['bash'],
-    };
-    const childStreamId = CHILD_STREAM_ID;
-    const initialHandle = {
-      childStreamId,
-      deliveryTargetStreamId: params.parentStreamId,
-      interrupt: vi.fn(),
-    };
-    mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {
-      options.onRun?.(initialHandle as never);
-      return toolUseTurnResult(STREAM_PHASE.WAITING, params.executionId);
-    });
-    const strategy = createNativeSubagentStrategy(params);
-    await Effect.runPromise(
-      strategy.launch(fakePorts(), new AbortController().signal),
-    );
-
-    mocks.readConfig.mockReturnValue(
-      Effect.succeed({ agentCategory: 'toolUse' }),
-    );
-    mocks.retrieveSessionResumeData.mockReturnValue(
-      Effect.succeed(
-        createToolUseResumeData({ executionId: params.executionId }),
-      ),
-    );
-    const turn = new AbortController();
-    const replacementInterrupt = vi.fn();
-    let replacementReady!: () => void;
-    const ready = new Promise<void>((resolve) => {
-      replacementReady = resolve;
-    });
-    mocks.resumeToolUseTurn.mockImplementationOnce(async (_resume, options) => {
-      options.onRun?.({
-        childStreamId,
-        deliveryTargetStreamId: params.parentStreamId,
-        interrupt: replacementInterrupt,
-      } as never);
-      replacementReady();
-      await new Promise<void>((resolve) =>
-        turn.signal.addEventListener('abort', () => resolve(), {
-          once: true,
+      expect(mocks.executeAgent).toHaveBeenCalledWith(
+        params.definition,
+        params.executionId,
+        expect.objectContaining({
+          isSubagent: true,
+          parentStreamId: params.parentStreamId,
+          stopAfterCycle: true,
+          workflowPhase: 'review',
         }),
       );
-      return toolUseTurnResult('cancelled', params.executionId);
-    });
+      expect(params.onStreamResolved).toHaveBeenCalledWith(CHILD_STREAM_ID);
+      expect(ports.notify).toHaveBeenCalledWith(progress);
+      expect(ports.recordCost).toHaveBeenCalledWith(0.17);
+    }),
+  );
 
-    const resumed = Effect.runPromise(
-      strategy.runTurn!([], fakePorts(), turn.signal),
-    );
-    await ready;
-    expect(mocks.resumeToolUseTurn).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        approvalPromptsUnavailable: true,
-        runtimeUnavailableTools: ['bash'],
+  it.effect(
+    'records a failed turn cost once through interactive loop settlement',
+    () =>
+      Effect.gen(function* () {
+        const params = baseParams();
+        const recordCost = vi.fn();
+        mocks.executeAgent.mockResolvedValueOnce(
+          toolUseTurnResult('failed', params.executionId, {
+            totalCostUsd: 0.29,
+            error: { message: 'provider failed', userRetryable: false },
+          }),
+        );
+
+        yield* childRunLoop({
+          session: params.session,
+          childStreamId: CHILD_STREAM_ID,
+          parentStreamId: params.parentStreamId,
+          executionId: params.executionId,
+          agentName: params.agentName,
+          strategy: createNativeSubagentStrategy(params),
+          recordCost,
+        });
+
+        expect(recordCost).toHaveBeenCalledOnce();
+        expect(recordCost).toHaveBeenCalledWith(0.29);
+        expect(mocks.persistChildRunDelivery).toHaveBeenCalledWith(
+          params.session,
+          params.executionId,
+          expect.any(String),
+          expect.objectContaining({
+            result: expect.objectContaining({ cost: 0.29, outcome: 'failed' }),
+          }),
+        );
       }),
-    );
-    turn.abort();
-    await resumed;
+  );
 
-    expect(initialHandle.interrupt).not.toHaveBeenCalled();
-    expect(replacementInterrupt).toHaveBeenCalledOnce();
-  });
+  it.effect(
+    'persists a typed result-only failure without formatting error prose',
+    () =>
+      Effect.gen(function* () {
+        const params = { ...baseParams(), resultOnly: true };
+        const failure = new Error('provider failed');
+        mocks.throwErrorFormatting = true;
+        mocks.executeAgent.mockImplementationOnce(
+          async (_config, _id, options) => {
+            options.onRunError?.(failure);
+            return toolUseTurnResult('failed', params.executionId, {
+              error: { message: failure.message, userRetryable: false },
+            });
+          },
+        );
+
+        yield* childRunLoop({
+          session: params.session,
+          childStreamId: CHILD_STREAM_ID,
+          parentStreamId: params.parentStreamId,
+          executionId: params.executionId,
+          agentName: params.agentName,
+          strategy: createNativeSubagentStrategy(params),
+        });
+
+        expect(mocks.persistChildRunDelivery).toHaveBeenCalledWith(
+          params.session,
+          params.executionId,
+          expect.any(String),
+          expect.objectContaining({
+            producer: 'subagent',
+            result: expect.objectContaining({
+              outcome: 'failed',
+              error: expect.objectContaining({ message: 'provider failed' }),
+            }),
+          }),
+        );
+      }),
+  );
+
+  it.effect(
+    'interrupts when the turn aborts before launch publishes its handle',
+    () =>
+      Effect.gen(function* () {
+        const turn = new AbortController();
+        turn.abort();
+        const interrupt = vi.fn();
+        const strategy = createNativeSubagentStrategy(baseParams());
+        mockLaunchPublishing({ interrupt }, 'cancelled');
+
+        yield* strategy.launch(fakePorts(), turn.signal);
+
+        expect(interrupt).toHaveBeenCalledOnce();
+      }),
+  );
+
+  it.effect('interrupts once for an already-aborted external signal', () =>
+    Effect.gen(function* () {
+      const external = new AbortController();
+      external.abort();
+      const interrupt = vi.fn();
+      const strategy = createNativeSubagentStrategy({
+        ...baseParams(),
+        signal: external.signal,
+      });
+      mockLaunchPublishing({ interrupt }, 'cancelled');
+
+      yield* strategy.launch(fakePorts(), new AbortController().signal);
+
+      expect(interrupt).toHaveBeenCalledOnce();
+    }),
+  );
+
+  it.effect('deduplicates the same external and per-turn abort signal', () =>
+    Effect.gen(function* () {
+      const controller = new AbortController();
+      const interrupt = vi.fn();
+      const strategy = createNativeSubagentStrategy({
+        ...baseParams(),
+        signal: controller.signal,
+      });
+      mockLaunchPublishing({ interrupt }, 'cancelled', () =>
+        controller.abort(),
+      );
+
+      yield* strategy.launch(fakePorts(), controller.signal);
+
+      expect(interrupt).toHaveBeenCalledOnce();
+    }),
+  );
+
+  it.effect(
+    'detaches from the run signal after launch and ignores later aborts',
+    () =>
+      Effect.gen(function* () {
+        const controller = new AbortController();
+        const interrupt = vi.fn();
+        const strategy = createNativeSubagentStrategy(baseParams());
+        mockLaunchPublishing({ interrupt }, 'completed');
+
+        yield* strategy.launch(fakePorts(), controller.signal);
+        controller.abort();
+
+        expect(interrupt).not.toHaveBeenCalled();
+      }),
+  );
+
+  it.live(
+    'binds resumed-turn cancellation and policy options to the replacement run',
+    () =>
+      Effect.gen(function* () {
+        const params = {
+          ...baseParams(),
+          approvalPromptsUnavailable: true,
+          runtimeUnavailableTools: ['bash'],
+        };
+        const childStreamId = CHILD_STREAM_ID;
+        const initialHandle = {
+          childStreamId,
+          deliveryTargetStreamId: params.parentStreamId,
+          interrupt: vi.fn(),
+        };
+        mocks.executeAgent.mockImplementationOnce(
+          async (_config, _id, options) => {
+            options.onRun?.(initialHandle as never);
+            return toolUseTurnResult(STREAM_PHASE.WAITING, params.executionId);
+          },
+        );
+        const strategy = createNativeSubagentStrategy(params);
+        yield* strategy.launch(fakePorts(), new AbortController().signal);
+
+        mocks.readConfig.mockReturnValue(
+          Effect.succeed({ agentCategory: 'toolUse' }),
+        );
+        mocks.retrieveSessionResumeData.mockReturnValue(
+          Effect.succeed(
+            createToolUseResumeData({ executionId: params.executionId }),
+          ),
+        );
+        const turn = new AbortController();
+        const replacementInterrupt = vi.fn();
+        let replacementReady!: () => void;
+        const ready = new Promise<void>((resolve) => {
+          replacementReady = resolve;
+        });
+        mocks.resumeToolUseTurn.mockImplementationOnce(
+          async (_resume, options) => {
+            options.onRun?.({
+              childStreamId,
+              deliveryTargetStreamId: params.parentStreamId,
+              interrupt: replacementInterrupt,
+            } as never);
+            replacementReady();
+            await new Promise<void>((resolve) =>
+              turn.signal.addEventListener('abort', () => resolve(), {
+                once: true,
+              }),
+            );
+            return toolUseTurnResult('cancelled', params.executionId);
+          },
+        );
+
+        const resumed = yield* Effect.forkChild(
+          strategy.runTurn!([], fakePorts(), turn.signal),
+        );
+        yield* Effect.promise(() => ready);
+        expect(mocks.resumeToolUseTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            approvalPromptsUnavailable: true,
+            runtimeUnavailableTools: ['bash'],
+          }),
+        );
+        turn.abort();
+        yield* Fiber.join(resumed);
+
+        expect(initialHandle.interrupt).not.toHaveBeenCalled();
+        expect(replacementInterrupt).toHaveBeenCalledOnce();
+      }),
+  );
 
   it('formatDelivery folds a WAITING turn into a completed-shaped delivery', async () => {
     const params = baseParams();
@@ -515,100 +547,120 @@ describe('NativeSubagentStrategy', () => {
     expect(msg).toContain('status="completed"');
   });
 
-  it('builds the durable result before fallible delivery formatting', async () => {
-    const params = baseParams();
-    const strategy = createNativeSubagentStrategy(params);
-    const turn = toolUseTurnResult('completed', params.executionId) as never;
+  it.effect(
+    'builds the durable result before fallible delivery formatting',
+    () =>
+      Effect.gen(function* () {
+        const params = baseParams();
+        const strategy = createNativeSubagentStrategy(params);
+        const turn = toolUseTurnResult(
+          'completed',
+          params.executionId,
+        ) as never;
 
-    const built = await Effect.runPromise(
-      strategy.buildResultMeta!(turn, false, 1000),
-    );
-    mocks.throwDeliveryFormatting = true;
+        const built = yield* strategy.buildResultMeta!(turn, false, 1000);
+        mocks.throwDeliveryFormatting = true;
 
-    await expect(strategy.formatDelivery(turn, 1000)).rejects.toThrow(
-      'delivery formatting failed',
-    );
-    await expect(
-      Effect.runPromise(strategy.buildResultMeta!(turn, false, 1000)),
-    ).resolves.toBe(built);
-  });
+        yield* Effect.promise(() =>
+          expect(strategy.formatDelivery(turn, 1000)).rejects.toThrow(
+            'delivery formatting failed',
+          ),
+        );
+        expect(yield* strategy.buildResultMeta!(turn, false, 1000)).toBe(built);
+      }),
+  );
 
-  it('does not format prose for a typed-result-only child', async () => {
-    const params = { ...baseParams(), resultOnly: true };
-    const strategy = createNativeSubagentStrategy(params);
-    const turn = toolUseTurnResult('completed', params.executionId) as never;
-    mocks.throwDeliveryFormatting = true;
+  it.effect('does not format prose for a typed-result-only child', () =>
+    Effect.gen(function* () {
+      const params = { ...baseParams(), resultOnly: true };
+      const strategy = createNativeSubagentStrategy(params);
+      const turn = toolUseTurnResult('completed', params.executionId) as never;
+      mocks.throwDeliveryFormatting = true;
 
-    await expect(strategy.formatDelivery(turn, 1000)).resolves.toBe('');
-    await expect(
-      Effect.runPromise(strategy.buildResultMeta!(turn, false, 1000)),
-    ).resolves.toBeDefined();
-  });
+      yield* Effect.promise(() =>
+        expect(strategy.formatDelivery(turn, 1000)).resolves.toBe(''),
+      );
+      expect(yield* strategy.buildResultMeta!(turn, false, 1000)).toBeDefined();
+    }),
+  );
 
-  it('reports a non-throwing subagent failure via isTurnError, captured from onRunError', async () => {
-    const params = baseParams();
-    const strategy = createNativeSubagentStrategy(params);
-    const failure = new Error('model overloaded');
+  it.effect(
+    'reports a non-throwing subagent failure via isTurnError, captured from onRunError',
+    () =>
+      Effect.gen(function* () {
+        const params = baseParams();
+        const strategy = createNativeSubagentStrategy(params);
+        const failure = new Error('model overloaded');
 
-    mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {
-      options.onRunError?.(failure);
-      return toolUseTurnResult('failed', params.executionId);
-    });
-
-    const turn = await Effect.runPromise(
-      strategy.launch(fakePorts(), new AbortController().signal),
-    );
-    expect(strategy.isTurnError?.(turn)).toBe(true);
-
-    const errMsg = await strategy.formatError(turn, null);
-    expect(errMsg).toContain('model overloaded');
-  });
-
-  it('persists a typed tool-use failure when no flow result exists', async () => {
-    const strategy = createNativeSubagentStrategy(baseParams());
-
-    await expect(
-      Effect.runPromise(strategy.buildResultMeta!(null, true, 10)),
-    ).resolves.toMatchObject({
-      producer: 'subagent',
-      agentName: 'review',
-      result: {
-        category: 'toolUse',
-        outcome: 'failed',
-        response: '',
-        files: [],
-        cost: 0,
-      },
-    });
-  });
-
-  it('stamps parent lineage onto both success and failure manifests', async () => {
-    const params = {
-      ...baseParams(),
-      parentExecutionId: 'parent-exec' as ExecutionId,
-    };
-    const strategy = createNativeSubagentStrategy(params);
-
-    await expect(
-      Effect.runPromise(strategy.buildResultMeta!(null, true, 10)),
-    ).resolves.toMatchObject({ parentExecutionId: 'parent-exec' });
-
-    await expect(
-      Effect.runPromise(
-        strategy.buildResultMeta!(
-          {
-            category: 'toolUse',
-            outcome: 'completed',
-            response: 'done',
-            executionId: params.executionId,
-            streamId: CHILD_STREAM_ID,
+        mocks.executeAgent.mockImplementationOnce(
+          async (_config, _id, options) => {
+            options.onRunError?.(failure);
+            return toolUseTurnResult('failed', params.executionId);
           },
-          false,
-          10,
-        ),
-      ),
-    ).resolves.toMatchObject({ parentExecutionId: 'parent-exec' });
-  });
+        );
+
+        const turn = yield* strategy.launch(
+          fakePorts(),
+          new AbortController().signal,
+        );
+        expect(strategy.isTurnError?.(turn)).toBe(true);
+
+        const errMsg = yield* Effect.promise(async () =>
+          strategy.formatError(turn, null),
+        );
+        expect(errMsg).toContain('model overloaded');
+      }),
+  );
+
+  it.effect(
+    'persists a typed tool-use failure when no flow result exists',
+    () =>
+      Effect.gen(function* () {
+        const strategy = createNativeSubagentStrategy(baseParams());
+
+        expect(yield* strategy.buildResultMeta!(null, true, 10)).toMatchObject({
+          producer: 'subagent',
+          agentName: 'review',
+          result: {
+            category: 'toolUse',
+            outcome: 'failed',
+            response: '',
+            files: [],
+            cost: 0,
+          },
+        });
+      }),
+  );
+
+  it.effect(
+    'stamps parent lineage onto both success and failure manifests',
+    () =>
+      Effect.gen(function* () {
+        const params = {
+          ...baseParams(),
+          parentExecutionId: 'parent-exec' as ExecutionId,
+        };
+        const strategy = createNativeSubagentStrategy(params);
+
+        expect(yield* strategy.buildResultMeta!(null, true, 10)).toMatchObject({
+          parentExecutionId: 'parent-exec',
+        });
+
+        expect(
+          yield* strategy.buildResultMeta!(
+            {
+              category: 'toolUse',
+              outcome: 'completed',
+              response: 'done',
+              executionId: params.executionId,
+              streamId: CHILD_STREAM_ID,
+            },
+            false,
+            10,
+          ),
+        ).toMatchObject({ parentExecutionId: 'parent-exec' });
+      }),
+  );
 
   it('preserves #7491: a failed direct resume throws for child-loop error delivery', async () => {
     const params = baseParams();
@@ -699,14 +751,16 @@ describe('NativeSubagentStrategy', () => {
     });
 
     const strategy = createNativeSubagentStrategy(params);
-    const completion = startChildRunLoop({
-      session: params.session,
-      childStreamId,
-      parentStreamId,
-      executionId,
-      agentName: params.agentName,
-      strategy,
-    });
+    const completion = Effect.runPromise(
+      childRunLoop({
+        session: params.session,
+        childStreamId,
+        parentStreamId,
+        executionId,
+        agentName: params.agentName,
+        strategy,
+      }),
+    );
     try {
       await vi.waitFor(() =>
         expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
@@ -791,105 +845,117 @@ describe('NativeSubagentStrategy', () => {
     }
   });
 
-  it('records the run cumulative cost via ports.recordCost on every turn', async () => {
-    const params = baseParams();
-    const strategy = createNativeSubagentStrategy(params);
-    const ports = fakePorts();
+  it.effect(
+    'records the run cumulative cost via ports.recordCost on every turn',
+    () =>
+      Effect.gen(function* () {
+        const params = baseParams();
+        const strategy = createNativeSubagentStrategy(params);
+        const ports = fakePorts();
 
-    mocks.executeAgent.mockResolvedValueOnce(
-      toolUseTurnResult(STREAM_PHASE.WAITING, params.executionId, {
-        totalCostUsd: 0.42,
+        mocks.executeAgent.mockResolvedValueOnce(
+          toolUseTurnResult(STREAM_PHASE.WAITING, params.executionId, {
+            totalCostUsd: 0.42,
+          }),
+        );
+
+        yield* strategy.launch(ports, new AbortController().signal);
+        expect(ports.recordCost).toHaveBeenCalledWith(0.42);
       }),
-    );
+  );
 
-    await Effect.runPromise(
-      strategy.launch(ports, new AbortController().signal),
-    );
-    expect(ports.recordCost).toHaveBeenCalledWith(0.42);
-  });
+  it.effect(
+    'derives stageLabel/isTerminal/buildResultMeta from a workflow-category config',
+    () =>
+      Effect.gen(function* () {
+        const params = baseParams(createTestSession(), 'workflow');
+        const strategy = createNativeSubagentStrategy(params);
 
-  it('derives stageLabel/isTerminal/buildResultMeta from a workflow-category config', async () => {
-    const params = baseParams(createTestSession(), 'workflow');
-    const strategy = createNativeSubagentStrategy(params);
+        expect(strategy.stageLabel).toBe('Native workflow subagent');
 
-    expect(strategy.stageLabel).toBe('Native workflow subagent');
+        const completedWorkflowTurn = {
+          category: 'workflow' as const,
+          outcome: 'completed' as const,
+          outputs: [],
+          compileFailures: [],
+          executionId: params.executionId,
+          streamId: CHILD_STREAM_ID,
+        };
+        // A workflow flow never produces a WAITING result, so every turn is
+        // terminal — `isWaitingFlowResult` requires `category === 'toolUse'`.
+        expect(strategy.isTerminal(completedWorkflowTurn)).toBe(true);
 
-    const completedWorkflowTurn = {
-      category: 'workflow' as const,
-      outcome: 'completed' as const,
-      outputs: [],
-      compileFailures: [],
-      executionId: params.executionId,
-      streamId: CHILD_STREAM_ID,
-    };
-    // A workflow flow never produces a WAITING result, so every turn is
-    // terminal — `isWaitingFlowResult` requires `category === 'toolUse'`.
-    expect(strategy.isTerminal(completedWorkflowTurn)).toBe(true);
+        expect(yield* strategy.buildResultMeta!(null, true, 10)).toMatchObject({
+          producer: 'subagent',
+          agentName: 'review',
+          result: {
+            category: 'workflow',
+            outcome: 'failed',
+          },
+        });
+      }),
+  );
 
-    await expect(
-      Effect.runPromise(strategy.buildResultMeta!(null, true, 10)),
-    ).resolves.toMatchObject({
-      producer: 'subagent',
-      agentName: 'review',
-      result: {
-        category: 'workflow',
-        outcome: 'failed',
-      },
-    });
-  });
+  it.live(
+    'never reaches runTurn for a workflow child — the loop breaks on the first terminal turn',
+    () =>
+      Effect.gen(function* () {
+        const session = defaultSession();
+        const childStreamId =
+          'native-workflow-loop-child#native-workflow-loop-exec' as StreamTabId;
+        const parentStreamId = 'native-workflow-loop-parent' as StreamTabId;
+        const executionId = 'native-workflow-loop-exec' as ExecutionId;
+        const interactions = { emit: vi.fn() } as never;
+        const params = {
+          ...baseParams(session, 'workflow'),
+          executionId,
+          parentStreamId,
+          interactions,
+        };
 
-  it('never reaches runTurn for a workflow child — the loop breaks on the first terminal turn', async () => {
-    const session = defaultSession();
-    const childStreamId =
-      'native-workflow-loop-child#native-workflow-loop-exec' as StreamTabId;
-    const parentStreamId = 'native-workflow-loop-parent' as StreamTabId;
-    const executionId = 'native-workflow-loop-exec' as ExecutionId;
-    const interactions = { emit: vi.fn() } as never;
-    const params = {
-      ...baseParams(session, 'workflow'),
-      executionId,
-      parentStreamId,
-      interactions,
-    };
+        mocks.executeAgent.mockResolvedValueOnce({
+          category: 'workflow',
+          outcome: 'completed',
+          outputs: [],
+          compileFailures: [],
+          executionId,
+          streamId: childStreamId,
+        });
 
-    mocks.executeAgent.mockResolvedValueOnce({
-      category: 'workflow',
-      outcome: 'completed',
-      outputs: [],
-      compileFailures: [],
-      executionId,
-      streamId: childStreamId,
-    });
+        const strategy = createNativeSubagentStrategy(params);
+        // `runTurn` is present on the merged strategy (unlike workflow-script's
+        // strategy), but the loop must never call it for a workflow child: the
+        // first turn is always terminal, and `childRunLoop.ts` breaks on a
+        // terminal turn before ever consulting `runTurn`.
+        expect(strategy.runTurn).toBeDefined();
 
-    const strategy = createNativeSubagentStrategy(params);
-    // `runTurn` is present on the merged strategy (unlike workflow-script's
-    // strategy), but the loop must never call it for a workflow child: the
-    // first turn is always terminal, and `childRunLoop.ts` breaks on a
-    // terminal turn before ever consulting `runTurn`.
-    expect(strategy.runTurn).toBeDefined();
+        try {
+          yield* childRunLoop({
+            session: params.session,
+            childStreamId,
+            parentStreamId,
+            executionId,
+            agentName: params.agentName,
+            strategy,
+          });
 
-    try {
-      await startChildRunLoop({
-        session: params.session,
-        childStreamId,
-        parentStreamId,
-        executionId,
-        agentName: params.agentName,
-        strategy,
-      });
+          yield* Effect.promise(() =>
+            vi.waitFor(() =>
+              expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
+            ),
+          );
+          yield* Effect.promise(() =>
+            vi.waitFor(() =>
+              expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
+            ),
+          );
 
-      await vi.waitFor(() =>
-        expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
-      );
-      await vi.waitFor(() =>
-        expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
-      );
-
-      expect(mocks.resumeToolUseTurn).not.toHaveBeenCalled();
-      expect(mocks.retrieveSessionResumeData).not.toHaveBeenCalled();
-    } finally {
-      session.followUps.terminalize(childStreamId);
-      session.status.clearStream(childStreamId);
-    }
-  });
+          expect(mocks.resumeToolUseTurn).not.toHaveBeenCalled();
+          expect(mocks.retrieveSessionResumeData).not.toHaveBeenCalled();
+        } finally {
+          session.followUps.terminalize(childStreamId);
+          session.status.clearStream(childStreamId);
+        }
+      }),
+  );
 });

--- a/src/test-kernel/tools/RunGeneratedFiles.vitest.ts
+++ b/src/test-kernel/tools/RunGeneratedFiles.vitest.ts
@@ -1,7 +1,8 @@
 import * as path from 'node:path';
 
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { platform } from '@platform/platform';
@@ -47,42 +48,48 @@ describe('listRunGeneratedFiles', () => {
   });
   afterEach(() => vi.restoreAllMocks());
 
-  it('lists in path order, skipping KV-named subtrees and concurrent disappearance', async () => {
-    failStatFor(
-      path.join(RUN_PATH, 'vanished.tex'),
-      fsError('ENOENT', 'entry disappeared after readDir'),
-    );
+  it.effect(
+    'lists in path order, skipping KV-named subtrees and concurrent disappearance',
+    () =>
+      Effect.gen(function* () {
+        failStatFor(
+          path.join(RUN_PATH, 'vanished.tex'),
+          fsError('ENOENT', 'entry disappeared after readDir'),
+        );
 
-    await expect(
-      Effect.runPromise(listRunGeneratedFiles(EXECUTION_ID, session)),
-    ).resolves.toEqual([
-      { path: 'blocked.tex', size: 7, isDirectory: false },
-      { path: 'sub', size: 0, isDirectory: true },
-      { path: 'sub/nested.tex', size: 6, isDirectory: false },
-      { path: 'unreadable.tex', size: 10, isDirectory: false },
-      { path: 'z.tex', size: 3, isDirectory: false },
-    ]);
-  });
+        expect(yield* listRunGeneratedFiles(EXECUTION_ID, session)).toEqual([
+          { path: 'blocked.tex', size: 7, isDirectory: false },
+          { path: 'sub', size: 0, isDirectory: true },
+          { path: 'sub/nested.tex', size: 6, isDirectory: false },
+          { path: 'unreadable.tex', size: 10, isDirectory: false },
+          { path: 'z.tex', size: 3, isDirectory: false },
+        ]);
+      }),
+  );
 
-  it('omits an entry whose intermediate component is no longer a directory', async () => {
-    failStatFor(
-      path.join(RUN_PATH, 'blocked.tex'),
-      fsError('ENOTDIR', 'parent path is no longer a directory'),
-    );
+  it.effect(
+    'omits an entry whose intermediate component is no longer a directory',
+    () =>
+      Effect.gen(function* () {
+        failStatFor(
+          path.join(RUN_PATH, 'blocked.tex'),
+          fsError('ENOTDIR', 'parent path is no longer a directory'),
+        );
 
-    const files = await Effect.runPromise(
-      listRunGeneratedFiles(EXECUTION_ID, session),
-    );
+        const files = yield* listRunGeneratedFiles(EXECUTION_ID, session);
 
-    expect(files.map((file) => file.path)).not.toContain('blocked.tex');
-  });
+        expect(files.map((file) => file.path)).not.toContain('blocked.tex');
+      }),
+  );
 
-  it('propagates operational stat failures', async () => {
-    const error = fsError('EACCES', 'generated file is unreadable');
-    failStatFor(path.join(RUN_PATH, 'unreadable.tex'), error);
+  it.effect('propagates operational stat failures', () =>
+    Effect.gen(function* () {
+      const error = fsError('EACCES', 'generated file is unreadable');
+      failStatFor(path.join(RUN_PATH, 'unreadable.tex'), error);
 
-    await expect(
-      Effect.runPromise(listRunGeneratedFiles(EXECUTION_ID, session)),
-    ).rejects.toBe(error);
-  });
+      expect(
+        yield* Effect.flip(listRunGeneratedFiles(EXECUTION_ID, session)),
+      ).toBe(error);
+    }),
+  );
 });

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -7,7 +7,8 @@
 // which callers may resolve differently from `configPayload.agent` (e.g. a
 // display name vs. the config's own registry name).
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
 
 import { getStreamTabId } from '@agent/runtime/streamTab';
@@ -103,14 +104,12 @@ describe('executeSubagent childStreamId derivation', () => {
   } as never;
 
   function runDefaultSubagent() {
-    return Effect.runPromise(
-      executeSubagent(
-        mocks.tryUseRunContext(),
-        mocks.getCurrentToolCallContext(),
-        defaultPayload,
-        'proof-checker',
-        orchestratorStreamId,
-      ),
+    return executeSubagent(
+      mocks.tryUseRunContext(),
+      mocks.getCurrentToolCallContext(),
+      defaultPayload,
+      'proof-checker',
+      orchestratorStreamId,
     );
   }
 
@@ -128,89 +127,101 @@ describe('executeSubagent childStreamId derivation', () => {
     mocks.getCurrentToolCallContext.mockReturnValue(undefined);
   });
 
-  it('requires the run context to carry its owning session', async () => {
-    mocks.tryUseRunContext.mockReturnValue({
-      executionId: 'parent-exec',
-      approvalPromptsUnavailable: false,
-      runtimeUnavailableTools: [],
-      stopAfterCycle: false,
-    });
+  it.effect('requires the run context to carry its owning session', () =>
+    Effect.gen(function* () {
+      mocks.tryUseRunContext.mockReturnValue({
+        executionId: 'parent-exec',
+        approvalPromptsUnavailable: false,
+        runtimeUnavailableTools: [],
+        stopAfterCycle: false,
+      });
 
-    await expect(runDefaultSubagent()).resolves.toMatchObject({
-      status: 'error',
-      summary: 'Delegation session unavailable',
-      diagnostics: { type: 'missing_session' },
-    });
-    expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
-  });
+      expect(yield* runDefaultSubagent()).toMatchObject({
+        status: 'error',
+        summary: 'Delegation session unavailable',
+        diagnostics: { type: 'missing_session' },
+      });
+      expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
+    }),
+  );
 
-  it('derives childStreamId from configPayload.agent, not the (possibly different) agentName parameter', async () => {
-    const configPayload = {
-      agent: 'proof-checker', // the config's own registry name
-      model: 'gpt5',
-      agentCategory: 'toolUse',
-      instruction: 'Check the proof.',
-    };
-    // A caller-resolved display name that intentionally differs from
-    // configPayload.agent — this is the exact mismatch the review flagged.
-    const agentName = 'Proof Checker (display)';
+  it.effect(
+    'derives childStreamId from configPayload.agent, not the (possibly different) agentName parameter',
+    () =>
+      Effect.gen(function* () {
+        const configPayload = {
+          agent: 'proof-checker', // the config's own registry name
+          model: 'gpt5',
+          agentCategory: 'toolUse',
+          instruction: 'Check the proof.',
+        };
+        // A caller-resolved display name that intentionally differs from
+        // configPayload.agent — this is the exact mismatch the review flagged.
+        const agentName = 'Proof Checker (display)';
 
-    await Effect.runPromise(
-      executeSubagent(
-        mocks.tryUseRunContext(),
-        mocks.getCurrentToolCallContext(),
-        configPayload as never,
-        agentName,
-        orchestratorStreamId,
-      ),
-    );
+        yield* executeSubagent(
+          mocks.tryUseRunContext(),
+          mocks.getCurrentToolCallContext(),
+          configPayload as never,
+          agentName,
+          orchestratorStreamId,
+        );
 
-    expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
-    const [loopParams] = mocks.startChildRunLoop.mock.calls[0] as [
-      {
-        childStreamId: StreamTabId;
-        executionId: string;
-        parentStreamId: StreamTabId;
-      },
-    ];
-    expect(loopParams.parentStreamId).toBe(orchestratorStreamId);
-    expect(mocks.registerExecution).toHaveBeenCalledWith(
-      mocks.tryUseRunContext().session,
-      loopParams.executionId,
-      expect.any(Object),
-      agentName,
-      expect.objectContaining({
-        parentExecutionId: 'parent-exec',
-        streamId: loopParams.childStreamId,
+        expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
+        const [loopParams] = mocks.startChildRunLoop.mock.calls[0] as [
+          {
+            childStreamId: StreamTabId;
+            executionId: string;
+            parentStreamId: StreamTabId;
+          },
+        ];
+        expect(loopParams.parentStreamId).toBe(orchestratorStreamId);
+        expect(mocks.registerExecution).toHaveBeenCalledWith(
+          mocks.tryUseRunContext().session,
+          loopParams.executionId,
+          expect.any(Object),
+          agentName,
+          expect.objectContaining({
+            parentExecutionId: 'parent-exec',
+            streamId: loopParams.childStreamId,
+          }),
+        );
+        const expectedChildStreamId = getStreamTabId(configPayload.agent, {
+          executionId: loopParams.executionId as never,
+        });
+        expect(loopParams.childStreamId).toBe(expectedChildStreamId);
+        // Confirms the bug the review flagged would have actually mismatched:
+        // the OLD (agentName-keyed) formula produces a different id.
+        expect(loopParams.childStreamId).not.toBe(
+          getStreamTabId(agentName, {
+            executionId: loopParams.executionId as never,
+          }),
+        );
       }),
-    );
-    const expectedChildStreamId = getStreamTabId(configPayload.agent, {
-      executionId: loopParams.executionId as never,
-    });
-    expect(loopParams.childStreamId).toBe(expectedChildStreamId);
-    // Confirms the bug the review flagged would have actually mismatched:
-    // the OLD (agentName-keyed) formula produces a different id.
-    expect(loopParams.childStreamId).not.toBe(
-      getStreamTabId(agentName, {
-        executionId: loopParams.executionId as never,
+  );
+
+  // `it.live`: the assertion waits on a detached fiber's late failure through
+  // `vi.waitFor`, which polls on the real clock.
+  it.live(
+    'logs a detached run-loop rejection through the childRunLoop channel log',
+    () =>
+      Effect.gen(function* () {
+        const lateFailure = new Error('late subagent finalization failed');
+        mocks.startChildRunLoop.mockReturnValue(
+          Effect.forkDetach(Effect.fail(lateFailure)),
+        );
+
+        expect(yield* runDefaultSubagent()).toMatchObject({
+          status: 'executed',
+        });
+        yield* Effect.promise(() =>
+          vi.waitFor(() => {
+            expect(mocks.childLoopError).toHaveBeenCalledWith(
+              "Subagent 'proof-checker' run loop failed after launch",
+              { data: lateFailure },
+            );
+          }),
+        );
       }),
-    );
-  });
-
-  it('logs a detached run-loop rejection through the childRunLoop channel log', async () => {
-    const lateFailure = new Error('late subagent finalization failed');
-    mocks.startChildRunLoop.mockReturnValue(
-      Effect.forkDetach(Effect.fail(lateFailure)),
-    );
-
-    await expect(runDefaultSubagent()).resolves.toMatchObject({
-      status: 'executed',
-    });
-    await vi.waitFor(() => {
-      expect(mocks.childLoopError).toHaveBeenCalledWith(
-        "Subagent 'proof-checker' run loop failed after launch",
-        { data: lateFailure },
-      );
-    });
-  });
+  );
 });

--- a/src/test-kernel/tools/ToolAvailabilityAppSignals.vitest.ts
+++ b/src/test-kernel/tools/ToolAvailabilityAppSignals.vitest.ts
@@ -1,6 +1,7 @@
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, vi } from 'vitest';
 
 afterEach(() => {
   vi.doUnmock('@tools/externalToolDefs');
@@ -8,109 +9,126 @@ afterEach(() => {
 });
 
 describe('tool availability app signals', () => {
-  it('emits toolAvailabilityChanged after a refresh', async () => {
-    vi.doMock('@tools/externalToolDefs', () => ({
-      EXTERNAL_TOOL_DEFS: [
-        {
-          id: 'test-tool',
-          tools: [],
-          name: 'Test tool',
-          category: 'ai-agents',
-          check: vi.fn(() => Effect.succeed(true)),
-        },
-      ],
-    }));
-    const { appSignals } = await import('@eventBus/AppSignals');
-    const { refreshToolAvailability } = await import('@tools/toolAvailability');
-    const events: undefined[] = [];
-    const dispose = appSignals.on('toolAvailabilityChanged', (payload) => {
-      events.push(payload);
-    });
+  it.effect('emits toolAvailabilityChanged after a refresh', () =>
+    Effect.gen(function* () {
+      vi.doMock('@tools/externalToolDefs', () => ({
+        EXTERNAL_TOOL_DEFS: [
+          {
+            id: 'test-tool',
+            tools: [],
+            name: 'Test tool',
+            category: 'ai-agents',
+            check: vi.fn(() => Effect.succeed(true)),
+          },
+        ],
+      }));
+      const { appSignals } = yield* Effect.promise(
+        () => import('@eventBus/AppSignals'),
+      );
+      const { refreshToolAvailability } = yield* Effect.promise(
+        () => import('@tools/toolAvailability'),
+      );
+      const events: undefined[] = [];
+      const dispose = appSignals.on('toolAvailabilityChanged', (payload) => {
+        events.push(payload);
+      });
 
-    try {
-      await Effect.runPromise(refreshToolAvailability());
+      try {
+        yield* refreshToolAvailability();
 
-      expect(events).toEqual([undefined]);
-    } finally {
-      dispose();
-    }
-  });
+        expect(events).toEqual([undefined]);
+      } finally {
+        dispose();
+      }
+    }),
+  );
 
-  it('derives unavailable tool names from the last probe results, with no cache to refresh', async () => {
-    vi.doMock('@tools/externalToolDefs', () => ({
-      EXTERNAL_TOOL_DEFS: [
-        {
-          id: 'present-tool',
-          tools: ['present'],
-          name: 'Present tool',
-          category: 'ai-agents',
-          check: vi.fn(() => Effect.succeed(true)),
-        },
-        {
-          id: 'missing-tool',
-          tools: ['missing'],
-          name: 'Missing tool',
-          category: 'ai-agents',
-          toggleable: true,
-          check: vi.fn(() => Effect.succeed(false)),
-        },
-      ],
-    }));
-    const { getUnavailableToolNamesCached, runExternalToolChecks } =
-      await import('@tools/toolAvailability');
+  it.effect(
+    'derives unavailable tool names from the last probe results, with no cache to refresh',
+    () =>
+      Effect.gen(function* () {
+        vi.doMock('@tools/externalToolDefs', () => ({
+          EXTERNAL_TOOL_DEFS: [
+            {
+              id: 'present-tool',
+              tools: ['present'],
+              name: 'Present tool',
+              category: 'ai-agents',
+              check: vi.fn(() => Effect.succeed(true)),
+            },
+            {
+              id: 'missing-tool',
+              tools: ['missing'],
+              name: 'Missing tool',
+              category: 'ai-agents',
+              toggleable: true,
+              check: vi.fn(() => Effect.succeed(false)),
+            },
+          ],
+        }));
+        const { getUnavailableToolNamesCached, runExternalToolChecks } =
+          yield* Effect.promise(() => import('@tools/toolAvailability'));
 
-    expect([...getUnavailableToolNamesCached()]).toEqual([]);
+        expect([...getUnavailableToolNamesCached()]).toEqual([]);
 
-    await Effect.runPromise(runExternalToolChecks());
+        yield* runExternalToolChecks();
 
-    // Toggling a tool on or off never changes this set — it reports missing
-    // external dependencies only — so there is nothing to rebuild after a
-    // toggle, which is why the availability answer is derived on read.
-    expect([...getUnavailableToolNamesCached()]).toEqual(['missing']);
-  });
-
-  it('distinguishes failed probes from missing tools without hiding optional-status failures', async () => {
-    vi.doMock('@tools/externalToolDefs', () => ({
-      EXTERNAL_TOOL_DEFS: [
-        {
-          id: 'broken-probe',
-          tools: ['broken'],
-          name: 'Broken probe',
-          category: 'ai-agents',
-          probe: vi.fn(() =>
-            Effect.fail(new Error('invalid local configuration')),
-          ),
-          check: vi.fn(() => Effect.succeed(true)),
-          statusLabel: vi.fn(() => Effect.succeed('Needs setup')),
-        },
-        {
-          id: 'broken-detail',
-          tools: ['present'],
-          name: 'Broken detail',
-          category: 'ai-agents',
-          check: vi.fn(() => Effect.succeed(true)),
-          detailCheck: vi.fn(() =>
-            Effect.fail(new Error('status command crashed')),
-          ),
-        },
-      ],
-    }));
-    const { runExternalToolChecks } = await import('@tools/toolAvailability');
-
-    await expect(Effect.runPromise(runExternalToolChecks())).resolves.toEqual([
-      expect.objectContaining({
-        id: 'broken-probe',
-        status: 'unknown',
-        detected: null,
-        statusLabel: undefined,
-        statusDetail: 'Availability check failed: invalid local configuration',
+        // Toggling a tool on or off never changes this set — it reports missing
+        // external dependencies only — so there is nothing to rebuild after a
+        // toggle, which is why the availability answer is derived on read.
+        expect([...getUnavailableToolNamesCached()]).toEqual(['missing']);
       }),
-      expect.objectContaining({
-        id: 'broken-detail',
-        status: 'available',
-        detected: true,
-        statusDetail: undefined,
+  );
+
+  it.effect(
+    'distinguishes failed probes from missing tools without hiding optional-status failures',
+    () =>
+      Effect.gen(function* () {
+        vi.doMock('@tools/externalToolDefs', () => ({
+          EXTERNAL_TOOL_DEFS: [
+            {
+              id: 'broken-probe',
+              tools: ['broken'],
+              name: 'Broken probe',
+              category: 'ai-agents',
+              probe: vi.fn(() =>
+                Effect.fail(new Error('invalid local configuration')),
+              ),
+              check: vi.fn(() => Effect.succeed(true)),
+              statusLabel: vi.fn(() => Effect.succeed('Needs setup')),
+            },
+            {
+              id: 'broken-detail',
+              tools: ['present'],
+              name: 'Broken detail',
+              category: 'ai-agents',
+              check: vi.fn(() => Effect.succeed(true)),
+              detailCheck: vi.fn(() =>
+                Effect.fail(new Error('status command crashed')),
+              ),
+            },
+          ],
+        }));
+        const { runExternalToolChecks } = yield* Effect.promise(
+          () => import('@tools/toolAvailability'),
+        );
+
+        expect(yield* runExternalToolChecks()).toEqual([
+          expect.objectContaining({
+            id: 'broken-probe',
+            status: 'unknown',
+            detected: null,
+            statusLabel: undefined,
+            statusDetail:
+              'Availability check failed: invalid local configuration',
+          }),
+          expect.objectContaining({
+            id: 'broken-detail',
+            status: 'available',
+            detected: true,
+            statusDetail: undefined,
+          }),
+        ]);
       }),
-    ]);
-  });
+  );
 });

--- a/src/test-kernel/tools/ToolAvailabilitySeeding.vitest.ts
+++ b/src/test-kernel/tools/ToolAvailabilitySeeding.vitest.ts
@@ -1,6 +1,7 @@
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect } from 'vitest';
 
 // Local imports
 import { platform } from '@platform/platform';
@@ -18,19 +19,21 @@ const EXPECTED_DEFAULTS = EXTERNAL_TOOL_DEFS.filter(
 describe('seedDisabledToolDefaults', () => {
   afterEach(() => installPlatform());
 
-  it('seeds every toggleable tool as disabled on a genuinely fresh install', async () => {
-    await installPlatform({ globalState: {} });
+  it.effect(
+    'seeds every toggleable tool as disabled on a genuinely fresh install',
+    () =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => installPlatform({ globalState: {} }));
 
-    await Effect.runPromise(
-      seedDisabledToolDefaults(platform().globalState, VERSION_KEY),
-    );
+        yield* seedDisabledToolDefaults(platform().globalState, VERSION_KEY);
 
-    expect(platform().globalState.get(GlobalStateKey.DISABLED_TOOLS)).toEqual(
-      EXPECTED_DEFAULTS,
-    );
-  });
+        expect(
+          platform().globalState.get(GlobalStateKey.DISABLED_TOOLS),
+        ).toEqual(EXPECTED_DEFAULTS);
+      }),
+  );
 
-  it.each([
+  it.effect.each([
     {
       name: 'a host with a prior-install version marker',
       globalState: { [VERSION_KEY]: '1.2.3' },
@@ -39,15 +42,15 @@ describe('seedDisabledToolDefaults', () => {
       name: 'an already-seeded DISABLED_TOOLS list, even an empty one',
       globalState: { [GlobalStateKey.DISABLED_TOOLS]: [] as string[] },
     },
-  ])('does not seed for $name', async ({ globalState }) => {
-    await installPlatform({ globalState });
+  ])('does not seed for $name', ({ globalState }) =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() => installPlatform({ globalState }));
 
-    await Effect.runPromise(
-      seedDisabledToolDefaults(platform().globalState, VERSION_KEY),
-    );
+      yield* seedDisabledToolDefaults(platform().globalState, VERSION_KEY);
 
-    expect(platform().globalState.get(GlobalStateKey.DISABLED_TOOLS)).toEqual(
-      globalState[GlobalStateKey.DISABLED_TOOLS],
-    );
-  });
+      expect(platform().globalState.get(GlobalStateKey.DISABLED_TOOLS)).toEqual(
+        globalState[GlobalStateKey.DISABLED_TOOLS],
+      );
+    }),
+  );
 });

--- a/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
+++ b/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
@@ -2,7 +2,8 @@
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { it } from '@effect/vitest';
+import { describe, expect } from 'vitest';
 import { Effect } from 'effect';
 import type { ExecutionListingEntry } from '@agent/storage';
 import { defaultSession } from '@agent/runtime/SessionHandle';
@@ -62,30 +63,31 @@ describe('tool status formatting', () => {
     );
   });
 
-  it('renders bash execution history as a process without a model', async () => {
-    const entry: ExecutionListingEntry = {
-      kind: 'run',
-      identity: { kind: 'process', tool: 'bash' },
-      id: '16c0f3f748e4',
-      timestamp: '2026-05-15T23:42:06.000Z',
-      parentExecutionId: 'fcf5150d37c6',
-      record: AgentConfigSchema.parse({
-        agent: 'bash',
-        model: 'gemini31p',
-        instruction: 'ls',
-        agentCategory: 'toolUse',
-      }),
-      outcome: 'completed',
-      checkpointPresent: false,
-    };
+  it.effect('renders bash execution history as a process without a model', () =>
+    Effect.gen(function* () {
+      const entry: ExecutionListingEntry = {
+        kind: 'run',
+        identity: { kind: 'process', tool: 'bash' },
+        id: '16c0f3f748e4',
+        timestamp: '2026-05-15T23:42:06.000Z',
+        parentExecutionId: 'fcf5150d37c6',
+        record: AgentConfigSchema.parse({
+          agent: 'bash',
+          model: 'gemini31p',
+          instruction: 'ls',
+          agentCategory: 'toolUse',
+        }),
+        outcome: 'completed',
+        checkpointPresent: false,
+      };
 
-    // The row's own `outcome` is a recorded durable fact, so the status column
-    // shows it without re-reading the metadata file it came from. The other
-    // columns under test are the `process` category and the suppressed model.
-    await expect(
-      Effect.runPromise(formatListingLine(entry, defaultSession())),
-    ).resolves.toBe(
-      '16c0f3f748e4  2026-05-15 23:42:06  bash  process  [completed]  parent=fcf5150d37c6',
-    );
-  });
+      // The row's own `outcome` is a recorded durable fact, so the status
+      // column shows it without re-reading the metadata file it came from. The
+      // other columns under test are the `process` category and the suppressed
+      // model.
+      expect(yield* formatListingLine(entry, defaultSession())).toBe(
+        '16c0f3f748e4  2026-05-15 23:42:06  bash  process  [completed]  parent=fcf5150d37c6',
+      );
+    }),
+  );
 });

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -1,6 +1,7 @@
 import '@test/support/defaultSessionTestSetup';
-import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { it } from '@effect/vitest';
+import { Effect, Fiber } from 'effect';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import { TraceEmitter } from '@agent/trace';
@@ -133,307 +134,368 @@ describe('createWorkflowScriptStrategy', () => {
     expect(strategy.resolveDeliveryTarget).toBeUndefined();
   });
 
-  it('runs a live call, settles its journal cost, and delivers the result', async () => {
-    const ports = fakePorts();
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'strategy-test',
-        createRunAgent: billingRunAgent,
+  // `it.live` throughout: launching runs the real script engine, so these
+  // cases wait on real promises rather than a test clock.
+  it.live(
+    'runs a live call, settles its journal cost, and delivers the result',
+    () =>
+      Effect.gen(function* () {
+        const ports = fakePorts();
+        const strategy = createWorkflowScriptStrategy(
+          strategyParams({
+            name: 'strategy-test',
+            createRunAgent: billingRunAgent,
+          }),
+        );
+
+        const turn = yield* strategy.launch(
+          ports,
+          new AbortController().signal,
+        );
+
+        // The live-attempt candidate and final journal agree on the total.
+        expect(ports.recordCost.mock.calls).toEqual([[0.42], [0.42]]);
+
+        const delivery = yield* Effect.promise(async () =>
+          strategy.formatDelivery(turn, 0),
+        );
+        expect(delivery).toContain('"category": "workflow"');
+        // The run log rides along so the invoking model sees what executed.
+        expect(delivery).toContain('=== Run log ===');
+        expect(delivery).toContain('Finished');
+        expect(delivery).toContain(
+          'Script file: .texra/workflow-scripts/draft-strategy.mjs',
+        );
+        expect(delivery).toContain('with scriptPath:');
+        expect(delivery).toContain('<workflow-summary>');
+        expect(delivery).toContain('"outcome":"completed"');
+        expect(delivery).toContain('"taskDone":1');
+        expect(delivery).toContain('"costUsd":0.42');
+        expect(delivery).toContain(
+          '"files":[{"path":"paper.tex","added":12,"removed":8}]',
+        );
       }),
-    );
+  );
 
-    const turn = await Effect.runPromise(
-      strategy.launch(ports, new AbortController().signal),
-    );
+  it.live('settles zero for a pure checkpoint replay', () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() =>
+        runPersistedWorkflowScript({
+          store: getExecutionStore(executionId),
+          checkpointId: checkpointIdFor('strategy-test'),
+          script,
+          runAgent: async () => finalResult,
+        }),
+      );
+      clearStoreCache();
+      const ports = fakePorts();
+      const strategy = createWorkflowScriptStrategy(
+        strategyParams({
+          name: 'strategy-test',
+          // A retrying model rewrites its source; same meta.name still resumes.
+          script: `${script}\n// retry rewrote me`,
+          createRunAgent: () => async () => {
+            throw new Error('replayed call must not re-execute');
+          },
+        }),
+      );
 
-    // The live-attempt candidate and final journal agree on the total.
-    expect(ports.recordCost.mock.calls).toEqual([[0.42], [0.42]]);
+      const turn = yield* strategy.launch(ports, new AbortController().signal);
 
-    const delivery = await strategy.formatDelivery(turn, 0);
-    expect(delivery).toContain('"category": "workflow"');
-    // The run log rides along so the invoking model sees what executed.
-    expect(delivery).toContain('=== Run log ===');
-    expect(delivery).toContain('Finished');
-    expect(delivery).toContain(
-      'Script file: .texra/workflow-scripts/draft-strategy.mjs',
-    );
-    expect(delivery).toContain('with scriptPath:');
-    expect(delivery).toContain('<workflow-summary>');
-    expect(delivery).toContain('"outcome":"completed"');
-    expect(delivery).toContain('"taskDone":1');
-    expect(delivery).toContain('"costUsd":0.42');
-    expect(delivery).toContain(
-      '"files":[{"path":"paper.tex","added":12,"removed":8}]',
-    );
-  });
+      expect(ports.recordCost).toHaveBeenCalledOnce();
+      expect(ports.recordCost).toHaveBeenCalledWith(0);
+      const delivery = yield* Effect.promise(async () =>
+        strategy.formatDelivery(turn, 0),
+      );
+      expect(delivery).toContain('Using saved result');
+      expect(delivery).toContain(
+        '"files":[{"path":"paper.tex","added":12,"removed":8}]',
+      );
+    }),
+  );
 
-  it('settles zero for a pure checkpoint replay', async () => {
-    await runPersistedWorkflowScript({
-      store: getExecutionStore(executionId),
-      checkpointId: checkpointIdFor('strategy-test'),
-      script,
-      runAgent: async () => finalResult,
-    });
-    clearStoreCache();
-    const ports = fakePorts();
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'strategy-test',
-        // A retrying model rewrites its source; same meta.name still resumes.
-        script: `${script}\n// retry rewrote me`,
-        createRunAgent: () => async () => {
-          throw new Error('replayed call must not re-execute');
-        },
-      }),
-    );
-
-    const turn = await Effect.runPromise(
-      strategy.launch(ports, new AbortController().signal),
-    );
-
-    expect(ports.recordCost).toHaveBeenCalledOnce();
-    expect(ports.recordCost).toHaveBeenCalledWith(0);
-    const delivery = await strategy.formatDelivery(turn, 0);
-    expect(delivery).toContain('Using saved result');
-    expect(delivery).toContain(
-      '"files":[{"path":"paper.tex","added":12,"removed":8}]',
-    );
-  });
-
-  it('passes JSON arguments through and formats a zero-call result', async () => {
-    const ports = fakePorts();
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'arguments',
-        script: `export const meta = {
+  it.live('passes JSON arguments through and formats a zero-call result', () =>
+    Effect.gen(function* () {
+      const ports = fakePorts();
+      const strategy = createWorkflowScriptStrategy(
+        strategyParams({
+          name: 'arguments',
+          script: `export const meta = {
   name: 'arguments',
   description: 'returns its arguments',
 }
 return args`,
-        args: { question: 'What is conserved?' },
-        createRunAgent: billingRunAgent,
-      }),
-    );
+          args: { question: 'What is conserved?' },
+          createRunAgent: billingRunAgent,
+        }),
+      );
 
-    const turn = await Effect.runPromise(
-      strategy.launch(ports, new AbortController().signal),
-    );
-    const delivery = await strategy.formatDelivery(turn, 0);
-    expect(delivery).toContain('"question": "What is conserved?"');
-    expect(ports.recordCost).toHaveBeenCalledWith(0);
-  });
+      const turn = yield* strategy.launch(ports, new AbortController().signal);
+      const delivery = yield* Effect.promise(async () =>
+        strategy.formatDelivery(turn, 0),
+      );
+      expect(delivery).toContain('"question": "What is conserved?"');
+      expect(ports.recordCost).toHaveBeenCalledWith(0);
+    }),
+  );
 
-  it('retains checkpoint arguments when a null retry omits them', async () => {
-    const argsScript = `export const meta = {
+  it.live('retains checkpoint arguments when a null retry omits them', () =>
+    Effect.gen(function* () {
+      const argsScript = `export const meta = {
   name: 'retained-arguments',
   description: 'retains omitted retry arguments',
 }
 return args`;
-    await runPersistedWorkflowScript({
-      store: getExecutionStore(executionId),
-      checkpointId: checkpointIdFor('retained-arguments'),
-      script: argsScript,
-      args: { topic: 'geometry' },
-      runAgent: async () => finalResult,
-    });
-    clearStoreCache();
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'retained-arguments',
-        script: `${argsScript}\n// revised retry`,
-        args: null,
-        createRunAgent: billingRunAgent,
-      }),
-    );
+      yield* Effect.promise(() =>
+        runPersistedWorkflowScript({
+          store: getExecutionStore(executionId),
+          checkpointId: checkpointIdFor('retained-arguments'),
+          script: argsScript,
+          args: { topic: 'geometry' },
+          runAgent: async () => finalResult,
+        }),
+      );
+      clearStoreCache();
+      const strategy = createWorkflowScriptStrategy(
+        strategyParams({
+          name: 'retained-arguments',
+          script: `${argsScript}\n// revised retry`,
+          args: null,
+          createRunAgent: billingRunAgent,
+        }),
+      );
 
-    const turn = await Effect.runPromise(
-      strategy.launch(fakePorts(), new AbortController().signal),
-    );
-    const delivery = await strategy.formatDelivery(turn, 0);
-    expect(delivery).toContain('"topic": "geometry"');
-  });
+      const turn = yield* strategy.launch(
+        fakePorts(),
+        new AbortController().signal,
+      );
+      const delivery = yield* Effect.promise(async () =>
+        strategy.formatDelivery(turn, 0),
+      );
+      expect(delivery).toContain('"topic": "geometry"');
+    }),
+  );
 
-  it('bounds and normalizes the model-visible run log', async () => {
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'bounded-log',
-        script: `export const meta = {
+  it.live('bounds and normalizes the model-visible run log', () =>
+    Effect.gen(function* () {
+      const strategy = createWorkflowScriptStrategy(
+        strategyParams({
+          name: 'bounded-log',
+          script: `export const meta = {
   name: 'bounded-log',
   description: 'bounds model-visible activity',
 }
 for (let index = 0; index < 100; index += 1) log('line-' + index)
 log('oversized\\n' + 'x'.repeat(2_000))
 return 'done'`,
-        createRunAgent: billingRunAgent,
-      }),
-    );
+          createRunAgent: billingRunAgent,
+        }),
+      );
 
-    const turn = await Effect.runPromise(
-      strategy.launch(fakePorts(), new AbortController().signal),
-    );
-    const delivery = await strategy.formatDelivery(turn, 0);
-    expect(delivery).toContain(
-      '=== Run log (last 80 lines; 21 earlier lines omitted) ===',
-    );
-    expect(delivery).not.toContain('line-20\n');
-    expect(delivery).toContain('line-21\n');
-    expect(delivery).toContain('oversized x');
-    expect(delivery.length).toBeLessThan(42_000);
-  });
+      const turn = yield* strategy.launch(
+        fakePorts(),
+        new AbortController().signal,
+      );
+      const delivery = yield* Effect.promise(async () =>
+        strategy.formatDelivery(turn, 0),
+      );
+      expect(delivery).toContain(
+        '=== Run log (last 80 lines; 21 earlier lines omitted) ===',
+      );
+      expect(delivery).not.toContain('line-20\n');
+      expect(delivery).toContain('line-21\n');
+      expect(delivery).toContain('oversized x');
+      expect(delivery.length).toBeLessThan(42_000);
+    }),
+  );
 
-  it('settles a retained journal and surfaces the resume hint when script code fails', async () => {
-    const failingScript = `export const meta = {
+  it.live(
+    'settles a retained journal and surfaces the resume hint when script code fails',
+    () =>
+      Effect.gen(function* () {
+        const failingScript = `export const meta = {
   name: 'retained-settlement',
   description: 'tests retained journal settlement',
 }
 await agent('saved call')
 throw new Error('script failed after replay')`;
-    await expect(
-      runPersistedWorkflowScript({
-        store: getExecutionStore(executionId),
-        checkpointId: checkpointIdFor('retained-settlement'),
-        script: failingScript,
-        runAgent: async () => finalResult,
+        yield* Effect.promise(() =>
+          expect(
+            runPersistedWorkflowScript({
+              store: getExecutionStore(executionId),
+              checkpointId: checkpointIdFor('retained-settlement'),
+              script: failingScript,
+              runAgent: async () => finalResult,
+            }),
+          ).rejects.toThrow('script failed after replay'),
+        );
+        clearStoreCache();
+        const ports = fakePorts();
+        const strategy = createWorkflowScriptStrategy(
+          strategyParams({
+            name: 'retained-settlement',
+            script: failingScript,
+            createRunAgent: () => async () => {
+              throw new Error('replayed call must not re-execute');
+            },
+          }),
+        );
+
+        const failure = yield* Effect.flip(
+          strategy.launch(ports, new AbortController().signal),
+        );
+        expect(failure.message).toContain('script failed after replay');
+        // Failure recovery excludes the pre-run journal from this invocation.
+        expect(ports.recordCost).toHaveBeenCalledWith(0);
+
+        const errText = yield* Effect.promise(async () =>
+          strategy.formatError(null, new Error('boom')),
+        );
+        expect(errText).toContain(
+          "journaled under meta.name 'retained-settlement'",
+        );
+        expect(errText).toContain('boom');
+        expect(errText).toContain(
+          'Script file: .texra/workflow-scripts/draft-strategy.mjs',
+        );
+        expect(errText).toContain('with scriptPath:');
+        expect(errText).toContain('"outcome":"failed"');
+        // The failure line's tallies come from the engine's terminal snapshot —
+        // the run replayed one cached call and declared no phases — not from a
+        // re-parse of the checkpoint's script.
+        expect(errText).toContain('"phaseCount":0');
+        expect(errText).toContain('"taskDone":1');
+        expect(errText).toContain('"taskTotal":1');
       }),
-    ).rejects.toThrow('script failed after replay');
-    clearStoreCache();
-    const ports = fakePorts();
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'retained-settlement',
-        script: failingScript,
-        createRunAgent: () => async () => {
-          throw new Error('replayed call must not re-execute');
-        },
-      }),
-    );
+  );
 
-    await expect(
-      Effect.runPromise(strategy.launch(ports, new AbortController().signal)),
-    ).rejects.toThrow('script failed after replay');
-    // Failure recovery excludes the pre-run journal from this invocation.
-    expect(ports.recordCost).toHaveBeenCalledWith(0);
-
-    const errText = await strategy.formatError(null, new Error('boom'));
-    expect(errText).toContain(
-      "journaled under meta.name 'retained-settlement'",
-    );
-    expect(errText).toContain('boom');
-    expect(errText).toContain(
-      'Script file: .texra/workflow-scripts/draft-strategy.mjs',
-    );
-    expect(errText).toContain('with scriptPath:');
-    expect(errText).toContain('"outcome":"failed"');
-    // The failure line's tallies come from the engine's terminal snapshot —
-    // the run replayed one cached call and declared no phases — not from a
-    // re-parse of the checkpoint's script.
-    expect(errText).toContain('"phaseCount":0');
-    expect(errText).toContain('"taskDone":1');
-    expect(errText).toContain('"taskTotal":1');
-  });
-
-  it('settles failures from the touched journal without stale entries', async () => {
-    const name = 'attempt-local-settlement';
-    const baselineScript = `export const meta = {
+  it.live(
+    'settles failures from the touched journal without stale entries',
+    () =>
+      Effect.gen(function* () {
+        const name = 'attempt-local-settlement';
+        const baselineScript = `export const meta = {
   name: '${name}',
   description: 'seeds stale recovery entries',
 }
 await agent('stale file')
 return await agent('malformed stale')`;
-    const staleResult: AgentFinalResult = {
-      ...finalResult,
-      outputs: [{ ...finalResult.outputs[0], relativePath: 'stale.tex' }],
-    };
-    await runPersistedWorkflowScript({
-      store: getExecutionStore(executionId),
-      checkpointId: checkpointIdFor(name),
-      script: baselineScript,
-      runAgent: async ({ prompt }) =>
-        prompt === 'stale file' ? staleResult : { malformed: true },
-    });
-    clearStoreCache();
+        const staleResult: AgentFinalResult = {
+          ...finalResult,
+          outputs: [{ ...finalResult.outputs[0], relativePath: 'stale.tex' }],
+        };
+        yield* Effect.promise(() =>
+          runPersistedWorkflowScript({
+            store: getExecutionStore(executionId),
+            checkpointId: checkpointIdFor(name),
+            script: baselineScript,
+            runAgent: async ({ prompt }) =>
+              prompt === 'stale file' ? staleResult : { malformed: true },
+          }),
+        );
+        clearStoreCache();
 
-    const currentResult: AgentFinalResult = {
-      ...finalResult,
-      cost: 0.25,
-      outputs: [{ ...finalResult.outputs[0], relativePath: 'current.tex' }],
-    };
-    const ports = fakePorts();
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name,
-        script: `export const meta = {
+        const currentResult: AgentFinalResult = {
+          ...finalResult,
+          cost: 0.25,
+          outputs: [{ ...finalResult.outputs[0], relativePath: 'current.tex' }],
+        };
+        const ports = fakePorts();
+        const strategy = createWorkflowScriptStrategy(
+          strategyParams({
+            name,
+            script: `export const meta = {
   name: '${name}',
   description: 'fails after current work',
 }
 await agent('current file')
 throw new Error('current revision failed')`,
-        createRunAgent: (hooks) => async (invocation) => {
-          hooks.onCost(invocation, currentResult.cost);
-          return currentResult;
-        },
+            createRunAgent: (hooks) => async (invocation) => {
+              hooks.onCost(invocation, currentResult.cost);
+              return currentResult;
+            },
+          }),
+        );
+
+        const failure = yield* Effect.flip(
+          strategy.launch(ports, new AbortController().signal),
+        );
+        expect(failure.message).toContain('current revision failed');
+        expect(ports.recordCost.mock.calls).toEqual([[0.25], [0.25]]);
+        const errText = yield* Effect.promise(async () =>
+          strategy.formatError(null, new Error('boom')),
+        );
+        expect(errText).toContain('current.tex');
+        expect(errText).not.toContain('stale.tex');
+        expect(errText).toContain('"costUsd":0.25');
       }),
-    );
+  );
 
-    await expect(
-      Effect.runPromise(strategy.launch(ports, new AbortController().signal)),
-    ).rejects.toThrow('current revision failed');
-    expect(ports.recordCost.mock.calls).toEqual([[0.25], [0.25]]);
-    const errText = await strategy.formatError(null, new Error('boom'));
-    expect(errText).toContain('current.tex');
-    expect(errText).not.toContain('stale.tex');
-    expect(errText).toContain('"costUsd":0.25');
-  });
+  it.live(
+    'keeps the delivery summary at the last persisted snapshot when snapshot writes fail',
+    () =>
+      Effect.gen(function* () {
+        const ports = fakePorts();
+        const strategy = createWorkflowScriptStrategy(
+          strategyParams({
+            name: 'snapshot-write-failure',
+            script,
+            createRunAgent: billingRunAgent,
+            onSnapshot: async () => {
+              throw new Error('snapshot disk full');
+            },
+          }),
+        );
 
-  it('keeps the delivery summary at the last persisted snapshot when snapshot writes fail', async () => {
-    const ports = fakePorts();
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'snapshot-write-failure',
-        script,
-        createRunAgent: billingRunAgent,
-        onSnapshot: async () => {
-          throw new Error('snapshot disk full');
-        },
+        const failure = yield* Effect.flip(
+          strategy.launch(ports, new AbortController().signal),
+        );
+        expect(failure.message).toContain(
+          'Failed to persist workflow execution snapshot',
+        );
+
+        // No snapshot was ever durably written, so the failure summary must
+        // report the durable view (nothing ran) rather than the newer in-memory
+        // snapshot the rejected write carried.
+        const errText = yield* Effect.promise(async () =>
+          strategy.formatError(null, new Error('boom')),
+        );
+        expect(errText).toContain('"outcome":"failed"');
+        expect(errText).toContain('"taskDone":0');
+        expect(errText).toContain('"taskTotal":0');
       }),
-    );
+  );
 
-    await expect(
-      Effect.runPromise(strategy.launch(ports, new AbortController().signal)),
-    ).rejects.toThrow('Failed to persist workflow execution snapshot');
-
-    // No snapshot was ever durably written, so the failure summary must
-    // report the durable view (nothing ran) rather than the newer in-memory
-    // snapshot the rejected write carried.
-    const errText = await strategy.formatError(null, new Error('boom'));
-    expect(errText).toContain('"outcome":"failed"');
-    expect(errText).toContain('"taskDone":0');
-    expect(errText).toContain('"taskTotal":0');
-  });
-
-  it('retains live spend when the completed journal result is malformed', async () => {
-    const malformedScript = `export const meta = {
+  it.live(
+    'retains live spend when the completed journal result is malformed',
+    () =>
+      Effect.gen(function* () {
+        const malformedScript = `export const meta = {
   name: 'malformed-cost',
   description: 'tests malformed journal cost settlement',
 }
 return await agent('saved call')`;
-    const ports = fakePorts();
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'malformed-cost',
-        script: malformedScript,
-        createRunAgent: (hooks) => async (invocation) => {
-          hooks.onCost(invocation, 0.2);
-          return { not: 'an agent result' };
-        },
-      }),
-    );
+        const ports = fakePorts();
+        const strategy = createWorkflowScriptStrategy(
+          strategyParams({
+            name: 'malformed-cost',
+            script: malformedScript,
+            createRunAgent: (hooks) => async (invocation) => {
+              hooks.onCost(invocation, 0.2);
+              return { not: 'an agent result' };
+            },
+          }),
+        );
 
-    await expect(
-      Effect.runPromise(strategy.launch(ports, new AbortController().signal)),
-    ).rejects.toThrow('Workflow journal entry 0 is not an agent final result');
-    expect(ports.recordCost.mock.calls).toEqual([[0.2]]);
-  });
+        const failure = yield* Effect.flip(
+          strategy.launch(ports, new AbortController().signal),
+        );
+        expect(failure.message).toContain(
+          'Workflow journal entry 0 is not an agent final result',
+        );
+        expect(ports.recordCost.mock.calls).toEqual([[0.2]]);
+      }),
+  );
 });
 
 /** Let queued abort/skip handling settle without resolving a hung run. */
@@ -521,136 +583,156 @@ describe('createWorkflowScriptStrategy interactive controls', () => {
   // engine's snapshot schema validates every id these fakes report.
   const grandchildExecutionId = 'ccccc0000001' as ExecutionId;
 
-  it('skips an in-flight grandchild by execution id via the session registry', async () => {
-    const fake = controllableRunAgent({
-      attemptExecutionIds: [grandchildExecutionId],
-    });
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'strategy-test',
-        createRunAgent: fake.createRunAgent,
+  it.live(
+    'skips an in-flight grandchild by execution id via the session registry',
+    () =>
+      Effect.gen(function* () {
+        const fake = controllableRunAgent({
+          attemptExecutionIds: [grandchildExecutionId],
+        });
+        const strategy = createWorkflowScriptStrategy(
+          strategyParams({
+            name: 'strategy-test',
+            createRunAgent: fake.createRunAgent,
+          }),
+        );
+
+        const launch = yield* Effect.forkChild(
+          strategy.launch(fakePorts(), new AbortController().signal),
+        );
+        yield* Effect.promise(() => fake.attemptStarted(1));
+        // An unknown execution id no-ops (the call stays in flight)...
+        workflowControls.control('ddddd0000009' as ExecutionId, 'skip');
+        // ...while the right one translates execId → index → engine skip.
+        workflowControls.control(grandchildExecutionId, 'skip');
+
+        const turn = yield* Fiber.join(launch);
+        expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);
+        expect(fake.attempts()).toBe(1);
+        // The registration is dropped when the run settles.
+        workflowControls.control(grandchildExecutionId, 'skip');
       }),
-    );
+  );
 
-    const launch = Effect.runPromise(
-      strategy.launch(fakePorts(), new AbortController().signal),
-    );
-    await fake.attemptStarted(1);
-    // An unknown execution id no-ops (the call stays in flight)...
-    workflowControls.control('ddddd0000009' as ExecutionId, 'skip');
-    // ...while the right one translates execId → index → engine skip.
-    workflowControls.control(grandchildExecutionId, 'skip');
+  it.live(
+    'retries an in-flight grandchild by execution id, re-running the call',
+    () =>
+      Effect.gen(function* () {
+        const fake = controllableRunAgent({
+          attemptExecutionIds: [grandchildExecutionId],
+          succeedAtAttempt: 2,
+          attemptCosts: [0.1, 0.5],
+        });
+        const logger = new TraceEmitter();
+        const completedTaskCosts: number[] = [];
+        logger.subscribe((event) => {
+          if (
+            event.type === 'workflow.call' &&
+            event.call.status === 'completed'
+          ) {
+            if (event.call.totalCostUsd !== undefined) {
+              completedTaskCosts.push(event.call.totalCostUsd);
+            }
+          }
+        });
+        const ports = fakePorts();
+        const strategy = createWorkflowScriptStrategy(
+          strategyParams({
+            name: 'strategy-test',
+            logger,
+            createRunAgent: fake.createRunAgent,
+          }),
+        );
 
-    const turn = await launch;
-    expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);
-    expect(fake.attempts()).toBe(1);
-    // The registration is dropped when the run settles.
-    workflowControls.control(grandchildExecutionId, 'skip');
-  });
+        const launch = yield* Effect.forkChild(
+          strategy.launch(ports, new AbortController().signal),
+        );
+        yield* Effect.promise(() => fake.attemptStarted(1));
+        workflowControls.control(grandchildExecutionId, 'retry');
 
-  it('retries an in-flight grandchild by execution id, re-running the call', async () => {
-    const fake = controllableRunAgent({
-      attemptExecutionIds: [grandchildExecutionId],
-      succeedAtAttempt: 2,
-      attemptCosts: [0.1, 0.5],
-    });
-    const logger = new TraceEmitter();
-    const completedTaskCosts: number[] = [];
-    logger.subscribe((event) => {
-      if (event.type === 'workflow.call' && event.call.status === 'completed') {
-        if (event.call.totalCostUsd !== undefined) {
-          completedTaskCosts.push(event.call.totalCostUsd);
-        }
-      }
-    });
-    const ports = fakePorts();
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'strategy-test',
-        logger,
-        createRunAgent: fake.createRunAgent,
+        const turn = yield* Fiber.join(launch);
+        // The second attempt settles with the real result, and the call ran twice.
+        expect(turn.result).toMatchObject({ category: 'workflow', cost: 0.42 });
+        expect(fake.attempts()).toBe(2);
+        expect(completedTaskCosts).toHaveLength(1);
+        expect(completedTaskCosts[0]).toBeCloseTo(0.6);
+        expect(ports.recordCost.mock.calls).toEqual([[0.1], [0.6], [0.6]]);
       }),
-    );
+  );
 
-    const launch = Effect.runPromise(
-      strategy.launch(ports, new AbortController().signal),
-    );
-    await fake.attemptStarted(1);
-    workflowControls.control(grandchildExecutionId, 'retry');
+  it.live(
+    'targets the attempt-specific execution id after a durable retry advances it',
+    () =>
+      Effect.gen(function* () {
+        // After a retry, the re-run registers its child stream under an
+        // attempt-specific id (not the logical id) — the id the roster exposes.
+        // The control bridge must follow that id, not the stale logical one.
+        const logicalExecutionId = grandchildExecutionId;
+        const attemptExecutionId = 'ccccc0000002' as ExecutionId;
+        const fake = controllableRunAgent({
+          attemptExecutionIds: [logicalExecutionId, attemptExecutionId],
+        });
+        const ports = fakePorts();
+        let settled = false;
+        const strategy = createWorkflowScriptStrategy(
+          strategyParams({
+            name: 'strategy-test',
+            createRunAgent: fake.createRunAgent,
+          }),
+        );
 
-    const turn = await launch;
-    // The second attempt settles with the real result, and the call ran twice.
-    expect(turn.result).toMatchObject({ category: 'workflow', cost: 0.42 });
-    expect(fake.attempts()).toBe(2);
-    expect(completedTaskCosts).toHaveLength(1);
-    expect(completedTaskCosts[0]).toBeCloseTo(0.6);
-    expect(ports.recordCost.mock.calls).toEqual([[0.1], [0.6], [0.6]]);
-  });
+        const launch = yield* Effect.forkChild(
+          strategy.launch(ports, new AbortController().signal).pipe(
+            Effect.tap(() =>
+              Effect.sync(() => {
+                settled = true;
+              }),
+            ),
+          ),
+        );
+        // Attempt 0 runs under the logical id; retry advances to attempt 1.
+        yield* Effect.promise(() => fake.attemptStarted(1));
+        workflowControls.control(logicalExecutionId, 'retry');
+        yield* Effect.promise(() => fake.attemptStarted(2));
 
-  it('targets the attempt-specific execution id after a durable retry advances it', async () => {
-    // After a retry, the re-run registers its child stream under an
-    // attempt-specific id (not the logical id) — the id the roster exposes.
-    // The control bridge must follow that id, not the stale logical one.
-    const logicalExecutionId = grandchildExecutionId;
-    const attemptExecutionId = 'ccccc0000002' as ExecutionId;
-    const fake = controllableRunAgent({
-      attemptExecutionIds: [logicalExecutionId, attemptExecutionId],
-    });
-    const ports = fakePorts();
-    let settled = false;
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'strategy-test',
-        createRunAgent: fake.createRunAgent,
+        // The stale logical id no longer maps to the in-flight attempt: a skip on
+        // it must no-op, leaving the run pending.
+        workflowControls.control(logicalExecutionId, 'skip');
+        yield* Effect.promise(drainMacrotasks);
+        expect(settled).toBe(false);
+
+        // The attempt-specific id the roster exposes reaches the engine index.
+        workflowControls.control(attemptExecutionId, 'skip');
+        const turn = yield* Fiber.join(launch);
+        expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);
+        expect(fake.attempts()).toBe(2);
       }),
-    );
+  );
 
-    const launch = Effect.runPromise(
-      strategy.launch(ports, new AbortController().signal),
-    ).then((turn) => {
-      settled = true;
-      return turn;
-    });
-    // Attempt 0 runs under the logical id; retry advances to attempt 1.
-    await fake.attemptStarted(1);
-    workflowControls.control(logicalExecutionId, 'retry');
-    await fake.attemptStarted(2);
+  it.live('reports skipped-attempt spend before the empty final journal', () =>
+    Effect.gen(function* () {
+      const fake = controllableRunAgent({
+        attemptExecutionIds: [grandchildExecutionId],
+      });
+      const ports = fakePorts();
+      const strategy = createWorkflowScriptStrategy(
+        strategyParams({
+          name: 'strategy-test',
+          createRunAgent: fake.createRunAgent,
+        }),
+      );
 
-    // The stale logical id no longer maps to the in-flight attempt: a skip on
-    // it must no-op, leaving the run pending.
-    workflowControls.control(logicalExecutionId, 'skip');
-    await drainMacrotasks();
-    expect(settled).toBe(false);
+      const launch = yield* Effect.forkChild(
+        strategy.launch(ports, new AbortController().signal),
+      );
+      yield* Effect.promise(() => fake.attemptStarted(1));
+      // Model tokens were spent before the user skipped the attempt.
+      fake.onCost(0.42);
+      workflowControls.control(grandchildExecutionId, 'skip');
 
-    // The attempt-specific id the roster exposes reaches the engine index.
-    workflowControls.control(attemptExecutionId, 'skip');
-    const turn = await launch;
-    expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);
-    expect(fake.attempts()).toBe(2);
-  });
-
-  it('reports skipped-attempt spend before the empty final journal', async () => {
-    const fake = controllableRunAgent({
-      attemptExecutionIds: [grandchildExecutionId],
-    });
-    const ports = fakePorts();
-    const strategy = createWorkflowScriptStrategy(
-      strategyParams({
-        name: 'strategy-test',
-        createRunAgent: fake.createRunAgent,
-      }),
-    );
-
-    const launch = Effect.runPromise(
-      strategy.launch(ports, new AbortController().signal),
-    );
-    await fake.attemptStarted(1);
-    // Model tokens were spent before the user skipped the attempt.
-    fake.onCost(0.42);
-    workflowControls.control(grandchildExecutionId, 'skip');
-
-    const turn = await launch;
-    expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);
-    expect(ports.recordCost.mock.calls).toEqual([[0.42], [0.42]]);
-  });
+      const turn = yield* Fiber.join(launch);
+      expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);
+      expect(ports.recordCost.mock.calls).toEqual([[0.42], [0.42]]);
+    }),
+  );
 });

--- a/src/test-kernel/tools/externalToolDefs.vitest.ts
+++ b/src/test-kernel/tools/externalToolDefs.vitest.ts
@@ -1,6 +1,7 @@
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, vi } from 'vitest';
 
 // Local imports - platform/test support/tools
 import { installPlatform } from '@test/support/setupPlatform';
@@ -23,57 +24,64 @@ function installToolAvailability(isTexraCliEntrypoint: boolean) {
   );
 }
 
+/** Restore the default platform the way each test's `finally` did. */
+const restorePlatform = <A, E, R>(
+  self: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  self.pipe(Effect.ensuring(Effect.promise(() => installPlatform())));
+
 describe('external tool definitions', () => {
-  it('detects the current TeXRA CLI process through the host checker', async () => {
-    const texraCli = findExternalToolDef('texra-cli');
-    if (!texraCli) throw new Error('TeXRA CLI tool definition should exist');
-    await installToolAvailability(true);
+  it.effect(
+    'detects the current TeXRA CLI process through the host checker',
+    () =>
+      restorePlatform(
+        Effect.gen(function* () {
+          const texraCli = findExternalToolDef('texra-cli');
+          if (!texraCli)
+            throw new Error('TeXRA CLI tool definition should exist');
+          yield* Effect.promise(() => installToolAvailability(true));
 
-    try {
-      const probeResult = await Effect.runPromise(texraCli.probe!());
+          const probeResult = yield* texraCli.probe!();
 
-      expect(probeResult).toBe(true);
-      expect(await Effect.runPromise(texraCli.check(probeResult))).toBe(true);
-      expect(await Effect.runPromise(texraCli.statusLabel!(probeResult))).toBe(
-        'Detected; integration coming soon',
-      );
-    } finally {
-      await installPlatform();
-    }
-  });
+          expect(probeResult).toBe(true);
+          expect(yield* texraCli.check(probeResult)).toBe(true);
+          expect(yield* texraCli.statusLabel!(probeResult)).toBe(
+            'Detected; integration coming soon',
+          );
+        }),
+      ),
+  );
 
-  it('detects Lean direct mode from the lake binary without running lake', async () => {
-    const lean = findExternalToolDef('lean4');
-    if (!lean) throw new Error('Lean tool definition should exist');
-    const findPath = vi
-      .spyOn(BinaryResolver, 'findPath')
-      .mockReturnValue('/usr/local/bin/lake');
-    await installToolAvailability(false);
+  it.effect(
+    'detects Lean direct mode from the lake binary without running lake',
+    () =>
+      restorePlatform(
+        Effect.gen(function* () {
+          const lean = findExternalToolDef('lean4');
+          if (!lean) throw new Error('Lean tool definition should exist');
+          const findPath = vi
+            .spyOn(BinaryResolver, 'findPath')
+            .mockReturnValue('/usr/local/bin/lake');
+          yield* Effect.promise(() => installToolAvailability(false));
 
-    try {
-      const probeResult = await Effect.runPromise(lean.probe!());
+          const probeResult = yield* lean.probe!();
 
-      expect(findPath).toHaveBeenCalledWith('lake');
-      expect(probeResult).toEqual({
-        extensionAvailable: false,
-        lakeAvailable: true,
-      });
-      await expect(Effect.runPromise(lean.check(probeResult))).resolves.toBe(
-        true,
-      );
+          expect(findPath).toHaveBeenCalledWith('lake');
+          expect(probeResult).toEqual({
+            extensionAvailable: false,
+            lakeAvailable: true,
+          });
+          expect(yield* lean.check(probeResult)).toBe(true);
 
-      findPath.mockReturnValue(null);
-      const missingProbeResult = await Effect.runPromise(lean.probe!());
+          findPath.mockReturnValue(null);
+          const missingProbeResult = yield* lean.probe!();
 
-      expect(missingProbeResult).toEqual({
-        extensionAvailable: false,
-        lakeAvailable: false,
-      });
-      await expect(
-        Effect.runPromise(lean.check(missingProbeResult)),
-      ).resolves.toBe(false);
-    } finally {
-      await installPlatform();
-    }
-  });
+          expect(missingProbeResult).toEqual({
+            extensionAvailable: false,
+            lakeAvailable: false,
+          });
+          expect(yield* lean.check(missingProbeResult)).toBe(false);
+        }),
+      ),
+  );
 });

--- a/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
+++ b/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
@@ -1,6 +1,7 @@
 // Third-party imports
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
 // Local imports
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -38,36 +39,34 @@ beforeEach(() => {
 });
 
 describe('shared setup capabilities', () => {
-  it('derives credential and configuration operations from platform ports', async () => {
-    const setup = getSetupPlatform();
+  it.effect(
+    'derives credential and configuration operations from platform ports',
+    () =>
+      Effect.gen(function* () {
+        const setup = getSetupPlatform();
 
-    expect(setup.host).toBe('extension');
-    expect(setup.commands).toBeUndefined();
-    expect(setup.extensions).toBeUndefined();
-    expect(setup.terminal).toBeUndefined();
-    await expect(
-      Effect.runPromise(setupSecrets.storedApiKeyExists('openai')),
-    ).resolves.toBe(true);
-    await expect(
-      Effect.runPromise(setupSecrets.hasUsableApiKey('openai')),
-    ).resolves.toBe(true);
-    await expect(
-      Effect.runPromise(setupSecrets.gitHubTokenExists()),
-    ).resolves.toBe('env');
-    await expect(
-      Effect.runPromise(setupSecrets.listStoredKeys()),
-    ).resolves.toContain('apiKey.openai');
+        expect(setup.host).toBe('extension');
+        expect(setup.commands).toBeUndefined();
+        expect(setup.extensions).toBeUndefined();
+        expect(setup.terminal).toBeUndefined();
+        expect(yield* setupSecrets.storedApiKeyExists('openai')).toBe(true);
+        expect(yield* setupSecrets.hasUsableApiKey('openai')).toBe(true);
+        expect(yield* setupSecrets.gitHubTokenExists()).toBe('env');
+        expect(yield* setupSecrets.listStoredKeys()).toContain('apiKey.openai');
 
-    expect(texraScopedConfig.get('texra.bib.defaultPath')).toBe(
-      'references.bib',
-    );
-    await Effect.runPromise(
-      texraScopedConfig.update('texra.bib.defaultPath', 'main.bib', 'user'),
-    );
-    expect(
-      workspaceRoots().config.inspect('texra.bib.defaultPath')?.globalValue,
-    ).toBe('main.bib');
-  });
+        expect(texraScopedConfig.get('texra.bib.defaultPath')).toBe(
+          'references.bib',
+        );
+        yield* texraScopedConfig.update(
+          'texra.bib.defaultPath',
+          'main.bib',
+          'user',
+        );
+        expect(
+          workspaceRoots().config.inspect('texra.bib.defaultPath')?.globalValue,
+        ).toBe('main.bib');
+      }),
+  );
 
   it('keeps the configuration boundary at texra.* keys', () => {
     expect(() => texraScopedConfig.get('editor.fontSize')).toThrow(
@@ -75,66 +74,74 @@ describe('shared setup capabilities', () => {
     );
   });
 
-  it('recognizes a stored key even when its value cannot be read', async () => {
-    vi.spyOn(platform().secrets, 'getStored').mockResolvedValue(undefined);
-    vi.spyOn(platform().secrets, 'listStoredKeys').mockResolvedValue([
-      'apiKey.openai',
-    ]);
+  it.effect('recognizes a stored key even when its value cannot be read', () =>
+    Effect.gen(function* () {
+      vi.spyOn(platform().secrets, 'getStored').mockResolvedValue(undefined);
+      vi.spyOn(platform().secrets, 'listStoredKeys').mockResolvedValue([
+        'apiKey.openai',
+      ]);
 
-    await expect(
-      Effect.runPromise(setupSecrets.storedApiKeyExists('openai')),
-    ).resolves.toBe(true);
-  });
+      expect(yield* setupSecrets.storedApiKeyExists('openai')).toBe(true);
+    }),
+  );
 
-  it('reports a signed-in account', async () => {
-    vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(true);
-    vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue(null);
+  it.effect('reports a signed-in account', () =>
+    Effect.gen(function* () {
+      vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(true);
+      vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue(null);
 
-    await expect(Effect.runPromise(getSetupAuthStatus())).resolves.toEqual({
-      authenticated: true,
-      email: undefined,
-    });
-  });
+      expect(yield* getSetupAuthStatus()).toEqual({
+        authenticated: true,
+        email: undefined,
+      });
+    }),
+  );
 
-  it('keeps API-key-only setup usable without reporting sign-in', async () => {
-    await expect(
-      Effect.runPromise(setupSecrets.anyUsableCredentialExists()),
-    ).resolves.toBe(true);
-    await expect(Effect.runPromise(getSetupAuthStatus())).resolves.toEqual({
-      authenticated: false,
-    });
-  });
+  it.effect('keeps API-key-only setup usable without reporting sign-in', () =>
+    Effect.gen(function* () {
+      expect(yield* setupSecrets.anyUsableCredentialExists()).toBe(true);
+      expect(yield* getSetupAuthStatus()).toEqual({
+        authenticated: false,
+      });
+    }),
+  );
 
-  it('does not expose ChatGPT account identifiers through setup tools', async () => {
-    vi.spyOn(codexAuth, 'getCodexStatus').mockResolvedValue({
-      signedIn: true,
-      email: 'researcher@example.com',
-      accountId: 'account-private-id',
-    });
+  it.effect(
+    'does not expose ChatGPT account identifiers through setup tools',
+    () =>
+      Effect.gen(function* () {
+        vi.spyOn(codexAuth, 'getCodexStatus').mockResolvedValue({
+          signedIn: true,
+          email: 'researcher@example.com',
+          accountId: 'account-private-id',
+        });
 
-    const status = await Effect.runPromise(getChatGptSubscriptionStatus());
+        const status = yield* getChatGptSubscriptionStatus();
 
-    expect(status.signedIn).toBe(true);
-    expect(status).not.toHaveProperty('account');
-    expect(JSON.stringify(status)).not.toContain('researcher@example.com');
-    expect(JSON.stringify(status)).not.toContain('account-private-id');
-  });
+        expect(status.signedIn).toBe(true);
+        expect(status).not.toHaveProperty('account');
+        expect(JSON.stringify(status)).not.toContain('researcher@example.com');
+        expect(JSON.stringify(status)).not.toContain('account-private-id');
+      }),
+  );
 
-  it('reports ChatGPT as disabled when runtime routing cannot use it', async () => {
-    vi.spyOn(codexAuth, 'getCodexStatus').mockResolvedValue({
-      signedIn: true,
-      email: 'researcher@example.com',
-    });
-    vi.spyOn(
-      providerCapabilities,
-      'isCodexSubscriptionActive',
-    ).mockResolvedValue(false);
+  it.effect(
+    'reports ChatGPT as disabled when runtime routing cannot use it',
+    () =>
+      Effect.gen(function* () {
+        vi.spyOn(codexAuth, 'getCodexStatus').mockResolvedValue({
+          signedIn: true,
+          email: 'researcher@example.com',
+        });
+        vi.spyOn(
+          providerCapabilities,
+          'isCodexSubscriptionActive',
+        ).mockResolvedValue(false);
 
-    await expect(
-      Effect.runPromise(getChatGptSubscriptionStatus()),
-    ).resolves.toEqual({
-      signedIn: true,
-      enabled: false,
-    });
-  });
+        expect(yield* getChatGptSubscriptionStatus()).toEqual({
+          signedIn: true,
+          enabled: false,
+        });
+      }),
+  );
 });

--- a/src/test-kernel/traceViewer/traceFrames.vitest.ts
+++ b/src/test-kernel/traceViewer/traceFrames.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { getExecutionRecords } from '@agent/storage';
 import { getStreamTabId } from '@agent/runtime/streamTab';
@@ -175,40 +176,44 @@ describe('traceEvents legacy-status fallback (issue #7188)', () => {
     expect(replayed).not.toHaveProperty('files');
   });
 
-  it('derives failed status from a real exported legacy trace without snapshot.status', async () => {
-    const executionId = 'abc124' as ExecutionId;
-    const config = parseConfig(AgentCategory.Workflow);
-    const streamId = getStreamTabId(config.agent, { executionId });
-    const session = createTestSession();
-    publishTestRunStart(session, streamId, executionId);
-    await session.settlePublications();
-    await Effect.runPromise(
-      getExecutionRecords(session, executionId).writeRunRecord(config),
-    );
-    session.publish([
-      {
-        type: 'stage.start',
-        aggregateId: qualifyAggregateId('stream', streamId),
-        id: 'terminal-stage',
-        label: 'Legacy run',
-      },
-      {
-        type: 'stage.end',
-        aggregateId: qualifyAggregateId('stream', streamId),
-        id: 'terminal-stage',
-        status: 'failed',
-      },
-    ]);
-    await session.settlePublications();
-    const result = await Effect.runPromise(assembleTrace(executionId, session));
-    session.dispose();
-    expect(result.status).toBe('ok');
-    if (result.status !== 'ok') return;
-    expect(result.trace.meta?.outcome).toBeUndefined();
-    expect(result.trace.snapshot.status).toBeUndefined();
+  // `it.live`: the session's publication settling and the record writes are
+  // real I/O, so nothing here waits on a test clock.
+  it.live(
+    'derives failed status from a real exported legacy trace without snapshot.status',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'abc124' as ExecutionId;
+        const config = parseConfig(AgentCategory.Workflow);
+        const streamId = getStreamTabId(config.agent, { executionId });
+        const session = createTestSession();
+        publishTestRunStart(session, streamId, executionId);
+        yield* Effect.promise(() => session.settlePublications());
+        yield* getExecutionRecords(session, executionId).writeRunRecord(config);
+        session.publish([
+          {
+            type: 'stage.start',
+            aggregateId: qualifyAggregateId('stream', streamId),
+            id: 'terminal-stage',
+            label: 'Legacy run',
+          },
+          {
+            type: 'stage.end',
+            aggregateId: qualifyAggregateId('stream', streamId),
+            id: 'terminal-stage',
+            status: 'failed',
+          },
+        ]);
+        yield* Effect.promise(() => session.settlePublications());
+        const result = yield* assembleTrace(executionId, session);
+        session.dispose();
+        expect(result.status).toBe('ok');
+        if (result.status !== 'ok') return;
+        expect(result.trace.meta?.outcome).toBeUndefined();
+        expect(result.trace.snapshot.status).toBeUndefined();
 
-    expect(foldTrace(result.trace)?.status).toBe('failed');
-  });
+        expect(foldTrace(result.trace)?.status).toBe('failed');
+      }),
+  );
 
   it('ignores nested group-end status when the root run stage never closed', () => {
     const trace: TraceDocument = {

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
 import { getExecutionRecords } from '@agent/storage';
 import { registerExecution } from '@agent/storage/executionLifecycle';
@@ -40,21 +41,16 @@ const tempDirs = useTempDirs();
 let session: ReturnType<typeof createTestSession>;
 
 /** Populate the transcript input consumed by the export. */
-async function appendLogEntry(
-  streamId: StreamTabId,
-  text: string,
-): Promise<void> {
-  await Effect.runPromise(
-    session.commit([
-      {
-        type: 'log',
-        aggregateId: aggregateId('stream', streamId),
-        level: LOG_LEVELS.INFO,
-        messageType: MESSAGE_TYPES.DEFAULT,
-        message: text,
-      },
-    ]),
-  );
+function appendLogEntry(streamId: StreamTabId, text: string) {
+  return session.commit([
+    {
+      type: 'log',
+      aggregateId: aggregateId('stream', streamId),
+      level: LOG_LEVELS.INFO,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      message: text,
+    },
+  ]);
 }
 
 function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
@@ -69,29 +65,29 @@ function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
 }
 
 /** Persist a run record plus a meta row for an execution. */
-async function writeExecution(
+function writeExecution(
   executionId: ExecutionId,
   meta: { outcome?: RunOutcome; streamId?: StreamTabId } = {},
   executionConfig: AgentConfig = config(),
-): Promise<void> {
-  const streamId =
-    meta.streamId ?? getStreamTabId(executionConfig.agent, { executionId });
-  publishTestRunStart(session, streamId, executionId);
-  await session.settlePublications();
-  await Effect.runPromise(
-    getExecutionRecords(session, executionId).writeRunRecord(executionConfig),
-  );
-  if (meta.outcome)
-    await Effect.runPromise(
-      session.commit([
+) {
+  return Effect.gen(function* () {
+    const streamId =
+      meta.streamId ?? getStreamTabId(executionConfig.agent, { executionId });
+    publishTestRunStart(session, streamId, executionId);
+    yield* Effect.promise(() => session.settlePublications());
+    yield* getExecutionRecords(session, executionId).writeRunRecord(
+      executionConfig,
+    );
+    if (meta.outcome)
+      yield* session.commit([
         {
           type: 'status',
           aggregateId: aggregateId('stream', streamId),
           phase: meta.outcome,
           cause: 'lifecycle',
         },
-      ]),
-    );
+      ]);
+  });
 }
 
 type AssembleTraceResult = Effect.Success<ReturnType<typeof assembleTrace>>;
@@ -116,123 +112,140 @@ describe('assembleTrace', () => {
     vi.restoreAllMocks();
   });
 
-  it('resolves a registered execution from its metadata without any sidecar scan (#9590 A1)', async () => {
-    const executionId = 'abc900abc900' as ExecutionId;
-    const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
-    // Registered under a stream the config would NOT derive: proves the read
-    // comes from execution metadata, not from agent/model reconstruction.
-    const registeredId = `chat@earlierModel#${executionId}` as StreamTabId;
-    await Effect.runPromise(
-      registerExecution(session, executionId, executionConfig, 'review', {
-        streamId: registeredId,
-        identity: { kind: 'agent', agent: 'review' },
+  it.effect(
+    'resolves a registered execution from its metadata without any sidecar scan (#9590 A1)',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'abc900abc900' as ExecutionId;
+        const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
+        // Registered under a stream the config would NOT derive: proves the
+        // read comes from execution metadata, not from agent/model
+        // reconstruction.
+        const registeredId = `chat@earlierModel#${executionId}` as StreamTabId;
+        yield* registerExecution(
+          session,
+          executionId,
+          executionConfig,
+          'review',
+          {
+            streamId: registeredId,
+            identity: { kind: 'agent', agent: 'review' },
+          },
+        );
+        yield* Effect.promise(() => releaseOwnedExecutionLease(executionId));
+        yield* appendLogEntry(registeredId, 'registered row');
+
+        const scan = vi.spyOn(
+          StreamSnapshotStore.prototype,
+          'listPersistedStreams',
+        );
+
+        const trace = unwrapOkTrace(yield* assembleTrace(executionId, session));
+
+        expect(trace.streamId).toBe(registeredId);
+        expect(scan).not.toHaveBeenCalled();
       }),
-    );
-    await releaseOwnedExecutionLease(executionId);
-    await appendLogEntry(registeredId, 'registered row');
+  );
 
-    const scan = vi.spyOn(
-      StreamSnapshotStore.prototype,
-      'listPersistedStreams',
-    );
+  it.effect(
+    'assembles a full trace document from the streamId stamped on execution metadata',
+    () =>
+      Effect.gen(function* () {
+        const executionId = 'aa11bb22cc33' as ExecutionId;
+        const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
+        const streamId = getStreamTabId('review', { executionId });
 
-    const trace = unwrapOkTrace(
-      await Effect.runPromise(assembleTrace(executionId, session)),
-    );
+        yield* writeExecution(
+          executionId,
+          { outcome: 'completed', streamId },
+          executionConfig,
+        );
+        yield* appendLogEntry(streamId, 'hello');
+        const todos = [
+          {
+            content: 'Check the argument',
+            activeForm: 'Checking the argument',
+            status: 'pending' as const,
+          },
+        ];
+        session.publish([
+          {
+            type: 'updateTodos',
+            aggregateId: aggregateId('stream', streamId),
+            todos,
+          },
+        ]);
+        yield* Effect.promise(() => settleSessionEvents());
 
-    expect(trace.streamId).toBe(registeredId);
-    expect(scan).not.toHaveBeenCalled();
-  });
+        const trace = unwrapOkTrace(yield* assembleTrace(executionId, session));
 
-  it('assembles a full trace document from the streamId stamped on execution metadata', async () => {
-    const executionId = 'aa11bb22cc33' as ExecutionId;
-    const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
-    const streamId = getStreamTabId('review', { executionId });
+        expect(trace.streamId).toBe(streamId);
+        expect(trace.config).toMatchObject({
+          agent: 'review',
+          model: 'sonnet46T',
+        });
+        expect(trace.entries).toHaveLength(1);
+        expect(trace.entries[0]).toMatchObject({
+          text: 'hello',
+        });
+        expect(trace.meta?.outcome).toBe('completed');
+        expect(trace.snapshot.streamId).toBe(streamId);
+        expect(trace.snapshot.todos).toEqual(todos);
+      }),
+  );
 
-    await writeExecution(
-      executionId,
-      { outcome: 'completed', streamId },
-      executionConfig,
-    );
-    await appendLogEntry(streamId, 'hello');
-    const todos = [
-      {
-        content: 'Check the argument',
-        activeForm: 'Checking the argument',
-        status: 'pending' as const,
-      },
-    ];
-    session.publish([
-      {
-        type: 'updateTodos',
-        aggregateId: aggregateId('stream', streamId),
-        todos,
-      },
-    ]);
-    await settleSessionEvents();
+  it.effect('returns config_missing when no config was ever written', () =>
+    Effect.gen(function* () {
+      const result = yield* assembleTrace(
+        'exec-no-config' as ExecutionId,
+        session,
+      );
+      expect(result).toEqual({ status: 'config_missing' });
+    }),
+  );
 
-    const trace = unwrapOkTrace(
-      await Effect.runPromise(assembleTrace(executionId, session)),
-    );
+  it.effect('exports a registered stream with an empty transcript', () =>
+    Effect.gen(function* () {
+      const executionId = 'eec000001' as ExecutionId;
+      const streamId = getStreamTabId('orchestrator', { executionId });
+      yield* writeExecution(executionId, { streamId });
 
-    expect(trace.streamId).toBe(streamId);
-    expect(trace.config).toMatchObject({
-      agent: 'review',
-      model: 'sonnet46T',
-    });
-    expect(trace.entries).toHaveLength(1);
-    expect(trace.entries[0]).toMatchObject({
-      text: 'hello',
-    });
-    expect(trace.meta?.outcome).toBe('completed');
-    expect(trace.snapshot.streamId).toBe(streamId);
-    expect(trace.snapshot.todos).toEqual(todos);
-  });
+      const result = yield* assembleTrace(executionId, session);
 
-  it('returns config_missing when no config was ever written', async () => {
-    const result = await Effect.runPromise(
-      assembleTrace('exec-no-config' as ExecutionId, session),
-    );
-    expect(result).toEqual({ status: 'config_missing' });
-  });
+      expect(unwrapOkTrace(result).entries).toEqual([]);
+    }),
+  );
 
-  it('exports a registered stream with an empty transcript', async () => {
-    const executionId = 'eec000001' as ExecutionId;
-    const streamId = getStreamTabId('orchestrator', { executionId });
-    await writeExecution(executionId, { streamId });
+  it.effect(
+    'resolves a tool-format child stream through its stamped metadata, not name derivation',
+    () =>
+      Effect.gen(function* () {
+        // Background child streams (bash/codex/claude subagents, see
+        // @tools/delegation/childStream.createChildStream) share
+        // getStreamTabId's format but carry a tool-specific prefix, disjoint
+        // from any agent name — the stamped meta.streamId is the only mapping
+        // that reaches them.
+        const executionId = 'eec000002' as ExecutionId;
+        const executionConfig = config({
+          agent: 'orchestrator',
+          model: 'deepseekT',
+        });
+        const actualChildStreamId = `bash@tool#${executionId}` as StreamTabId;
+        expect(actualChildStreamId).not.toBe(
+          getStreamTabId('orchestrator', { executionId }),
+        );
+        yield* writeExecution(
+          executionId,
+          { outcome: 'completed', streamId: actualChildStreamId },
+          executionConfig,
+        );
 
-    const result = await Effect.runPromise(assembleTrace(executionId, session));
+        yield* appendLogEntry(actualChildStreamId, 'child stream output');
 
-    expect(unwrapOkTrace(result).entries).toEqual([]);
-  });
+        const trace = unwrapOkTrace(yield* assembleTrace(executionId, session));
 
-  it('resolves a tool-format child stream through its stamped metadata, not name derivation', async () => {
-    // Background child streams (bash/codex/claude subagents, see
-    // @tools/delegation/childStream.createChildStream) share getStreamTabId's
-    // format but carry a tool-specific prefix, disjoint from any agent name —
-    // the stamped meta.streamId is the only mapping that reaches them.
-    const executionId = 'eec000002' as ExecutionId;
-    const executionConfig = config({
-      agent: 'orchestrator',
-      model: 'deepseekT',
-    });
-    const actualChildStreamId = `bash@tool#${executionId}` as StreamTabId;
-    expect(actualChildStreamId).not.toBe(
-      getStreamTabId('orchestrator', { executionId }),
-    );
-    await writeExecution(
-      executionId,
-      { outcome: 'completed', streamId: actualChildStreamId },
-      executionConfig,
-    );
-
-    await appendLogEntry(actualChildStreamId, 'child stream output');
-
-    const trace = unwrapOkTrace(
-      await Effect.runPromise(assembleTrace(executionId, session)),
-    );
-
-    expect(trace.streamId).toBe(actualChildStreamId);
-    expect(trace.entries).toHaveLength(1);
-  });
+        expect(trace.streamId).toBe(actualChildStreamId);
+        expect(trace.entries).toHaveLength(1);
+      }),
+  );
 });

--- a/src/test-kernel/transcript/traceViewerSchema.vitest.ts
+++ b/src/test-kernel/transcript/traceViewerSchema.vitest.ts
@@ -1,5 +1,6 @@
+import { it } from '@effect/vitest';
 import { Effect } from 'effect';
-import { describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { getExecutionRecords } from '@agent/storage';
 import { getStreamTabId } from '@agent/runtime/streamTab';
@@ -72,49 +73,51 @@ function expectTraceRejected(payload: unknown): void {
 describe('trace-viewer TraceDataSchema', () => {
   setupPlatform(() => createTempDirPlatform('texra-trace-viewer-', tempDirs));
 
-  it('accepts a real trace document produced by assembleTrace', async () => {
-    const executionId = 'abc12345' as ExecutionId;
-    const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
+  it.live('accepts a real trace document produced by assembleTrace', () =>
+    Effect.gen(function* () {
+      const executionId = 'abc12345' as ExecutionId;
+      const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
 
-    const streamId = getStreamTabId('review', { executionId });
-    const session = createTestSession();
-    publishTestRunStart(session, streamId, executionId);
-    await session.settlePublications();
-    await Effect.runPromise(
-      getExecutionRecords(session, executionId).writeRunRecord(executionConfig),
-    );
-    session.publish([
-      {
-        type: 'log',
-        aggregateId: aggregateId('stream', streamId),
-        message: 'hello',
-        level: LOG_LEVELS.INFO,
-        messageType: MESSAGE_TYPES.DEFAULT,
-      },
-      {
-        type: 'status',
-        aggregateId: aggregateId('stream', streamId),
-        phase: 'completed',
-        cause: 'lifecycle',
-      },
-    ]);
-    await session.settlePublications();
-    const result = await Effect.runPromise(assembleTrace(executionId, session));
-    session.dispose();
-    expect(result.status).toBe('ok');
-    if (result.status !== 'ok') return;
+      const streamId = getStreamTabId('review', { executionId });
+      const session = createTestSession();
+      publishTestRunStart(session, streamId, executionId);
+      yield* Effect.promise(() => session.settlePublications());
+      yield* getExecutionRecords(session, executionId).writeRunRecord(
+        executionConfig,
+      );
+      session.publish([
+        {
+          type: 'log',
+          aggregateId: aggregateId('stream', streamId),
+          message: 'hello',
+          level: LOG_LEVELS.INFO,
+          messageType: MESSAGE_TYPES.DEFAULT,
+        },
+        {
+          type: 'status',
+          aggregateId: aggregateId('stream', streamId),
+          phase: 'completed',
+          cause: 'lifecycle',
+        },
+      ]);
+      yield* Effect.promise(() => session.settlePublications());
+      const result = yield* assembleTrace(executionId, session);
+      session.dispose();
+      expect(result.status).toBe('ok');
+      if (result.status !== 'ok') return;
 
-    const parsed = TraceDataSchema.safeParse(result.trace);
-    expect(parsed.success).toBe(true);
-    if (!parsed.success) return;
-    expect(parsed.data.executionId).toBe(executionId);
-    expect(parsed.data.streamId).toBe(streamId);
-    expect(parsed.data.meta?.outcome).toBe('completed');
-    expect(parsed.data.entries).toHaveLength(1);
+      const parsed = TraceDataSchema.safeParse(result.trace);
+      expect(parsed.success).toBe(true);
+      if (!parsed.success) return;
+      expect(parsed.data.executionId).toBe(executionId);
+      expect(parsed.data.streamId).toBe(streamId);
+      expect(parsed.data.meta?.outcome).toBe('completed');
+      expect(parsed.data.entries).toHaveLength(1);
 
-    // parseTraceData must accept the same real document without throwing.
-    expect(() => parseTraceData(result.trace)).not.toThrow();
-  });
+      // parseTraceData must accept the same real document without throwing.
+      expect(() => parseTraceData(result.trace)).not.toThrow();
+    }),
+  );
 
   it('rejects a trace missing required top-level fields', () => {
     // config, meta, entries and snapshot all missing.


### PR DESCRIPTION
## What

The test-kernel has 213 files importing `effect` but only 78 using `@effect/vitest`. This converts the mechanical half of that gap.

Suites whose test bodies hand-run Effect programs now use the idiom the 78 existing files already established:

```ts
// before
it('does the thing', async () => {
  const result = await Effect.runPromise(program);
  expect(result).toBe(42);
});

// after
it.effect('does the thing', () =>
  Effect.gen(function* () {
    const result = yield* program;
    expect(result).toBe(42);
  }));
```

**52 files converted, 8017 insertions / 7158 deletions.** No production code, tsconfig, or ratchet baseline touched.

## Behavior preservation

Diffed every file against the base:

- Test-declaration counts identical in all 52 (alias-aware — batch 12 uses an `effectIt` alias)
- `expect()` counts identical in all 52 — no assertion dropped or stranded outside a generator
- No `.skip` / `.only` / `.todo` and no `describe.skip/only` introduced; the 1 skipped test is pre-existing
- `expect` still imported from `vitest`. The repo's dual assert+expect style is deliberate and is not normalized here.

## What was deliberately left alone

39 of the 91 candidate files. Skipping was a designed outcome, not a shortfall — the two recurring reasons:

- **The `run*` site is fixture plumbing, not the program under test.** `beforeAll(() => Effect.runPromise(refresh(...)))` with promise-shaped assertions in every body; converting means wrapping awaits in `Effect.promise` for no gain.
- **`vi.useFakeTimers`.** It fights `TestClock`, and the interaction is not mechanical.

Also left partial: 10 of 35 tests in `AgentRunLifecycle.vitest.ts` — 4 assert via `.rejects.toThrow()` (an Exit/flip rewrite would change the assertion) and 6 are stop/kill races that fork an unawaited run and poll with `vi.waitFor`.

## Gates

| Gate | Result |
|---|---|
| `tsc -p tsconfig.test-kernel.json` | 0 errors |
| workspace / agent / llm / cli / cli-scripts / trace-viewer / desktop (×5) | 0 errors each |
| `vitest run src/test-kernel` | 741 files, 9052 passed, 1 skipped (pre-existing) — run twice, identical |
| `lint` | clean |
| `check-effect-migration-ratchet` | at baseline, no `--update` needed |
| `prettier --check` on all 52 | clean |

Note for anyone reproducing in a worktree: `npm run typecheck` cannot run end-to-end where the root `node_modules` is a symlink (pnpm refuses the task-run-state path), and the per-package `node_modules` must be symlinked too or tsc reports ~2700 phantom errors. The seven sub-project compilers were run directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)