### PR TITLE
simplify(tools): derive update_config from the catalog; inline the edit-approval pass-through

### DIFF
--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -574,7 +574,7 @@ const CORE_SETTING_ROWS: Record<
     honoredBy: everyHost('src/model/xai/xaiPreference.ts'),
   },
   maxImageDimension: {
-    schema: z.number().min(100).max(10000).prefault(2000),
+    schema: z.int().min(100).max(10000).prefault(2000),
     description:
       'Maximum dimension (width or height) in pixels for images before resizing. Images larger than this will be resized to fit within this dimension while maintaining aspect ratio.',
     honoredBy: everyHost('src/utils/media/img.ts'),
@@ -586,7 +586,7 @@ const CORE_SETTING_ROWS: Record<
     honoredBy: everyHost('src/tools/latex/ExtractBibliographyTool.ts'),
   },
   'bib.zoteroPort': {
-    schema: z.number().min(1).max(65535).prefault(23119),
+    schema: z.int().min(1).max(65535).prefault(23119),
     description:
       'Port number for Zotero integration (default: 23119). Used by both the Connector API and Better BibTeX JSON-RPC.',
     honoredBy: everyHost('src/tools/zotero/bbtClient.ts'),
@@ -678,7 +678,7 @@ const CORE_SETTING_ROWS: Record<
   // assistant's host-neutral `update_config` writer is recorded separately so
   // a CLI-written value is recognized without mislabeling the writer as a reader.
   'git.numberOfCommitsToShow': {
-    schema: z.number().min(1).max(1000).prefault(20),
+    schema: z.int().min(1).max(1000).prefault(20),
     description:
       'Number of recent commits to show in the commit selection dropdown',
     honoredBy: {

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -84,7 +84,6 @@ const edit = Effect.fn('EditFileTool.execute')(function* (
     originalContent,
     proposedContent: replacement.content,
     sourceTool: 'edit_file',
-    startLine: 'approval',
     present: () => ({
       summary: `Edited ${displayPath}: replaced ${replacement.count} ${occurrenceWord}`,
       output: `Replaced ${replacement.count} ${occurrenceWord}.`,

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -45,7 +45,6 @@ const write = Effect.fn('WriteFileTool.execute')(function* (
     originalContent,
     proposedContent,
     sourceTool: 'write_file',
-    startLine: 'approval',
     present: ({ appliedContent }) => {
       const originalLineCount = countLines(originalContent);
       const newLineCount = countLines(appliedContent);

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -310,18 +310,16 @@ export async function writeApprovedContent(
 /**
  * Append the unified user-adjustment diff note to a base output message, or
  * return the base message unchanged when the user made no adjustments.
- * `separator` defaults to a blank line between the base message and the note.
  */
 export function appendApprovalDiffNote(
   baseOutput: string,
   path: string,
   proposedContent: string,
   appliedContent: string,
-  separator: string = '\n\n',
 ): string {
   const diffBody = unifiedDiffText(proposedContent, appliedContent);
   return diffBody
-    ? `${baseOutput}${separator}User adjustments to ${path}:\n\n\`\`\`diff\n${diffBody}\n\`\`\``
+    ? `${baseOutput}\n\nUser adjustments to ${path}:\n\n\`\`\`diff\n${diffBody}\n\`\`\``
     : baseOutput;
 }
 
@@ -362,52 +360,4 @@ export function buildApprovalRejectedResult(
     summary,
     ...(feedback && { userInstruction: feedback }),
   });
-}
-
-interface WrittenApprovedEdit extends WriteApprovedContentResult {
-  approval: AcceptedToolEditApprovalResult;
-}
-
-/**
- * Full approve-then-write handshake for a proposed edit: request approval,
- * then write the resolved content (the user's adjustments if any, else the
- * proposal). `sourceTool` is named once and the rejection message is uniform
- * across every straight-through edit call site.
- *
- * Returns `{ rejected }` (a {@link ToolResult} to return directly) when the
- * user declines. `beforeWrite` covers work that must happen only after
- * acceptance, such as creating a new file's parent directory.
- */
-export async function requestAndWriteApprovedEdit(request: {
-  path: string;
-  displayPath: string;
-  originalContent: string;
-  proposedContent: string;
-  sourceTool: string;
-  beforeWrite?: () => void | Promise<void>;
-}): Promise<{ rejected: ToolResult } | WrittenApprovedEdit> {
-  const { path, displayPath, originalContent, proposedContent, sourceTool } =
-    request;
-
-  const approval = await requestToolEditApproval({
-    path,
-    originalContent,
-    proposedContent,
-    sourceTool,
-  });
-
-  if (approval.action !== 'apply') {
-    return {
-      rejected: buildApprovalRejectedResult(displayPath, sourceTool, approval),
-    };
-  }
-
-  await request.beforeWrite?.();
-
-  const written = await writeApprovedContent(
-    path,
-    originalContent,
-    approval.appliedContent,
-  );
-  return { approval, ...written };
 }

--- a/src/tools/fileEditFlow.ts
+++ b/src/tools/fileEditFlow.ts
@@ -16,7 +16,9 @@ import {
 } from '@tools/pathResolution';
 import {
   appendApprovalDiffNote,
-  requestAndWriteApprovedEdit,
+  buildApprovalRejectedResult,
+  requestToolEditApproval,
+  writeApprovedContent,
   type AcceptedToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
@@ -228,18 +230,13 @@ interface ApprovedFileEditRequest {
   proposedContent: string;
   sourceTool: string;
   present: (edit: AppliedFileEdit) => FileEditPresentation;
-  beforeWrite?: () => void | Promise<void>;
-  afterWrite?: (edit: AppliedFileEdit) => void | Promise<void>;
-  startLine?: 'approval' | 'omit';
-  diffSeparator?: string;
 }
 
 /**
- * Apply an approved edit and shape its canonical tool result.
- *
- * Callers declare presentation and the few lifecycle hooks that are genuinely
- * tool-specific; approval, writing, rejection, diff notes, and edit metadata
- * remain one invariant pipeline.
+ * Request approval for an edit, write the approved content (the user's
+ * adjustments if any, else the proposal), and shape the canonical tool
+ * result. Callers declare only the presentation; approval, writing,
+ * rejection, diff notes, and edit metadata remain one invariant pipeline.
  */
 export const applyApprovedFileEdit = Effect.fn('applyApprovedFileEdit')(
   function* ({
@@ -249,48 +246,40 @@ export const applyApprovedFileEdit = Effect.fn('applyApprovedFileEdit')(
     proposedContent,
     sourceTool,
     present,
-    beforeWrite,
-    afterWrite,
-    startLine = 'omit',
-    diffSeparator,
   }: ApprovedFileEditRequest): Effect.fn.Return<ToolResult, unknown> {
-    const outcome = yield* hostPort(() =>
-      requestAndWriteApprovedEdit({
+    const approval = yield* hostPort(() =>
+      requestToolEditApproval({
         path,
-        displayPath,
         originalContent,
         proposedContent,
         sourceTool,
-        beforeWrite,
       }),
     );
-    if ('rejected' in outcome) {
-      return outcome.rejected;
+    if (approval.action !== 'apply') {
+      return buildApprovalRejectedResult(displayPath, sourceTool, approval);
     }
 
-    const edit: AppliedFileEdit = outcome;
-    yield* hostPort(() => afterWrite?.(edit));
-    const presentation = present(edit);
+    const written = yield* hostPort(() =>
+      writeApprovedContent(path, originalContent, approval.appliedContent),
+    );
+    const presentation = present({ approval, ...written });
     const output = appendApprovalDiffNote(
       presentation.output,
       displayPath,
       proposedContent,
-      edit.appliedContent,
-      diffSeparator,
+      written.appliedContent,
     );
 
     return {
       status: 'executed',
       summary: presentation.summary,
       output,
-      userPatch: edit.approval.userPatch,
+      userPatch: approval.userPatch,
       edits: [
         {
           path: displayPath,
-          lineChanges: edit.approval.lineChanges,
-          ...(startLine === 'approval' && {
-            startLine: edit.approval.startLine,
-          }),
+          lineChanges: approval.lineChanges,
+          startLine: approval.startLine,
         },
       ],
     };

--- a/src/tools/setup/ConfigTools.ts
+++ b/src/tools/setup/ConfigTools.ts
@@ -13,78 +13,48 @@ import { Effect } from 'effect';
 import { z } from 'zod';
 
 import { effectRuntime } from '@platform/processRuntime';
-import { ToolError, type ToolResult } from '@shared/schemas';
+import {
+  settingByKey,
+  settingSchemaWithoutPrefault,
+  ToolError,
+  type StateSettingEntry,
+  type ToolResult,
+} from '@shared/schemas';
 
 import { executed } from '@tools/core/result';
 import { defineTool } from '../core/define';
 import { texraScopedConfig } from './platform';
 
 /**
- * Per-key value validators for `update_config`. Read access (`read_config`)
- * is open across all `texra.*` keys, but writes must clear a strict schema
- * so a hallucinated payload cannot, say, set `texra.git.numberOfCommitsToShow`
- * to `"yes please"` or flip a destructive toggle.
- *
- * Each entry pairs a Zod schema with a one-line summary the tool echoes back
- * to the agent (and surfaces in the description) so the assistant can
- * explain the setting before changing it.
+ * Keys `update_config` may write. Read access (`read_config`) is open across
+ * all `texra.*` keys, but writes are limited to this allowlist so a
+ * hallucinated payload cannot flip an arbitrary setting. Each key's value
+ * schema and description come from the settings catalog, so the tool
+ * validates against, and explains, exactly what every host reads. The catalog
+ * is consulted when a tool runs, never while this module loads.
  */
-const UPDATABLE_KEYS = {
-  'texra.bib.defaultPath': {
-    schema: z.string().describe('Workspace path to the default .bib file'),
-    summary:
-      'Default bibliography file used by tools that scan citations (e.g. extract_bib_entries).',
-  },
-  'texra.bib.zoteroPort': {
-    schema: z
-      .int()
-      .min(1)
-      .max(65535)
-      .describe('Local port the Zotero Better BibTeX server listens on'),
-    summary:
-      'Local port for the Zotero Better BibTeX integration. Default 23119.',
-  },
-  'texra.audio.soxPath': {
-    schema: z.string().describe('Absolute path to the sox binary'),
-    summary:
-      'Path override for the SoX audio tool (used by the audio transcription agent).',
-  },
-  'texra.latex.tikzInputDirectory': {
-    schema: z
-      .string()
-      .describe('Workspace-relative directory containing TikZ source files'),
-    summary:
-      'Where the TikZ extraction/compilation flows look for figure source files.',
-  },
-  'texra.git.numberOfCommitsToShow': {
-    schema: z
-      .int()
-      .min(1)
-      .max(1000)
-      .describe('How many recent commits to surface in the Git picker'),
-    summary:
-      'Depth of the recent-commits dropdown surfaced by the Git integration.',
-  },
-  'texra.maxImageDimension': {
-    schema: z
-      .int()
-      .min(64)
-      .max(8192)
-      .describe('Maximum pixel dimension for images sent to vision models'),
-    summary:
-      'Image dimension cap before downscaling. Lower values save tokens; higher values preserve fidelity.',
-  },
-} satisfies Record<string, { schema: z.ZodType<unknown>; summary: string }>;
+const UPDATABLE_KEY_LIST = [
+  'texra.bib.defaultPath',
+  'texra.bib.zoteroPort',
+  'texra.audio.soxPath',
+  'texra.latex.tikzInputDirectory',
+  'texra.git.numberOfCommitsToShow',
+  'texra.maxImageDimension',
+] as const;
 
-type UpdatableKey = keyof typeof UPDATABLE_KEYS;
+type UpdatableKey = (typeof UPDATABLE_KEY_LIST)[number];
 
-const UPDATABLE_KEY_LIST = Object.keys(UPDATABLE_KEYS) as UpdatableKey[];
-
-function describeAllowlist(): string {
-  return UPDATABLE_KEY_LIST.map(
-    (k) => `- \`${k}\`: ${UPDATABLE_KEYS[k].summary}`,
-  ).join('\n');
+function catalogEntry(key: UpdatableKey): StateSettingEntry {
+  const entry = settingByKey(key);
+  if (!entry) {
+    throw new Error(`update_config allowlist key ${key} is not in the catalog`);
+  }
+  return entry;
 }
+
+const ALLOWLIST_TEXT = UPDATABLE_KEY_LIST.map((key) => `- \`${key}\``).join(
+  '\n',
+);
 
 const ReadConfigInputSchema = z.strictObject({
   key: z
@@ -112,20 +82,24 @@ Accepts any key starting with \`texra.\`. Returns the current resolved value (wo
   protected async execute(input: ReadConfigInput): Promise<ToolResult> {
     const value = texraScopedConfig.get(input.key);
     const json = JSON.stringify(value, null, 2) ?? 'undefined';
-    return executed(`${input.key}:\n${json}`, `Read ${input.key}`);
+    const description = settingByKey(input.key)?.description;
+    return executed(
+      `${input.key}:\n${json}${description ? `\n\n${description}` : ''}`,
+      `Read ${input.key}`,
+    );
   }
 }
 
 const UpdateConfigInputSchema = z.strictObject({
   key: z
-    .enum(UPDATABLE_KEY_LIST as [UpdatableKey, ...UpdatableKey[]])
+    .enum(UPDATABLE_KEY_LIST)
     .describe(
-      `Configuration key to update. Must be on the setup allowlist:\n${describeAllowlist()}`,
+      `Configuration key to update. Must be on the setup allowlist:\n${ALLOWLIST_TEXT}`,
     ),
   value: z
     .unknown()
     .describe(
-      "New value. Type depends on the key: see the allowlist for each key's expected schema.",
+      "New value, validated against the setting's schema. Call read_config first to see what the setting controls.",
     ),
   target: z
     .enum(['user', 'workspace'])
@@ -140,12 +114,13 @@ type UpdateConfigInput = z.infer<typeof UpdateConfigInputSchema>;
 const updateConfig = Effect.fn('UpdateConfigTool.execute')(function* (
   input: UpdateConfigInput,
 ) {
-  const entry = UPDATABLE_KEYS[input.key];
-  const parsed = entry.schema.safeParse(input.value);
+  const entry = catalogEntry(input.key);
+  const schema = settingSchemaWithoutPrefault(entry) as z.ZodType;
+  const parsed = schema.safeParse(input.value);
   if (!parsed.success) {
     return yield* Effect.fail(
       new ToolError(
-        `Value rejected for ${input.key}: ${z.prettifyError(parsed.error)}. ${entry.summary}`,
+        `Value rejected for ${input.key}: ${z.prettifyError(parsed.error)}. ${entry.description ?? ''}`,
       ),
     );
   }
@@ -169,7 +144,7 @@ export class UpdateConfigTool extends defineTool({
 Use this AFTER calling \`read_config\` and explaining to the user what the setting does and what the new value will mean. Explain every change clearly. Pass \`target: "workspace"\` only when the change is genuinely workspace-specific (e.g. a project-local bib path); default to \`"user"\` for general preferences shared across workspaces.
 
 Allowlisted keys:
-${describeAllowlist()}
+${ALLOWLIST_TEXT}
 
 Anything outside this list must be changed through the host's regular configuration surface.`,
   schema: UpdateConfigInputSchema,


### PR DESCRIPTION
## Summary

Two duplicated authorities in the tool layer, each deleted in favour of the one that already owns the fact.

**1. `update_config` re-declared schemas the settings catalog owns, and two had drifted.** `ConfigTools.ts` hand-wrote a Zod schema and a summary for six keys that `stateSettings.ts` already defines. The tool's copies disagreed with the catalog:

- `texra.maxImageDimension`: `int 64..8192` in the tool vs `number 100..10000` in the catalog, so the setup agent could persist `64`, which `src/utils/media/img.ts` reads.
- `texra.latex.tikzInputDirectory`: the tool told the model it is a *workspace-relative* directory; the catalog (and `texTools.ts`) require an *absolute* path.

The allowlist is now a list of keys. `update_config` validates against `settingSchemaWithoutPrefault(settingByKey(key))` and quotes the catalog description in its errors. `read_config` now appends the catalog description to the value it reads, which is where the model learns what a setting controls, matching the tool's "read first, explain, then change" guidance. The per-key write allowlist, which is the security boundary, is unchanged.

The catalog is consulted only when a tool runs, never while `ConfigTools` loads. A version that built the tool description from the catalog at import time hung `TuiApprovalRetry` ("approves delegated work already queued"): the suite passes on main, and with key names alone it passes again. So the static description lists key names only.

**2. `fileEditFlow` → `toolEditApproval` pass-through.** `applyApprovedFileEdit` has two callers (`EditTool`, `WriteTool`). Both passed `startLine: 'approval'` and neither passed `beforeWrite`, `afterWrite` or `diffSeparator`. It delegated to `requestAndWriteApprovedEdit`, whose only caller it was. This PR:

- inlines that middle layer (approve, then reject or `writeApprovedContent`);
- deletes the four unused options and `appendApprovalDiffNote`'s `separator` parameter;
- deletes the `WrittenApprovedEdit` type.

`startLine` is always the approval's, which is what both callers asked for. Tool results are unchanged.

Items `domain-tools-5` and `tools-core-11` of the 1.0 clean-slate simplification audit (coauthor-21).

## Net elements (R6)

- Files: 5 changed, 0 added, 0 deleted
- `^[+-]export` symbols: −1 (`requestAndWriteApprovedEdit`)
- Class/interface/enum declarations: −1 (`WrittenApprovedEdit`)
- Net LoC: +67 / −155

## Consumer counts (R8)

- `requestAndWriteApprovedEdit`: 1 production caller (`applyApprovedFileEdit`), 0 tests
- `beforeWrite` / `afterWrite` / `diffSeparator` on `applyApprovedFileEdit`: 0 of 2 callers pass them
- `startLine: 'omit'` (the default): 0 of 2 callers use it
- `appendApprovalDiffNote` `separator`: 1 caller, which only forwarded `diffSeparator`
- `UPDATABLE_KEYS` schemas: 6 duplicated catalog rows, 2 drifted

## Test plan

- [x] `npm run typecheck` (all projects)
- [x] `npx vitest run` over the 16 suites touching edit approval and ConfigTools (240 tests), including `TuiApprovalRetry`
- [x] eslint on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
