### PR TITLE
simplify(latex): drop the mid-era round-directory scan from latexdiff

### DIFF
--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -1,6 +1,7 @@
 /**
  * Build and execute latexdiff operations from either run metadata
- * (`OutputFileInfo` per round) or a workspace scan of legacy/mid-era layouts.
+ * (`OutputFileInfo` per round) or a workspace scan of flat
+ * `<base>_<chunk>_r{N}_<model>.tex` copies.
  */
 
 // Node imports
@@ -18,18 +19,14 @@ import {
   RoundKeySchema,
 } from '@shared/schemas';
 import type { OutputFileInfo, ReadonlyRoundIndexed } from '@shared/schemas';
-import {
-  legacyWorkflowOutputRoundRegex,
-  midEraWorkflowOutputStem,
-  parseWorkflowOutputRoundDir,
-} from '@shared/constants/workflowOutput';
+import { legacyWorkflowOutputRoundRegex } from '@shared/constants/workflowOutput';
 import { getSafeDocumentRelativePath } from '@utils/files/outputFileUtils';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { ensureError } from '@utils/errors/errorMessage';
 import { pathToLocation } from '@utils/files/fileLocation';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { hasExtension } from '@utils/core/pathCore';
-import { isDirectory, isFile, isSymlink } from '@utils/files/fsEntryType';
+import { isFile, isSymlink } from '@utils/files/fsEntryType';
 
 // Local file imports
 import type {
@@ -292,49 +289,11 @@ export const runLatexdiffViaWorkspaceScan = Effect.fn(
         roundOutputs.set(round.data, path.join(outputDirPath, fileName));
       }
 
-      // Mid-era layout: outputs under `r{round}/<base>_<cleanAgent>_<model>.tex`.
-      // Some upgraded workspaces may still hold these files. Only look in
-      // known `r{round}/` subdirectories so we don't descend the whole tree.
-      const midEraFilename = `${midEraWorkflowOutputStem({
-        base: baseInputName,
-        agent,
-        model,
-      })}.tex`;
-      for (const [entryName, entryType] of dirEntries) {
-        if (!isDirectory(entryType) || isSymlink(entryType)) continue;
-        const round = parseWorkflowOutputRoundDir(entryName);
-        if (round == null) continue;
-        if (roundOutputs.has(round)) continue;
-
-        const roundAbsoluteDir = path.join(absoluteDir, entryName);
-        // Skip unreadable round dirs but record which one so a missing round
-        // output isn't silently invisible during diagnosis.
-        const roundEntries = yield* readDir(roundAbsoluteDir).pipe(
-          Effect.catch((error) =>
-            Effect.logDebug(
-              `Skipping round dir '${roundAbsoluteDir}': ${error}`,
-            ).pipe(Effect.as<[string, number][] | null>(null)),
-          ),
-        );
-        if (roundEntries === null) continue;
-        const match = roundEntries.find(
-          ([fileName, nestedType]) =>
-            isFile(nestedType) &&
-            !isSymlink(nestedType) &&
-            fileName === midEraFilename,
-        );
-        if (!match) continue;
-        roundOutputs.set(
-          round,
-          path.join(outputDirPath, entryName, midEraFilename),
-        );
-      }
-
-      // New-layout workflow outputs live inside task-run storage
+      // Workflow outputs themselves live inside task-run storage
       // (`executions/{id}/r{round}/output.tex`), not in the workspace. That
       // path is driven by execution metadata (`OutputFileInfo.outputsByRound`)
-      // via `runLatexdiffFromMetadata`; the workspace scan here only covers
-      // pre-refactor files.
+      // via `runLatexdiffFromMetadata`; the workspace scan here covers only
+      // the flat names above, which Save-as-copy still writes.
 
       if (roundOutputs.size > 0) {
         inputToOutputsMap.set(

--- a/src/test-kernel/latex/DiffOperations.vitest.ts
+++ b/src/test-kernel/latex/DiffOperations.vitest.ts
@@ -106,7 +106,7 @@ describe('diffOperations diagnostics', () => {
           progress,
         });
 
-        // A bare source name matches no legacy/mid-era round layout, so the scan
+        // A bare source name matches no flat round-copy name, so the scan
         // reports the empty outcome instead of dispatching diff operations.
         expect(outcome).toEqual({ results: [] });
         expect(logs.has('DEBUG', CHANNEL, 'Input files: paper.tex')).toBe(true);


### PR DESCRIPTION
## Summary

`runLatexdiffViaWorkspaceScan` searched the workspace in two layouts. This deletes the second one: the mid-era `r{N}/<base>_<cleanAgent>_<model>.tex` round directories that builds wrote beside the source between the filename-era refactor and the move of workflow outputs into execution storage (#3082, 2026-04-21). No current writer produces that layout, and TeXRA 1.0 does not read 0.x run state (AGENTS.md, "TeXRA 1.0 direction"). Files already on disk are left untouched and can still be diffed by hand.

The scan's **flat** half (`<base>_<chunk>_r{N}_<model>.tex`) is kept on purpose. The extension's Save-as-copy still writes that name beside the source (`compareCommands.ts`, `workflowOutputCopyStem`), so `texra latexdiff -m/-i` and diffs of runs that can no longer be discovered still find live 1.0 copies through it. Retiring it needs a ruling on Save-as-copy first. The comments now say this instead of calling the whole scan "pre-refactor only".

`midEraWorkflowOutputStem` keeps one consumer (housekeeping pack/clean), which coauthor-dc's follow-up removes together with the constant once this merges.

Item `storage-4` (mid-era half) of the 1.0 clean-slate simplification audit (coauthor-21); the split was agreed with coauthor-dc.

## Net elements (R6)

- Files: 2 changed, 0 added, 0 deleted
- `^[+-]export` symbols: 0
- Class/interface/enum declarations: 0
- Net LoC: +8 / −49

## Consumer counts (R8)

- mid-era `r{N}/` workspace layout: 0 current writers
- `midEraWorkflowOutputStem`: 2 production consumers → 1 (housekeeping, removed by the dc follow-up)
- `parseWorkflowOutputRoundDir` in `diffOperations.ts`: 1 use (the deleted branch); its other consumers are unchanged

## Test plan

- [x] `npm run typecheck` (all projects)
- [x] `npx vitest run` DiffOperations, RunLatexdiff, LegacyWorkflowOutput (25 tests)
- [x] eslint on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
