### PR TITLE
refactor: one abort-tolerant reader-cancel finalizer for the packages/llm codecs (1.0 clean slate)

### DIFF
--- a/packages/llm/src/googleInteractions.ts
+++ b/packages/llm/src/googleInteractions.ts
@@ -14,6 +14,7 @@ import {
   JsonObjectSchema,
   ModelConfigurationSchema,
   ModelError,
+  readerAbortSignal,
   ResolvedTurnSchema,
   sameModelOrigin,
   TurnRequestSchema,
@@ -708,37 +709,7 @@ export function googleInteractionsModel(
 
           let reader: ReadableStreamDefaultReader<unknown> | undefined =
             undefined;
-          // Finalizers are LIFO: abort the request before awaiting reader cleanup.
-          yield* Effect.addFinalizer((exit) => {
-            const body = reader;
-            if (body === undefined) return Effect.void;
-            const cancel = Effect.tryPromise({
-              try: () => body.cancel(),
-              catch: (cause) => cause,
-            }).pipe(
-              Effect.catch((cause) => {
-                // Cancel repeats an errored reader's original failure; distinct
-                // cleanup defects remain part of the scope's combined failure.
-                if (
-                  (signal.aborted && cause === signal.reason) ||
-                  (Exit.isFailure(exit) &&
-                    exit.cause.reasons.some(
-                      (reason) =>
-                        Cause.isFailReason(reason) &&
-                        reason.error instanceof ModelError &&
-                        reason.error.kind === 'transport' &&
-                        reason.error.cause === cause,
-                    ))
-                )
-                  return Effect.void;
-                return Effect.die(cause);
-              }),
-            );
-            return cancel.pipe(
-              Effect.ensuring(Effect.sync(() => body.releaseLock())),
-            );
-          });
-          const signal = yield* Effect.abortSignal;
+          const signal = yield* readerAbortSignal(() => reader);
           const source = yield* Effect.tryPromise({
             try: () =>
               client.interactions.create(

--- a/packages/llm/src/openaiChat.ts
+++ b/packages/llm/src/openaiChat.ts
@@ -11,6 +11,7 @@ import {
   JsonObjectSchema,
   ModelConfigurationSchema,
   ModelError,
+  readerAbortSignal,
   ResolvedTurnSchema,
   TurnRequestSchema,
   TurnResultSchema,
@@ -1029,37 +1030,7 @@ export function openaiChatModel(
           const parameters = yield* chatParameters(turn, config);
           let reader: ReadableStreamDefaultReader<Uint8Array> | undefined =
             undefined;
-          // Registered first: the later signal finalizer aborts before cancel joins.
-          yield* Effect.addFinalizer((exit) => {
-            if (reader === undefined) return Effect.void;
-            const body = reader;
-            const cancel = Effect.tryPromise({
-              try: () => body.cancel(),
-              catch: (cause) => cause,
-            }).pipe(
-              Effect.catch((cause) => {
-                // An errored reader repeats its read error when cancelled. Preserve
-                // distinct cleanup defects; Scope combines them with the primary exit.
-                if (
-                  (signal.aborted && cause === signal.reason) ||
-                  (Exit.isFailure(exit) &&
-                    exit.cause.reasons.some(
-                      (reason) =>
-                        Cause.isFailReason(reason) &&
-                        reason.error instanceof ModelError &&
-                        reason.error.kind === 'transport' &&
-                        reason.error.cause === cause,
-                    ))
-                )
-                  return Effect.void;
-                return Effect.die(cause);
-              }),
-            );
-            return cancel.pipe(
-              Effect.ensuring(Effect.sync(() => body.releaseLock())),
-            );
-          });
-          const signal = yield* Effect.abortSignal;
+          const signal = yield* readerAbortSignal(() => reader);
           const source = yield* Effect.tryPromise({
             try: () =>
               client.chat.completions

--- a/packages/llm/src/openrouterChat.ts
+++ b/packages/llm/src/openrouterChat.ts
@@ -2,7 +2,7 @@
 import { isDeepStrictEqual } from 'node:util';
 
 // Third-party imports
-import { Cause, Effect, Exit, Stream } from 'effect';
+import { Cause, Effect, Stream } from 'effect';
 import { Sse } from 'effect/unstable/encoding';
 import { z } from 'zod';
 
@@ -11,6 +11,7 @@ import {
   JsonObjectSchema,
   ModelConfigurationSchema,
   ModelError,
+  readerAbortSignal,
   ResolvedTurnSchema,
   TurnRequestSchema,
   TurnResultSchema,
@@ -701,33 +702,7 @@ export function openrouterChatModel(
           const parameters = yield* requestBody(turn, config);
           let reader: ReadableStreamDefaultReader<Uint8Array> | undefined =
             undefined;
-          // The later signal finalizer aborts before cancellation is awaited.
-          yield* Effect.addFinalizer((exit) => {
-            if (reader === undefined) return Effect.void;
-            const body = reader;
-            return Effect.tryPromise({
-              try: () => body.cancel(),
-              catch: (cause) => cause,
-            }).pipe(
-              Effect.catch((cause) => {
-                if (
-                  (signal.aborted && cause === signal.reason) ||
-                  (Exit.isFailure(exit) &&
-                    exit.cause.reasons.some(
-                      (reason) =>
-                        Cause.isFailReason(reason) &&
-                        reason.error instanceof ModelError &&
-                        reason.error.kind === 'transport' &&
-                        reason.error.cause === cause,
-                    ))
-                )
-                  return Effect.void;
-                return Effect.die(cause);
-              }),
-              Effect.ensuring(Effect.sync(() => body.releaseLock())),
-            );
-          });
-          const signal = yield* Effect.abortSignal;
+          const signal = yield* readerAbortSignal(() => reader);
           const response = yield* Effect.tryPromise({
             try: () =>
               http(endpoint.toString(), {

--- a/packages/llm/src/turn.ts
+++ b/packages/llm/src/turn.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { Data, Effect, Result, Stream } from 'effect';
+import { Cause, Data, Effect, Exit, Result, type Scope, Stream } from 'effect';
 import { z } from 'zod';
 
 const TextPartSchema = z
@@ -1593,6 +1593,45 @@ const ModelErrorFieldsSchema = z.strictObject({
 export class ModelError extends Data.TaggedError('ModelError')<
   z.infer<typeof ModelErrorFieldsSchema> & { readonly cause?: unknown }
 > {}
+
+/**
+ * The request signal for a streamed body, with the body reader cancelled at
+ * scope close. The cancel finalizer is registered before the signal's abort
+ * finalizer, so LIFO order aborts the request before cancellation joins a
+ * pending read. Cancel repeats an errored reader's original failure; only that
+ * repeat (the abort reason or the primary transport cause) is dropped, and
+ * distinct cleanup defects stay in the scope's combined failure.
+ */
+export const readerAbortSignal = (
+  reader: () => ReadableStreamDefaultReader<unknown> | undefined,
+): Effect.Effect<AbortSignal, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    yield* Effect.addFinalizer((exit) => {
+      const body = reader();
+      if (body === undefined) return Effect.void;
+      return Effect.tryPromise({
+        try: () => body.cancel(),
+        catch: (cause) => cause,
+      }).pipe(
+        Effect.catch((cause) =>
+          (signal.aborted && cause === signal.reason) ||
+          (Exit.isFailure(exit) &&
+            exit.cause.reasons.some(
+              (reason) =>
+                Cause.isFailReason(reason) &&
+                reason.error instanceof ModelError &&
+                reason.error.kind === 'transport' &&
+                reason.error.cause === cause,
+            ))
+            ? Effect.void
+            : Effect.die(cause),
+        ),
+        Effect.ensuring(Effect.sync(() => body.releaseLock())),
+      );
+    });
+    const signal = yield* Effect.abortSignal;
+    return signal;
+  });
 
 /** An input estimate with its counted scope, not generation usage. */
 export const InputTokenEstimateSchema = z


### PR DESCRIPTION
## Summary

**coauthor-e3:llm-reader-cancel-finalizer.** Three packages/llm codecs (OpenAI chat, OpenRouter chat, Google Interactions) each registered the same abort-tolerant reader-cancel finalizer right before `Effect.abortSignal`. Each copy was about 25 lines. This PR replaces them with one `readerAbortSignal(() => reader)` in `turn.ts`, next to `ModelError`, and each call site becomes one line: `const signal = yield* readerAbortSignal(() => reader);`.

Behavior is unchanged. The helper does not cancel a reader that was never set. It cancels through `tryPromise` and drops only the repeated failure, meaning the abort reason or the primary transport `ModelError` cause. Any other cleanup defect still dies into the scope's combined failure. `releaseLock` still always runs.

**Deviation from the proposal: `signal` is not hoisted above the call.** `Effect.abortSignal` is `acquireRelease(new AbortController(), abort)`, so it registers its own scope finalizer. Finalizers run LIFO, so the cancel finalizer has to be registered *before* the signal is acquired. That way the request is aborted before cancellation joins a pending read. Hoisting the signal would reverse that order. The helper registers the cancel finalizer, then acquires the signal and returns it. The ordering now holds by construction in one place instead of depending on statement order at each call site.

**Kimi estimate site left alone** (per the batch note and the LLM1-3 ruling). LLM1-3, which is confirmed and doable, replaces that hand-rolled reader wholesale with `ownedJsonRequest`. Folding it here would conflict with that change. The divergent-predicate sites (googleInteractions `ownedRequest`, openaiResponses, anthropicMessages, acquireVscodeLanguageModel) are also untouched.

`Exit` is no longer used in `openrouterChat.ts`, so its import is dropped.

## Net elements (R6)

- Files: 4 changed, 0 added, 0 deleted
- `^[+-]export`: +1 (`readerAbortSignal`), −0
- class/interface/enum: 0 / 0 / 0
- `git diff --stat`: 4 files changed, 47 insertions(+), 91 deletions(-), net −44 prod LOC, 0 test LOC

## Consumer counts (R8)

- `readerAbortSignal`: 3 callers (`openaiChat.ts` chat stream, `openrouterChat.ts`, `googleInteractions.ts`)
- `Effect.addFinalizer` in packages/llm: 4 → 2 (the helper, plus the Kimi estimate that LLM1-3 will delete)

## Skipped

- Kimi estimate reader-cancel finalizer (`openaiChat.ts` `estimateInputTokens`): it belongs to LLM1-3, which deletes it along with the rest of the hand-rolled reader.

## Verified

- `prettier --write` on the 4 files: exit 0 (unchanged)
- `eslint` on the 4 files: exit 0
- `gate.sh env CI=true npm run typecheck`: GATE_EXIT=0
- `vitest run` GoogleInteractions / OpenaiChat / OpenrouterChat suites: 3 files, 255 tests passed
- `gate.sh vitest run --changed origin/main`: GATE_EXIT=0 (11 files, 448 tests)
- `gate.sh vitest run --project pure`: GATE_EXIT=0 (275 files, 3975 tests)
- `node scripts/check-effect-migration-ratchet.mjs`: exit 0 (no count grew, no headroom)
- Dead-code ratchet not run: no exports removed, and the one added export has 3 consumers
- Rebased onto origin/main; no tracked `node_modules` symlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
