### PR TITLE
fix(tools): accept ssh:// GitHub remotes, null tool-input defaults, and gate Lean on its real host

### DIFF
--- a/packages/cli/src/commands/installGithubAction.ts
+++ b/packages/cli/src/commands/installGithubAction.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { parseGitHubSlug, type GitHubSlug } from '@tools/github/githubSlug';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { CliExitCode } from '../runtime/exitCodes';
@@ -15,10 +16,8 @@ import {
   git,
   isGitRepo,
   localBranchExists,
-  parseGitHubSlug,
   remoteUrl,
   repoRoot,
-  type GitHubSlug,
 } from '../runtime/gitOps';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';

--- a/packages/cli/src/runtime/gitOps.ts
+++ b/packages/cli/src/runtime/gitOps.ts
@@ -55,21 +55,3 @@ export function localBranchExists(cwd: string, branch: string): boolean {
 export function ghAvailable(cwd: string): boolean {
   return gh(cwd, '--version').success;
 }
-
-export interface GitHubSlug {
-  readonly owner: string;
-  readonly repo: string;
-}
-
-/** Parse `owner/repo` from an https or ssh GitHub remote URL. */
-export function parseGitHubSlug(url: string): GitHubSlug | null {
-  const cleaned = url
-    .trim()
-    .replace(/\/+$/, '')
-    .replace(/\.git$/, '');
-  const match = cleaned.match(/github\.com[/:]([^/]+)\/([^/]+)$/);
-  if (!match) return null;
-  const [, owner, repo] = match;
-  if (!owner || !repo) return null;
-  return { owner, repo };
-}

--- a/src/test-kernel/cli/InstallGithubAction.vitest.ts
+++ b/src/test-kernel/cli/InstallGithubAction.vitest.ts
@@ -189,8 +189,11 @@ describe('parseGitHubSlug', () => {
     expect(parseGitHubSlug(url)).toEqual(expected);
   });
 
-  it('rejects remotes outside GitHub', () => {
-    expect(parseGitHubSlug('https://gitlab.com/owner/repo.git')).toBeNull();
+  it.each([
+    'https://gitlab.com/owner/repo.git',
+    'https://gitlab.com/group/github.com/owner/repo.git',
+  ])('rejects %s, which is not a GitHub remote', (url) => {
+    expect(parseGitHubSlug(url)).toBeNull();
   });
 });
 

--- a/src/test-kernel/cli/InstallGithubAction.vitest.ts
+++ b/src/test-kernel/cli/InstallGithubAction.vitest.ts
@@ -6,9 +6,10 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { runCli } from '@cli/commands/root';
-import { defaultBranch, parseGitHubSlug } from '@cli/runtime/gitOps';
+import { defaultBranch } from '@cli/runtime/gitOps';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
+import { parseGitHubSlug } from '@tools/github/githubSlug';
 
 const browserMocks = vi.hoisted(() => ({
   tryOpenBrowser: vi.fn().mockResolvedValue(true),
@@ -182,6 +183,7 @@ describe('parseGitHubSlug', () => {
   it.each([
     ['https://github.com/owner/repo.git', { owner: 'owner', repo: 'repo' }],
     ['git@github.com:owner/repo.git', { owner: 'owner', repo: 'repo' }],
+    ['ssh://git@github.com/owner/repo.git', { owner: 'owner', repo: 'repo' }],
     ['https://github.com/owner/repo/', { owner: 'owner', repo: 'repo' }],
   ])('parses %s', (url, expected) => {
     expect(parseGitHubSlug(url)).toEqual(expected);

--- a/src/test-kernel/tools/externalToolDefs.vitest.ts
+++ b/src/test-kernel/tools/externalToolDefs.vitest.ts
@@ -6,6 +6,10 @@ import { afterEach, describe, expect, vi } from 'vitest';
 // Local imports - platform/test support/tools
 import { installPlatform } from '@test/support/setupPlatform';
 import { findExternalToolDef } from '@tools/externalToolDefs';
+import {
+  getProcessSettingHost,
+  initProcessSettingHost,
+} from '@utils/config/platformSettings';
 import { BinaryResolver } from '@utils/system/binaryResolver';
 
 afterEach(() => {
@@ -29,6 +33,21 @@ const restorePlatform = <A, E, R>(
   self: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> =>
   self.pipe(Effect.ensuring(Effect.promise(() => installPlatform())));
+
+/** Run as the given process host, restoring the previous one afterwards. */
+const asHost = <A, E, R>(
+  host: Parameters<typeof initProcessSettingHost>[0],
+  self: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = getProcessSettingHost();
+      initProcessSettingHost(host);
+      return previous;
+    }),
+    () => self,
+    (previous) => Effect.sync(() => initProcessSettingHost(previous)),
+  );
 
 describe('external tool definitions', () => {
   it.effect(
@@ -56,32 +75,58 @@ describe('external tool definitions', () => {
     'detects Lean direct mode from the lake binary without running lake',
     () =>
       restorePlatform(
+        asHost(
+          'cli',
+          Effect.gen(function* () {
+            const lean = findExternalToolDef('lean4');
+            if (!lean) throw new Error('Lean tool definition should exist');
+            const findPath = vi
+              .spyOn(BinaryResolver, 'findPath')
+              .mockReturnValue('/usr/local/bin/lake');
+            yield* Effect.promise(() => installToolAvailability(false));
+
+            const probeResult = yield* lean.probe!();
+
+            expect(findPath).toHaveBeenCalledWith('lake');
+            expect(probeResult).toEqual({
+              extensionAvailable: false,
+              lakeAvailable: true,
+              requiresExtension: false,
+            });
+            expect(yield* lean.check(probeResult)).toBe(true);
+
+            findPath.mockReturnValue(null);
+            const missingProbeResult = yield* lean.probe!();
+
+            expect(missingProbeResult).toEqual({
+              extensionAvailable: false,
+              lakeAvailable: false,
+              requiresExtension: false,
+            });
+            expect(yield* lean.check(missingProbeResult)).toBe(false);
+          }),
+        ),
+      ),
+  );
+
+  it.effect('requires the lean4 extension in the VS Code build', () =>
+    restorePlatform(
+      asHost(
+        'vscode',
         Effect.gen(function* () {
           const lean = findExternalToolDef('lean4');
           if (!lean) throw new Error('Lean tool definition should exist');
-          const findPath = vi
-            .spyOn(BinaryResolver, 'findPath')
-            .mockReturnValue('/usr/local/bin/lake');
+          vi.spyOn(BinaryResolver, 'findPath').mockReturnValue(
+            '/usr/local/bin/lake',
+          );
           yield* Effect.promise(() => installToolAvailability(false));
 
           const probeResult = yield* lean.probe!();
 
-          expect(findPath).toHaveBeenCalledWith('lake');
-          expect(probeResult).toEqual({
-            extensionAvailable: false,
-            lakeAvailable: true,
-          });
-          expect(yield* lean.check(probeResult)).toBe(true);
-
-          findPath.mockReturnValue(null);
-          const missingProbeResult = yield* lean.probe!();
-
-          expect(missingProbeResult).toEqual({
-            extensionAvailable: false,
-            lakeAvailable: false,
-          });
-          expect(yield* lean.check(missingProbeResult)).toBe(false);
+          expect(yield* lean.check(probeResult)).toBe(false);
+          expect(yield* lean.statusLabel!(probeResult)).toBe('Needs setup');
         }),
       ),
+    ),
   );
 });

--- a/src/tools/delegation/inputFields.ts
+++ b/src/tools/delegation/inputFields.ts
@@ -25,6 +25,7 @@ import type { ToolResult } from '@shared/schemas';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { errorResult } from '@tools/core/result';
 import { displayToStoragePath } from '@tools/memory/memoryUtils';
+import { nullishWithDefault } from '@tools/core/inputSchema';
 import { runStorageLocationFromAnyAbsolutePath } from '@utils/files/runStorageFs';
 import { StorageFS } from '@utils/files/storageFS';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -46,9 +47,7 @@ const LARGE_BIB_LIMIT_BYTES = 100 * 1024;
  * (prefix + traversal checks). Existence is NOT checked — getAttachedMemories
  * handles read failures gracefully, avoiding a TOCTOU race.
  */
-export const memoriesField = z
-  .array(z.string())
-  .prefault([])
+export const memoriesField = nullishWithDefault(z.array(z.string()), [])
   .describe(
     'Memory file paths to attach (e.g. /memories/conventions.md). Content is injected into the agent prompt as read-only context. Use for project conventions, style guides, or accumulated knowledge the agent should follow.',
   )
@@ -86,16 +85,12 @@ export const WorkflowAgentInputSchema = z.strictObject({
     .describe(
       'Files the agent rewrites. List every file you want it to touch. The agent emits one revised <document> per entry.',
     ),
-  contextFiles: z
-    .array(z.string())
-    .prefault([])
-    .describe(
-      'Read-only context the agent should see but not modify: guidance, examples, related papers, bibliographies (.bib), style/macro definitions (.sty/.cls). Explain each one in the instruction.',
-    ),
-  mediaFiles: z
-    .array(z.string())
-    .prefault([])
-    .describe('Images, figures, PDFs, or audio files the agent should view.'),
+  contextFiles: nullishWithDefault(z.array(z.string()), []).describe(
+    'Read-only context the agent should see but not modify: guidance, examples, related papers, bibliographies (.bib), style/macro definitions (.sty/.cls). Explain each one in the instruction.',
+  ),
+  mediaFiles: nullishWithDefault(z.array(z.string()), []).describe(
+    'Images, figures, PDFs, or audio files the agent should view.',
+  ),
   extractFigures: z
     .boolean()
     .nullish()
@@ -108,12 +103,9 @@ export const WorkflowAgentInputSchema = z.strictObject({
     .describe(
       'When true, extracts TikZ figures from the input LaTeX file(s), compiles them into standalone PDFs, and attaches them as media files.',
     ),
-  outputFiles: z
-    .array(z.string())
-    .prefault([])
-    .describe(
-      'Output file paths. Must be a subset of input files. Never create new files or change format. Leave empty for default suffix-based outputs.',
-    ),
+  outputFiles: nullishWithDefault(z.array(z.string()), []).describe(
+    'Output file paths. Must be a subset of input files. Never create new files or change format. Leave empty for default suffix-based outputs.',
+  ),
   memories: memoriesField,
 });
 

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -425,17 +425,11 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
   },
   {
     id: 'lean4',
-    tools: [
-      'lean_diagnostics',
-      'lean_file',
-      'lean_project',
-      'lean_inspect',
-      'lean_loogle',
-    ],
+    tools: ['lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect'],
     name: 'Lean 4 Proof Assistant',
     category: 'lean',
     description:
-      'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files. Active language servers are listed below.',
+      'Interact with Lean 4 projects: check diagnostics, inspect terms, and manage files. Active language servers are listed below. (lean_loogle needs only network access and is always available.)',
     installGuide:
       'TeXRA can drive Lean 4 in two ways:\n\n' +
       '  • VS Code build: uses the "lean4" extension\n' +

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -52,6 +52,7 @@ import {
 import { isGitRepository } from '@utils/git/isGitRepository';
 import { formatResultCount } from '@utils/text/stringUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { getProcessSettingHost } from '@utils/config/platformSettings';
 
 /**
  * Node.js semver range the `texra` CLI supports; the same value
@@ -179,14 +180,27 @@ const probeTexraCli = Effect.fn('probeTexraCli')(function* () {
 interface Lean4Prerequisites {
   extensionAvailable: boolean;
   lakeAvailable: boolean;
+  /** The VS Code build drives Lean through the lean4 extension; other hosts spawn `lake` directly. */
+  requiresExtension: boolean;
 }
 
 function resolveLean4Prerequisites(probeResult: unknown): Lean4Prerequisites {
   // In-process probe shape is structurally guaranteed; only a missing/absent
   // probe (probeResult undefined) falls back to the not-detected defaults.
   return probeResult === undefined
-    ? { extensionAvailable: false, lakeAvailable: false }
+    ? {
+        extensionAvailable: false,
+        lakeAvailable: false,
+        requiresExtension: false,
+      }
     : (probeResult as Lean4Prerequisites);
+}
+
+/** Lean tools work through the extension in VS Code and through `lake` elsewhere. */
+function leanReady(prerequisites: Lean4Prerequisites): boolean {
+  return prerequisites.requiresExtension
+    ? prerequisites.extensionAvailable
+    : prerequisites.lakeAvailable;
 }
 
 /** True when an SDK import failure means the package simply isn't installed. */
@@ -453,30 +467,34 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
               LEAN4_EXTENSION_ID,
             );
           const lakeAvailable = BinaryResolver.findPath('lake') !== null;
-          return { extensionAvailable, lakeAvailable };
+          const requiresExtension = getProcessSettingHost() === 'vscode';
+          return { extensionAvailable, lakeAvailable, requiresExtension };
         }),
       resolve: (probeResult) =>
         Effect.succeed(resolveLean4Prerequisites(probeResult)),
-      check: ({ extensionAvailable, lakeAvailable }) =>
-        extensionAvailable || lakeAvailable,
-      statusLabel: ({ extensionAvailable, lakeAvailable }) => {
-        if (!extensionAvailable && !lakeAvailable) return 'Needs setup';
+      check: leanReady,
+      statusLabel: (prerequisites) => {
+        if (!leanReady(prerequisites)) return 'Needs setup';
         const activeCount = listLeanServers().filter(isLeanServerActive).length;
         return activeCount > 0
           ? `${formatResultCount(activeCount, 'server')} active`
           : undefined;
       },
-      detailCheck: ({ extensionAvailable, lakeAvailable }) => {
+      detailCheck: (prerequisites) => {
+        const { extensionAvailable, lakeAvailable, requiresExtension } =
+          prerequisites;
         const lines: string[] = [];
         if (extensionAvailable) {
           lines.push('VS Code Lean 4 extension installed.');
         }
-        if (lakeAvailable) {
+        if (lakeAvailable && !requiresExtension) {
           lines.push('Direct LSP mode available (`lake` on PATH).');
         }
-        if (!extensionAvailable && !lakeAvailable) {
+        if (!leanReady(prerequisites)) {
           lines.push(
-            'Neither the leanprover.lean4 extension nor a `lake` binary was detected. Install one of them to enable Lean tools.',
+            requiresExtension
+              ? 'The VS Code build drives Lean through the leanprover.lean4 extension; install it to enable Lean tools. `lake` on PATH alone is not enough here.'
+              : 'No `lake` binary was detected. Install elan and make sure `lake` is on PATH to enable Lean tools.',
           );
         }
         lines.push('');

--- a/src/tools/github/githubSlug.ts
+++ b/src/tools/github/githubSlug.ts
@@ -1,0 +1,24 @@
+/** A GitHub repository named by owner and repository name. */
+export interface GitHubSlug {
+  readonly owner: string;
+  readonly repo: string;
+}
+
+/**
+ * Parse `owner/repo` from a GitHub remote URL: `https://github.com/o/r`,
+ * `git@github.com:o/r` or `ssh://git@github.com/o/r`, each with or without
+ * `.git` and a trailing slash. Repository names may contain dots
+ * (`org.github.io`). Any other host yields null.
+ */
+export function parseGitHubSlug(url: string): GitHubSlug | null {
+  const cleaned = url
+    .trim()
+    .replace(/\/+$/, '')
+    .replace(/\.git$/, '');
+  const match = cleaned.match(
+    /(?:^|[/@])(?:www\.)?github\.com[/:]([^/]+)\/([^/]+)$/,
+  );
+  if (!match) return null;
+  const [, owner, repo] = match;
+  return owner && repo ? { owner, repo } : null;
+}

--- a/src/tools/github/githubSlug.ts
+++ b/src/tools/github/githubSlug.ts
@@ -16,7 +16,7 @@ export function parseGitHubSlug(url: string): GitHubSlug | null {
     .replace(/\/+$/, '')
     .replace(/\.git$/, '');
   const match = cleaned.match(
-    /(?:^|[/@])(?:www\.)?github\.com[/:]([^/]+)\/([^/]+)$/,
+    /^(?:https?:\/\/(?:[^@/]+@)?(?:www\.)?github\.com\/|git@github\.com:|ssh:\/\/(?:[^@/]+@)?github\.com(?::\d+)?\/)([^/]+)\/([^/]+)$/,
   );
   if (!match) return null;
   const [, owner, repo] = match;

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -54,6 +54,7 @@ import {
 } from './subscriptionBindings';
 import { SharedIssuePollingSource } from './IssuePollingSource';
 import { SharedPRPollingSource } from './PRPollingSource';
+import { parseGitHubSlug } from './githubSlug';
 import type { GhIssue } from './prTypes';
 
 const SUBSCRIPTION_PATH_DESCRIPTION =
@@ -386,19 +387,6 @@ function execList(): ToolResult {
   );
 }
 
-// GitHub SSH/HTTPS URL → { owner, repo }. Handles `.git` suffix, and repo
-// names that themselves contain dots (e.g. `org.github.io`, `my.config`).
-const GITHUB_URL_RE =
-  /^(?:git@github\.com:|https:\/\/github\.com\/)([^/]+)\/(.+?)(?:\.git)?\/?$/;
-
-function parseGitHubRemote(
-  remoteUrl: string,
-): { owner: string; repo: string } | undefined {
-  const m = remoteUrl.trim().match(GITHUB_URL_RE);
-  if (!m) return undefined;
-  return { owner: m[1], repo: m[2] };
-}
-
 const gitInDir = (
   args: string[],
   cwd: string,
@@ -522,7 +510,7 @@ const execFindCurrent = Effect.fn('GitHubSubscriptionTool.findCurrent')(
           ),
       ),
     );
-    const remote = parseGitHubRemote(remoteUrl);
+    const remote = parseGitHubSlug(remoteUrl);
     if (!remote) {
       return yield* Effect.fail(
         new ToolError(`origin remote is not a github.com URL: ${remoteUrl}`),

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -15,6 +15,7 @@ import { ToolResult } from '@shared/schemas';
 import { retryTransientFetch } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 import { errorResult, executed } from '@tools/core/result';
+import { nullishWithDefault } from '@tools/core/inputSchema';
 import { ensureArray } from '@utils/core';
 import {
   formatResultCount,
@@ -39,12 +40,9 @@ const LeanLoogleInputSchema = z.strictObject({
       'Search query (type signature or name pattern). Pass an array of strings to batch multiple searches in one call.',
     ),
   /** Maximum number of results to return per query */
-  limit: z
-    .int()
-    .min(1)
-    .max(20)
-    .prefault(10)
-    .describe('Max results per query (default: 10)'),
+  limit: nullishWithDefault(z.int().min(1).max(20), 10).describe(
+    'Max results per query (default: 10)',
+  ),
 });
 
 type LeanLoogleInput = z.infer<typeof LeanLoogleInputSchema>;

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -5,6 +5,7 @@ import { effectRuntime } from '@platform/processRuntime';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { defineTool } from '@tools/core/define';
 import { errorResult, executed } from '@tools/core/result';
+import { nullishWithDefault } from '@tools/core/inputSchema';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { formatResultCount } from '@utils/text/stringUtils';
 import {
@@ -63,10 +64,9 @@ const PROJECT_COMMAND_GROUP_INDEX = [...PROJECT_COMMAND_GROUPS]
 
 const LeanDiagnosticsInputSchema = z.strictObject({
   /** Command: list for full messages, count for summary */
-  command: z
-    .enum(['list', 'count'])
-    .prefault('list')
-    .describe('Use "list" for full messages or "count" for summary only'),
+  command: nullishWithDefault(z.enum(['list', 'count']), 'list').describe(
+    'Use "list" for full messages or "count" for summary only',
+  ),
   /** Path to the Lean file */
   file: z.string().describe('Path to the .lean file'),
 });
@@ -109,11 +109,9 @@ const LeanInspectInputSchema = z.strictObject({
   /** 1-indexed line number */
   line: z.int().min(1).describe('Line number (1-indexed)'),
   /** 1-indexed column number */
-  column: z
-    .int()
-    .min(1)
-    .prefault(1)
-    .describe('Column number (1-indexed, default: 1)'),
+  column: nullishWithDefault(z.int().min(1), 1).describe(
+    'Column number (1-indexed, default: 1)',
+  ),
 });
 
 type LeanInspectInput = z.infer<typeof LeanInspectInputSchema>;

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -14,6 +14,7 @@ import {
 import { executed } from '@tools/core/result';
 
 // Local file imports
+import { nullishWithDefault } from '@tools/core/inputSchema';
 import { defineTool } from '../core/define';
 import { getSetupPlatform } from './platform';
 
@@ -33,12 +34,9 @@ const SendToTerminalInputSchema = z.strictObject({
     .describe(
       'The command to run inside the integrated terminal. One line; no embedded newlines.',
     ),
-  label: z
-    .string()
-    .prefault('setup')
-    .describe(
-      `Short suffix for the terminal tab name; the tool prepends "${TERMINAL_NAME_PREFIX}".`,
-    ),
+  label: nullishWithDefault(z.string(), 'setup').describe(
+    `Short suffix for the terminal tab name; the tool prepends "${TERMINAL_NAME_PREFIX}".`,
+  ),
   timeout: z
     .int()
     .min(1_000)

--- a/src/utils/config/platformSettings.ts
+++ b/src/utils/config/platformSettings.ts
@@ -28,6 +28,11 @@ export function initProcessSettingHost(host: SettingHost): void {
   processSettingHost = host;
 }
 
+/** The host this process is, as installed by {@link initProcessSettingHost}. */
+export function getProcessSettingHost(): SettingHost {
+  return processSettingHost;
+}
+
 /**
  * The three setting slots for the calling context: the session's workspace
  * config and state, and the process global state. `settingsAccess` resolves


### PR DESCRIPTION
## Summary

Three defects in the tool layer. Each fix deletes a duplicated authority.

**1. `ssh://` GitHub remotes were rejected by `github_subscription`.** The tool parsed `origin` with its own regex, which accepted only `git@github.com:` and `https://github.com/`. So `ssh://git@github.com/owner/repo.git`, a form git writes and users configure, failed with "origin remote is not a github.com URL". The CLI (`texra install-github-action`) already had a second, more permissive parser. There is now one: `parseGitHubSlug` in `src/tools/github/githubSlug.ts`. It anchors the whole URL to the supported forms: `https://[user@][www.]github.com/`, `git@github.com:` and `ssh://[user@]github.com[:port]/`. So `mygithub.com` and a GitHub-looking path on another host (`https://gitlab.com/group/github.com/owner/repo`) are both rejected. The GitHub tool and the CLI both import it, and the CLI copy is deleted. The existing `parseGitHubSlug` table gains the `ssh://` case and a rejection case for an embedded `github.com` path.

**2. Tool-input defaults used `.prefault()`.** Seven tool-input fields used it: `delegate_workflow`'s `contextFiles`/`mediaFiles`/`outputFiles`/`memories`, `lean_diagnostics.command`, `lean_inspect.column`, `lean_loogle.limit` and `send_to_terminal.label`. `.prefault()` substitutes only for `undefined`, but OpenAI-compatible providers (DeepSeek, Kimi, …) send an omitted optional field as `null`. Those calls were rejected at validation. CLAUDE.md requires `.nullish()` here, and `src/tools/core/inputSchema.ts` already provides `nullishWithDefault` for this case. All seven now use it. The output types are unchanged. `update_config`'s `target` has the same issue, but it sits in the open #12217 and is left there to avoid a conflict.

**3. VS Code advertised Lean tools that always fail.** The lean4 availability check passed on `extensionAvailable || lakeAvailable`. In VS Code the tools run only through the lean4 extension: the bridge returns no client and prompts for install when it is missing, and the direct `lake` pool is registered only on CLI and desktop. So a VS Code user with `lake` on PATH but no lean4 extension saw Lean as available, and every call failed. The check now needs the extension on VS Code and `lake` elsewhere. `lean_loogle` leaves the lean4 group: it only calls Loogle's public HTTPS API, so gating it on the extension or `lake` was wrong, both before and after this fix. The group has no toggle, so nothing user-visible is lost. It reads the process host through a new `getProcessSettingHost()` getter over the fact `initProcessSettingHost` already records. The status label and details say which piece is missing. One regression test covers VS Code with `lake` only.

Items `D07-9` and `D07-8` (coauthor-97's audit) and the `domain-tools-1` fallback (coauthor-21's audit).

## Net elements (R6)

- Files: 12 changed, 1 added (`githubSlug.ts`), 0 deleted
- `^[+-]export` symbols: +1 `getProcessSettingHost`; `parseGitHubSlug`/`GitHubSlug` move from `gitOps.ts` to `githubSlug.ts` (net 0)
- Class/interface/enum declarations: 0 net (`GitHubSlug` moved)
- Net LoC: see the diff stat

## Consumer counts (R8)

- GitHub remote parsers: 2 → 1 (the tool's `GITHUB_URL_RE`/`parseGitHubRemote` deleted; `parseGitHubSlug` has 2 production callers)
- `.prefault(` in tool-input schemas under `src/tools/**`: 8 → 1 (the remaining one is in #12217)
- `getProcessSettingHost`: 1 production caller (`externalToolDefs.ts`), 1 test

## Test plan

- [x] `npm run typecheck` (all projects)
- [x] `npx vitest run` over the suites touching the changed tools, CLI install-github-action and external tool definitions
- [x] eslint on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

