### PR TITLE
simplify(tools): delete write-only agent-CLI session-id persistence

### DIFF
--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -33,7 +33,6 @@ import {
   launchAgentCliSession,
   reraiseAgentCliCallFailure,
 } from '@tools/agentCliShared';
-import { codexThreadsFor } from '@tools/agentCliSessionStores';
 import {
   createChildStream,
   type ChildStream,
@@ -519,7 +518,6 @@ describe('child stream progress events', () => {
               description: 'Cancelled admission',
               config,
               registerFailedMessage: 'registration failed',
-              store: codexThreadsFor,
               startLoop,
               summary: 'unreachable',
               launchedLine: 'unreachable',
@@ -586,7 +584,6 @@ describe('child stream progress events', () => {
                 description: 'Fail during synchronous loop setup',
                 config,
                 registerFailedMessage: 'registration failed',
-                store: codexThreadsFor,
                 startLoop: (context) => {
                   childStream = context.childStream;
                   childExecutionId = context.executionId;

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -329,10 +329,7 @@ describe('childRunLoop E2E fixtures', () => {
 
   it('unwinds provider ownership and loop resources when synchronous setup fails', async () => {
     const { childStreamId, executionId } = loopIds('setup-failure');
-    const registry = new AgentCliSessionRegistry(
-      'test_session_id',
-      session.executions,
-    );
+    const registry = new AgentCliSessionRegistry(session.executions);
     const releaseSessionOwnership = vi.fn(() =>
       registry.releaseByExecutionId(executionId),
     );

--- a/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
+++ b/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { it } from '@effect/vitest';
-import { Effect, Fiber, type Scheduler } from 'effect';
+import { Effect, Fiber } from 'effect';
 import { describe, expect, vi } from 'vitest';
 
 // Local imports
@@ -12,201 +12,13 @@ import {
 } from '@test/support/executionHandleFixtures';
 import { AgentCliSessionRegistry } from '@tools/agentCliSessionRegistry';
 
-/** Run the registry's persistence drain at the test's edge until it ends. */
-const withDrain = <A, E, R>(
-  registry: AgentCliSessionRegistry,
-  body: Effect.Effect<A, E, R>,
-): Effect.Effect<A, E, R> =>
-  Effect.acquireUseRelease(
-    Effect.forkChild(registry.persistenceDrain()),
-    () => body,
-    (drain) => Fiber.interrupt(drain),
-  );
-
 describe('AgentCliSessionRegistry', () => {
-  // `it.live`: the sweep drives a custom real-time scheduler by hand and
-  // polls with `vi.waitFor`, neither of which the TestClock `it.effect`
-  // installs can advance.
-  it.live(
-    'keeps a queued mapping when a drain is interrupted at a scheduler handoff',
-    () =>
-      Effect.gen(function* () {
-        // Sweep actual runtime yield points through dequeue and persistence. A
-        // surviving drain must find the write unless the retiring drain owns it.
-        for (let pauseAfter = 2; pauseAfter < 80; pauseAfter++) {
-          const tasks: Array<() => void> = [];
-          let operations = 0;
-          const scheduler: Scheduler.Scheduler = {
-            executionMode: 'async',
-            shouldYield: () => ++operations === pauseAfter,
-            makeDispatcher: () => ({
-              scheduleTask: (task) => tasks.push(task),
-              flush: () => {
-                while (tasks.length > 0) tasks.shift()?.();
-              },
-            }),
-          };
-          const executions = testExecutionRegistry();
-          const persistSessionId = vi.fn(async () => {});
-          const registry = new AgentCliSessionRegistry(
-            'test_session_id',
-            executions,
-            {
-              persistSessionId,
-              reportPersistenceFailure: vi.fn(),
-            },
-          );
-          registry.register('session-handoff', {
-            childStreamId: 'child-handoff' as StreamTabId,
-            executionId: 'execution-handoff' as ExecutionId,
-          });
-          const retiring = Effect.runFork(registry.persistenceDrain(), {
-            scheduler,
-          });
-          // runFork starts the interrupt synchronously: the signal must be
-          // set before the drain below, because the retiring fiber can be
-          // suspended at a scheduler handoff whose only resumption lives in
-          // `tasks`. Signaling late deadlocks the interrupt's settlement.
-          const interrupting = Effect.runFork(Fiber.interrupt(retiring));
-          // The paused scheduler also owns cancellation cleanup and promise
-          // settlement. Drain it before starting the surviving consumer.
-          yield* Effect.promise(async () => {
-            for (let step = 0; step < 100; step++) {
-              while (tasks.length > 0) tasks.shift()?.();
-              await Promise.resolve();
-            }
-          });
-          yield* Fiber.join(interrupting);
-          try {
-            yield* withDrain(
-              registry,
-              Effect.promise(() =>
-                vi.waitFor(() =>
-                  expect(persistSessionId).toHaveBeenCalledOnce(),
-                ),
-              ),
-            );
-            expect(persistSessionId).toHaveBeenCalledWith(
-              'execution-handoff',
-              'test_session_id',
-              'session-handoff',
-            );
-          } finally {
-            executions.dispose();
-          }
-        }
-      }),
-  );
-
-  it.live.each([
-    {
-      kind: 'rejected',
-      makePersist: (error: Error) => vi.fn().mockRejectedValueOnce(error),
-    },
-    {
-      kind: 'thrown',
-      makePersist: (error: Error) =>
-        vi.fn(() => {
-          throw error;
-        }),
-    },
-  ])(
-    'contains a $kind session mapping write failure without awaiting registration',
-    ({ makePersist }) =>
-      Effect.gen(function* () {
-        const executionId = 'execution-write-failure' as ExecutionId;
-        const writeError = new Error('storage unavailable');
-        const persistSessionId = makePersist(writeError);
-        const reportPersistenceFailure = vi.fn();
-        const executions = testExecutionRegistry();
-        const registry = new AgentCliSessionRegistry(
-          'test_session_id',
-          executions,
-          {
-            persistSessionId,
-            reportPersistenceFailure,
-          },
-        );
-
-        try {
-          yield* withDrain(
-            registry,
-            Effect.gen(function* () {
-              expect(
-                registry.register('session-write-failure', {
-                  childStreamId: 'child-write-failure' as StreamTabId,
-                  executionId,
-                }),
-              ).toBeUndefined();
-
-              yield* Effect.promise(() =>
-                vi.waitFor(() => {
-                  expect(reportPersistenceFailure).toHaveBeenCalledWith(
-                    executionId,
-                    writeError,
-                  );
-                }),
-              );
-              expect(reportPersistenceFailure).toHaveBeenCalledOnce();
-              expect(persistSessionId).toHaveBeenCalledOnce();
-              expect(registry.lookup('session-write-failure')).toBeDefined();
-            }),
-          );
-        } finally {
-          registry.release('session-write-failure');
-          executions.dispose();
-        }
-      }),
-  );
-
-  it.live('contains diagnostic failures after a rejected mapping write', () =>
-    Effect.gen(function* () {
-      const persistSessionId = vi
-        .fn()
-        .mockRejectedValueOnce(new Error('storage unavailable'));
-      const executions = testExecutionRegistry();
-      const registry = new AgentCliSessionRegistry(
-        'test_session_id',
-        executions,
-        {
-          persistSessionId,
-          reportPersistenceFailure: () => {
-            throw new Error('log sink unavailable');
-          },
-        },
-      );
-
-      yield* withDrain(
-        registry,
-        Effect.gen(function* () {
-          registry.register('session-log-failure', {
-            childStreamId: 'child-log-failure' as StreamTabId,
-            executionId: 'execution-log-failure' as ExecutionId,
-          });
-
-          yield* Effect.promise(() =>
-            vi.waitFor(() => expect(persistSessionId).toHaveBeenCalledOnce()),
-          );
-          yield* Effect.promise(
-            () => new Promise((resolve) => setImmediate(resolve)),
-          );
-          expect(registry.lookup('session-log-failure')).toBeDefined();
-        }),
-      );
-      registry.release('session-log-failure');
-      executions.dispose();
-    }),
-  );
-
   it.effect(
     'atomically claims a session id and wakes waiters when it becomes active',
     () =>
       Effect.gen(function* () {
         const executions = testExecutionRegistry();
-        const registry = new AgentCliSessionRegistry(
-          'test_session_id',
-          executions,
-        );
+        const registry = new AgentCliSessionRegistry(executions);
         const entry = {
           childStreamId: 'child-a' as StreamTabId,
           executionId: 'execution-a' as ExecutionId,
@@ -251,10 +63,7 @@ describe('AgentCliSessionRegistry', () => {
     () =>
       Effect.gen(function* () {
         const executions = testExecutionRegistry();
-        const registry = new AgentCliSessionRegistry(
-          'test_session_id',
-          executions,
-        );
+        const registry = new AgentCliSessionRegistry(executions);
 
         try {
           const releaseClaim = registry.claim('session-a');
@@ -279,7 +88,7 @@ describe('AgentCliSessionRegistry', () => {
 
   it('releases every active alias owned by one execution', () => {
     const executions = testExecutionRegistry();
-    const registry = new AgentCliSessionRegistry('test_session_id', executions);
+    const registry = new AgentCliSessionRegistry(executions);
     const executionA = 'execution-a' as ExecutionId;
     const executionB = 'execution-b' as ExecutionId;
     const entry = (executionId: ExecutionId, childStreamId: StreamTabId) => ({
@@ -318,7 +127,7 @@ describe('AgentCliSessionRegistry', () => {
   it('interrupts an in-flight loop without promoting its reserved resume id', () => {
     const executionId = 'execution-in-flight' as ExecutionId;
     const interrupt = vi.fn();
-    const registry = new AgentCliSessionRegistry('test_session_id', {
+    const registry = new AgentCliSessionRegistry({
       getAgentHandleByStream: () => ({ interrupt }),
     } as unknown as ExecutionRegistry);
     const releaseClaim = registry.claim('reserved-session');
@@ -340,7 +149,7 @@ describe('AgentCliSessionRegistry', () => {
 
   it('interrupts each child through the session execution registry', () => {
     const executions = testExecutionRegistry();
-    const registry = new AgentCliSessionRegistry('test_session_id', executions);
+    const registry = new AgentCliSessionRegistry(executions);
     const interruptA = vi.fn();
     const interruptB = vi.fn();
 

--- a/src/tools/agentCliSessionRegistry.ts
+++ b/src/tools/agentCliSessionRegistry.ts
@@ -1,69 +1,8 @@
-import { Data, Deferred, Effect, Option, Queue } from 'effect';
+import { Deferred, Effect } from 'effect';
 
-import { getExecutionStore } from '@agent/storage';
 import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
-import { createLog } from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-
-const logger = createLog('AgentCliSessionRegistry');
-
-interface AgentCliSessionRegistryDependencies {
-  persistSessionId(
-    executionId: ExecutionId,
-    key: string,
-    sessionId: string,
-  ): Promise<void>;
-  reportPersistenceFailure(executionId: ExecutionId, error: unknown): void;
-}
-
-const DEFAULT_DEPENDENCIES: AgentCliSessionRegistryDependencies = {
-  persistSessionId: (executionId, key, sessionId) =>
-    getExecutionStore(executionId).write(key, sessionId),
-  reportPersistenceFailure: (executionId, error) => {
-    logger.debug(`Failed to persist CLI session mapping for ${executionId}`, {
-      data: error,
-    });
-  },
-};
-
-/** The session-mapping write rejected or threw; `cause` is what it raised. */
-class SessionMappingWriteFailed extends Data.TaggedError(
-  'SessionMappingWriteFailed',
-)<{ readonly cause: unknown }> {}
-
-/**
- * Persist one SDK session id for a child execution. A write failure is
- * reported through the injected diagnostics sink and otherwise contained:
- * registration never waits on it and never fails because of it. The sink
- * itself throwing is a defect of the drain fiber, not a rejection anyone
- * observes.
- */
-const persistSessionMapping = Effect.fn(
-  'AgentCliSessionRegistry.persistSessionMapping',
-)(function* (
-  dependencies: AgentCliSessionRegistryDependencies,
-  executionId: ExecutionId,
-  key: string,
-  sessionId: string,
-) {
-  yield* Effect.tryPromise({
-    try: () => dependencies.persistSessionId(executionId, key, sessionId),
-    catch: (cause) => new SessionMappingWriteFailed({ cause }),
-  }).pipe(
-    Effect.catchTag('SessionMappingWriteFailed', (failure) =>
-      Effect.sync(() =>
-        dependencies.reportPersistenceFailure(executionId, failure.cause),
-      ),
-    ),
-  );
-});
-
-/** One queued session-mapping persistence write. */
-interface SessionMappingWrite {
-  readonly executionId: ExecutionId;
-  readonly sessionId: string;
-}
 
 /**
  * What the registry tracks about one live agent-CLI session: the child run's
@@ -97,19 +36,8 @@ function settleReservation(
 export class AgentCliSessionRegistry {
   private readonly sessions = new Map<string, AgentCliSessionState>();
   private readonly inFlight = new Map<ExecutionId, AgentCliSessionEntry>();
-  /**
-   * The write queue a live drain takes from. Created by the first
-   * {@link persistenceDrain}; absent before any drain starts, in which case
-   * {@link register} buffers instead.
-   */
-  private writes: Queue.Queue<SessionMappingWrite> | undefined;
-  private readonly bufferedWrites: SessionMappingWrite[] = [];
 
-  constructor(
-    private readonly persistedSessionKey: string,
-    private readonly executions: ExecutionRegistry,
-    private readonly dependencies: AgentCliSessionRegistryDependencies = DEFAULT_DEPENDENCIES,
-  ) {}
+  constructor(private readonly executions: ExecutionRegistry) {}
 
   /**
    * Atomically reserve an unowned SDK session id. Returns a release handle
@@ -132,70 +60,14 @@ export class AgentCliSessionRegistry {
   }
 
   /**
-   * Register an active external-agent session and queue its SDK id for
-   * persistence (for later display or cross-reference after an extension
-   * reload clears memory). When the id was reserved, registration also wakes
-   * callers waiting to enqueue a follow-up on the new loop. The write itself
-   * is taken by a {@link persistenceDrain} fiber — the boundary that launches
-   * a loop forks one — so registration never waits on it and never fails
-   * because of it. A write registered before the first drain starts is
-   * buffered and flushed when one does.
+   * Register an active external-agent session. When the id was reserved,
+   * registration also wakes callers waiting to enqueue a follow-up on the new
+   * loop.
    */
   register(sessionId: string, entry: AgentCliSessionEntry): void {
     const previous = this.sessions.get(sessionId);
     this.sessions.set(sessionId, { kind: 'active', entry });
     settleReservation(previous, entry);
-    const write: SessionMappingWrite = {
-      executionId: entry.executionId,
-      sessionId,
-    };
-    if (this.writes) Queue.offerUnsafe(this.writes, write);
-    else this.bufferedWrites.push(write);
-  }
-
-  /**
-   * The session-mapping write drain: takes queued writes one at a time and
-   * runs each to completion. One write is uninterruptible once taken, so a
-   * write racing its loop's teardown still lands; interruption between
-   * writes ends the drain at once. The boundary launching a loop forks this
-   * and races it against that loop's settlement; concurrent drains are safe
-   * because each queued write is taken exactly once. The first drain creates
-   * the queue and flushes anything buffered before it started.
-   */
-  persistenceDrain(): Effect.Effect<void> {
-    return Effect.suspend(() => {
-      if (this.writes) return this.drainWrites(this.writes);
-      return Effect.flatMap(Queue.unbounded<SessionMappingWrite>(), (queue) => {
-        this.writes = queue;
-        for (const write of this.bufferedWrites.splice(0)) {
-          Queue.offerUnsafe(queue, write);
-        }
-        return this.drainWrites(queue);
-      });
-    });
-  }
-
-  private drainWrites(
-    queue: Queue.Queue<SessionMappingWrite>,
-  ): Effect.Effect<void> {
-    return Effect.forever(
-      Effect.uninterruptibleMask((restore) =>
-        // Waiting owns no write. Dequeue and persistence share the mask;
-        // another drain may consume the peeked item before our poll.
-        Effect.flatMap(restore(Queue.peek(queue)), () =>
-          Effect.flatMap(Queue.poll(queue), (write) =>
-            Option.isSome(write)
-              ? persistSessionMapping(
-                  this.dependencies,
-                  write.value.executionId,
-                  this.persistedSessionKey,
-                  write.value.sessionId,
-                )
-              : Effect.void,
-          ),
-        ),
-      ),
-    );
   }
 
   /** Track a launched loop before its SDK session id is safe to publish. */

--- a/src/tools/agentCliSessionStores.ts
+++ b/src/tools/agentCliSessionStores.ts
@@ -19,17 +19,14 @@ import type { Effect } from 'effect';
 // codex/claude registry, so per-session teardown interrupts exactly its own
 // agent-CLI children and a registry dies with its session instead of living
 // as a process singleton.
-function sessionRegistries(persistedSessionKey: string) {
+function sessionRegistries() {
   const registries = new WeakMap<SessionHandle, AgentCliSessionRegistry>();
   return {
     registries,
     for: (session: SessionHandle): AgentCliSessionRegistry => {
       let registry = registries.get(session);
       if (!registry) {
-        registry = new AgentCliSessionRegistry(
-          persistedSessionKey,
-          session.executions,
-        );
+        registry = new AgentCliSessionRegistry(session.executions);
         registries.set(session, registry);
       }
       return registry;
@@ -37,8 +34,8 @@ function sessionRegistries(persistedSessionKey: string) {
   };
 }
 
-const codexThreads = sessionRegistries('codex_thread_id');
-const claudeAgentSessions = sessionRegistries('claude_agent_session_id');
+const codexThreads = sessionRegistries();
+const claudeAgentSessions = sessionRegistries();
 
 /** The session's registry of live codex threads. */
 export const codexThreadsFor = codexThreads.for;

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -1,7 +1,7 @@
 // Shared helpers for the agent-CLI tool modules (codex.ts, claudeAgent.ts).
 // Host-agnostic, VS Code-free.
 
-import { Cause, Data, Deferred, Effect, Exit, Fiber } from 'effect';
+import { Cause, Data, Effect, Exit, Fiber } from 'effect';
 
 import { registerExecution } from '@agent/storage';
 import { type AgentTrace } from '@agent/trace';
@@ -252,13 +252,9 @@ interface AgentCliLaunchParams {
   description: string;
   config: AgentConfig;
   registerFailedMessage: string;
-  /** Session-keyed registry accessor; the launched loop's drain forks here. */
-  store: AgentCliSessionStoreAccessor;
   startLoop: (ctx: {
     childStream: ChildStream;
     executionId: ExecutionId;
-    /** Settled by the loop wrapper when the loop's completion settles. */
-    loopSettled: Deferred.Deferred<void>;
   }) => Effect.Effect<void, Error>;
   summary: string;
   launchedLine: string;
@@ -268,13 +264,6 @@ interface AgentCliLaunchParams {
 /**
  * Register a fresh agent-CLI execution, create its child stream tab, start the
  * provider's turn loop, and return the "launched" ToolResult.
- *
- * The registry's persistence drain is forked here — on the tool's run edge,
- * which is where this Effect runs — and raced against the loop's settlement,
- * so the drain lives exactly as long as the loop it persists for. Session
- * writes the loop registers afterwards queue into the drain without any
- * fiber of their own, and an in-flight write still lands when the loop ends
- * (see `AgentCliSessionRegistry.persistenceDrain`).
  */
 export const launchAgentCliSession = Effect.fn(
   'agentCliShared.launchAgentCliSession',
@@ -296,8 +285,6 @@ export const launchAgentCliSession = Effect.fn(
         tool: params.agentName,
       } as const;
 
-      const registry = params.store(params.session);
-      const loopSettled = Deferred.makeUnsafe<void>();
       yield* registerExecution(
         params.session,
         executionId,
@@ -330,13 +317,6 @@ export const launchAgentCliSession = Effect.fn(
         executionId,
         Effect.gen(function* () {
           yield* restore(Effect.void);
-          yield* Effect.forkDetach(
-            Effect.raceFirst(
-              registry.persistenceDrain(),
-              Deferred.await(loopSettled),
-            ),
-            { startImmediately: true },
-          );
 
           const stream = yield* createChildStream(
             params.session,
@@ -352,11 +332,7 @@ export const launchAgentCliSession = Effect.fn(
           );
           const started = yield* Effect.exit(
             Effect.suspend(() =>
-              params.startLoop({
-                childStream: stream,
-                executionId,
-                loopSettled,
-              }),
+              params.startLoop({ childStream: stream, executionId }),
             ),
           );
           if (Exit.isFailure(started)) {
@@ -382,7 +358,6 @@ export const launchAgentCliSession = Effect.fn(
         }),
       ).pipe(
         Effect.uninterruptible,
-        Effect.onError(() => Deferred.succeed(loopSettled, undefined)),
         Effect.mapError((cause) => new AgentCliCallFailed({ cause })),
       );
 
@@ -558,11 +533,6 @@ interface AgentCliLoopParams<TTurn> {
   /** Session/thread registry the loop tracks in-flight and successful turns in. */
   store: AgentCliSessionStoreAccessor;
   /**
-   * Settled when the loop's completion promise settles, ending the
-   * persistence drain the launch forked for this loop.
-   */
-  loopSettled: Deferred.Deferred<void>;
-  /**
    * The disk-based fallback session/thread id claimed synchronously before the
    * loop starts, if any. Release it if the loop exits before promoting it.
    */
@@ -619,7 +589,6 @@ export function startAgentCliLoop<TTurn>(
       stageLabel,
       initialPrompt,
       store,
-      loopSettled,
       releaseFallbackClaim,
       runProviderTurn,
       resolveSessionIds,
@@ -713,7 +682,6 @@ export function startAgentCliLoop<TTurn>(
             logger.error(loopFailedMessage, { data: Cause.squash(cause) });
           }),
         ),
-        Effect.ensuring(Deferred.succeed(loopSettled, undefined)),
       ),
     );
   }).pipe(Effect.uninterruptible);

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -25,7 +25,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
  */
 
 // Third-party imports
-import { Effect, type Deferred } from 'effect';
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
@@ -428,8 +428,6 @@ function startClaudeAgentLoop(params: {
   resumeSessionId: string | undefined;
   /** Release the fallback claim if the loop exits before promoting it. */
   releaseFallbackClaim: (() => void) | undefined;
-  /** Settled by the loop wrapper when the loop's completion settles. */
-  loopSettled: Deferred.Deferred<void>;
 }): Effect.Effect<void, Error> {
   const { childStream, parentStreamId, executionId, initialPrompt } = params;
   const { logger } = childStream;
@@ -452,7 +450,6 @@ function startClaudeAgentLoop(params: {
     stageLabel: 'Claude Code session',
     initialPrompt,
     store: claudeAgentSessionsFor,
-    loopSettled: params.loopSettled,
     releaseFallbackClaim: params.releaseFallbackClaim,
     runProviderTurn: async (prompt, _ports, signal) => {
       const forkSession = isFirstTurn && params.forkSession;
@@ -644,8 +641,7 @@ const launchClaudeAgentSession = Effect.fn(
     description: input.prompt,
     config: agentConfig,
     registerFailedMessage: 'Failed to register Claude Code CLI execution.',
-    store: claudeAgentSessionsFor,
-    startLoop: ({ childStream, executionId, loopSettled }) =>
+    startLoop: ({ childStream, executionId }) =>
       startClaudeAgentLoop({
         session,
         childStream,
@@ -662,7 +658,6 @@ const launchClaudeAgentSession = Effect.fn(
         resumeSessionId: input.session_id ?? undefined,
         forkSession: input.fork_session === true,
         releaseFallbackClaim,
-        loopSettled,
       }),
     summary: `Launched Claude Code CLI: ${preview}`,
     launchedLine: `Claude Code agent launched (model: ${model}, permission: ${permissionMode}).`,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -19,7 +19,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
  */
 
 // Third-party imports
-import { Effect, type Deferred } from 'effect';
+import { Effect } from 'effect';
 import { z } from 'zod';
 
 // Local imports
@@ -367,8 +367,6 @@ function startCodexLoop(params: {
   resumeThreadId: string | undefined;
   /** Release the fallback claim if the loop exits before promoting it. */
   releaseFallbackClaim: (() => void) | undefined;
-  /** Settled by the loop wrapper when the loop's completion settles. */
-  loopSettled: Deferred.Deferred<void>;
 }): Effect.Effect<void, Error> {
   const {
     thread,
@@ -378,7 +376,6 @@ function startCodexLoop(params: {
     initialPrompt,
     resumeThreadId: fallbackThreadId,
     releaseFallbackClaim,
-    loopSettled,
   } = params;
   const { childStreamId, logger } = childStream;
 
@@ -391,7 +388,6 @@ function startCodexLoop(params: {
     stageLabel: 'Codex session',
     initialPrompt,
     store: codexThreadsFor,
-    loopSettled,
     releaseFallbackClaim,
     runProviderTurn: (prompt, _ports, signal) =>
       runStreamedTurn(thread, prompt, childStreamId, logger, signal),
@@ -570,8 +566,7 @@ const launchCodexSession = Effect.fn('codex.launchCodexSession')(function* (
     description: input.prompt,
     config,
     registerFailedMessage: 'Failed to register Codex execution.',
-    store: codexThreadsFor,
-    startLoop: ({ childStream, executionId, loopSettled }) =>
+    startLoop: ({ childStream, executionId }) =>
       startCodexLoop({
         session,
         thread,
@@ -581,7 +576,6 @@ const launchCodexSession = Effect.fn('codex.launchCodexSession')(function* (
         initialPrompt: input.prompt,
         resumeThreadId: input.thread_id ?? undefined,
         releaseFallbackClaim,
-        loopSettled,
       }),
     summary: `Launched Codex: ${preview}`,
     launchedLine: `Codex agent launched (sandbox: ${sandboxMode}).`,


### PR DESCRIPTION
## Summary

`AgentCliSessionRegistry` queued every codex thread id and claude-agent session id into a per-launch persistence drain that wrote them to execution KV keys `codex_thread_id` and `claude_agent_session_id`. Nothing reads those keys. `rg` over `src/`, `packages/`, `supabase/` and `prompts/` finds only the two definition lines, and `git log -G` shows they have been write-only since introduction. Resume after a reload uses the SDK's own on-disk session (the disk-based fallback in `agentCliShared.ts`), and the thread/session id already reaches the parent in the follow-up delivery text.

This deletes the write path and everything that existed only to serve it:

- the injected persistence dependencies, the tagged write error, the write queue, the pre-drain buffer, `persistenceDrain`/`drainWrites`, and the `persistedSessionKey` constructor argument (`agentCliSessionRegistry.ts`);
- the detached drain fork raced against the loop in `launchAgentCliSession`, and the `loopSettled` `Deferred` threaded through `AgentCliLaunchParams`, `AgentCliLoopParams`, `startCodexLoop` and `startClaudeAgentLoop`;
- `AgentCliLaunchParams.store`, whose only reader was the drain;
- the three drain tests (scheduler-handoff sweep and write-failure containment).

Claim, register, lookup, `waitForActive`, release and `interruptAll` are unchanged.

Side effect: the two stray `codex_thread_id.json` / `claude_agent_session_id.json` files, which `isKVFile` did not recognize and which therefore appeared as generated files in `/executions/{id}/files` and the CLI history file listing, are no longer written. Existing files on disk are left untouched.

Under the TeXRA 1.0 direction (AGENTS.md), these keys are also not carried into the SQLite execution store. The `execution.codexThread` / `execution.claudeSession` row in the 2026-09-03 persistence-substrate doc is left for the docs owner. This PR also shrinks #12082's KV consumer inventory by one.

Found independently by two auditors (storage-substrate and tools-core) in the 1.0 clean-slate simplification audit (coauthor-21).

## Net elements (R6)

- Files: 8 changed, 0 added, 0 deleted
- `^[+-]export` symbols: 0 (no exports added or removed)
- Class/interface/enum declarations: −3 (`AgentCliSessionRegistryDependencies`, `SessionMappingWriteFailed`, `SessionMappingWrite`)
- Net LoC: +22 / −393 (production −190, tests −203)

## Consumer counts (R8)

- `codex_thread_id` / `claude_agent_session_id` readers: 0 production, 0 test
- `persistenceDrain`: 1 production caller (the drain fork deleted here), 1 test helper (deleted)
- `loopSettled`: its only reader was the drain race deleted here
- `AgentCliLaunchParams.store`: 1 reader (the drain), 2 production and 2 test producers, all removed

## Test plan

- [x] `npm run typecheck` (all projects)
- [x] `npx vitest run` AgentCliSessionRegistry, ChildRunLoop, ChildStreamProgressEvents (45 tests)
- [x] eslint on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
