### PR TITLE
fix(tools): read the gitignore policy per call; drop dead pre-identity warnings

### DIFF
--- a/src/test-kernel/tools/GitignoreMatcher.vitest.ts
+++ b/src/test-kernel/tools/GitignoreMatcher.vitest.ts
@@ -10,7 +10,6 @@ const fsState = vi.hoisted(() => ({
   homeDirectory: undefined as string | undefined,
   workspaceFiles: new Map<string, string>(),
   workspaceReadErrors: new Map<string, Error>(),
-  workspaceReadCounts: new Map<string, number>(),
   absoluteFiles: new Map<string, string>(),
   absoluteReadErrors: new Map<string, Error>(),
   reset(): void {
@@ -18,7 +17,6 @@ const fsState = vi.hoisted(() => ({
     this.homeDirectory = undefined;
     this.workspaceFiles.clear();
     this.workspaceReadErrors.clear();
-    this.workspaceReadCounts.clear();
     this.absoluteFiles.clear();
     this.absoluteReadErrors.clear();
   },
@@ -53,10 +51,6 @@ vi.mock('@utils/files/workspaceFS', () => {
         fsState.workspaceFiles.has(relativePath.replace(/^\/+/, '')),
       read: async (relativePath: string) => {
         const normalized = relativePath.replace(/^\/+/, '');
-        fsState.workspaceReadCounts.set(
-          normalized,
-          (fsState.workspaceReadCounts.get(normalized) ?? 0) + 1,
-        );
         return readFrom(
           fsState.workspaceFiles,
           fsState.workspaceReadErrors,
@@ -155,35 +149,18 @@ describe('getGitignoreMatcher', () => {
     await expect(loadMatcher()).rejects.toBe(constructionError);
   });
 
-  it('retries after a failed shared load attempt', async () => {
-    const error = errnoError('EACCES', 'Temporarily unavailable');
-    fsState.workspaceFiles.set('.gitignore', 'dist/\n');
-    fsState.workspaceReadErrors.set('.gitignore', error);
+  it('rereads the ignore policy on every call', async () => {
     vi.resetModules();
     const { getGitignoreMatcher } = await import('@tools/gitignore');
+    fsState.workspaceFiles.set('.gitignore', 'dist/\n');
+    const before = await Effect.runPromise(getGitignoreMatcher());
 
-    const failedCalls = await Promise.allSettled([
-      Effect.runPromise(getGitignoreMatcher()),
-      Effect.runPromise(getGitignoreMatcher()),
-    ]);
+    fsState.workspaceFiles.set('.gitignore', 'build/\n');
+    const after = await Effect.runPromise(getGitignoreMatcher());
 
-    for (const result of failedCalls) {
-      expect(result.status).toBe('rejected');
-      if (result.status === 'rejected') {
-        expect(result.reason).toBe(error);
-      }
-    }
-    expect(fsState.workspaceReadCounts.get('.gitignore')).toBe(1);
-
-    fsState.workspaceReadErrors.delete('.gitignore');
-    const [matcher, concurrentMatcher] = await Promise.all([
-      Effect.runPromise(getGitignoreMatcher()),
-      Effect.runPromise(getGitignoreMatcher()),
-    ]);
-
-    expect(matcher).toBe(concurrentMatcher);
-    expect(matcher.ignores('dist')).toBe(true);
-    expect(fsState.workspaceReadCounts.get('.gitignore')).toBe(2);
+    expect(before.ignores('dist')).toBe(true);
+    expect(after.ignores('dist')).toBe(false);
+    expect(after.ignores('build')).toBe(true);
   });
 
   it('preserves directory-only rules for bare directory entries', async () => {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -33,7 +33,6 @@ import {
   getRunContextExecutionId,
   getRunContextStreamId,
 } from '@agent/runtime/RunContext';
-import { createLog } from '@logger/logUtils';
 import type { FileStat } from '@platform/interfaces';
 import { effectRuntime } from '@platform/processRuntime';
 import {
@@ -106,8 +105,6 @@ import {
   shouldSkipWait,
 } from './executions/waitCoordination';
 import { workflowExecutionView } from './executions/workflowSummaryView';
-
-const log = createLog('ExecutionsTool');
 
 /**
  * Bound on the durable reads one listing page or one children block fans

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -541,15 +541,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         );
       }
 
-      // Identity comes only from the stamped execution row; pre-identity rows
-      // lost their reader per #9590 Stage 7 and degrade to the config-derived
-      // display category, loudly.
+      // Identity comes only from the stamped execution row, which always
+      // carries one; without a row the display falls back to the config.
       const identity = meta?.identity;
-      if (meta && !identity) {
-        log.warn(
-          `Execution ${executionId} is a pre-identity row; showing config-derived category only (reader retired per #9590 Stage 7)`,
-        );
-      }
       const category = executionDisplayCategory(identity, record);
       const info = yield* getExecutionStatusInfo(
         executionId,
@@ -813,16 +807,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       }
 
       // Filter out fields irrelevant to this agent's category. Identity comes
-      // only from the stamped execution row; a pre-identity row (reader retired
-      // per #9590 Stage 7) degrades to the config-derived category, loudly.
+      // only from the stamped execution row.
       const meta = yield* records.readMeta();
-      const identity = meta?.identity;
-      if (meta && !identity) {
-        log.warn(
-          `Execution ${executionId} is a pre-identity row; filtering config by its config-derived category only (reader retired per #9590 Stage 7)`,
-        );
-      }
-      const category = executionDisplayCategory(identity, record);
+      const category = executionDisplayCategory(meta?.identity, record);
       return executed(serializeFilteredConfig(record, category));
     },
   );

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 // Third-party imports
-import { Deferred, Effect, Exit } from 'effect';
+import { Effect } from 'effect';
 import ignore from 'ignore';
 
 // Local imports - common
@@ -30,13 +30,6 @@ const EMPTY_GITIGNORE_MATCHER: GitignoreMatcher = {
   ignores: () => false,
   ignoreFiles: [],
 };
-
-/**
- * The shared load, or nothing when no load has succeeded yet. Callers that
- * arrive while a load is in flight await its outcome instead of starting a
- * second one; a failed load clears this so the next caller retries.
- */
-let sharedLoad: Deferred.Deferred<GitignoreMatcher, unknown> | undefined;
 
 const readGitignoreFile = (
   absolutePath: string,
@@ -83,72 +76,54 @@ const readGlobalGitignore = (): Effect.Effect<
   );
 };
 
-const loadGitignoreMatcher = Effect.fn('loadGitignoreMatcher')(function* () {
-  const workspacePath = WorkspaceFS.getPath();
-  if (!workspacePath) {
-    return EMPTY_GITIGNORE_MATCHER;
-  }
-
-  const sources = (yield* Effect.all(
-    [
-      readGlobalGitignore(),
-      readWorkspaceGitignore('.gitignore_global'),
-      readWorkspaceGitignore('.gitignore'),
-    ],
-    // The three policies were read together and fail fast, as Promise.all did.
-    { concurrency: 'unbounded' },
-  )).filter(filterNotNull);
-
-  if (sources.length === 0) {
-    return EMPTY_GITIGNORE_MATCHER;
-  }
-
-  const ig = ignore();
-  for (const source of sources) {
-    ig.add(source.content);
-  }
-
-  return {
-    ignores: (relativePath: string): boolean => {
-      if (!relativePath || relativePath === '.') {
-        return false;
-      }
-      const normalized = toPosixPath(relativePath);
-      // Try plain path first; also try with trailing slash so that
-      // directory-only rules (e.g. "dist/") match bare directory names
-      // ("dist") the same way the old minimatch-based parser did.
-      // Known deviation from strict git spec: a *file* named "dist" would
-      // also be ignored by a "dist/" rule, because we cannot distinguish
-      // files from directories without a stat call. The old parser had the
-      // same behaviour (it expanded "dist/" → ["dist", "dist/**"]).
-      return ig.ignores(normalized) || ig.ignores(normalized + '/');
-    },
-    ignoreFiles: sources.map((source) => source.absolutePath),
-  };
-});
-
+/**
+ * Build the ignore matcher for the current workspace from its ignore policy
+ * files. Read on every call: the workspace is scoped per session and a
+ * process can serve several projects, and each call should see the policy as
+ * it is on disk now.
+ */
 export const getGitignoreMatcher = Effect.fn('getGitignoreMatcher')(
-  function* (): Effect.fn.Return<GitignoreMatcher, unknown> {
-    const inFlight = sharedLoad;
-    if (inFlight) {
-      return yield* Deferred.await(inFlight);
+  function* () {
+    const workspacePath = WorkspaceFS.getPath();
+    if (!workspacePath) {
+      return EMPTY_GITIGNORE_MATCHER;
     }
-    const deferred = Deferred.makeUnsafe<GitignoreMatcher, unknown>();
-    sharedLoad = deferred;
-    // The load completes even if the caller that started it is interrupted:
-    // every other caller is waiting on this Deferred, and an interrupted
-    // shared load would strand them.
-    return yield* Effect.uninterruptible(
-      loadGitignoreMatcher().pipe(
-        Effect.onExit((exit) =>
-          Effect.sync(() => {
-            if (Exit.isFailure(exit) && sharedLoad === deferred) {
-              sharedLoad = undefined;
-            }
-            Deferred.doneUnsafe(deferred, exit);
-          }),
-        ),
-      ),
-    );
+
+    const sources = (yield* Effect.all(
+      [
+        readGlobalGitignore(),
+        readWorkspaceGitignore('.gitignore_global'),
+        readWorkspaceGitignore('.gitignore'),
+      ],
+      // The three policies were read together and fail fast, as Promise.all did.
+      { concurrency: 'unbounded' },
+    )).filter(filterNotNull);
+
+    if (sources.length === 0) {
+      return EMPTY_GITIGNORE_MATCHER;
+    }
+
+    const ig = ignore();
+    for (const source of sources) {
+      ig.add(source.content);
+    }
+
+    return {
+      ignores: (relativePath: string): boolean => {
+        if (!relativePath || relativePath === '.') {
+          return false;
+        }
+        const normalized = toPosixPath(relativePath);
+        // Try plain path first; also try with trailing slash so that
+        // directory-only rules (e.g. "dist/") match bare directory names
+        // ("dist") the same way the old minimatch-based parser did.
+        // Known deviation from strict git spec: a *file* named "dist" would
+        // also be ignored by a "dist/" rule, because we cannot distinguish
+        // files from directories without a stat call. The old parser had the
+        // same behaviour (it expanded "dist/" → ["dist", "dist/**"]).
+        return ig.ignores(normalized) || ig.ignores(normalized + '/');
+      },
+      ignoreFiles: sources.map((source) => source.absolutePath),
+    };
   },
 );


### PR DESCRIPTION
## Summary

Two small corrections in the tool layer, one a real bug.

**1. The gitignore matcher was cached for the life of the process.** `getGitignoreMatcher` loaded the ignore policy once into a module-global `sharedLoad` `Deferred` that was never invalidated or keyed by workspace. But `WorkspaceFS.getPath()` is session-scoped, and the desktop main process serves several projects at once. So `glob`, `grep` and the arXiv source listing in the second project filtered by the *first* project's `.gitignore`, and a long-lived extension, desktop or TUI never saw `.gitignore` edits.

The matcher is now built on every call. That means reading at most three small policy files: `~/.gitignore_global`, `<ws>/.gitignore_global` and `<ws>/.gitignore`. This deletes the shared-load `Deferred`, its in-flight coalescing, its retry-after-failure bookkeeping and the uninterruptible wrapper those needed. The cache-pinning test is replaced by one regression test: a second call sees an edited policy.

Deliberately out of scope: the audit also proposed dropping the matcher for `rg`'s native ignore handling and rewriting `glob` on `rg --files`. That changes glob semantics, requires `rg` on `PATH` for `glob`, and drops the `.gitignore_global` policies, so it is a product call and not part of this PR.

**2. Dead pre-identity warnings in `/executions`.** `ExecutionsTool` warned at two sites when an execution row had metadata but no identity ("pre-identity row … reader retired per #9590 Stage 7"). Both `ExecutionMetaCoreSchema.identity` and `RunStartEventSchema.identity` are required, so a decoded row with metadata always has an identity. The warnings are unreachable and are deleted. The `identity === undefined` arms in `executionFormatters` stay: they still serve a record whose metadata row is missing.

Items `tools-core-3` (minimal fix) and `delegation-workflows-4(a)` of the 1.0 clean-slate simplification audit (coauthor-21).

## Net elements (R6)

- Files: 3 changed, 0 added, 0 deleted
- `^[+-]export` symbols: 0 (`getGitignoreMatcher` keeps its name and signature)
- Class/interface/enum declarations: 0
- Net LoC: production +51 / −92 (−41: `gitignore.ts` −25, `ExecutionsTool.ts` −16, after the follow-up commit dropped the now-unused `log`); tests: one cache test replaced by one regression test

## Consumer counts (R8)

- `getGitignoreMatcher`: 3 production callers (`grep.ts`, `glob.ts`, `ArxivDownloadTool.ts`), each calls it once per tool invocation; unchanged
- `sharedLoad`: module-private, 1 reader (deleted)
- pre-identity warn branches: 2, 0 reachable (identity is required in both schemas)

## Test plan

- [x] `npm run typecheck` (all projects)
- [x] `npx vitest run` GitignoreMatcher, grep, GlobTool, ArxivDownloadTool, the ExecutionsTool suites (161 tests)
- [x] eslint on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

