### PR TITLE
refactor(llm): one generateTurn fold, SSE-only MiniMax, no unowned provider controls (1.0 clean slate)

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1004,22 +1004,10 @@
       "name": "ExecutionLeaseSchema"
     },
     {
-      "file": "src/agent/trace/events.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "StageStartEvent"
-    },
-    {
       "file": "src/agent/trace/index.ts",
       "category": "production-dead",
       "kind": "exports",
       "name": "noopTrace"
-    },
-    {
-      "file": "src/agent/trace/index.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "StageStartEvent"
     },
     {
       "file": "src/agent/types/StopReasonTypes.ts",
@@ -1320,12 +1308,6 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "resolveDefaultModels"
-    },
-    {
-      "file": "src/model/providerCapabilities.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT"
     },
     {
       "file": "src/platform/defaults/workspaceStorage.ts",

--- a/packages/extension/src/frontend/lm/acquireVscodeLanguageModel.ts
+++ b/packages/extension/src/frontend/lm/acquireVscodeLanguageModel.ts
@@ -16,6 +16,7 @@ import {
   type TurnEvent,
   type TurnResult,
   type VscodeLanguageModelConfiguration,
+  completedTurn,
 } from '@texra-ai/llm/turn';
 import { Cause, Effect, Exit, Stream, type Scope } from 'effect';
 import * as vscode from 'vscode';
@@ -572,19 +573,6 @@ export const acquireVscodeLanguageModel = Effect.fn(
       }),
     );
   const generateTurn: Model['generateTurn'] = (turn) =>
-    streamTurn(turn).pipe(
-      Stream.runFold(
-        () => undefined as TurnResult | undefined,
-        (result, event) => (event.kind === 'completed' ? event.result : result),
-      ),
-      Effect.flatMap((result) =>
-        result === undefined
-          ? new ModelError({
-              kind: 'malformed-output',
-              message: 'The editor stream ended without a completed response.',
-            })
-          : Effect.succeed(result),
-      ),
-    );
+    completedTurn(streamTurn(turn));
   return Object.freeze({ prepareTurn, streamTurn, generateTurn });
 });

--- a/packages/llm/README.md
+++ b/packages/llm/README.md
@@ -104,22 +104,18 @@ video and documents remain unsupported in these Chat branches. Hosted execution,
 background, storage, cache-lifetime, stopping and geography controls are also
 unsupported.
 
-MiniMax uses the same Chat implementation with explicitly selected
-`outputMode: 'complete'` or `'incremental'`. Complete mode reads one ordinary
-JSON response and emits observed
-identity followed by the completed result; it does not invent incremental text
-or phase events. Selected model, endpoint, reasoning-split choice and the existing
+MiniMax uses the same Chat implementation and always streams SSE. Selected model, endpoint, reasoning-split choice and the existing
 `max_tokens` field are retained. Plain reasoning and ordered reasoning details
 remain separate, including reported empty values, as required for
 [reasoning replay](https://platform.minimax.io/docs/api-reference/text-openai-api).
-Original complete local calls retain their identities and order. Usage counts
+Local calls retain their original identities and order. Usage counts
 remain independently unknown when absent, and reported character counts are
 retained. Embedded nonzero provider status is a failure even under HTTP 200;
 sensitivity observations are retained without inventing a filtering outcome.
 The inherited stop, parallel-call and tool-choice controls preserve the selected
 old request behavior; the current
 [request schema](https://platform.minimax.io/docs/api-reference/text/api/openapi-chat-openai.json)
-does not independently document those controls. Incremental mode uses the same scoped HTTP reader and SSE parser as the other
+does not independently document those controls. MiniMax uses the same scoped HTTP reader and SSE parser as the other
 Chat protocols. It appends text and reasoning fragments exactly, including repeated
 fragments, assembles local calls by index and preserves their original identities.
 Reasoning detail indices must form a contiguous ordered list; a missing index uses

--- a/packages/llm/README.md
+++ b/packages/llm/README.md
@@ -101,7 +101,7 @@ accept inline JPEG/PNG/GIF/WebP/BMP/HEIC/HEIF user images; selected GLM routes a
 JPEG/PNG. MIME spelling and base64 bytes are retained exactly, including empty
 encodings, with ordered text labels. Image detail, tool-result images, audio,
 video and documents remain unsupported in these Chat branches. Hosted execution,
-background, storage, cache-lifetime, stopping and geography controls are also
+background, storage, cache-lifetime and stopping controls are also
 unsupported.
 
 MiniMax uses the same Chat implementation and always streams SSE. Selected model, endpoint, reasoning-split choice and the existing
@@ -162,9 +162,7 @@ calls. Neither branch supports background work, hosted execution, uploads or
 tool-result media. Pricing and credential-route selection remain runtime-owned;
 no application caller has switched and neither old handler is deleted yet.
 
-Kimi preparation retains a caller-supplied `prompt_cache_key`; selected routes
-that require it reject missing keys. No session identity is invented. Application
-admission must not treat the old automatically assigned image detail as authored
+Application admission must not treat the old automatically assigned image detail as authored
 intent; those production consumers have not switched.
 
 Selected routes expose one optional `estimateInputTokens` operation when
@@ -367,7 +365,7 @@ text, inline JPEG/PNG/GIF/WebP images and PDF documents. Other image MIME types,
 image detail, audio, video and non-PDF documents fail explicitly. Prepared controls
 cover disabled/manual/adaptive thinking, independent nullable effort, selected
 temperature capability, output limit, parallel calls and supported named-tool choice,
-cache lifetime, stop sequences, service tier and geography. Thinking permits
+cache lifetime and stop sequences. Thinking permits
 temperature one or omission; manual thinking cannot force a named tool.
 Completion follows the semantic `message_stop` event, not connection closure.
 Hosted execution, beta APIs, compaction, uploads and `pause_turn` remain unsupported.

--- a/packages/llm/README.md
+++ b/packages/llm/README.md
@@ -191,8 +191,8 @@ Broader input fails explicitly; Kimi retains its existing wider coverage. Zero i
 a valid measurement, while missing or malformed counts fail. None of these
 receipts is total usage, a bill or a generation allowance. There is no automatic
 preflight, retry or budget adjustment. Application admission still owns context
-limits, output reduction and count-failure policy, and must supply the stable Kimi
-cache identity. Configured production helpers have not switched.
+limits, output reduction and count-failure policy. Configured production helpers
+have not switched.
 
 Streaming Chat reads one SDK HTTP response through the native Effect SSE parser. This retains
 Kimi's and xAI's required `[DONE]` terminator, which the SDK's parsed iterator suppresses;

--- a/packages/llm/src/anthropicMessages.ts
+++ b/packages/llm/src/anthropicMessages.ts
@@ -22,6 +22,7 @@ import {
   type ResolvedTurn,
   type TurnEvent,
   type TurnResult,
+  completedTurn,
 } from './turn.js';
 import type {
   ContentBlockParam,
@@ -973,21 +974,8 @@ export function anthropicMessagesModel(
         }).pipe(Effect.mapError(enrich)),
       );
     });
-  const generateTurn: Model['generateTurn'] = Effect.fn(
-    'llm.anthropic.generateTurn',
-  )(function* (turn) {
-    const completed = yield* Stream.runFold(
-      streamTurn(turn),
-      () => null as TurnResult | null,
-      (result, event) => (event.kind === 'completed' ? event.result : result),
-    );
-    if (completed === null)
-      return yield* new ModelError({
-        kind: 'malformed-output',
-        message: 'Anthropic produced no completed turn.',
-      });
-    return completed;
-  });
+  const generateTurn: Model['generateTurn'] = (turn) =>
+    completedTurn(streamTurn(turn));
   const estimateInputTokens: NonNullable<Model['estimateInputTokens']> =
     Effect.fn('llm.anthropic.estimateInputTokens')(function* (input) {
       const parsed = ResolvedTurnSchema.safeParse(input);

--- a/packages/llm/src/anthropicMessages.ts
+++ b/packages/llm/src/anthropicMessages.ts
@@ -375,11 +375,6 @@ const invocationBody = Effect.fn('llm.anthropic.invocationBody')(function* (
     ...(controls.effort === null
       ? {}
       : { output_config: { effort: controls.effort } }),
-    ...(controls.inferenceGeo === null
-      ? {}
-      : { inference_geo: controls.inferenceGeo }),
-    service_tier:
-      controls.serviceTier === 'standard-only' ? 'standard_only' : 'auto',
     stop_sequences: [...controls.stopSequences],
     thinking: wireThinking,
     ...(controls.cache === 'disabled'
@@ -460,13 +455,11 @@ export function anthropicMessagesModel(
       input.mode === 'background' ||
       input.continuation !== undefined ||
       input.store !== undefined ||
-      input.promptCacheKey !== undefined ||
       input.reasoning !== undefined ||
       input.effort === 'none' ||
       input.effort === 'minimal' ||
       input.thinkingLevel !== undefined ||
-      input.serviceTier === 'fast' ||
-      input.serviceTier === null ||
+      input.serviceTier !== undefined ||
       (!config.supportsTemperature && input.temperature !== undefined)
     )
       return yield* new ModelError({
@@ -508,11 +501,6 @@ export function anthropicMessagesModel(
           input.effort === undefined ? config.defaults.effort : input.effort,
         cache: input.cache ?? config.defaults.cache,
         stopSequences: input.stopSequences ?? config.defaults.stopSequences,
-        serviceTier: input.serviceTier ?? config.defaults.serviceTier,
-        inferenceGeo:
-          input.inferenceGeo === undefined
-            ? config.defaults.inferenceGeo
-            : input.inferenceGeo,
       },
     });
     if (!prepared.success)

--- a/packages/llm/src/googleInteractions.ts
+++ b/packages/llm/src/googleInteractions.ts
@@ -25,6 +25,7 @@ import {
   type ResolvedTurn,
   type TurnEvent,
   type TurnResult,
+  completedTurn,
 } from './turn.js';
 
 // SDK stream parsing does not validate the JSON values it returns.
@@ -1088,21 +1089,8 @@ export function googleInteractionsModel(
       );
     });
 
-  const generateTurn: Model['generateTurn'] = Effect.fn(
-    'llm.google.generateTurn',
-  )(function* (turn) {
-    const result = yield* Stream.runFold(
-      streamTurn(turn),
-      () => null as TurnResult | null,
-      (result, event) => (event.kind === 'completed' ? event.result : result),
-    );
-    if (result === null)
-      return yield* new ModelError({
-        kind: 'malformed-output',
-        message: 'Google produced no completed result.',
-      });
-    return result;
-  });
+  const generateTurn: Model['generateTurn'] = (turn) =>
+    completedTurn(streamTurn(turn));
   const boundOperation = Effect.fn('llm.google.boundOperation')(function* (
     input: RemoteOperation,
   ) {

--- a/packages/llm/src/googleInteractions.ts
+++ b/packages/llm/src/googleInteractions.ts
@@ -636,9 +636,7 @@ export function googleInteractionsModel(
         parsed.data.thinking !== undefined ||
         parsed.data.effort !== undefined ||
         parsed.data.cache !== undefined ||
-        parsed.data.promptCacheKey !== undefined ||
         parsed.data.stopSequences !== undefined ||
-        parsed.data.inferenceGeo !== undefined ||
         (parsed.data.continuation !== undefined &&
           parsed.data.continuation.origin.protocol !== 'google-interactions')
       ) {

--- a/packages/llm/src/openaiChat.ts
+++ b/packages/llm/src/openaiChat.ts
@@ -165,86 +165,41 @@ const MiniMaxEnvelopeSchema = z.object({
   output_sensitive_type: z.int().optional(),
   output_sensitive_int: z.int().optional(),
 });
-const MiniMaxCompletionSchema = z.strictObject({
-  ...MiniMaxEnvelopeSchema.shape,
-  id: z.string().min(1),
-  model: z.string().min(1),
-  created: z.int(),
-  object: z.literal('chat.completion'),
-  choices: z
-    .array(
-      z.strictObject({
-        index: z.literal(0),
-        finish_reason: z.enum([
-          'stop',
-          'length',
-          'content_filter',
-          'tool_calls',
-        ]),
-        message: z.strictObject({
-          role: z.literal('assistant'),
-          content: z.string(),
-          name: z.string().optional(),
-          // Current ordinary examples report an empty placeholder, not audio output.
-          audio_content: z.literal('').optional(),
-          reasoning_content: z.string().optional(),
-          reasoning_details: z
-            .array(
-              z.strictObject({
-                type: z.string().optional(),
-                id: z.string().optional(),
-                format: z.string().optional(),
-                index: z.int().optional(),
-                text: z.string().optional(),
-              }),
-            )
-            .optional(),
-          tool_calls: z
-            .array(
-              z.strictObject({
-                id: z.string().min(1),
-                type: z.literal('function'),
-                index: z.int().optional(),
-                function: z.strictObject({
-                  name: z.string().min(1),
-                  arguments: z.string(),
-                }),
-              }),
-            )
-            .optional(),
-        }),
-      }),
-    )
-    .length(1),
-  // MiniMax documents partial receipts; no principal count is manufactured.
-  usage: z
-    .strictObject({
-      prompt_tokens: z.int().nonnegative().optional(),
-      completion_tokens: z.int().nonnegative().optional(),
-      total_tokens: z.int().nonnegative().optional(),
-      total_characters: z.int().nonnegative().optional(),
-      prompt_tokens_details: z
-        .strictObject({ cached_tokens: z.int().nonnegative().optional() })
-        .optional(),
-      completion_tokens_details: z
-        .strictObject({ reasoning_tokens: z.int().nonnegative().optional() })
-        .optional(),
-    })
+// MiniMax documents partial receipts; no principal count is manufactured.
+const MiniMaxUsageSchema = z.strictObject({
+  prompt_tokens: z.int().nonnegative().optional(),
+  completion_tokens: z.int().nonnegative().optional(),
+  total_tokens: z.int().nonnegative().optional(),
+  total_characters: z.int().nonnegative().optional(),
+  prompt_tokens_details: z
+    .strictObject({ cached_tokens: z.int().nonnegative().optional() })
+    .optional(),
+  completion_tokens_details: z
+    .strictObject({ reasoning_tokens: z.int().nonnegative().optional() })
     .optional(),
 });
-// Incremental routes use the provider's delta grammar, never prefix guessing.
+const MiniMaxReasoningDetailsSchema = z
+  .array(
+    z.strictObject({
+      type: z.string().optional(),
+      id: z.string().optional(),
+      format: z.string().optional(),
+      index: z.int().optional(),
+      text: z.string().optional(),
+    }),
+  )
+  .optional();
+// MiniMax routes use the provider's delta grammar, never prefix guessing.
 const MiniMaxChunkSchema = ChunkSchema.extend({
   ...MiniMaxEnvelopeSchema.omit({ id: true, model: true }).shape,
-  usage: MiniMaxCompletionSchema.shape.usage.nullable(),
+  usage: MiniMaxUsageSchema.optional().nullable(),
   choices: z
     .array(
       ChunkSchema.shape.choices.element.extend({
         delta: ReasoningChunkSchema.shape.choices.element.shape.delta.extend({
           name: z.string().optional(),
           audio_content: z.literal('').optional(),
-          reasoning_details:
-            MiniMaxCompletionSchema.shape.choices.element.shape.message.shape
-              .reasoning_details,
+          reasoning_details: MiniMaxReasoningDetailsSchema,
         }),
       }),
     )
@@ -303,7 +258,7 @@ const miniMaxFailure = (
 };
 
 const miniMaxUsage = (
-  receipt: z.infer<typeof MiniMaxCompletionSchema>['usage'],
+  receipt: z.infer<typeof MiniMaxUsageSchema> | undefined,
 ): TurnResult['usage'] =>
   receipt === undefined
     ? null
@@ -615,8 +570,7 @@ const chatParameters = Effect.fn('llm.chatParameters')(function* (
   if (turn.protocol === 'minimax-chat') {
     if (
       config.protocol !== 'minimax-chat' ||
-      turn.controls.reasoningSplit !== config.reasoningSplit ||
-      turn.outputMode !== config.outputMode
+      turn.controls.reasoningSplit !== config.reasoningSplit
     ) {
       return yield* new ModelError({
         kind: 'unsupported',
@@ -624,14 +578,8 @@ const chatParameters = Effect.fn('llm.chatParameters')(function* (
           'The prepared MiniMax format does not match the selected response route.',
       });
     }
-    const { stream_options: _streamOptions, ...completeParameters } =
-      parameters;
     return {
-      ...completeParameters,
-      stream: turn.outputMode === 'incremental',
-      ...(turn.outputMode === 'incremental'
-        ? { stream_options: parameters.stream_options }
-        : {}),
+      ...parameters,
       max_tokens: turn.controls.maxOutputTokens,
       reasoning_split: turn.controls.reasoningSplit,
       ...(turn.controls.stopSequences.length > 0
@@ -913,9 +861,6 @@ export function openaiChatModel(
         system: parsed.data.system,
         messages: parsed.data.messages,
         tools,
-        ...(config.protocol === 'minimax-chat'
-          ? { outputMode: config.outputMode }
-          : {}),
       };
       const maxOutputTokens =
         parsed.data.maxOutputTokens ?? config.defaults.maxOutputTokens;
@@ -1149,186 +1094,6 @@ export function openaiChatModel(
           }
           reader = source.body.getReader();
           const body = reader;
-          if (
-            turn.protocol === 'minimax-chat' &&
-            turn.outputMode === 'complete'
-          ) {
-            // Complete mode owns this same reader, but never interprets JSON as SSE.
-            const decoder = new TextDecoder('utf-8', { fatal: true });
-            let text = '';
-            while (true) {
-              const next = yield* Effect.tryPromise({
-                try: () => body.read(),
-                catch: openaiFailure,
-              });
-              text += yield* Effect.try({
-                try: () =>
-                  next.done
-                    ? decoder.decode()
-                    : decoder.decode(next.value, { stream: true }),
-                catch: (cause) =>
-                  new ModelError({
-                    kind: 'malformed-output',
-                    message: 'MiniMax returned invalid UTF-8 completion data.',
-                    cause,
-                  }),
-              });
-              if (next.done) break;
-            }
-            const raw: unknown = yield* Effect.try({
-              try: () => JSON.parse(text),
-              catch: (cause) =>
-                new ModelError({
-                  kind: 'malformed-output',
-                  message: 'MiniMax returned malformed completion JSON.',
-                  cause,
-                }),
-            });
-            const envelope = MiniMaxEnvelopeSchema.safeParse(raw);
-            if (!envelope.success) {
-              return yield* new ModelError({
-                kind: 'malformed-output',
-                message: 'MiniMax returned malformed completion metadata.',
-                cause: envelope.error,
-              });
-            }
-            responseId = envelope.data.id === '' ? undefined : envelope.data.id;
-            returnedModel =
-              envelope.data.model === '' ? undefined : envelope.data.model;
-            const detection = miniMaxDetection(envelope.data);
-            const rejection = miniMaxFailure(
-              envelope.data,
-              origin,
-              source.status,
-              raw,
-            );
-            if (rejection !== undefined) return yield* rejection;
-            const decoded = MiniMaxCompletionSchema.safeParse(raw);
-            if (!decoded.success) {
-              return yield* new ModelError({
-                kind: 'malformed-output',
-                message:
-                  'MiniMax returned malformed or unsupported completion content.',
-                cause: decoded.error,
-              });
-            }
-            const completion = decoded.data;
-            const choice = completion.choices[0];
-            const message = choice.message;
-            if (
-              (choice.finish_reason === 'tool_calls') !==
-              (message.tool_calls?.length ?? 0) > 0
-            ) {
-              return yield* new ModelError({
-                kind: 'malformed-output',
-                message:
-                  'MiniMax reported contradictory tool calls and completion reason.',
-              });
-            }
-            const content: TurnResult['content'][number][] = [];
-            if (
-              message.reasoning_content !== undefined ||
-              message.reasoning_details !== undefined
-            ) {
-              content.push({
-                kind: 'reasoning',
-                summary: [],
-                evidence: {
-                  kind: 'minimax-reasoning',
-                  ...(message.reasoning_content !== undefined
-                    ? { plain: message.reasoning_content }
-                    : {}),
-                  ...(message.reasoning_details !== undefined
-                    ? { details: message.reasoning_details }
-                    : {}),
-                },
-              });
-            }
-            content.push({
-              kind: 'message',
-              content: [{ kind: 'text', text: message.content }],
-              ...(message.name !== undefined ||
-              message.audio_content !== undefined
-                ? {
-                    evidence: {
-                      kind: 'minimax-message' as const,
-                      ...(message.name !== undefined
-                        ? { name: message.name }
-                        : {}),
-                      ...(message.audio_content !== undefined
-                        ? { audioContent: message.audio_content }
-                        : {}),
-                    },
-                  }
-                : {}),
-            });
-            for (const call of message.tool_calls ?? []) {
-              const args: unknown = yield* Effect.try({
-                try: () => JSON.parse(call.function.arguments),
-                catch: (cause) =>
-                  new ModelError({
-                    kind: 'malformed-output',
-                    message: 'MiniMax returned malformed tool arguments.',
-                    cause,
-                  }),
-              });
-              const parsedArguments = JsonObjectSchema.safeParse(args);
-              if (!parsedArguments.success) {
-                return yield* new ModelError({
-                  kind: 'malformed-output',
-                  message:
-                    'MiniMax tool arguments must be supported JSON objects.',
-                  cause: parsedArguments.error,
-                });
-              }
-              content.push({
-                kind: 'local-call',
-                providerCallId: call.id,
-                name: call.function.name,
-                argumentsText: call.function.arguments,
-                arguments: parsedArguments.data,
-                ...(call.index !== undefined
-                  ? {
-                      evidence: {
-                        kind: 'minimax-function-call' as const,
-                        index: call.index,
-                      },
-                    }
-                  : {}),
-              });
-            }
-            const receipt = completion.usage;
-            const result = TurnResultSchema.safeParse({
-              kind: 'http',
-              providerResponseId: completion.id,
-              requestedOrigin: origin,
-              returnedModel: completion.model,
-              modelFingerprint: null,
-              content,
-              finishReason: choice.finish_reason.replaceAll('_', '-'),
-              // Detection flags do not establish that the provider filtered a reply.
-              ...(Object.keys(detection).length > 0
-                ? { finishEvidence: { kind: 'minimax', ...detection } }
-                : {}),
-              usage: miniMaxUsage(receipt),
-            });
-            if (!result.success) {
-              return yield* new ModelError({
-                kind: 'malformed-output',
-                message: 'MiniMax returned an inconsistent completed response.',
-                cause: result.error,
-              });
-            }
-            return Stream.fromArray<TurnEvent>([
-              {
-                kind: 'identified',
-                providerResponseId: completion.id,
-                requestedOrigin: origin,
-                returnedModel: completion.model,
-              },
-              { kind: 'completed', result: result.data },
-            ]);
-          }
           let fingerprint: string | null = null;
           let finishReason: TurnResult['finishReason'] | undefined;
           let usage: TurnResult['usage'] = null;
@@ -1346,7 +1111,7 @@ export function openaiChatModel(
           let miniMaxAudio: '' | undefined;
           let miniMaxContentSeen = false;
           let miniMaxEvidence: ReturnType<typeof miniMaxDetection> = {};
-          let miniMaxReceipt: z.infer<typeof MiniMaxCompletionSchema>['usage'];
+          let miniMaxReceipt: z.infer<typeof MiniMaxUsageSchema> | undefined;
           let activePhase: 'reasoning' | 'text' | undefined;
           let receivedSentinel = false;
           const content: Array<{ kind: 'text' | 'refusal'; text: string }> = [];
@@ -1523,7 +1288,7 @@ export function openaiChatModel(
                   if (chunk.usage != null) {
                     // Validated by MiniMaxChunkSchema for this selected protocol.
                     const receipt = chunk.usage as NonNullable<
-                      z.infer<typeof MiniMaxCompletionSchema>['usage']
+                      z.infer<typeof MiniMaxUsageSchema> | undefined
                     >;
                     miniMaxReceipt = {
                       ...miniMaxReceipt,

--- a/packages/llm/src/openaiChat.ts
+++ b/packages/llm/src/openaiChat.ts
@@ -22,6 +22,7 @@ import {
   type TurnEvent,
   type TurnRequest,
   type TurnResult,
+  completedTurn,
 } from './turn.js';
 
 type ChatTurn = Extract<
@@ -1960,22 +1961,8 @@ export function openaiChatModel(
       );
     });
 
-  const generateTurn: Model['generateTurn'] = Effect.fn('llm.generateTurn')(
-    function* (turn) {
-      const completed = yield* Stream.runFold(
-        streamTurn(turn),
-        () => null as TurnResult | null,
-        (result, event) => (event.kind === 'completed' ? event.result : result),
-      );
-      if (completed === null) {
-        return yield* new ModelError({
-          kind: 'malformed-output',
-          message: 'The model stream produced no completed result.',
-        });
-      }
-      return completed;
-    },
-  );
+  const generateTurn: Model['generateTurn'] = (turn) =>
+    completedTurn(streamTurn(turn));
   const estimateInputTokens =
     config.protocol === 'kimi-chat' && config.supportsInputTokenEstimation
       ? Effect.fn('llm.estimateInputTokens')(function* (

--- a/packages/llm/src/openaiChat.ts
+++ b/packages/llm/src/openaiChat.ts
@@ -675,18 +675,6 @@ const chatParameters = Effect.fn('llm.chatParameters')(function* (
     parameters.thinking = { type: thinking.mode };
   } else if (turn.protocol === 'kimi-chat' && config.protocol === 'kimi-chat') {
     if (
-      config.requiresPromptCacheKey &&
-      turn.controls.promptCacheKey === null
-    ) {
-      return yield* new ModelError({
-        kind: 'invalid-request',
-        message:
-          'The selected Kimi route requires a caller-supplied prompt cache key.',
-      });
-    }
-    if (turn.controls.promptCacheKey !== null)
-      parameters.prompt_cache_key = turn.controls.promptCacheKey;
-    if (
       turn.controls.temperature !==
         config.temperatureByThinking[thinking.mode] ||
       (config.thinkingControl !== 'toggle' &&
@@ -822,10 +810,7 @@ export function openaiChatModel(
         parsed.data.cache !== undefined ||
         (parsed.data.stopSequences !== undefined &&
           config.protocol !== 'dashscope-chat' &&
-          config.protocol !== 'minimax-chat') ||
-        parsed.data.inferenceGeo !== undefined ||
-        (parsed.data.promptCacheKey !== undefined &&
-          config.protocol !== 'kimi-chat')
+          config.protocol !== 'minimax-chat')
       ) {
         return yield* new ModelError({
           kind: 'unsupported',
@@ -978,9 +963,6 @@ export function openaiChatModel(
           temperature,
           maxOutputTokens,
           toolChoice,
-          ...(config.protocol === 'kimi-chat'
-            ? { promptCacheKey: parsed.data.promptCacheKey ?? null }
-            : {}),
         };
       }
       const prepared = ResolvedTurnSchema.safeParse({ ...common, controls });

--- a/packages/llm/src/openaiResponses.ts
+++ b/packages/llm/src/openaiResponses.ts
@@ -977,12 +977,9 @@ const prepareResponsesTurn = Effect.fn('llm.responses.prepareTurn')(function* (
     author.thinking !== undefined ||
     author.effort !== undefined ||
     author.cache !== undefined ||
-    author.inferenceGeo !== undefined ||
     author.stopSequences !== undefined ||
-    author.promptCacheKey !== undefined ||
     (author.continuation !== undefined &&
       author.continuation.origin.protocol !== 'openai-responses') ||
-    (author.serviceTier != null && author.serviceTier !== 'fast') ||
     (author.mode === 'background' &&
       (config.background !== 'supported' || transport.kind !== 'http')) ||
     (!config.supportsTemperature && author.temperature !== undefined) ||

--- a/packages/llm/src/openaiResponses.ts
+++ b/packages/llm/src/openaiResponses.ts
@@ -35,6 +35,7 @@ import {
   type BackgroundSubmission,
   type Continuation,
   type RemoteOperation,
+  completedTurn,
 } from './turn.js';
 import type { ResponseCreateParamsBase } from 'openai/resources/responses/responses';
 
@@ -902,22 +903,6 @@ function responseEvents(
     return Stream.concat(progress, completion).pipe(Stream.mapError(enrich));
   });
 }
-
-const completedTurn = Effect.fn('llm.responses.generateTurn')(function* (
-  events: Stream.Stream<TurnEvent, ModelError>,
-) {
-  const result = yield* Stream.runFold(
-    events,
-    () => null as TurnResult | null,
-    (current, event) => (event.kind === 'completed' ? event.result : current),
-  );
-  if (result === null)
-    return yield* new ModelError({
-      kind: 'malformed-output',
-      message: 'The model stream produced no completed result.',
-    });
-  return result;
-});
 
 /** Owns only the foreign iterator lifetime shared by create and retrieve. */
 const sdkEvents = Effect.fn('llm.responses.sdkEvents')(function* (

--- a/packages/llm/src/openrouterChat.ts
+++ b/packages/llm/src/openrouterChat.ts
@@ -20,6 +20,7 @@ import {
   type ResolvedTurn,
   type TurnEvent,
   type TurnResult,
+  completedTurn,
 } from './turn.js';
 
 type OpenRouterTurn = Extract<ResolvedTurn, { protocol: 'openrouter-chat' }>;
@@ -1273,20 +1274,7 @@ export function openrouterChatModel(
         }).pipe(Effect.mapError(enrich)),
       );
     });
-  const generateTurn: Model['generateTurn'] = Effect.fn('llm.generateTurn')(
-    function* (turn) {
-      const completed = yield* Stream.runFold(
-        streamTurn(turn),
-        () => null as TurnResult | null,
-        (result, event) => (event.kind === 'completed' ? event.result : result),
-      );
-      if (completed === null)
-        return yield* new ModelError({
-          kind: 'malformed-output',
-          message: 'OpenRouter produced no completed result.',
-        });
-      return completed;
-    },
-  );
+  const generateTurn: Model['generateTurn'] = (turn) =>
+    completedTurn(streamTurn(turn));
   return { prepareTurn, streamTurn, generateTurn };
 }

--- a/packages/llm/src/openrouterChat.ts
+++ b/packages/llm/src/openrouterChat.ts
@@ -622,8 +622,6 @@ export function openrouterChatModel(
         authored.reasoning !== undefined ||
         authored.serviceTier !== undefined ||
         authored.cache !== undefined ||
-        authored.inferenceGeo !== undefined ||
-        authored.promptCacheKey !== undefined ||
         authored.parallelToolCalls !== undefined ||
         authored.thinking !== undefined
       )

--- a/packages/llm/src/turn.ts
+++ b/packages/llm/src/turn.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { Data, Result, type Effect, type Stream } from 'effect';
+import { Data, Effect, Result, Stream } from 'effect';
 import { z } from 'zod';
 
 const TextPartSchema = z
@@ -1653,3 +1653,20 @@ export interface Model {
     ): Effect.Effect<CancellationEvidence, ModelError>;
   };
 }
+
+/** The `generateTurn` every model shares: the stream's completed result. */
+export const completedTurn = Effect.fn('llm.generateTurn')(function* (
+  events: Stream.Stream<TurnEvent, ModelError>,
+) {
+  const result = yield* Stream.runFold(
+    events,
+    () => null as TurnResult | null,
+    (current, event) => (event.kind === 'completed' ? event.result : current),
+  );
+  if (result === null)
+    return yield* new ModelError({
+      kind: 'malformed-output',
+      message: 'The model stream produced no completed result.',
+    });
+  return result;
+});

--- a/packages/llm/src/turn.ts
+++ b/packages/llm/src/turn.ts
@@ -693,7 +693,6 @@ const EffortSchema = ReasoningEffortSchema.unwrap()
   .exclude(['none', 'minimal'])
   .nullable();
 const CacheSchema = z.enum(['disabled', '5m', '1h']);
-const InferenceGeoSchema = z.enum(['global', 'us']).nullable();
 
 /** Materialized input; no SDK value, credential, file path or storage reference. */
 export const TurnRequestSchema = z
@@ -709,16 +708,11 @@ export const TurnRequestSchema = z
     store: z.boolean().optional(),
     thinkingLevel: z.enum(['low', 'medium', 'high']).optional(),
     reasoning: ResponsesReasoningSchema.optional(),
-    serviceTier: z
-      .enum(['fast', 'auto', 'standard-only'])
-      .nullable()
-      .optional(),
+    serviceTier: z.literal('fast').nullable().optional(),
     thinking: AuthoredThinkingSchema.optional(),
     effort: ReasoningEffortSchema.optional(),
     cache: CacheSchema.optional(),
-    promptCacheKey: z.string().min(1).optional(),
     stopSequences: z.array(z.string()).readonly().optional(),
-    inferenceGeo: InferenceGeoSchema.optional(),
     continuation: ContinuationSchema.optional(),
   })
   .readonly();
@@ -758,8 +752,6 @@ const AnthropicControlsSchema = z.strictObject({
   effort: EffortSchema,
   cache: CacheSchema,
   stopSequences: z.array(z.string()).readonly(),
-  serviceTier: z.enum(['auto', 'standard-only']),
-  inferenceGeo: InferenceGeoSchema,
 });
 const ChatReasoningControlsSchema = z.strictObject({
   maxOutputTokens: z.int().positive(),
@@ -772,9 +764,6 @@ const ChatReasoningControlsSchema = z.strictObject({
 });
 const KimiControlsSchema = ChatReasoningControlsSchema.extend({
   preserveThinking: z.boolean(),
-  promptCacheKey: TurnRequestSchema.unwrap()
-    .shape.promptCacheKey.unwrap()
-    .nullable(),
 });
 const GlmControlsSchema = ChatReasoningControlsSchema.extend({
   temperature: z.number().min(0).max(1).nullable(),
@@ -904,7 +893,6 @@ export const ModelConfigurationSchema = z.discriminatedUnion('protocol', [
     protocol: z.literal('kimi-chat'),
     supportsImageInput: z.boolean(),
     supportsInputTokenEstimation: z.boolean(),
-    requiresPromptCacheKey: z.boolean(),
     thinkingControl: z.enum(['toggle', 'always', 'effort']),
     supportedEfforts: z.array(EffortSchema.unwrap()).readonly(),
     supportsForcedToolChoice: z.boolean(),
@@ -917,7 +905,6 @@ export const ModelConfigurationSchema = z.discriminatedUnion('protocol', [
     defaults: KimiControlsSchema.omit({
       toolChoice: true,
       temperature: true,
-      promptCacheKey: true,
     }).readonly(),
   }).readonly(),
   BindingSchema.extend({

--- a/packages/llm/src/turn.ts
+++ b/packages/llm/src/turn.ts
@@ -851,7 +851,6 @@ function validateEffortDefault<E extends string>(
 export const ModelConfigurationSchema = z.discriminatedUnion('protocol', [
   BindingSchema.extend({
     protocol: z.literal('minimax-chat'),
-    outputMode: z.enum(['complete', 'incremental']),
     reasoningSplit: z.boolean(),
     defaults: MiniMaxControlsSchema.omit({
       toolChoice: true,
@@ -1086,7 +1085,6 @@ export const ResolvedTurnSchema = z.discriminatedUnion('mode', [
   z.discriminatedUnion('protocol', [
     PreparedInputSchema.extend({
       protocol: z.literal('minimax-chat'),
-      outputMode: z.enum(['complete', 'incremental']),
       controls: MiniMaxControlsSchema.readonly(),
     }).readonly(),
     EditorOriginSchema.extend({

--- a/packages/llm/src/turn.ts
+++ b/packages/llm/src/turn.ts
@@ -1010,10 +1010,6 @@ export const ModelConfigurationSchema = z.discriminatedUnion('protocol', [
     .readonly(),
 ]);
 export type ModelConfiguration = z.infer<typeof ModelConfigurationSchema>;
-export type OpenAIChatConfiguration = Extract<
-  ModelConfiguration,
-  { protocol: 'openai-chat' }
->;
 export type ChatConfiguration = Extract<
   ModelConfiguration,
   {

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -72,7 +72,7 @@ interface LogEvent extends StageStamp {
 }
 
 /** Stage opened (parent of subsequent events until matching stage.end). */
-export interface StageStartEvent extends StageStamp {
+interface StageStartEvent extends StageStamp {
   readonly type: 'stage.start';
   readonly id: string;
   readonly label: string;

--- a/src/agent/trace/index.ts
+++ b/src/agent/trace/index.ts
@@ -10,12 +10,7 @@
  *
  * See `.agents/docs/archived/architecture/2026-05-22-agent-trace-sdk-surface.md` for the design.
  */
-export type {
-  AgentEvent,
-  ResultEvent,
-  StageStartEvent,
-  StatusEvent,
-} from './events';
+export type { AgentEvent, ResultEvent, StatusEvent } from './events';
 
 export type { AgentTrace, StageHandle, StreamHandle } from './AgentTrace';
 

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -41,15 +41,6 @@ interface ProviderCapabilityKey {
   readonly useOpenRouter: boolean;
 }
 
-/**
- * Default ChatGPT-subscription Codex input budget. The 272k default mirrors
- * the Codex CLI default `context_window`; GPT-5.6 supports an 872k
- * `max_context_window`, which users can select with
- * `texra.chatgptCodex.contextWindow`.
- */
-export const CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT =
-  CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue;
-
 /** Trailing llm-zoo date pin (`-2026-04-23`) on a model `fullName`. */
 const CODEX_MODEL_DATE_PIN = /-\d{4}-\d{2}-\d{2}$/;
 

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -6,12 +6,14 @@ import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex
 import type { ModelCredentialRoute } from '@agent/types/ModelHandlerContracts';
 import { CODEX_BACKEND_BASE_URL, resetCodexCoordinator } from '@auth/codex';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
-import { CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT } from '@model/providerCapabilities';
 import {
   setPreferCodexSubscription,
   isPreferCodexSubscription,
 } from '@model/codex/codexPreference';
-import { AgentCategory } from '@shared/schemas';
+import {
+  AgentCategory,
+  CHATGPT_CODEX_CONTEXT_WINDOW_SETTING,
+} from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
@@ -57,7 +59,8 @@ const largeWindowConfig: ModelConfig = {
 };
 
 const LARGE_WINDOW_SUBSCRIPTION_CONTEXT =
-  CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT + largeWindowConfig.maxOutputTokens;
+  CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue +
+  largeWindowConfig.maxOutputTokens;
 
 const ONE_MILLION_INPUT_TOKENS = {
   input_tokens: 1_000_000,
@@ -181,7 +184,7 @@ describe('ModelHandlerCodex subscription fallback', () => {
       const requestSpy = vi.fn();
       setCumulativeInputTokens(
         handler,
-        CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT - headroom,
+        CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue - headroom,
       );
 
       await expect(

--- a/src/test-kernel/agent/trace/AgentTrace.vitest.ts
+++ b/src/test-kernel/agent/trace/AgentTrace.vitest.ts
@@ -4,7 +4,6 @@ import {
   type AgentTrace,
   emitToolUseCard,
   logFileCategory,
-  type StageStartEvent,
   TraceEmitter,
 } from '@agent/trace';
 import { MESSAGE_TYPES } from '@shared/schemas';
@@ -30,7 +29,8 @@ describe('TraceEmitter stage metadata', () => {
         total: 3,
       }).id;
     }).filter(
-      (event): event is StageStartEvent => event.type === 'stage.start',
+      (event): event is Extract<AgentEvent, { type: 'stage.start' }> =>
+        event.type === 'stage.start',
     );
 
     expect(starts).toEqual([

--- a/src/test-kernel/llm/AnthropicMessages.vitest.ts
+++ b/src/test-kernel/llm/AnthropicMessages.vitest.ts
@@ -29,8 +29,6 @@ const CONFIG: AnthropicMessagesConfiguration = {
     effort: 'high',
     cache: '1h',
     stopSequences: [],
-    serviceTier: 'auto',
-    inferenceGeo: 'us',
   },
 };
 const REQUEST: TurnRequest = {
@@ -627,8 +625,6 @@ describe('canonical Anthropic Messages protocol', () => {
           thinking: { type: 'adaptive', display: 'summarized' },
           output_config: { effort: 'high' },
           cache_control: { type: 'ephemeral', ttl: '1h' },
-          service_tier: 'auto',
-          inference_geo: 'us',
           tool_choice: {
             type: 'tool',
             name: 'search',
@@ -660,8 +656,6 @@ describe('canonical Anthropic Messages protocol', () => {
             JSON.stringify({
               ...REQUEST,
               effort: null,
-              inferenceGeo: null,
-              serviceTier: 'standard-only',
               messages: [
                 ...REQUEST.messages,
                 {
@@ -706,8 +700,10 @@ describe('canonical Anthropic Messages protocol', () => {
         expect(sent.system).toEqual(first.system);
         expect(sent.cache_control).toEqual(first.cache_control);
         expect(sent).not.toHaveProperty('output_config');
-        expect(sent).not.toHaveProperty('inference_geo');
-        expect(sent.service_tier).toBe('standard_only');
+        for (const body of [first, sent]) {
+          expect(body).not.toHaveProperty('inference_geo');
+          expect(body).not.toHaveProperty('service_tier');
+        }
         expect(sent.messages.slice(1)).toEqual([
           {
             role: 'assistant',
@@ -889,7 +885,6 @@ describe('canonical Anthropic Messages protocol', () => {
     { serviceTier: 'fast' },
     { mode: 'background' },
     { store: true },
-    { promptCacheKey: 'run-cache-key' },
     { effort: 'none' },
     { effort: 'minimal' },
     {

--- a/src/test-kernel/llm/GoogleInteractions.vitest.ts
+++ b/src/test-kernel/llm/GoogleInteractions.vitest.ts
@@ -1188,7 +1188,6 @@ describe('canonical Google Interactions protocol', () => {
     'parallel-control',
     'reasoning-control',
     'service-tier-control',
-    'prompt-cache-key',
     'anthropic-controls',
     'background-mode',
   ] as const)(
@@ -1219,15 +1218,11 @@ describe('canonical Google Interactions protocol', () => {
           effort: null,
           cache: 'disabled',
           stopSequences: [],
-          inferenceGeo: null,
         });
         expectedMessage = 'Google does not support';
       } else if (unsupported === 'background-mode') {
         next.mode = 'background';
         expectedMessage = 'Google background execution';
-      } else if (unsupported === 'prompt-cache-key') {
-        next.promptCacheKey = 'run-cache-key';
-        expectedMessage = 'Google does not support';
       } else if (unsupported === 'raw-audio') {
         expectedMessage = 'Raw Google audio';
         next.messages.push({

--- a/src/test-kernel/llm/OpenaiChat.vitest.ts
+++ b/src/test-kernel/llm/OpenaiChat.vitest.ts
@@ -58,7 +58,6 @@ const REASONING_CONFIGS = [
     protocol: 'kimi-chat',
     supportsImageInput: true,
     supportsInputTokenEstimation: false,
-    requiresPromptCacheKey: false,
     thinkingControl: 'toggle',
     supportedEfforts: [],
     supportsForcedToolChoice: false,
@@ -640,7 +639,7 @@ describe('native OpenAI Chat protocol', () => {
     },
   );
 
-  it('estimates Kimi messages explicitly and preserves the caller cache key on generation', async () => {
+  it('estimates Kimi messages explicitly with the exact generation input', async () => {
     const fetch = vi
       .fn<typeof globalThis.fetch>()
       .mockResolvedValueOnce(
@@ -655,19 +654,12 @@ describe('native OpenAI Chat protocol', () => {
     const config = {
       ...REASONING_CONFIGS[1],
       supportsInputTokenEstimation: true,
-      requiresPromptCacheKey: true,
     };
     const model = openaiChatModel(config, { apiKey: 'synthetic', fetch });
     assert(model.estimateInputTokens !== undefined);
-    const missingKey = await Effect.runPromise(
-      Effect.flip(model.prepareTurn(REQUEST)),
-    );
-    expect(missingKey.kind).toBe('invalid-request');
-    const promptCacheKey = ' retained-session-key ';
     const prepared = await Effect.runPromise(
       model.prepareTurn({
         system: 'Estimate this system too.',
-        promptCacheKey,
         tools: TOOLS,
         messages: [
           {
@@ -738,36 +730,20 @@ describe('native OpenAI Chat protocol', () => {
     expect({ model: generation.model, messages: generation.messages }).toEqual(
       estimate,
     );
-    expect(generation).toMatchObject({
-      prompt_cache_key: promptCacheKey,
-      max_tokens: 100,
-    });
-    expect(rehydrated.controls).toMatchObject({
-      promptCacheKey,
-      maxOutputTokens: 100,
-    });
-    for (const rejected of [
-      {
-        ...rehydrated,
-        controls: { ...rehydrated.controls, promptCacheKey: null },
-      },
-      {
-        ...rehydrated,
-        deployment: { ...config.deployment, credentialScope: 'foreign' },
-      },
-    ]) {
-      await Effect.runPromise(Effect.flip(model.estimateInputTokens(rejected)));
-      await Effect.runPromise(Effect.flip(model.generateTurn(rejected)));
-    }
+    expect(generation).toMatchObject({ max_tokens: 100 });
+    expect(generation).not.toHaveProperty('prompt_cache_key');
+    const rejected = {
+      ...rehydrated,
+      deployment: { ...config.deployment, credentialScope: 'foreign' },
+    };
+    await Effect.runPromise(Effect.flip(model.estimateInputTokens(rejected)));
+    await Effect.runPromise(Effect.flip(model.generateTurn(rejected)));
     expect(fetch).toHaveBeenCalledTimes(2);
     const ordinary = openaiChatModel(REASONING_CONFIGS[1], {
       apiKey: 'synthetic',
       fetch,
     });
     expect(ordinary.estimateInputTokens).toBeUndefined();
-    const ordinaryTurn = await Effect.runPromise(ordinary.prepareTurn(REQUEST));
-    assert(ordinaryTurn.protocol === 'kimi-chat');
-    expect(ordinaryTurn.controls.promptCacheKey).toBeNull();
   });
 
   it.each([
@@ -2481,9 +2457,7 @@ describe('native OpenAI Chat protocol', () => {
     'none effort',
     'minimal effort',
     'cache control',
-    'prompt cache key',
     'stop control',
-    'inference geography',
     'Responses message evidence',
     'Responses call evidence',
   ] as const)('rejects unsupported %s before transport', async (scenario) => {
@@ -2555,12 +2529,8 @@ describe('native OpenAI Chat protocol', () => {
       request = { ...REQUEST, effort: 'minimal' };
     if (scenario === 'cache control')
       request = { ...REQUEST, cache: 'disabled' };
-    if (scenario === 'prompt cache key')
-      request = { ...REQUEST, promptCacheKey: 'session' };
     if (scenario === 'stop control')
       request = { ...REQUEST, stopSequences: [] };
-    if (scenario === 'inference geography')
-      request = { ...REQUEST, inferenceGeo: null };
     if (scenario === 'Responses message evidence')
       request = {
         messages: [

--- a/src/test-kernel/llm/OpenaiChat.vitest.ts
+++ b/src/test-kernel/llm/OpenaiChat.vitest.ts
@@ -105,7 +105,6 @@ const QWEN_CONFIG = {
 const MINIMAX_CONFIG = {
   ...BASE_CONFIG,
   protocol: 'minimax-chat',
-  outputMode: 'complete',
   reasoningSplit: true,
   defaults: { ...BASE_CONFIG.defaults, stopSequences: ['</answer>'] },
 } as const satisfies ChatConfiguration;
@@ -254,13 +253,25 @@ describe('native OpenAI Chat protocol', () => {
         const fetch = vi.fn<typeof globalThis.fetch>(async () =>
           response(sse(...frames)),
         );
-        const model = openaiChatModel(
-          { ...MINIMAX_CONFIG, outputMode: 'incremental' },
-          { apiKey: 'synthetic', fetch },
-        );
-        const prepared = yield* model.prepareTurn({ ...REQUEST, tools: TOOLS });
+        const model = openaiChatModel(MINIMAX_CONFIG, {
+          apiKey: 'synthetic',
+          fetch,
+        });
+        const prepared = yield* model.prepareTurn({
+          ...REQUEST,
+          tools: TOOLS,
+          toolChoice: { name: 'search' },
+          parallelToolCalls: false,
+        });
         assert(prepared.mode === 'foreground');
         const events = yield* Stream.runCollect(model.streamTurn(prepared));
+        expect(
+          JSON.parse(String(fetch.mock.calls[0]?.[1]?.body)),
+        ).toMatchObject({
+          stop: ['</answer>'],
+          parallel_tool_calls: false,
+          tool_choice: { type: 'function', function: { name: 'search' } },
+        });
         expect(events[0]?.kind).toBe('identified');
         expect(
           events
@@ -358,9 +369,30 @@ describe('native OpenAI Chat protocol', () => {
         });
         assert(prepared.protocol === 'minimax-chat');
         const rejected = yield* Effect.flip(
-          model.generateTurn({ ...prepared, outputMode: 'complete' }),
+          model.generateTurn({
+            ...prepared,
+            controls: { ...prepared.controls, reasoningSplit: false },
+          }),
         );
         expect(rejected.kind).toBe('unsupported');
+        for (const request of [
+          { effort: null },
+          { thinking: { mode: 'disabled' } },
+          { mode: 'background' },
+          {
+            messages: [
+              {
+                role: 'user',
+                content: [{ kind: 'image', mimeType: 'image/png', base64: '' }],
+              },
+            ],
+          },
+        ] as const) {
+          const failure = yield* Effect.flip(
+            model.prepareTurn({ ...REQUEST, ...request }),
+          );
+          expect(failure.kind).toBe('unsupported');
+        }
         expect(fetch).toHaveBeenCalledTimes(2);
       }),
   );
@@ -390,10 +422,10 @@ describe('native OpenAI Chat protocol', () => {
           signal = init?.signal;
           return response(body);
         });
-        const model = openaiChatModel(
-          { ...MINIMAX_CONFIG, outputMode: 'incremental' },
-          { apiKey: 'synthetic', fetch },
-        );
+        const model = openaiChatModel(MINIMAX_CONFIG, {
+          apiKey: 'synthetic',
+          fetch,
+        });
         const turn = yield* model.prepareTurn(REQUEST);
         assert(turn.mode === 'foreground');
         const completed = vi.fn();
@@ -432,6 +464,11 @@ describe('native OpenAI Chat protocol', () => {
       name: 'embedded rejection',
       frames: [{ base_resp: { status_code: 1008, status_msg: 'balance' } }],
       kind: 'provider-rejection',
+    },
+    {
+      name: 'embedded authentication failure',
+      frames: [{ base_resp: { status_code: 1004, status_msg: 'key' } }],
+      kind: 'authentication',
     },
     {
       name: 'changed reasoning identity',
@@ -477,417 +514,14 @@ describe('native OpenAI Chat protocol', () => {
         const fetch = vi.fn<typeof globalThis.fetch>(async () =>
           response(body),
         );
-        const model = openaiChatModel(
-          { ...MINIMAX_CONFIG, outputMode: 'incremental' },
-          { apiKey: 'synthetic', fetch },
-        );
+        const model = openaiChatModel(MINIMAX_CONFIG, {
+          apiKey: 'synthetic',
+          fetch,
+        });
         const failure = yield* Effect.flip(generate(model));
         expect(failure.kind).toBe(kind);
         expect(fetch).toHaveBeenCalledTimes(1);
       }),
-  );
-
-  it.each([true, false])(
-    'preserves MiniMax complete JSON and exact replay with split=%s',
-    async (reasoningSplit) => {
-      const details = [
-        {
-          type: 'reasoning.text',
-          id: 'same',
-          format: 'MiniMax-response-v1',
-          index: 7,
-          text: 'first',
-        },
-        { id: 'same', index: 7, text: '' },
-        {},
-      ];
-      const message = {
-        role: 'assistant',
-        content: reasoningSplit ? '' : '<think>original</think>answer',
-        name: 'MiniMax AI',
-        audio_content: '',
-        ...(reasoningSplit
-          ? { reasoning_content: 'separate text', reasoning_details: details }
-          : {}),
-        tool_calls: [
-          {
-            type: 'function',
-            id: 'call_0',
-            index: 9,
-            function: { name: 'search', arguments: '{"query":"first"}' },
-          },
-        ],
-      };
-      const reply = {
-        id: 'minimax-response',
-        model: 'returned-minimax',
-        created: 0,
-        object: 'chat.completion',
-        choices: [{ index: 0, finish_reason: 'tool_calls', message }],
-        usage: {
-          total_tokens: 19,
-          prompt_tokens_details: { cached_tokens: 0 },
-          completion_tokens_details: { reasoning_tokens: 4 },
-          total_characters: 0,
-        },
-        input_sensitive: true,
-        input_sensitive_type: 3,
-        output_sensitive: true,
-        output_sensitive_type: 5,
-        output_sensitive_int: 1,
-        base_resp: { status_code: 0, status_msg: '' },
-      };
-      const fetch = vi
-        .fn<typeof globalThis.fetch>()
-        .mockImplementation(async () => Response.json(reply));
-      const config = structuredClone({
-        ...MINIMAX_CONFIG,
-        reasoningSplit,
-        requestedModel: 'MiniMax-01',
-      });
-      const model = openaiChatModel(config, { apiKey: 'synthetic', fetch });
-      const prepared = await Effect.runPromise(
-        model.prepareTurn({
-          messages: [
-            {
-              role: 'user',
-              content: [
-                { kind: 'text', text: 'first' },
-                { kind: 'text', text: 'second' },
-              ],
-            },
-          ],
-          tools: TOOLS,
-          toolChoice: { name: 'search' },
-          parallelToolCalls: false,
-        }),
-      );
-      assert(prepared.protocol === 'minimax-chat');
-      expect(prepared.outputMode).toBe('complete');
-      expect(prepared.controls.reasoningSplit).toBe(reasoningSplit);
-      Object.assign(config, { reasoningSplit: !reasoningSplit });
-      const events = await Effect.runPromise(
-        Stream.runCollect(model.streamTurn(prepared)),
-      );
-      expect(events.map((event) => event.kind)).toEqual([
-        'identified',
-        'completed',
-      ]);
-      const completed = events.at(-1);
-      assert(completed?.kind === 'completed');
-      const result = completed.result;
-      expect(result).toMatchObject({
-        providerResponseId: 'minimax-response',
-        returnedModel: 'returned-minimax',
-        finishReason: 'tool-calls',
-        usage: {
-          inputTokens: null,
-          outputTokens: null,
-          totalTokens: 19,
-          cachedInputTokens: 0,
-          reasoningTokens: 4,
-          providerUsage: { kind: 'minimax', totalCharacters: 0 },
-        },
-        finishEvidence: {
-          kind: 'minimax',
-          inputSensitive: true,
-          inputSensitiveType: 3,
-          outputSensitive: true,
-          outputSensitiveType: 5,
-          outputSensitiveInt: 1,
-        },
-      });
-      expect(result.content).toEqual([
-        ...(reasoningSplit
-          ? [
-              {
-                kind: 'reasoning',
-                summary: [],
-                evidence: {
-                  kind: 'minimax-reasoning',
-                  plain: 'separate text',
-                  details,
-                },
-              },
-            ]
-          : []),
-        {
-          kind: 'message',
-          content: [{ kind: 'text', text: message.content }],
-          evidence: {
-            kind: 'minimax-message',
-            name: 'MiniMax AI',
-            audioContent: '',
-          },
-        },
-        {
-          kind: 'local-call',
-          providerCallId: 'call_0',
-          name: 'search',
-          argumentsText: '{"query":"first"}',
-          arguments: { query: 'first' },
-          evidence: { kind: 'minimax-function-call', index: 9 },
-        },
-      ]);
-      const firstBody = JSON.parse(String(fetch.mock.calls[0]?.[1]?.body));
-      expect(firstBody).toMatchObject({
-        model: 'MiniMax-01',
-        stream: false,
-        reasoning_split: reasoningSplit,
-        max_tokens: 100,
-        temperature: 0,
-        stop: ['</answer>'],
-        parallel_tool_calls: false,
-        tool_choice: { type: 'function', function: { name: 'search' } },
-        messages: [{ role: 'user', content: 'first\nsecond' }],
-      });
-      for (const key of [
-        'stream_options',
-        'max_completion_tokens',
-        'outputMode',
-        'reasoning_effort',
-      ])
-        expect(firstBody).not.toHaveProperty(key);
-      const history: TurnRequest = {
-        messages: [
-          ...REQUEST.messages,
-          {
-            role: 'assistant',
-            origin: result.requestedOrigin,
-            content: result.content,
-          },
-          {
-            role: 'tool',
-            results: [
-              {
-                callOrdinal: 0,
-                status: 'success',
-                content: [{ kind: 'text', text: 'found' }],
-              },
-            ],
-          },
-        ],
-        tools: TOOLS,
-      };
-      const next = await Effect.runPromise(model.prepareTurn(history));
-      assert(next.protocol === 'minimax-chat');
-      fetch.mockImplementation(async () =>
-        Response.json({
-          ...reply,
-          choices: [
-            {
-              index: 0,
-              finish_reason: 'stop',
-              message: {
-                role: 'assistant',
-                content: '',
-                ...(reasoningSplit
-                  ? { reasoning_content: '', reasoning_details: [] }
-                  : {}),
-              },
-            },
-          ],
-          usage: { completion_tokens: 0 },
-        }),
-      );
-      const final = await Effect.runPromise(model.generateTurn(next));
-      expect(final.finishReason).toBe('stop');
-      expect(final.content).toEqual([
-        ...(reasoningSplit
-          ? [
-              {
-                kind: 'reasoning',
-                summary: [],
-                evidence: { kind: 'minimax-reasoning', plain: '', details: [] },
-              },
-            ]
-          : []),
-        { kind: 'message', content: [{ kind: 'text', text: '' }] },
-      ]);
-      expect(final.usage).toEqual({
-        inputTokens: null,
-        outputTokens: 0,
-        totalTokens: null,
-        cachedInputTokens: null,
-        reasoningTokens: null,
-      });
-      expect(
-        JSON.parse(String(fetch.mock.calls[1]?.[1]?.body)).messages[1],
-      ).toEqual(message);
-      expect(Object.isFrozen(result.content)).toBe(true);
-      const thought = result.content[0];
-      if (
-        thought.kind === 'reasoning' &&
-        thought.evidence?.kind === 'minimax-reasoning'
-      ) {
-        expect(Object.isFrozen(thought.evidence.details)).toBe(true);
-        expect(Object.isFrozen(thought.evidence.details?.[0])).toBe(true);
-      }
-      for (const controls of [
-        { reasoningSplit: !reasoningSplit },
-        { toolChoice: { name: 'missing' } },
-      ]) {
-        const failure = await Effect.runPromise(
-          Effect.flip(
-            model.generateTurn({
-              ...next,
-              controls: { ...next.controls, ...controls },
-            }),
-          ),
-        );
-        expect(['unsupported', 'invalid-request']).toContain(failure.kind);
-      }
-      for (const request of [
-        { effort: null },
-        { thinking: { mode: 'disabled' } },
-        { mode: 'background' },
-        {
-          messages: [
-            {
-              role: 'user',
-              content: [{ kind: 'image', mimeType: 'image/png', base64: '' }],
-            },
-          ],
-        },
-      ] as const) {
-        const failure = await Effect.runPromise(
-          Effect.flip(model.prepareTurn({ ...REQUEST, ...request })),
-        );
-        expect(failure.kind).toBe('unsupported');
-      }
-      const foreign = modelWith(vi.fn<typeof globalThis.fetch>());
-      expect(
-        (await Effect.runPromise(Effect.flip(foreign.prepareTurn(history))))
-          .kind,
-      ).toBe('unsupported');
-      expect(fetch).toHaveBeenCalledTimes(2);
-    },
-  );
-
-  it.each([
-    { name: 'input detection', finish: 'stop', input_sensitive: true },
-    {
-      name: 'filtered empty reply',
-      finish: 'content_filter',
-      output_sensitive: true,
-    },
-    { name: 'limited empty reply', finish: 'length' },
-    { name: 'provider refusal code', code: 1027, kind: 'provider-rejection' },
-    {
-      name: 'provider authentication code',
-      code: 1004,
-      noIdentity: true,
-      kind: 'authentication',
-    },
-    {
-      name: 'missing terminal reason',
-      finish: undefined,
-      kind: 'malformed-output',
-    },
-    {
-      name: 'contradictory tools',
-      finish: 'tool_calls',
-      kind: 'malformed-output',
-    },
-    {
-      name: 'unrepresented audio',
-      finish: 'stop',
-      extraMessage: { audio_content: 'audio bytes' },
-      kind: 'malformed-output',
-    },
-    {
-      name: 'unknown reasoning payload',
-      finish: 'stop',
-      extraMessage: { reasoning_details: [{ data: 'opaque' }] },
-      kind: 'malformed-output',
-    },
-    {
-      name: 'null reasoning',
-      finish: 'stop',
-      extraMessage: { reasoning_content: null },
-      kind: 'malformed-output',
-    },
-    {
-      name: 'malformed call arguments',
-      finish: 'tool_calls',
-      kind: 'malformed-output',
-      extraMessage: {
-        tool_calls: [call(0, { function: { name: 'search', arguments: '{' } })],
-      },
-    },
-    {
-      name: 'duplicate call identities',
-      finish: 'tool_calls',
-      kind: 'malformed-output',
-      extraMessage: { tool_calls: [call(0), call(1, { id: 'call_0' })] },
-    },
-  ])(
-    'respects MiniMax terminal evidence: $name',
-    async ({ finish, code, kind, extraMessage, noIdentity, ...flags }) => {
-      const raw = {
-        id: noIdentity ? '' : 'minimax-response',
-        model: noIdentity ? '' : 'returned-minimax',
-        object: 'chat.completion',
-        created: 0,
-        choices: [
-          {
-            index: 0,
-            finish_reason: finish,
-            message: { role: 'assistant', content: '', ...extraMessage },
-          },
-        ],
-        ...(code === undefined
-          ? {}
-          : {
-              base_resp: {
-                status_code: code,
-                status_msg: 'original rejection',
-              },
-            }),
-        ...(flags.input_sensitive === undefined
-          ? {}
-          : { input_sensitive: flags.input_sensitive }),
-        ...(flags.output_sensitive === undefined
-          ? {}
-          : { output_sensitive: flags.output_sensitive }),
-      };
-      const fetch = vi
-        .fn<typeof globalThis.fetch>()
-        .mockImplementation(async () =>
-          Response.json(raw, {
-            headers: { 'x-request-id': 'minimax-request' },
-          }),
-        );
-      const model = openaiChatModel(MINIMAX_CONFIG, {
-        apiKey: 'synthetic',
-        fetch,
-      });
-      if (kind !== undefined) {
-        const failure = await Effect.runPromise(Effect.flip(generate(model)));
-        expect(failure).toMatchObject({
-          kind,
-          responseId: noIdentity ? undefined : 'minimax-response',
-          model: noIdentity
-            ? MINIMAX_CONFIG.requestedModel
-            : 'returned-minimax',
-          requestId: 'minimax-request',
-        });
-        if (code !== undefined) {
-          expect(failure.status).toBe(200);
-          expect(failure.providerEvidence).toMatchObject({
-            kind: 'minimax',
-            statusCode: code,
-            statusMessage: 'original rejection',
-          });
-          expect(failure.cause).toEqual(raw);
-        }
-      } else {
-        const result = await Effect.runPromise(generate(model));
-        expect(result.finishReason).toBe(finish?.replaceAll('_', '-'));
-        expect(result.usage).toBeNull();
-      }
-      expect(fetch).toHaveBeenCalledTimes(1);
-    },
   );
 
   it.each([REASONING_CONFIGS[1], REASONING_CONFIGS[2]])(
@@ -3190,11 +2824,10 @@ describe('native OpenAI Chat protocol', () => {
     },
   );
 
-  it.each(['generation', 'estimation', 'MiniMax completion'] as const)(
+  it.each(['generation', 'estimation'] as const)(
     'preserves a body-read failure and the HTTP request identity during %s',
     async (operation) => {
       const estimating = operation === 'estimation';
-      const complete = operation === 'MiniMax completion';
       const cause = new Error('Original body failure');
       let controller: ReadableStreamDefaultController<Uint8Array>;
       let requestSignal: AbortSignal | null | undefined;
@@ -3203,7 +2836,7 @@ describe('native OpenAI Chat protocol', () => {
           controller = current;
           current.enqueue(
             new TextEncoder().encode(
-              estimating || complete
+              estimating
                 ? '{"data":'
                 : `data: ${JSON.stringify(
                     chunk({
@@ -3221,7 +2854,7 @@ describe('native OpenAI Chat protocol', () => {
           );
         },
         pull() {
-          if (estimating || complete) controller.error(cause);
+          if (estimating) controller.error(cause);
         },
       });
       const fetch = vi
@@ -3230,16 +2863,14 @@ describe('native OpenAI Chat protocol', () => {
           requestSignal = init?.signal;
           return new Response(body, {
             headers: {
-              'content-type':
-                estimating || complete
-                  ? 'application/json'
-                  : 'text/event-stream',
+              'content-type': estimating
+                ? 'application/json'
+                : 'text/event-stream',
               'x-request-id': 'http-original-request',
             },
           });
         });
       let config: ChatConfiguration = REASONING_CONFIGS[2];
-      if (complete) config = MINIMAX_CONFIG;
       if (estimating)
         config = {
           ...REASONING_CONFIGS[1],
@@ -3264,14 +2895,11 @@ describe('native OpenAI Chat protocol', () => {
       );
       expect(failure).toMatchObject({
         kind: 'transport',
-        model:
-          estimating || complete
-            ? CONFIG.requestedModel
-            : 'returned-model-version',
+        model: estimating ? CONFIG.requestedModel : 'returned-model-version',
         requestId: 'http-original-request',
       });
       expect(failure.responseId).toBe(
-        estimating || complete ? undefined : 'synthetic-response',
+        estimating ? undefined : 'synthetic-response',
       );
       expect(failure.cause).toBe(cause);
       expect(requestSignal?.aborted).toBe(true);
@@ -3291,22 +2919,13 @@ describe('native OpenAI Chat protocol', () => {
     'successful-take',
     'malformed-frame-and-cancel',
     'interruption-and-cancel',
-    'complete-headers',
-    'complete-body',
-    'complete-interruption-and-cancel',
-    'complete-malformed-bytes-and-cancel',
   ] as const)(
     'interrupts a pending %s read and joins cleanup',
     async (phase) => {
       const estimating = phase.startsWith('estimate-');
-      const complete = phase.startsWith('complete-');
-      const malformed =
-        phase === 'malformed-frame-and-cancel' ||
-        phase === 'complete-malformed-bytes-and-cancel';
+      const malformed = phase === 'malformed-frame-and-cancel';
       const waitingForHeaders =
-        phase === 'headers' ||
-        phase === 'estimate-headers' ||
-        phase === 'complete-headers';
+        phase === 'headers' || phase === 'estimate-headers';
       let requestSignal: AbortSignal | null | undefined;
       let cancelledAfterAbort = false;
       const cancellation = new Error('Cancellation failed');
@@ -3316,9 +2935,7 @@ describe('native OpenAI Chat protocol', () => {
           phase === 'successful-take' ||
           phase === 'malformed-frame-and-cancel' ||
           phase === 'interruption-and-cancel' ||
-          phase === 'estimate-interruption-and-cancel' ||
-          phase === 'complete-interruption-and-cancel' ||
-          phase === 'complete-malformed-bytes-and-cancel'
+          phase === 'estimate-interruption-and-cancel'
         )
           throw cancellation;
       });
@@ -3329,7 +2946,7 @@ describe('native OpenAI Chat protocol', () => {
         start(controller) {
           controller.enqueue(
             new TextEncoder().encode(
-              estimating || complete
+              estimating
                 ? '{"data":'
                 : `data: ${JSON.stringify(chunk({ choices: [{ index: 0, delta: phase === 'reasoning' ? { reasoning_content: 'partial' } : { content: 'partial' }, finish_reason: null }] }))}\n\n`,
             ),
@@ -3344,8 +2961,6 @@ describe('native OpenAI Chat protocol', () => {
             controller.enqueue(
               new TextEncoder().encode('data: malformed JSON\n\n'),
             );
-          if (phase === 'complete-malformed-bytes-and-cancel')
-            controller.enqueue(new Uint8Array([0xff]));
         },
         cancel,
       });
@@ -3357,10 +2972,9 @@ describe('native OpenAI Chat protocol', () => {
             return Promise.resolve(
               new Response(body, {
                 headers: {
-                  'content-type':
-                    estimating || complete
-                      ? 'application/json'
-                      : 'text/event-stream',
+                  'content-type': estimating
+                    ? 'application/json'
+                    : 'text/event-stream',
                 },
               }),
             );
@@ -3373,7 +2987,6 @@ describe('native OpenAI Chat protocol', () => {
           );
         });
       let config: ChatConfiguration = CONFIG;
-      if (complete) config = MINIMAX_CONFIG;
       if (phase === 'reasoning') config = REASONING_CONFIGS[0];
       if (estimating)
         config = {
@@ -3413,9 +3026,7 @@ describe('native OpenAI Chat protocol', () => {
       await vi.waitFor(() => {
         expect(requestSignal).toBeDefined();
         if (!waitingForHeaders) {
-          if (estimating || (complete && !malformed))
-            expect(body.locked).toBe(true);
-          else if (complete) expect(cancel).toHaveBeenCalledTimes(1);
+          if (estimating) expect(body.locked).toBe(true);
           else expect(onDelta).toHaveBeenCalledTimes(1);
         }
       });
@@ -3424,8 +3035,7 @@ describe('native OpenAI Chat protocol', () => {
       if (
         malformed ||
         phase === 'interruption-and-cancel' ||
-        phase === 'estimate-interruption-and-cancel' ||
-        phase === 'complete-interruption-and-cancel'
+        phase === 'estimate-interruption-and-cancel'
       ) {
         const exit = await Effect.runPromise(Fiber.await(fiber));
         assert(Exit.isFailure(exit));

--- a/src/test-kernel/llm/OpenaiResponses.vitest.ts
+++ b/src/test-kernel/llm/OpenaiResponses.vitest.ts
@@ -2122,7 +2122,6 @@ describe('native OpenAI Responses protocol', () => {
           anchor: { interactionId: 'int_1', coveredSteps: 1 },
         },
       },
-      { ...REQUEST, promptCacheKey: 'admitted-invocation' },
       ...(
         [
           {

--- a/src/test-kernel/llm/OpenrouterChat.vitest.ts
+++ b/src/test-kernel/llm/OpenrouterChat.vitest.ts
@@ -557,7 +557,6 @@ describe('native OpenRouter Chat', () => {
     ['parallel', { parallelToolCalls: false }],
     ['background', { mode: 'background' }],
     ['foreign thinking', { thinking: { mode: 'disabled' } }],
-    ['cache key', { promptCacheKey: 'key' }],
     ['unknown named tool', { toolChoice: { name: 'missing' } }],
   ] as const)(
     'rejects %s and does not issue an automatic request',

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -13,12 +13,12 @@ import {
   resolveDirectModelApiKeyProvider,
   shouldRouteModelThroughOpenRouter,
 } from '@model/openRouterRouting';
-import {
-  CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
-  isCodexSubscriptionEligible,
-} from '@model/providerCapabilities';
+import { isCodexSubscriptionEligible } from '@model/providerCapabilities';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
-import type { ModelOptionData } from '@shared/schemas';
+import {
+  CHATGPT_CODEX_CONTEXT_WINDOW_SETTING,
+  type ModelOptionData,
+} from '@shared/schemas';
 import { FAST_FIRST_RESPONSE_HINT } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { FakeSecrets } from '@test/support/FakePlatform';
@@ -318,7 +318,7 @@ describe('computeModelOptionsData availability', () => {
     expect(model.availability).toBe('subscription-access');
     expect(model.context).toBe(
       `${Math.round(
-        (CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT +
+        (CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue +
           MODEL_CONFIGS.gpt55.maxOutputTokens) /
           1000,
       )}K`,

--- a/src/test-kernel/model/ProviderCapabilities.vitest.ts
+++ b/src/test-kernel/model/ProviderCapabilities.vitest.ts
@@ -12,11 +12,11 @@ import { CODEX_SESSION_SECRET_KEY } from '@auth/codex/codexConstants';
 import type { CodexSession } from '@auth/codex/codexSessionTypes';
 import { installTexraAccountProbes } from '@controllers/modelAccess/installTexraAccountProbes';
 import {
-  CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
   isCodexSubscriptionActive,
   resolveCodexSubscriptionCapabilities,
   resolveCodexSubscriptionProfile,
 } from '@model/providerCapabilities';
+import { CHATGPT_CODEX_CONTEXT_WINDOW_SETTING } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
 
 const gpt55Config: ModelConfig = {
@@ -75,8 +75,9 @@ describe('provider capabilities', () => {
 
     expect(capabilities).toMatchObject({
       contextWindow:
-        CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT + gpt55Config.maxOutputTokens,
-      inputTokenLimit: CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
+        CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue +
+        gpt55Config.maxOutputTokens,
+      inputTokenLimit: CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue,
       inputPrice: 0,
       outputPrice: 0,
       usageRoute: 'chatgpt-subscription',
@@ -110,8 +111,9 @@ describe('provider capabilities', () => {
       expect(model.codexSubscription).toBe(true);
       expect(capabilities).toMatchObject({
         contextWindow:
-          CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT + model.maxOutputTokens,
-        inputTokenLimit: CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
+          CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue +
+          model.maxOutputTokens,
+        inputTokenLimit: CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue,
       });
     },
   );
@@ -146,7 +148,7 @@ describe('provider capabilities', () => {
           useOpenRouter: false,
         }),
       ).toMatchObject({
-        inputTokenLimit: CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
+        inputTokenLimit: CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue,
       });
     });
   });


### PR DESCRIPTION
## Summary

- **LLM1-2**: collapse the six copies of `Model.generateTurn` into one fold. Every provider had the same `Stream.runFold` over the `completed` event, plus a "no completed result" `ModelError`: openaiChat, openrouterChat, anthropicMessages, googleInteractions, the two Responses models, and the vscode-lm model in the extension. The existing Responses helper moves to `turn.ts` as `completedTurn`, and each `generateTurn` is now `(turn) => completedTurn(streamTurn(turn))`. The `Model` interface member stays, so no caller or test changes. What gives: the per-provider wording of the "no completed result" message and the per-provider span names are now one of each.
- **LLM2-1**: MiniMax always streams SSE, and the `complete` (non-streamed JSON) output mode is deleted. `outputMode` was the only per-provider wire-streaming knob left in the contract: every other Chat, Responses, Anthropic, OpenRouter and Google codec already sends `stream: true` and collects the result through `generateTurn`. Deleted: the roughly 180-line complete-body reader, the complete-only `MiniMaxCompletionSchema` (its usage and `reasoning_details` sub-shapes stay as standalone consts that the SSE schema reuses), the `outputMode` fields in `ModelConfiguration` and `ResolvedTurn`, and their prepare/params branches. Nothing outside the package and its tests uses the mode. Under 1.0 it would need a source, and the only candidate is the old per-provider streaming toggle, which coauthor-21:model-handlers-6 deletes.
- **LLM2-2**, the confirmed half only: delete provider controls that no settings row, registry field or old handler supplies. That covers `inferenceGeo` and the Anthropic `serviceTier` `auto`/`standard-only` control (Anthropic now omits `service_tier` and `inference_geo`, which the API defaults cover and which is what the old handler sent). It also covers the Kimi `promptCacheKey` and `requiresPromptCacheKey` (no caller supplies a key; the old handler never sent one). `TurnRequest.serviceTier` narrows to `'fast'` for the Responses fast tier. The reject clauses in four other codecs, which existed only because the flat `TurnRequest` carried these fields, go too. The provider-returned receipt fields (`usage.serviceTier` / `inferenceGeo`) stay. Kimi `preserveThinking` and GLM `clearThinking` stay: they make the documented reasoning replay effective (the verifier refuted that half).
- **LXDEAD-4**, reduced scope: delete `OpenAIChatConfiguration` (no reference since it was added), and `CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT` (it aliased `CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue`, and only three tests read it; they now read the setting). The `StageStartEvent` barrel re-export and its `export` keyword go too (one test used them; it now narrows with `Extract<AgentEvent, …>`). The knip baseline loses 3 rows.

## Net elements (R6)

- Files: 21 changed, 0 added, 0 deleted.
- `^[+-]export` lines: +2 / -4. `+export` is the moved `completedTurn` and the de-exported `interface StageStartEvent` line; `-export` is `OpenAIChatConfiguration`, `CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT`, `StageStartEvent`, and the old `StageStartEvent` line. Net exported symbols: `completedTurn` +1, and -3 for the three deleted exports.
- class/interface/enum declarations: +1 / -1. This is the `StageStartEvent` interface losing `export`; no declaration is added.
- `git diff --stat origin/main`: 21 files changed, 179 insertions(+), 994 deletions(-). Production code is +68 / -432 (-364). Tests are +105 / -532 (-427). README is +6 / -12, and knip-baseline -18.

## Consumer counts (R8)

Counts are at origin/main, production code outside `packages/llm` and outside tests:

- `Model.generateTurn` copies: 1 production caller (`SettingsViewMessageHandler.ts:738`). It is untouched because the interface member stays. `completedTurn` now has 7 importing files.
- `outputMode` (MiniMax): 0. The only other hit is `src/tools/grep.ts`, which is unrelated. `@texra-ai/llm/openai-chat` has 0 production importers.
- `promptCacheKey` / `requiresPromptCacheKey` / `inferenceGeo` / `standard-only`: 0.
- `OpenAIChatConfiguration`: 0, and no test either.
- `CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT`: 0 readers (its only hit is its own definition), plus 3 test files.
- `StageStartEvent` export: 0 readers (its definition plus the barrel re-export), plus 1 test.

## Skipped

- **LLM1-3**: reusing `ownedJsonRequest` for the Kimi token estimate was tried and reverted. The shared helper joins `response.json()` after aborting. That depends on the injected `fetch` erroring the body when the signal aborts. The Kimi path deliberately cancels the reader itself instead. Two existing suites pin that guarantee and time out with the shared helper: `interrupts a pending estimate-body read` and `estimate-interruption-and-cancel`, which also asserts the reader-cancel defect. Dropping it would give up interruption safety for a body that ignores abort. The verifier missed this, so it needs a ruling rather than a deletion.
- **LXDEAD-4** partial:
  - `assistantMessageFromResult` stays. Run-ledger PR 1 plans to use it (#12115 L1).
  - The `assertSupported` move into test support was not done: it is net-zero LOC and churns 3 desktop suites.
- **LLM2-2** refuted half: Kimi `preserveThinking` and GLM `clearThinking` are kept.

## Verified

- G1 `prettier --write` on the changed files: done, and `prettier --check config/ratchets/knip-baseline.json` passes.
- G2 eslint on the 19 changed .ts files: `GATE_EXIT=0`.
- G3 `CI=true npm run typecheck` (every project): `GATE_EXIT=0`.
- G4a `vitest run --changed origin/main`: `GATE_EXIT=1`, with 1 failed / 4354 passed. The one failure is `DesktopPreviewHost.vitest.ts > presents 'openFile' failure once` timing out at 10 s under a loaded machine (2261 s of cumulative setup time). It passes alone in this worktree (19/19). It is unrelated to the changed files.
- G4b `vitest run --project pure`: `GATE_EXIT=0` (276 files, 4009 tests).
- G5 `check-dead-code-ratchet.mjs`: `GATE_EXIT=0` (263 findings vs 263 baselined, after the 3-row shrink). `check-effect-migration-ratchet.mjs`: exit 0, no headroom.
- Targeted runs: `src/test-kernel/llm` 379/379, and ProviderCapabilities, ComputeModelOptions, CodexSubscriptionFallback and AgentTrace 63/63.
- The rebase onto origin/main was clean. Main did not touch any file in this diff, so the gates stand.
- Overlap notes:
  - Open PRs #12222, #12223 and #12225 also touch `config/ratchets/knip-baseline.json`, a generated file that is regenerated on rebase.
  - #12223 also edits `CodexSubscriptionFallback.vitest.ts`, which here is a 3-line import repoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNfYGNNxcPzD3JRXs4DdoM
