### PR TITLE
refactor: one launch-failure presentation, park unpresented requests, drop the delivery contract and dead polish context (1.0 clean slate)

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -3,9 +3,10 @@
 //
 // The runtime publishes `approval.requested` before it dispatches a request
 // here, and the fold lists it in `view.approvals` until `approval.resolved`;
-// the modal reads that list (`approvalQueue.ts`). A hook therefore parks:
-// its promise stays pending while the surface answers through a
-// `decision.*` runtime request, which settles the runtime's pending set.
+// the modal reads that list (`approvalQueue.ts`). A hook therefore returns
+// nothing (or has no method at all) and the runtime parks the request while
+// the surface answers through a `decision.*` runtime request, which settles
+// the runtime's pending set.
 // Three kinds still settle through their hook, because the runtime has no
 // request arm for them yet or their answer is host work: a tool edit (no
 // `decision.toolEdit` arm), a retry (its credential switch and
@@ -22,13 +23,10 @@ import PQueue from 'p-queue';
 import {
   currentSession,
   matchesCancelSelector,
-  type BashSettlement,
-  type HostBashApprovalRequest,
   type HostInteractionCancelSelector,
   type HostInteractions,
   type HostRetryInteractionOptions,
   type HostRetryRequest,
-  type HostUserQuestionRequest,
   type PlanApprovalResult,
   type ProposalResult,
   type RetryResult,
@@ -69,13 +67,7 @@ import {
   isCodingPlanQuotaRoute,
   type QuotaFallbackRouteId,
 } from '@shared/quotaFallbackRoutes';
-import {
-  type AgentProposalPermission,
-  type ExternalInquiryPermission,
-  type PermissionPayload,
-  type PlanApprovalPermission,
-  type RunId,
-} from '@shared/schemas';
+import { type ExternalInquiryPermission } from '@shared/schemas';
 import { subscribeToSignalChanges } from '@shared/signals';
 import { handleExternalInquiryAction } from '@tools/inquiry/inquiryActions';
 import { onAbort } from '@utils/core';
@@ -130,24 +122,6 @@ function maybeAutoSwitchRetry(
   return { accepted: true, disableQuotaRoute: route.id };
 }
 
-/** A request the surface answers through a `decision.*` runtime request:
- *  the hook's promise stays pending; the runtime's own settlement resolves
- *  the caller. A runless request has no fact for the fold to list, so
- *  nothing could answer it; it is declined rather than parked forever. */
-function park<T>(
-  kind: PermissionPayload['kind'],
-  runId: RunId | string | null | undefined,
-): Promise<T> | undefined {
-  if (!runId) {
-    logWarning(
-      'cli.tui',
-      `A ${kind} request named no stream; the TUI cannot present it.`,
-    );
-    return undefined;
-  }
-  return new Promise<T>(() => {});
-}
-
 /**
  * Create the typed approval pipeline for the active TUI session.
  */
@@ -185,20 +159,11 @@ export function createTuiHostInteractions(
         reservation.release();
       }
     },
-    requestBashApproval(request: HostBashApprovalRequest) {
-      return park<BashSettlement>('bash', request.runId);
+    requestPlanApproval() {
+      return settleByPolicy<PlanApprovalResult>(context);
     },
-    requestPlanApproval(request: PlanApprovalPermission) {
-      return (
-        settleByPolicy<PlanApprovalResult>(context) ??
-        park('planApproval', request.runId)
-      );
-    },
-    requestAgentProposal(request: AgentProposalPermission) {
-      return (
-        settleByPolicy<ProposalResult>(context) ??
-        park('proposal', request.runId)
-      );
+    requestAgentProposal() {
+      return settleByPolicy<ProposalResult>(context);
     },
     requestRetry(request, options) {
       return requestRetryInteraction(
@@ -208,15 +173,13 @@ export function createTuiHostInteractions(
         options,
       );
     },
-    askUserQuestion(request: HostUserQuestionRequest) {
+    askUserQuestion() {
       const denial = settleHumanInputDenial(context);
-      if (denial != null) {
-        return Promise.resolve<UserQuestionSettlement>({
-          action: 'reject',
-          reason: denial.reason,
-        });
-      }
-      return park<UserQuestionSettlement>('userQuestion', request.runId);
+      if (denial == null) return undefined;
+      return Promise.resolve<UserQuestionSettlement>({
+        action: 'reject',
+        reason: denial.reason,
+      });
     },
     async openExternalInquiry(request) {
       handleExternalInquiry(request, context, interactionOwner);

--- a/packages/cli/src/runtime/cliPresentationHost.ts
+++ b/packages/cli/src/runtime/cliPresentationHost.ts
@@ -1,6 +1,5 @@
 // Local imports - runtime
 import {
-  dispatchPresentationEvent,
   type HostApprovalBypassStateUpdate,
   type PresentationEventHandlers,
   type RuntimePresentationEvent,
@@ -65,8 +64,8 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
 
   /**
    * The one runtime-presentation handler map, both modes. Every event returns
-   * `true` when it rendered a user-visible record so the session can report
-   * delivery. `showAgentConfigBanner` is rendered as a visible, actionable
+   * `true` when it rendered a user-visible record. `showAgentConfigBanner` is
+   * rendered as a visible, actionable
    * "agent not found" error so CLI launch failures surface once through the
    * targeted path. Reproduced per-key rather than as a catch-all, so a future
    * `RuntimePresentationEventPayloads` addition is a compile error to decide
@@ -140,7 +139,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       payload: RuntimePresentationEventPayloads[K],
     ): boolean {
       if (closed) return false;
-      return dispatchPresentationEvent(handlers, event, payload) === true;
+      return handlers[event](payload) === true;
     },
     async close() {
       closed = true;

--- a/packages/cli/src/runtime/executeCli.ts
+++ b/packages/cli/src/runtime/executeCli.ts
@@ -576,13 +576,13 @@ export function executeCliRequest(
       } else if (!(err instanceof AgentError)) {
         primaryRunFailure = { error: err };
       } else if (!failurePresented && !hasErrorPresentationClaimed(err)) {
-        // A failure before lifecycle startup has no `result` event. Preserve the
-        // ordinary toast path when it ran, and provide the missing direct fallback
+        // A failure before registration (agent or model resolution) has no
+        // `result` event; one after registration is presented by the result
+        // toast, which sets `failurePresented`. Provide the direct fallback
         // while the presentation host is still attached. A launch failure that
-        // already presented itself through a targeted notification is marked by
-        // the delivery-confirmed throw site (model-not-recognized, and now also
-        // agent-not-found because `showAgentConfigBanner` renders a visible CLI
-        // error) -- this CLI-local `failurePresented` flag only tracks
+        // already presented itself through a targeted notification
+        // (model-not-recognized, agent-not-found) is marked claimed at its
+        // throw site -- this CLI-local `failurePresented` flag only tracks
         // `requestShowError`, so it would otherwise re-surface that failure a
         // second time here.
         terminalResult.reportUnhandled(() =>

--- a/packages/desktop/src/main/desktopAgentRun.ts
+++ b/packages/desktop/src/main/desktopAgentRun.ts
@@ -159,9 +159,10 @@ export function createDesktopAgentRun(
       Effect.sync(() => toolEditApprovals.handleSessionEvent(event)),
     ),
   );
-  // Attached for the window's life: the runtime parks a request until a
-  // host is attached, so the presentation must be there before the first
-  // run of this window asks anything.
+  // Attached for the window's life, before the first run of this window
+  // asks anything. Requests this host does not present (bash, plan,
+  // proposal, retry, question) stay parked in the runtime until a surface's
+  // approval row decides them.
   const detachHostInteractions = session.interactions.use({
     emit: handlePresentationEvent,
     requestToolEditApproval: (request) =>

--- a/packages/desktop/src/main/desktopAgentRun.ts
+++ b/packages/desktop/src/main/desktopAgentRun.ts
@@ -13,9 +13,6 @@ import { Cause, Effect, Exit, Fiber, Stream } from 'effect';
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import {
-  dispatchPresentationEvent,
-  toPresentationDelivery,
-  type PresentationDelivery,
   type PresentationEventHandlers,
   type RuntimePresentationEvent,
   type RuntimePresentationEventPayloads,
@@ -87,24 +84,25 @@ export function createDesktopAgentRun(
   let disposed = false;
 
   /**
-   * Settle a host dialog promise and report whether it was presented. The
-   * desktop dialog await rejects when its window is torn down beneath it;
-   * voiding the promise would leave that rejection unhandled, and reporting
-   * nothing would read as not-delivered even when the dialog did render.
+   * Settle a host dialog promise, logging a rejection. The desktop dialog
+   * await rejects when its window is torn down beneath it; voiding the
+   * promise would leave that rejection unhandled.
    */
   async function settleHostDialog(
     dialog: Promise<unknown> | void,
     logMessage: string,
-  ): Promise<boolean> {
+  ): Promise<void> {
     const presented = await effectRuntime().runPromiseExit(
       Effect.tryPromise({
         try: async () => dialog,
         catch: (error) => error,
       }),
     );
-    if (Exit.isSuccess(presented)) return true;
-    logger.warn(logMessage, { data: toLogData(Cause.squash(presented.cause)) });
-    return false;
+    if (Exit.isFailure(presented)) {
+      logger.warn(logMessage, {
+        data: toLogData(Cause.squash(presented.cause)),
+      });
+    }
   }
 
   const presentationEventHandlers: PresentationEventHandlers<RuntimePresentationEventPayloads> =
@@ -124,10 +122,8 @@ export function createDesktopAgentRun(
           host.showInstructionDialog(instruction.message, instruction.actions),
           'Failed to present the instruction dialog',
         ),
-      showAgentConfigBanner: ({ agentName, category }) => {
-        options.showAgentConfigBanner({ agentName, category });
-        return true;
-      },
+      showAgentConfigBanner: ({ agentName, category }) =>
+        options.showAgentConfigBanner({ agentName, category }),
       requestOpenFile: (data: RequestOpenFilePayload) =>
         // Desktop has no editor integration to preview through, so the
         // resolved path goes to the preview-with-fallback host directly.
@@ -140,11 +136,9 @@ export function createDesktopAgentRun(
   function handlePresentationEvent<K extends RuntimePresentationEvent>(
     event: K,
     payload: RuntimePresentationEventPayloads[K],
-  ): PresentationDelivery {
-    if (disposed) return false;
-    return toPresentationDelivery(
-      dispatchPresentationEvent(presentationEventHandlers, event, payload),
-    );
+  ): unknown {
+    if (disposed) return undefined;
+    return presentationEventHandlers[event](payload);
   }
 
   // The tool-edit preview: staged copies of the original and proposed

--- a/packages/extension/resources/templates/instructionPolish.yaml
+++ b/packages/extension/resources/templates/instructionPolish.yaml
@@ -1,17 +1,15 @@
 # Prompt template for polishing user instruction text.
-# Used by polishModel.ts: not an agent definition.
+# Used by src/agent/runtime/textEnhancement.ts: not an agent definition.
+# Rendered verbatim (no templating): the user text is appended after it.
 prompts:
   userRequest: |
     Correct any spelling errors, typos, grammatical mistakes, or punctuation issues. Preserve the original meaning and tone without adding new content or changing the structure unless necessary for clarity.
 
-    {% if FILE_CONTEXT %}{{ FILE_CONTEXT }}This text will be used as an instruction for editing the files mentioned above. If the text contains references to these files, make them match the exact filenames.
-
-    {% endif %}Apply these formatting rules:
+    Apply these formatting rules:
     1. If you spot inline LaTeX formulas, ensure they are wrapped with $ symbols (e.g., $E=mc^2$)
     2. If you spot XML tags, fix any unbalanced or unpaired tags
     3. If you spot Markdown syntax (like headers, lists, emphasis, links), fix any incorrect syntax
-    {% if FILE_CONTEXT %}4. If there are partial or ambiguous references to filenames from the context provided above, correct them to use the proper full filename
-    {% endif %}
+
     Return the corrected text wrapped in <corrected_text> XML tags.
 
     Text to correct:

--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -10,9 +10,6 @@
 import * as vscode from 'vscode';
 
 import {
-  dispatchPresentationEvent,
-  toPresentationDelivery,
-  type PresentationDelivery,
   type PresentationEventHandlers,
   type RuntimePresentationEvent,
   type RuntimePresentationEventPayloads,
@@ -76,7 +73,7 @@ const INSTRUCTION_ACTION_VIEW: Record<
 
 async function handleRequestShowInstruction(
   payload: RequestShowInstructionPayload,
-): Promise<boolean> {
+): Promise<void> {
   const actions = (payload.actions ?? []).map((token) => {
     const view = INSTRUCTION_ACTION_VIEW[token];
     return {
@@ -87,10 +84,9 @@ async function handleRequestShowInstruction(
   });
 
   try {
-    // Report delivery once VS Code has accepted the dialog, not once the user
-    // dismisses it: `validateModelExists` awaits this emit, and keeping launch
-    // cleanup tied to modal dismissal would leave the reserved stream STARTING
-    // for as long as the notification is open.
+    // Settle once VS Code has accepted the dialog, not once the user
+    // dismisses it. The "never remind again" path returns without rendering:
+    // the user opted out of this notice.
     await showInstructionWithSuppress(
       payload.key,
       payload.message,
@@ -98,47 +94,38 @@ async function handleRequestShowInstruction(
       payload.showSuppress,
       { deferDismissal: true },
     );
-    // The "never remind again" suppression path also reports delivered:
-    // `showInstructionWithSuppress` returns without rendering when the user
-    // previously opted out of this key, and firing the caller's generic
-    // fallback then would resurface the same notice through a toast the user
-    // cannot suppress. The launch error itself still surfaces through the
-    // failed run.
-    return true;
   } catch (err) {
     log.warn(
       `Failed to show instruction "${payload.key}": ${toErrorMessage(err)}`,
     );
-    return false;
+    // The instruction may be a launch failure's only surface, so fall back
+    // to the error toast rather than dropping it.
+    handleRequestShowError({ message: payload.message });
   }
 }
 
 function handleShowAgentConfigBanner(
   payload: ShowAgentConfigBannerPayload,
   progressViewProvider: ProgressViewProvider,
-): boolean {
+): void {
   progressViewProvider.showAgentConfigBanner(
     payload.agentName,
     payload.category,
   );
-  return true;
 }
 
-function handleRequestShowError({ message }: RequestShowErrorPayload): boolean {
+function handleRequestShowError({ message }: RequestShowErrorPayload): void {
   try {
-    // Delivery is the toast handoff: `showErrorMessage` resolves only on
-    // dismissal, which no caller should wait on, so report once VS Code has
-    // accepted the request. The returned Thenable is still observed so a
-    // post-handoff rejection (e.g. while the extension host is tearing down)
-    // is logged instead of becoming an unhandled rejection.
+    // `showErrorMessage` resolves only on dismissal, which no caller should
+    // wait on. The returned Thenable is still observed so a post-handoff
+    // rejection (e.g. while the extension host is tearing down) is logged
+    // instead of becoming an unhandled rejection.
     const toast = vscode.window.showErrorMessage(message);
     void Promise.resolve(toast).catch((err: unknown) => {
       log.warn(`Error toast failed after handoff: ${toErrorMessage(err)}`);
     });
-    return true;
   } catch (err) {
     log.warn(`Failed to show the error toast: ${toErrorMessage(err)}`);
-    return false;
   }
 }
 
@@ -231,10 +218,8 @@ export function createAgentPresentationHost(
     emit<K extends RuntimePresentationEvent>(
       event: K,
       payload: RuntimePresentationEventPayloads[K],
-    ): PresentationDelivery {
-      return toPresentationDelivery(
-        dispatchPresentationEvent(handlers, event, payload),
-      );
+    ): unknown {
+      return handlers[event](payload);
     },
   };
 }

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -240,9 +240,10 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     });
     this.disposables.push({ dispose: () => hostRequests.dispose() });
 
-    // Attached for the window's life: the runtime parks a request until a
-    // host is attached, so the presentation must be there before the first
-    // run of this window asks anything.
+    // Attached for the window's life, before the first run of this window
+    // asks anything. Requests this host does not present (bash, plan,
+    // proposal, retry, question) stay parked in the runtime until the
+    // view's approval row decides them.
     const detachHostInteractions = session.interactions.use({
       ...createAgentPresentationHost(this),
       readDiagnostics: getLinterMessages,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -164,7 +164,9 @@ export function withLaunchRunContext<T>(
 /**
  * Present a launch error through its targeted host notice (replayed if no
  * host is attached yet) and throw it claimed: the notice is its one surface,
- * so the launch catch adds no generic toast.
+ * so the launch catch adds no generic toast. A live host that throws (a
+ * renderer torn down mid-post, #10466) leaves it unclaimed: no run exists
+ * yet, so the launch catch's generic toast is then its only surface.
  */
 function presentLaunchError<K extends RuntimePresentationEvent>(
   interactions: Pick<SessionHostInteractions, 'emit'>,
@@ -172,8 +174,8 @@ function presentLaunchError<K extends RuntimePresentationEvent>(
   event: K,
   payload: RuntimePresentationEventPayloads[K],
 ): never {
-  interactions.emit(event, payload, { replayWhenAttached: true });
-  attachErrorPresentationClaimed(err);
+  if (interactions.emit(event, payload, { replayWhenAttached: true }) !== false)
+    attachErrorPresentationClaimed(err);
   throw err;
 }
 

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -162,28 +162,18 @@ export function withLaunchRunContext<T>(
 }
 
 /**
- * Present an error through the host and throw it, tracking whether the host
- * actually rendered it so the caller can avoid a duplicate fallback toast.
+ * Present a launch error through its targeted host notice (replayed if no
+ * host is attached yet) and throw it claimed: the notice is its one surface,
+ * so the launch catch adds no generic toast.
  */
-async function presentLaunchError<K extends RuntimePresentationEvent>(
+function presentLaunchError<K extends RuntimePresentationEvent>(
   interactions: Pick<SessionHostInteractions, 'emit'>,
   err: AgentError,
   event: K,
   payload: RuntimePresentationEventPayloads[K],
-): Promise<never> {
-  const delivered = await interactions.emit(event, payload, {
-    replayWhenAttached: true,
-    onReplayScheduled: () => attachErrorPresentationClaimed(err),
-    onReplayNotDelivered: (host) => {
-      host.emit?.('requestShowError', { message: toErrorMessage(err) });
-    },
-  });
-  // Claim presentation only when a live host confirmed it rendered the
-  // targeted notice, or when the notice was retained for replay (the replay
-  // owns the eventual fallback). A live-host emit that throws synchronously
-  // is normalized to `false` by `SessionHostInteractions.emit`, leaving the
-  // marker unset so the launch catch emits the generic fallback.
-  if (delivered) attachErrorPresentationClaimed(err);
+): never {
+  interactions.emit(event, payload, { replayWhenAttached: true });
+  attachErrorPresentationClaimed(err);
   throw err;
 }
 
@@ -201,7 +191,7 @@ async function getAgentPath(
   const result = resolveAgentForLaunch(category, agentIdentifier, source);
   if (result) return result;
 
-  throw await presentLaunchError(
+  return presentLaunchError(
     interactions,
     new AgentError(`Could not find agent: ${agentIdentifier}`),
     'showAgentConfigBanner',
@@ -216,7 +206,7 @@ async function validateModelExists(
   const modelConfig = await resolveRuntimeModelConfig(modelName);
   if (modelConfig) return modelConfig;
 
-  throw await presentLaunchError(
+  return presentLaunchError(
     interactions,
     new AgentError(`Model ${modelName} is not registered`),
     'requestShowInstruction',

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -115,8 +115,6 @@ interface AgentLaunchInput {
   checkpointId?: string;
   /** Runtime behavior declared by the launch source, stamped on `run.start`. */
   userFollowUpSupport?: UserFollowUpSupport;
-  /** Skip the `requestShowError` toast -- for callers that show their own UI. */
-  suppressErrorNotification?: boolean;
   /** Session owning this run's coordination state. Defaults to the launcher's session (`currentSession()`). */
   session?: SessionHandle;
   /** Resume using this persisted provider-message format instead of today's default route. */
@@ -277,23 +275,6 @@ function beginRunStage(
   return agentLogger.openStage(label, { kind: 'run' });
 }
 
-function notifyLaunchFailure(
-  error: unknown,
-  input: { session: SessionHandle; suppressErrorNotification?: boolean },
-): void {
-  if (
-    !input.suppressErrorNotification &&
-    !(error instanceof ZodError) &&
-    !hasErrorPresentationClaimed(error)
-  ) {
-    input.session.interactions.emit(
-      'requestShowError',
-      { message: toErrorMessage(error) },
-      { replayWhenAttached: true },
-    );
-  }
-}
-
 export const prepareAgentDefinition = Effect.fn('prepareAgentDefinition')(
   function* (
     input: {
@@ -359,16 +340,44 @@ export const prepareAgentDefinition = Effect.fn('prepareAgentDefinition')(
       );
     }
 
+    // Validated before registration, so a typo'd model name registers no
+    // FAILED execution and surfaces only its targeted instruction.
+    const modelConfig = yield* Effect.tryPromise({
+      try: async () =>
+        runInSession(input.session, () =>
+          validateModelExists(fullConfig.model, interactions),
+        ),
+      catch: ensureError,
+    });
+    yield* failIfAborted(input.signal);
+
     const config: AgentConfig = {
       ...fullConfig,
       agentCategory: setting.agentCategory,
     };
-    return { config, setting, prompt, resolution };
+    return { config, setting, prompt, resolution, modelConfig };
   },
+  // No run exists yet, so no `result` event will present this failure: the
+  // generic toast is its one surface. Once assembly begins, the terminal
+  // `result` event is the only presentation.
   (effect, input) =>
     effect.pipe(
       Effect.onError((cause) =>
-        Effect.sync(() => notifyLaunchFailure(Cause.squash(cause), input)),
+        Effect.sync(() => {
+          const error = Cause.squash(cause);
+          if (
+            input.suppressErrorNotification ||
+            error instanceof ZodError ||
+            hasErrorPresentationClaimed(error)
+          ) {
+            return;
+          }
+          input.session.interactions.emit(
+            'requestShowError',
+            { message: toErrorMessage(error) },
+            { replayWhenAttached: true },
+          );
+        }),
       ),
     ),
 );
@@ -383,16 +392,8 @@ const assembleAgentLaunchContext = Effect.fn('assembleAgentLaunchContext')(
     resources: Array<() => void | Promise<void>>,
   ): Effect.fn.Return<AgentLaunchContext, Error> {
     yield* failIfAborted(input.signal);
-    const { config, setting, prompt, resolution } = input.definition;
-    const interactions = input.session.interactions;
-    const modelConfig = yield* Effect.tryPromise({
-      try: async () =>
-        runInSession(input.session, () =>
-          validateModelExists(config.model, interactions),
-        ),
-      catch: ensureError,
-    });
-    yield* failIfAborted(input.signal);
+    const { config, setting, prompt, resolution, modelConfig } =
+      input.definition;
 
     // The session is resolved once at the boundary (buildAgentLaunchContext)
     // and carried in, so a delegated launch inherits the parent run's session
@@ -645,7 +646,6 @@ export const buildAgentLaunchContext = Effect.fn('buildAgentLaunchContext')(
               },
             );
           }
-          notifyLaunchFailure(err, input);
         }),
       ),
     );

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -164,9 +164,9 @@ export function withLaunchRunContext<T>(
 /**
  * Present a launch error through its targeted host notice (replayed if no
  * host is attached yet) and throw it claimed: the notice is its one surface,
- * so the launch catch adds no generic toast. A live host that throws (a
- * renderer torn down mid-post, #10466) leaves it unclaimed: no run exists
- * yet, so the launch catch's generic toast is then its only surface.
+ * so the launch catch adds no generic toast. No run exists yet, so a host
+ * that throws on the notice, live or on replay (a renderer torn down
+ * mid-post, #10398/#10466), shows the generic toast in its place.
  */
 function presentLaunchError<K extends RuntimePresentationEvent>(
   interactions: Pick<SessionHostInteractions, 'emit'>,
@@ -174,8 +174,11 @@ function presentLaunchError<K extends RuntimePresentationEvent>(
   event: K,
   payload: RuntimePresentationEventPayloads[K],
 ): never {
-  if (interactions.emit(event, payload, { replayWhenAttached: true }) !== false)
-    attachErrorPresentationClaimed(err);
+  interactions.emit(event, payload, {
+    replayWhenAttached: true,
+    fallbackMessage: toErrorMessage(err),
+  });
+  attachErrorPresentationClaimed(err);
   throw err;
 }
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -340,7 +340,9 @@ export function matchesCancelSelector(
  *
  * Runtime code asks the session for an interaction. The session owns the
  * request until it settles or is explicitly cancelled, while concrete host
- * adapters own presentation, request-id resolution, and local disposal.
+ * adapters own presentation, request-id resolution, and local disposal. A
+ * request method that is absent or returns `undefined` leaves a
+ * run-scoped request parked for a surface's decision on its approval row.
  */
 export interface HostInteractions {
   /**
@@ -898,6 +900,21 @@ export class SessionHostInteractions implements HostInteractions {
       return;
     }
     if (!result) {
+      // The host does not present this request. A run-scoped one stays
+      // pending for a surface's decision on its `approval.requested` row
+      // (`settleRequest`/`settleRetry`), a cancel, or disposal. A runless
+      // one has no row any surface could answer, so it is declined.
+      if (pending.fact) {
+        logger.info(
+          `The interaction host does not present ${pending.kind} requests: ` +
+            `parked on run ${pending.fact.runId} for a decision on its approval row.`,
+        );
+        return;
+      }
+      logger.warn(
+        `A ${pending.kind} request named no run and the interaction host ` +
+          'does not present it: declined.',
+      );
       this.deletePending(pending);
       pending.settle(pending.cancellationResult());
       return;
@@ -919,8 +936,9 @@ export class SessionHostInteractions implements HostInteractions {
       logger.warn(
         `No interaction host is attached: parked the ${pending.kind} request ` +
           `(run ${pending.runId ?? 'none'}) until one attaches. A ` +
-          'headless embedder must attach at least `{ cancel: () => {} }`, or ' +
-          'blocking requests never settle.',
+          'headless embedder must attach a host that answers requests, or ' +
+          'settle or cancel them through the session, or blocking requests ' +
+          'never settle.',
       );
     } catch {
       // A diagnostic sink must not reject or remove the request it describes.

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -344,15 +344,14 @@ export function matchesCancelSelector(
  */
 export interface HostInteractions {
   /**
-   * Present a runtime event through the active host attachment. A host that
-   * renders the event returns `true` (or a `Promise<true>` once rendered);
-   * a host that ignores it or cannot deliver it returns `false`, so callers
-   * can keep a fallback surface instead of assuming fire-and-forget delivery.
+   * Present a runtime event through the active host attachment. Presentation
+   * is fire-and-forget: a host that cannot render an event logs the cause. A
+   * host may return a promise that settles once the event is on screen.
    */
   emit?<K extends RuntimePresentationEvent>(
     event: K,
     payload: RuntimePresentationEventPayloads[K],
-  ): boolean | Promise<boolean>;
+  ): unknown;
   /** Read diagnostics from the active host integration. */
   readonly readDiagnostics?: DiagnosticsReader;
   /** Add one manual criticism to the active host diagnostics surface. */
@@ -512,57 +511,23 @@ export class SessionHostInteractions implements HostInteractions {
     event: K,
     payload: RuntimePresentationEventPayloads[K],
     options: AgentRuntimeEmitOptions = {},
-  ): boolean | Promise<boolean> {
+  ): unknown {
     const active = this.activeAttachment;
     if (active) {
       try {
-        return active.interactions.emit?.(event, payload) ?? false;
+        return active.interactions.emit?.(event, payload);
       } catch (error) {
         logger.warn('Live presentation emit failed', { data: error });
-        return false;
+        return undefined;
       }
     }
+    // The replay loop warn-logs a replay that throws or rejects.
     if (options.replayWhenAttached && !this.disposed) {
-      // A retained replay is not delivery: nothing has been rendered yet, so
-      // the caller must not treat this as confirmed presentation. The replay
-      // closure reports the eventual delivery result back through the
-      // option callbacks once a live host actually renders (or declines) it.
-      this.queuePresentationReplay((interactions) => {
-        if (!options.onReplayNotDelivered) {
-          return interactions.emit?.(event, payload);
-        }
-        // A synchronous throw from the host's emit (a desktop renderer post
-        // during teardown, a development assertion) escapes the promise
-        // chain below and would otherwise be caught only by the replay
-        // loop's warn-log, leaving the caller's presentation-pending marker
-        // stuck and the failure surfaced zero times. Route it through the
-        // same not-delivered fallback as a returned `false` or a rejection.
-        let delivered: boolean | Promise<boolean> | undefined;
-        try {
-          delivered = interactions.emit?.(event, payload);
-        } catch (error) {
-          logger.warn('Replayed presentation notice failed', {
-            data: error,
-          });
-          options.onReplayNotDelivered?.(interactions);
-          return undefined;
-        }
-        return Promise.resolve(delivered).then(
-          (value) => {
-            if (value !== true) options.onReplayNotDelivered?.(interactions);
-          },
-          (error: unknown) => {
-            logger.warn('Replayed presentation notice failed', {
-              data: error,
-            });
-            options.onReplayNotDelivered?.(interactions);
-          },
-        );
-      });
-      options.onReplayScheduled?.();
-      return false;
+      this.queuePresentationReplay((interactions) =>
+        interactions.emit?.(event, payload),
+      );
     }
-    return false;
+    return undefined;
   }
 
   get readDiagnostics(): DiagnosticsReader | undefined {

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -509,6 +509,11 @@ export class SessionHostInteractions implements HostInteractions {
     };
   }
 
+  /**
+   * Present `event` through the active host, or queue it for the next one
+   * when `replayWhenAttached` is set. Returns `false` when the live host
+   * threw, so a caller whose notice is a failure's only surface can fall back.
+   */
   emit<K extends RuntimePresentationEvent>(
     event: K,
     payload: RuntimePresentationEventPayloads[K],
@@ -520,7 +525,7 @@ export class SessionHostInteractions implements HostInteractions {
         return active.interactions.emit?.(event, payload);
       } catch (error) {
         logger.warn('Live presentation emit failed', { data: error });
-        return undefined;
+        return false;
       }
     }
     // The replay loop warn-logs a replay that throws or rejects.

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -509,30 +509,38 @@ export class SessionHostInteractions implements HostInteractions {
     };
   }
 
-  /**
-   * Present `event` through the active host, or queue it for the next one
-   * when `replayWhenAttached` is set. Returns `false` when the live host
-   * threw, so a caller whose notice is a failure's only surface can fall back.
-   */
   emit<K extends RuntimePresentationEvent>(
     event: K,
     payload: RuntimePresentationEventPayloads[K],
     options: AgentRuntimeEmitOptions = {},
   ): unknown {
+    // Live or replayed, a host that throws on a notice carrying a fallback
+    // shows the generic error toast on the same host instead.
+    const present = (interactions: HostInteractions) => {
+      try {
+        return interactions.emit?.(event, payload);
+      } catch (error) {
+        if (options.fallbackMessage === undefined) throw error;
+        logger.warn('Presentation emit failed; showing the generic error', {
+          data: error,
+        });
+        return interactions.emit?.('requestShowError', {
+          message: options.fallbackMessage,
+        });
+      }
+    };
     const active = this.activeAttachment;
     if (active) {
       try {
-        return active.interactions.emit?.(event, payload);
+        return present(active.interactions);
       } catch (error) {
         logger.warn('Live presentation emit failed', { data: error });
-        return false;
+        return undefined;
       }
     }
     // The replay loop warn-logs a replay that throws or rejects.
     if (options.replayWhenAttached && !this.disposed) {
-      this.queuePresentationReplay((interactions) =>
-        interactions.emit?.(event, payload),
-      );
+      this.queuePresentationReplay(present);
     }
     return undefined;
   }

--- a/src/agent/runtime/bundledPrompts.ts
+++ b/src/agent/runtime/bundledPrompts.ts
@@ -31,7 +31,6 @@ import { z } from 'zod';
 import { Result } from 'effect';
 import { parseYamlWith } from '@common/parsing/safeParseYaml';
 import { createLog } from '@logger/logUtils';
-import { createTexraNunjucksEnvironment } from '@utils/prompt';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 
@@ -165,23 +164,11 @@ function loadGoalPrompts(): Promise<GoalPrompts> {
 }
 
 /**
- * Render the polish prompt from the YAML template.
- * FILE_CONTEXT goes through nunjucks; user text is appended raw (safe from injection).
+ * The polish prompt: the YAML instruction prefix followed by the raw user
+ * text. Nothing is templated, so user text can't inject template syntax.
  */
-export async function renderPolishPrompt(
-  fileContext: string,
-  text: string,
-): Promise<string> {
-  const [{ prompts }, { default: nunjucks }] = await Promise.all([
-    loadPolishPrompts(),
-    import('nunjucks'),
-  ]);
-  const environment = createTexraNunjucksEnvironment(nunjucks);
-  return (
-    environment.renderString(prompts.userRequest, {
-      FILE_CONTEXT: fileContext,
-    }) + text
-  );
+export async function renderPolishPrompt(text: string): Promise<string> {
+  return (await loadPolishPrompts()).prompts.userRequest + text;
 }
 
 export async function getContinuationTemplate(): Promise<string> {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -345,7 +345,10 @@ export interface ExecuteAgentOptions extends SubagentRunOptions {
   launchSignal?: AbortSignal;
   /** The run's `run.start` was committed by an earlier activation (a resume). */
   resumed?: boolean;
-  /** The caller owns presentation for failures before the run lifecycle. */
+  /**
+   * The caller owns presentation for failures before registration (read by
+   * `runAgent`'s prepare step; after that the run's `result` event presents).
+   */
   suppressErrorNotification?: boolean;
   /**
    * Fires with the run id once its `run.start` is published, before the run
@@ -413,8 +416,6 @@ export function executeAgent(
       onRunResolved: options.onRunResolved,
       parentRunId: options.parentRunId,
       userFollowUpSupport: options.userFollowUpSupport,
-      suppressErrorNotification:
-        options.suppressErrorNotification ?? isSubagent,
       session: options.session,
       modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
       copilotRouteOverride: options.copilotRouteOverride,
@@ -577,7 +578,6 @@ const resumeToolUseWithOwnedLease = Effect.fn('resumeToolUseWithOwnedLease')(
             resume.shared.modelHandlerCompatibilityKey,
           parentRunId,
           userFollowUpSupport,
-          suppressErrorNotification: true,
           session: runSession,
           toolPolicy: {
             approvalPromptsUnavailable: options.approvalPromptsUnavailable,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -346,11 +346,6 @@ export interface ExecuteAgentOptions extends SubagentRunOptions {
   /** The run's `run.start` was committed by an earlier activation (a resume). */
   resumed?: boolean;
   /**
-   * The caller owns presentation for failures before registration (read by
-   * `runAgent`'s prepare step; after that the run's `result` event presents).
-   */
-  suppressErrorNotification?: boolean;
-  /**
    * Fires with the run id once its `run.start` is published, before the run
    * begins: the run exists for every fold, so a host may select it as its
    * own surface state. The run's trace comes with it, before its first

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -88,12 +88,7 @@ export { describeFollowUpFailure } from '@agent/followUp/ToolUseFollowUp';
 export { detachSubagentsOnStop } from './detachSubagentsOnStop';
 
 // runtimePresentationEvents
-export {
-  dispatchPresentationEvent,
-  toPresentationDelivery,
-} from './runtimePresentationEvents';
 export type {
-  PresentationDelivery,
   PresentationEventHandlers,
   RuntimePresentationEvent,
   RuntimePresentationEventPayloads,

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -30,7 +30,6 @@ import type { AgentFlowResult } from './AgentFlowResult';
  */
 export interface RunAgentOptions extends Pick<
   ExecuteAgentOptions,
-  | 'suppressErrorNotification'
   | 'stopAfterCycle'
   | 'approvalPromptsUnavailable'
   | 'onApprovalPolicyDenial'
@@ -47,6 +46,11 @@ export interface RunAgentOptions extends Pick<
   readonly session: SessionHandle;
   /** Reject an explicitly supplied category that differs from the resolved definition. */
   readonly enforceCategory?: boolean;
+  /**
+   * The caller owns presentation for failures before registration; after
+   * that the run's `result` event presents.
+   */
+  suppressErrorNotification?: boolean;
   /**
    * Persist host-owned final state before the ordinary session drain. Return
    * true when the hook already drained artifacts and disposed of ownership.
@@ -95,6 +99,7 @@ export const runAgent = Effect.fn('runAgent')(function* (
     beforeLeaseRelease,
     onRunLeaseAcquired,
     preferHelperModel,
+    suppressErrorNotification,
     ...executeAgentOptions
   } = options;
   const runId = request.runId ?? generateRunId();
@@ -145,7 +150,7 @@ export const runAgent = Effect.fn('runAgent')(function* (
           session: runSession,
           enforceCategory: request.kind === 'resume' || options.enforceCategory,
           signal: launchSignal,
-          suppressErrorNotification: options.suppressErrorNotification,
+          suppressErrorNotification,
         });
         const { config } = definition;
         const userFollowUpSupport =

--- a/src/agent/runtime/runtimePresentationEvents.ts
+++ b/src/agent/runtime/runtimePresentationEvents.ts
@@ -28,6 +28,12 @@ export type RuntimePresentationEvent = keyof RuntimePresentationEventPayloads;
 export interface AgentRuntimeEmitOptions {
   /** Retain a presentation event until a temporarily detached UI returns. */
   readonly replayWhenAttached?: boolean;
+  /**
+   * Shown through `requestShowError` on the same host when presenting this
+   * event throws, live or on replay: for a notice that is a failure's only
+   * surface.
+   */
+  readonly fallbackMessage?: string;
 }
 
 /**

--- a/src/agent/runtime/runtimePresentationEvents.ts
+++ b/src/agent/runtime/runtimePresentationEvents.ts
@@ -5,9 +5,6 @@ import type {
   RequestShowInstructionPayload,
   ShowAgentConfigBannerPayload,
 } from '@shared/schemas';
-import { isThenable } from '@utils/core';
-
-import type { HostInteractions } from './HostInteractions';
 
 /**
  * Host-presentation requests emitted by agent/runtime code.
@@ -15,6 +12,8 @@ import type { HostInteractions } from './HostInteractions';
  * These are not progress facts and do not belong to the frozen host progress
  * compatibility vocabulary. Hosts may render them, ignore them, or route them
  * to their own presentation channel without changing the agent loop.
+ * Presentation is fire-and-forget: a host that cannot render an event logs
+ * the cause itself.
  */
 export interface RuntimePresentationEventPayloads {
   requestOpenFile: RequestOpenFilePayload;
@@ -29,90 +28,18 @@ export type RuntimePresentationEvent = keyof RuntimePresentationEventPayloads;
 export interface AgentRuntimeEmitOptions {
   /** Retain a presentation event until a temporarily detached UI returns. */
   readonly replayWhenAttached?: boolean;
-  /**
-   * Invoked synchronously when `replayWhenAttached` retains the event because
-   * no host is attached. Callers use this to record "presentation is pending"
-   * without claiming it was delivered.
-   */
-  readonly onReplayScheduled?: () => void;
-  /**
-   * Invoked once a retained event is actually replayed to a host and that
-   * host reports non-delivery (or rejects). The callback receives the host
-   * that performed the replay so the caller can present its fallback surface
-   * on the same host.
-   */
-  readonly onReplayNotDelivered?: (interactions: HostInteractions) => unknown;
 }
 
 /**
  * One handler per {@link RuntimePresentationEventPayloads} key, each typed to
- * that event's own payload. Building a value of this type as an object
- * literal (rather than a `switch (event) { case ... }`) is what lets
- * TypeScript correlate the map's value type to a specific key through the
- * object's own indexed-access type, instead of through a hand-written
- * `payload as Payloads['x']` cast repeated on every branch.
+ * that event's own payload. A host builds this as an object literal and
+ * dispatches with `handlers[event](payload)` from a generic
+ * `emit<K extends RuntimePresentationEvent>`: the mapped type correlates the
+ * handler to the key, so no per-event `payload as Payloads['x']` cast is
+ * needed, and omitting a key is a compile error rather than a dropped event.
  */
 export type PresentationEventHandlers<
   Payloads = RuntimePresentationEventPayloads,
 > = {
   [K in keyof Payloads]: (payload: Payloads[K]) => unknown;
 };
-
-/**
- * Dispatches a `(event, payload)` pair — as received from a
- * `SessionHostInteractions.emit`-style call — to the matching entry of a
- * {@link PresentationEventHandlers} map.
- *
- * Every host that reacts to `RuntimePresentationEvent`s (CLI, desktop, VS
- * Code extension) used to hand-write its own
- * `switch (event) { case 'x': (payload as Payloads['x'])... }` dispatcher,
- * re-asserting the event/payload correlation with a cast on every branch.
- * Calling this instead — with `handlers` built as a
- * `PresentationEventHandlers` object literal — needs no cast: `K` narrows
- * `handlers[event]` to `(payload: Payloads[K]) => unknown` and `payload` is
- * already `Payloads[K]`, so the call typechecks structurally. This mirrors
- * the `HandlerRegistry`/`createDispatcher` idiom the progressView/
- * settingsView message dispatchers already use
- * (`src/shared/utils/dispatcher.ts`), minus the schema-parsing step those
- * need for a raw `unknown` wire message — this dispatcher's `(event,
- * payload)` pair is already typed at the call site.
- */
-export function dispatchPresentationEvent<Payloads, K extends keyof Payloads>(
-  handlers: PresentationEventHandlers<Payloads>,
-  event: K,
-  payload: Payloads[K],
-): unknown {
-  return handlers[event](payload);
-}
-
-/**
- * Result contract for a presentation handler that can report delivery. A
- * handler that renders the event synchronously returns `true`; a handler that
- * renders asynchronously (e.g. awaiting a webview post) returns
- * `Promise<boolean>`. Any other result means "not delivered", so callers can
- * keep a fallback surface instead of assuming best-effort delivery.
- *
- * Every handler implements this contract, not only the events a caller
- * currently marks on (`showAgentConfigBanner`, `requestShowInstruction`): a
- * handler that presented its event must say so, because the next caller to
- * mark on the result will trust it. A deliberate no-op (the CLI's
- * `requestOpenFile`, the desktop progress-view reveal) truthfully reports
- * "not delivered". Deliberate suppression by user choice — the extension's
- * "never remind again" instruction state — counts as delivered: the user
- * opted out of that surface, and the generic fallback would resurface the
- * notice through a channel they cannot suppress.
- */
-export type PresentationDelivery = boolean | Promise<boolean>;
-
-/**
- * Normalizes a {@link dispatchPresentationEvent} return value to the
- * {@link PresentationDelivery} contract. Non-boolean, non-promise results are
- * treated as not delivered.
- */
-export function toPresentationDelivery(result: unknown): PresentationDelivery {
-  if (typeof result === 'boolean') return result;
-  if (isThenable(result)) {
-    return Promise.resolve(result).then((delivered) => delivered === true);
-  }
-  return false;
-}

--- a/src/agent/runtime/textEnhancement.ts
+++ b/src/agent/runtime/textEnhancement.ts
@@ -8,50 +8,11 @@ import { createHelperModelKit, runHelperModelCompletion } from './helperModel';
 
 const log = createLog('TextEnhancement');
 
-// ── Types ────────────────────────────────────────────────────
-
-export interface FileContext {
-  agent?: string;
-  inputFiles?: string[];
-  contextFiles?: string[];
-  mediaFiles?: string[];
-  outputFiles?: string[];
-}
-
-// ── File context ─────────────────────────────────────────────
-
-function formatFileContext(ctx: FileContext): string {
-  const lines: string[] = ['Current context:'];
-  if (ctx.agent) lines.push(`Agent: ${ctx.agent}`);
-
-  const fileEntries: string[] = [];
-
-  const arrays: [string, string[] | undefined][] = [
-    ['Input Files', ctx.inputFiles],
-    ['Context Files', ctx.contextFiles],
-    ['Media Files', ctx.mediaFiles],
-    ['Output Files', ctx.outputFiles],
-  ];
-  for (const [label, files] of arrays) {
-    if (files?.length) fileEntries.push(`${label}: ${files.join(', ')}`);
-  }
-
-  if (fileEntries.length > 0) {
-    lines.push('', 'Files in the task:', ...fileEntries);
-  }
-
-  return lines.join('\n') + '\n';
-}
-
-// ── Polishing ────────────────────────────────────────────────
-
 export async function polishTextWithAI(
   text: string,
-  fileContext?: FileContext,
 ): Promise<{ success: boolean; text: string; error?: string }> {
   try {
-    const fileContextString = fileContext ? formatFileContext(fileContext) : '';
-    const prompt = await renderPolishPrompt(fileContextString, text);
+    const prompt = await renderPolishPrompt(text);
 
     const helperResult = await createHelperModelKit();
     if (!helperResult.kit) {

--- a/src/test-kernel/agent/BundledPrompts.vitest.ts
+++ b/src/test-kernel/agent/BundledPrompts.vitest.ts
@@ -60,10 +60,9 @@ describe('bundled prompt loader', () => {
   it('renders the polish prompt from the packaged resource bundle', async () => {
     initializeBundledPrompts(RESOURCES_PATH);
 
-    const prompt = await renderPolishPrompt('<paper & notes>', 'Fix teh typo.');
+    const prompt = await renderPolishPrompt('Fix teh typo.');
 
     expect(prompt).toContain('Correct any spelling errors');
-    expect(prompt).toContain('<paper & notes>');
     expect(prompt).toContain('Fix teh typo.');
   });
 
@@ -71,7 +70,7 @@ describe('bundled prompt loader', () => {
     const root = await makeBrokenResources();
     initializeBundledPrompts(root);
 
-    await expect(renderPolishPrompt('', 'text')).rejects.toThrow(
+    await expect(renderPolishPrompt('text')).rejects.toThrow(
       `Failed to parse polish prompt YAML at ${join(root, 'templates', 'instructionPolish.yaml')}`,
     );
   });

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -214,12 +214,7 @@ export function reflectionFlowShared(
   };
 }
 
-interface RecordingHostOptions {
-  /** What the fake host's `emit` reports as its presentation delivery. */
-  readonly emitDelivery?: boolean;
-}
-
-export function createRecordingHost(options: RecordingHostOptions = {}): {
+export function createRecordingHost(): {
   events: RecordedProgressEvent[];
   interactions: HostInteractions;
   decisions: RecordingHostDecisions;
@@ -311,7 +306,6 @@ export function createRecordingHost(options: RecordingHostOptions = {}): {
   const interactions: HostInteractions = {
     emit: (event, payload) => {
       events.push({ event, payload });
-      return options.emitDelivery ?? false;
     },
     setApprovalBypassState: (update) =>
       events.push({ event: 'setApprovalBypassState', payload: update }),

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -39,6 +39,7 @@ import {
   type AgentLaunchContext,
   prepareAgentDefinition,
 } from '@agent/runtime/AgentLaunchContext';
+import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { hasErrorPresentationClaimed } from '@common/errors/sdkError/errorMetadata';
 import {
   RUN_OUTCOME,
@@ -294,15 +295,18 @@ describe('AgentLaunchContext', () => {
     ]);
 
     try {
+      // Rejected while preparing the definition, before any execution is
+      // registered for the unknown model.
       await expect(
-        buildAgentLaunchContext({
-          config: AgentConfigSchema.parse({
-            agent: 'chat',
-            model: '__unregistered_model_for_launch_context_test__',
+        Effect.runPromise(
+          prepareAgentDefinition({
+            config: AgentConfigSchema.parse({
+              agent: 'chat',
+              model: '__unregistered_model_for_launch_context_test__',
+            }),
+            session,
           }),
-          runId: EXECUTION_ID,
-          session,
-        }),
+        ),
       ).rejects.toThrow('is not registered');
     } finally {
       session.dispose();
@@ -318,6 +322,47 @@ describe('AgentLaunchContext', () => {
         (event) => event.event === 'requestShowInstruction',
       ),
     ).toHaveLength(1);
+  });
+
+  it('presents an assembly failure once, through its terminal result', async () => {
+    // Regression: the launch catch used to toast an assembly failure beside
+    // the `result` event's own toast, so the user saw the error twice.
+    const recording = createRecordingHost();
+    const session = createTestSession();
+    session.interactions.use(recording.interactions);
+    const detachToast = attachTerminalResultToast(
+      session,
+      session.interactions,
+    );
+    publishTestRunStart(session, EXECUTION_ID);
+    mocks.resolve.mockReturnValueOnce({ entry: { path: '/agents/chat.yaml' } });
+    mocks.load.mockResolvedValueOnce([
+      { agentCategory: AgentCategory.ToolUse },
+      {},
+    ]);
+    mocks.createHandler.mockRejectedValueOnce(new Error('handler failed'));
+
+    try {
+      await expect(
+        buildAgentLaunchContext({
+          config: AgentConfigSchema.parse({
+            agent: 'chat',
+            model: 'gpt55',
+            agentCategory: AgentCategory.ToolUse,
+          }),
+          runId: EXECUTION_ID,
+          session,
+          resumed: true,
+          modelHandlerCompatibilityKey: 'ModelHandlerOpenAIResponse',
+        }),
+      ).rejects.toThrow('handler failed');
+      expect(
+        recording.events.filter((event) => event.event === 'requestShowError'),
+      ).toHaveLength(1);
+    } finally {
+      detachToast();
+      session.dispose();
+    }
   });
 
   it('projects model changes into the active run context', async () => {

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -186,6 +186,29 @@ describe('AgentLaunchContext', () => {
     );
   });
 
+  it('emits the generic fallback when a queued banner replay throws synchronously', async () => {
+    // The banner was queued (no host attached) and claimed; a host whose
+    // replayed post throws must still surface the failure once (#10398).
+    const events: string[] = [];
+    const session = await triggerQueuedMissingAgentFailure(createTestSession());
+    session.interactions.use({
+      emit: (event) => {
+        if (event === 'showAgentConfigBanner') {
+          throw new Error('renderer torn down mid-post');
+        }
+        events.push(event);
+      },
+      cancel: () => {},
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events.filter((event) => event === 'requestShowError')).toHaveLength(
+      1,
+    );
+    session.dispose();
+  });
+
   it('does not double-surface a model-not-recognized failure via the generic error toast', async () => {
     const recording = createRecordingHost();
     const session = createTestSession();

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -159,6 +159,33 @@ describe('AgentLaunchContext', () => {
     session.dispose();
   });
 
+  it('falls back to the generic toast when a live host throws on the missing-agent banner', async () => {
+    // A live host whose banner post throws synchronously (a renderer torn
+    // down mid-post, #10466) must leave the failure unclaimed: it is
+    // pre-registration, so no `result` event exists to present it instead.
+    const events: string[] = [];
+    const session = createTestSession();
+    session.interactions.use({
+      emit: (event) => {
+        if (event === 'showAgentConfigBanner') {
+          throw new Error('renderer torn down mid-post');
+        }
+        events.push(event);
+      },
+      cancel: () => {},
+    });
+
+    try {
+      await launchWithMissingAgent(session);
+    } finally {
+      session.dispose();
+    }
+
+    expect(events.filter((event) => event === 'requestShowError')).toHaveLength(
+      1,
+    );
+  });
+
   it('does not double-surface a model-not-recognized failure via the generic error toast', async () => {
     const recording = createRecordingHost();
     const session = createTestSession();

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -113,9 +113,8 @@ async function triggerQueuedMissingAgentFailure(
 
 describe('AgentLaunchContext', () => {
   it('publishes missing-agent banners through the supplied host interactions', async () => {
-    // Delivery is confirmed so the launch catch adds no generic toast; the
-    // undelivered variant is covered by the generic-error-toast test below.
-    const explicit = createRecordingHost({ emitDelivery: true });
+    // The banner claims the failure, so the launch catch adds no generic toast.
+    const explicit = createRecordingHost();
     const session = createTestSession();
     session.interactions.use(explicit.interactions);
 
@@ -139,33 +138,9 @@ describe('AgentLaunchContext', () => {
     ]);
   });
 
-  it('keeps the generic error toast when the missing-agent banner is not delivered', async () => {
-    // A host that reports no delivery (for example an older/no-op adapter)
-    // must still surface the launch failure once through the generic toast.
-    const recording = createRecordingHost({ emitDelivery: false });
-    const session = createTestSession();
-    session.interactions.use(recording.interactions);
-
-    try {
-      await launchWithMissingAgent(session);
-    } finally {
-      session.dispose();
-    }
-
-    expect(
-      recording.events.filter((event) => event.event === 'requestShowError'),
-    ).toHaveLength(1);
-    expect(
-      recording.events.filter(
-        (event) => event.event === 'showAgentConfigBanner',
-      ),
-    ).toHaveLength(1);
-  });
-
   it('renders a queued missing-agent banner once a live host replays it', async () => {
-    // The retained replay owns the delivery decision: it renders the targeted
-    // banner and emits no generic fallback.
-    const recording = createRecordingHost({ emitDelivery: true });
+    // The retained replay renders the targeted banner and no generic toast.
+    const recording = createRecordingHost();
     const session = await triggerQueuedMissingAgentFailure(createTestSession());
     const owner = session.interactions;
 
@@ -184,105 +159,8 @@ describe('AgentLaunchContext', () => {
     session.dispose();
   });
 
-  it('emits the generic fallback when a queued banner replay throws synchronously', async () => {
-    // A host adapter whose emit throws synchronously (e.g. a desktop renderer
-    // post during teardown) escapes the replay closure's promise chain. It
-    // must still trip the not-delivered fallback — otherwise the launch
-    // error stays presentation-pending and surfaces zero times (#10398).
-    const events: Array<{ event: string; payload: unknown }> = [];
-    const session = await triggerQueuedMissingAgentFailure(createTestSession());
-    const owner = session.interactions;
-
-    owner.use({
-      emit: (event, payload) => {
-        if (event === 'showAgentConfigBanner') {
-          throw new Error('renderer torn down mid-post');
-        }
-        events.push({ event, payload });
-        return false;
-      },
-      cancel: () => {},
-    });
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(
-      events.filter((entry) => entry.event === 'requestShowError'),
-    ).toHaveLength(1);
-    session.dispose();
-  });
-
-  it('normalizes a live-host synchronous banner throw into the generic toast fallback', async () => {
-    // A live (already attached) host whose emit throws synchronously is
-    // normalized to `false` by `SessionHostInteractions.emit`, leaving the
-    // error unmarked so the launch catch emits the generic fallback on the
-    // same host (#10466).
-    const events: Array<{ event: string; payload: unknown }> = [];
-    const session = createTestSession();
-    const owner = session.interactions;
-    owner.use({
-      emit: (event, payload) => {
-        if (event === 'showAgentConfigBanner') {
-          throw new Error('renderer torn down mid-post');
-        }
-        events.push({ event, payload });
-        return false;
-      },
-      cancel: () => {},
-    });
-    let thrown: unknown;
-
-    try {
-      await buildAgentLaunchContext({
-        config: AgentConfigSchema.parse({ agent: '', model: '' }),
-        runId: EXECUTION_ID,
-        session,
-      }).catch((error: unknown) => {
-        thrown = error;
-      });
-    } finally {
-      session.dispose();
-    }
-
-    expect(String(thrown)).toContain('Could not find agent');
-    expect(hasErrorPresentationClaimed(thrown)).toBe(false);
-    expect(
-      events.filter((entry) => entry.event === 'requestShowError'),
-    ).toHaveLength(1);
-    owner.dispose();
-  });
-
-  it('does not queue a second generic toast while a missing-agent banner replay is pending', async () => {
-    const recording = createRecordingHost({ emitDelivery: false });
-    const session = createTestSession();
-    const owner = session.interactions;
-
-    try {
-      await launchWithMissingAgent(session);
-
-      // The launch catch saw the pending-replay marker and left the fallback
-      // to the queued targeted event; it must not have queued a duplicate.
-      expect(recording.events).toEqual([]);
-
-      owner.use(recording.interactions);
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(
-        recording.events.filter(
-          (event) => event.event === 'showAgentConfigBanner',
-        ),
-      ).toHaveLength(1);
-      expect(
-        recording.events.filter((event) => event.event === 'requestShowError'),
-      ).toHaveLength(1);
-    } finally {
-      session.dispose();
-    }
-  });
-
   it('does not double-surface a model-not-recognized failure via the generic error toast', async () => {
-    const recording = createRecordingHost({ emitDelivery: true });
+    const recording = createRecordingHost();
     const session = createTestSession();
     session.interactions.use(recording.interactions);
 

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -486,13 +486,22 @@ describe('session.interactions request bookkeeping', () => {
     }
   });
 
-  it('settles against the documented minimal `{ cancel }` host', async () => {
+  it('parks a run-scoped request against a `{ cancel }` host until settleRequest', async () => {
+    // Regression: a host without a request method (the extension and desktop
+    // for bash, plan, proposal, retry, question) used to auto-reject it
+    // before any surface could answer its approval row.
     const session = createTestSession();
     session.interactions.use({ cancel: vi.fn() });
     try {
-      await expect(
-        requestPlan(session, 'approval:minimal-host'),
-      ).resolves.toEqual({ action: 'reject' });
+      const pending = requestPlan(session, 'approval:minimal-host');
+      expect(
+        session.interactions.settleRequest(
+          'planApproval',
+          'approval:minimal-host',
+          { action: 'approve' },
+        ),
+      ).toBe(true);
+      await expect(pending).resolves.toEqual({ action: 'approve' });
     } finally {
       session.dispose();
     }

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -358,61 +358,6 @@ describe('session.interactions immediate capabilities', () => {
     session.dispose();
   });
 
-  it('reports a synchronously throwing live-host emit as not delivered', () => {
-    // The live-host immediate-attachment branch must apply the same guard as
-    // the queued replay path: a host adapter whose emit throws synchronously
-    // (a desktop renderer post during teardown) must read as not delivered,
-    // not escape as an arbitrary host exception (#10466).
-    const session = createTestSession();
-    session.interactions.use({
-      emit: () => {
-        throw new Error('renderer torn down mid-post');
-      },
-      cancel: vi.fn(),
-    });
-
-    expect(
-      session.interactions.emit('requestShowError', { message: 'boom' }),
-    ).toBe(false);
-    session.dispose();
-  });
-
-  it('reports a synchronously throwing replayed emit through onReplayNotDelivered', async () => {
-    // A host adapter whose emit throws synchronously (a desktop renderer
-    // post during teardown) escapes the replay closure's promise chain; the
-    // throw must land in the same not-delivered callback as a returned
-    // `false` or a rejection, not vanish into the replay loop's warn-log
-    // (#10398).
-    const session = createTestSession();
-    const onReplayScheduled = vi.fn();
-    const onReplayNotDelivered = vi.fn();
-
-    session.interactions.emit(
-      'requestShowError',
-      { message: 'queued before attach' },
-      {
-        replayWhenAttached: true,
-        onReplayScheduled,
-        onReplayNotDelivered,
-      },
-    );
-    expect(onReplayScheduled).toHaveBeenCalledOnce();
-
-    const throwingHost: HostInteractions = {
-      emit: () => {
-        throw new Error('renderer torn down mid-post');
-      },
-      cancel: vi.fn(),
-    };
-    session.interactions.use(throwingHost);
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(onReplayNotDelivered).toHaveBeenCalledOnce();
-    expect(onReplayNotDelivered).toHaveBeenCalledWith(throwingHost);
-    session.dispose();
-  });
-
   it('does not queue an opted-in notice delivered to an attached presentation', () => {
     const session = createTestSession();
     const firstEmit = vi.fn();
@@ -615,21 +560,6 @@ describe('session.interactions request bookkeeping', () => {
       session.interactions.use({ emit, cancel: vi.fn() });
       await Promise.resolve();
       expect(emit).not.toHaveBeenCalled();
-    } finally {
-      session.dispose();
-    }
-  });
-
-  it('reports replayable notices queued before host attach as not delivered', () => {
-    const session = createTestSession();
-    try {
-      expect(
-        session.interactions.emit(
-          'showAgentConfigBanner',
-          { agentName: 'ghost', category: AgentCategory.ToolUse },
-          { replayWhenAttached: true },
-        ),
-      ).toBe(false);
     } finally {
       session.dispose();
     }


### PR DESCRIPTION
## Summary

Four verified candidates from the TeXRA 1.0 clean-slate sweep (session coauthor-dc, runtime slice). Two are user-facing bug fixes; each deletes the machinery that let the bug happen.

- **RT2-2 (bug fix): park a request the host does not present, instead of rejecting it.** Since #11883 the extension and desktop attach no `requestBashApproval` / `requestPlanApproval` / `requestAgentProposal` / `requestRetry` / `askUserQuestion`. `SessionHostInteractions.dispatch` settled any request whose host method returned `undefined` with its cancellation result. So on both GUI hosts, every bash command, plan, delegation proposal and user question auto-rejected, and every model retry auto-cancelled, before the fold's approval row could be answered. Now a stream-scoped request stays pending until `settleRequest`/`settleRetry`, a cancel, or disposal; a streamless one is still declined, now with a warning. The TUI's hand-written `park()` copy of this behavior and its `requestBashApproval` are deleted.
- **RT1-2 (bug fix): one presentation owner for launch failures.** Once launch-context assembly begins (model handler, run residency, trace attach, user vars), the run's terminal `result` event is the only presentation. The second `requestShowError` from the launch catch is deleted, so the extension and CLI chat no longer toast the same error twice. Model validation moves into `prepareAgentDefinition`, so a typo'd model shows only its instruction and never registers a phantom FAILED execution. The now-unread `AgentLaunchInput.suppressErrorNotification` and its two pass-through sites are deleted; `notifyLaunchFailure` has one caller left and is inlined there.
- **RT2-1: delete the presentation-delivery contract.** The boolean `emit` returned had one reader, `presentLaunchError`. For its two events every live host reports delivery, so the generic fallback only ever went back to the host that had just failed. `emit` is now fire-and-forget. `onReplayScheduled`/`onReplayNotDelivered`, `dispatchPresentationEvent` (inlined as `handlers[event](payload)` at its 3 callers), `PresentationDelivery` and `toPresentationDelivery` are deleted. A launch notice now claims its error unconditionally. The one host with a second surface, the extension, keeps a local fallback: if an instruction fails to render, it shows the error toast.
- **RT3-1: delete the dead file-context branch of instruction polish.** `polishTextWithAI` has one caller, and it passes no file context; the wire request cannot carry any (`{ kind: 'polish', text }`) since #11883. `FileContext`, `formatFileContext`, the nunjucks render and the two `{% if FILE_CONTEXT %}` template blocks are deleted. The prompt is now the YAML prefix plus the raw text, byte-identical to what rendered before.

Behavior changes to note:
- A delegated child with an unknown model now fails at delegation prepare, as a tool error to the parent, not as a registered FAILED child.
- An out-of-tree embedder that attaches only `{ cancel }` now sees stream-scoped requests park instead of auto-reject. In-tree hosts are unaffected: the SDK host implements `requestRetry`, and `approvalPromptsUnavailable` strips every approval-requiring tool.

## Net elements (R6)

- Files: 0 added, 0 deleted, 18 modified.
- `^[+-] *export` lines: +2 / -7 (+2 are signature rewrites of `renderPolishPrompt` and `createRecordingHost`; removed: `dispatchPresentationEvent`, `PresentationDelivery`, `toPresentationDelivery`, `FileContext`, plus one barrel `export {` block).
- class/interface/enum/type declarations: 0 added, 13 removed (diff-line count).
- `git diff --stat origin/main...HEAD`: 18 files changed, 227 insertions(+), 588 deletions(-).
- Production: +155 / -371 (net -216). Tests: +72 / -217 (net -145).

## Consumer counts (R8)

Grepped at origin/main, production code only:
- `dispatchPresentationEvent`: 3 callers (cliPresentationHost, desktopAgentExecution, agentEventListeners), all inlined.
- `toPresentationDelivery` / `PresentationDelivery`: 2 (desktop, extension).
- `onReplayScheduled` / `onReplayNotDelivered`: 1 producer (`presentLaunchError`), read only by the `SessionHostInteractions.emit` replay closure.
- Readers of `emit`'s delivery boolean: 1 (`presentLaunchError`). Every other emit site drops or only awaits it.
- `notifyLaunchFailure`: 2 call sites. The assembly one is deleted and the prepare one inlined.
- `FileContext` / `formatFileContext`: 0 outside `textEnhancement.ts`; `polishTextWithAI(text, fileContext)`: 0 callers pass a second argument.
- TUI `park`: 4 callers, all replaced by core parking.
- Hosts without the response-bearing request methods: extension (`ProgressViewProvider` attach) and desktop (`desktopAgentExecution` attach), both regressed by #11883.

## Skipped

- **RT2-3** (delete the CLI-only `setApprovalBypassState` push; `approval.policy` as the one emitter). The three NDJSON bypass records are public CLI output. Keeping them needs a new `approval.policy` diff projection in `sessionProgressSubscription.ts` (coauthor-97's slice, about 25 new lines), plus retargeting about 11 suites that observe bypass changes through the push: TuiApprovalRetry, RunExecution, RunProgressRenderer, PlanToolWorkPlanState, ChildStreamYoloInheritance, HumanPromptProgressEvents, ToolUseWaitNode, and others. That exceeds the spillover cap. Dropping the records instead needs an owner ruling on the public wire. It's still a verified candidate (peer coauthor-2c agent-runtime#3) for the CLI-slice owner or an owner ruling.
- **Doc not updated (ceded):** `docs/architecture/2026-07-26-embedding-the-agent-runtime.md` (lines ~185-188, ~383, ~499-501) still says a minimal `{ cancel }` host auto-rejects every request. After RT2-2 that holds only for streamless requests. The file is claimed by coauthor-dc/v1-platform-store-sdk (implementing), so it's left to that owner.

## Verified

All heavy gates ran through the machine-wide semaphore; exit codes are the real `GATE_EXIT` lines.

- G1 `prettier --write` on the 18 changed files: exit 0, every file unchanged.
- G2 `eslint` on the changed `.ts` files: GATE_EXIT=0.
- G3 `CI=true npm run typecheck` (every project: workspace, test-kernel, agent, llm, cli, trace-viewer, desktop): GATE_EXIT=0.
- G4a `vitest run --changed origin/main`: GATE_EXIT=1, from a single test: 202 files, 2689 passed, 1 skipped, 1 failed. The failure is `ChildRunLoop.vitest.ts > childRunLoop E2E fixtures > '$name' interrupts a real initial-turn loop and releases ownership once`, which asserts the execution handle has unregistered right after the follow-up owner releases.
  - Isolated reruns of the suite on this branch: 7 of 8 passed, and the one failure hit a different case (`ClaudeAgentSessions`, not `CodexThreads`). The suite passed 5 of 5 on an origin/main worktree run under similar load.
  - The suite drives a fake child strategy with no host interactions, so it never reaches `buildAgentLaunchContext`, `emit`, or request dispatch, the three paths this PR changes. I read it as a load-sensitive race in the release ordering, but a branch-side cause isn't ruled out.
  - Worth a rerun in CI.
- G4b `vitest run --project pure`: GATE_EXIT=0 (276 files, 4028 tests).
- G5 `check-dead-code-ratchet.mjs`: GATE_EXIT=0 ("no new findings"; no baseline entry named the removed exports). `check-effect-migration-ratchet.mjs`: exit 0, no count grew and no headroom to shrink.
- Targeted suites, run directly on the edited files: AgentLaunchContext, BundledPrompts, SessionInteractions, TuiApprovalRetry, PlanToolWorkPlanState all pass.
- Rebased onto origin/main at 6bd56508b7. The last two upstream commits (#12217, #12220) touch none of these files, so G3 and G4 were not rerun after that rebase.
- No committed `node_modules` symlink; `pnpm-lock.yaml` unchanged.
- Heads-up: open PR #12222 (one run model S1, 719 files) touches 10 of these 18 files. It's a rename, not these deletions, so whichever lands second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNfYGNNxcPzD3JRXs4DdoM
