### PR TITLE
test: move two suites into the pure tier

### DIFF
--- a/src/test-kernel/architecture/supportMockImportOrder.vitest.ts
+++ b/src/test-kernel/architecture/supportMockImportOrder.vitest.ts
@@ -16,7 +16,7 @@ import {
 /**
  * Architecture guard for the shared mock modules extracted by #10361.
  *
- * Those modules register `vi.mock(...)` when they evaluate, and their factories
+ * Those modules register a repository-module mock when they evaluate, and their factories
  * close over `vi.hoisted` bags, so a suite must evaluate each shared-mock
  * import before anything that could load the mocked module. The mechanical
  * convention is: shared `@test/support/*Mock` imports sit immediately after


### PR DESCRIPTION
## What

Two suites move from the `kernel` Vitest project to `pure`. Pure tier: **276 → 278 files, 4032 → 4040 tests.**

- `loadChatExportInput.vitest.ts` mocked `@agent/export/chatExportInput` to avoid re-deriving its output. It now calls the real module over a fixture — the shape AGENTS.md "Test tiers" asks for, and enough to clear the scan.
- `supportMockImportOrder.vitest.ts` **never had a mock.** It is the architecture guard *for* shared mock modules, and the tier scan's `/\bvi\.(?:do)?[mM]ock\s*\(/` matched the phrase inside its own doc comment. Reworded the comment.

Test-declaration and `expect()` counts unchanged in both files.

## Why this PR is two files and not ninety

I ran this as a 14-agent sweep over 91 candidate suites on the theory that `vi.mock` on a repository module is what pins a suite to the slow tier, so removing it is a wide mechanical win. **The theory is mostly wrong, and the measurement is the useful output.**

Of 132 suites under `PURE_DIRS` containing a `vi.mock`:

| | count |
|---|---|
| also match another `REACHES_A_HOST` pattern — de-mocking moves nothing | **72** |
| `vi.mock` is the only source-level marker | 60 |
| …of those, actually moved when a batch tried | **~5%** |

The dominant blocker on the remaining 60 is the one the source scan cannot see and the `pure-tier-kernel-suites.json` baseline exists to record: **the module under test reads the host itself.** `getEnabledModels()` falls through to `platform().globalState`; `buildUserVars` reads workspace roots; `setupSecrets` is a frozen module-level const over `currentPlatform().secrets`. De-mocking those needs a production injection seam, which is out of scope for a test-only change and is exactly the Effect-services work the migration is already sequencing.

A second, smaller class: suites where the mock *is* the observation point (`expect(mockedResolveAgentForLaunch).toHaveBeenCalledWith(...)`). De-mocking deletes the assertion.

**Recommendation: do not run this as a sweep again.** The tier improves as a by-product of giving production modules their dependencies as services/layers — not as a test-only pass. Tracking the 60 here so nobody re-derives it.

## Config note for whoever owns `vitest.config.mjs`

`REACHES_A_HOST` is a regex over raw source, so a comment or string literal counts as a host marker. Exactly one suite is misclassified this way today (the one fixed above) — I checked all 607 — so this is a footnote, not a bug worth a refactor. But the durable fix is the one `check-effect-migration-ratchet.mjs` already uses: parse with the TypeScript compiler API, where "comments and string literals never count."

## Gates

| Gate | Result |
|---|---|
| `vitest --project pure run` | 278 files, 4040 tests, all passing |
| `vitest run src/test-kernel` | 741 files, 9041 passed, 1 skipped — identical to main |
| `tsc -p tsconfig.test-kernel.json` | 0 errors |
| `eslint src/test-kernel` | clean |
| `prettier --check` | clean |

Rebased onto `e6972efaa6`. Heavy gates run through the shared `gate.sh` semaphore; claimed in the coordination ledger as `claude-effect-waves`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)