### PR TITLE
fix: un-export grep buildArguments to unbreak the dead-code ratchet on main

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1,5 +1,5 @@
 {
-  "semantics": "Single baseline for the two Knip inputs owned by scripts/check-dead-code-ratchet.mjs: the normal run preserves ordinary findings, while findings emitted by the production run but absent from the normal run are categorized as production-dead. Each finding is identified by (file, category, kind, name), never by line number. Category is unused or production-dead; kind preserves Knip’s files, exports, types, or duplicates issue kind so same-name findings of different kinds remain distinct. The ratchet fails when the combined result contains a finding not in this list. Removing resolved entries is always welcome; an intentional new finding must be added in sorted order by file, category, kind, then name. Run `npm run check:dead-code-ratchet` as the authoritative dead-code check.",
+  "semantics": "Single baseline for the two Knip inputs owned by scripts/check-dead-code-ratchet.mjs: the normal run preserves ordinary findings, while findings emitted by the production run but absent from the normal run are categorized as production-dead. Each finding is identified by (file, category, kind, name), never by line number. Category is unused or production-dead; kind preserves Knip\u2019s files, exports, types, or duplicates issue kind so same-name findings of different kinds remain distinct. The ratchet fails when the combined result contains a finding not in this list. Removing resolved entries is always welcome; an intentional new finding must be added in sorted order by file, category, kind, then name. Run `npm run check:dead-code-ratchet` as the authoritative dead-code check.",
   "findings": [
     {
       "file": "packages/cli/src/chat/tui/commands/SlashPalette.tsx",
@@ -938,22 +938,10 @@
       "name": "RunLeaseSchema"
     },
     {
-      "file": "src/agent/trace/events.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "StageStartEvent"
-    },
-    {
       "file": "src/agent/trace/index.ts",
       "category": "production-dead",
       "kind": "exports",
       "name": "noopTrace"
-    },
-    {
-      "file": "src/agent/trace/index.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "StageStartEvent"
     },
     {
       "file": "src/agent/workflowScript/persistence.ts",
@@ -1232,12 +1220,6 @@
       "name": "resolveDefaultModels"
     },
     {
-      "file": "src/model/providerCapabilities.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT"
-    },
-    {
       "file": "src/platform/defaults/workspaceStorage.ts",
       "category": "production-dead",
       "kind": "exports",
@@ -1422,12 +1404,6 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "parseOriginHeadDefaultBranch"
-    },
-    {
-      "file": "src/tools/grep.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "buildArguments"
     },
     {
       "file": "src/tools/lean/direct/directLspAdapter.ts",

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -77,10 +77,7 @@ const CHANNEL = 'GrepTool';
 // failure boundary to a dependency default or killing rg after one page.
 const GREP_MAX_BUFFER_CHARS = 100_000_000;
 
-export function buildArguments(
-  input: GrepInput,
-  outputMode: OutputMode,
-): string[] {
+function buildArguments(input: GrepInput, outputMode: OutputMode): string[] {
   const args: string[] = ['--color=never'];
 
   // Output mode flags


### PR DESCRIPTION
## Summary
`main` has been red since #12223 (ebae9b3223). `static checks` → the dead-code ratchet reports a new finding: `[unused/exports] src/tools/grep.ts: buildArguments`. #12223 pruned the only test that imported `buildArguments`, so its `production-dead` baseline row became an `unused/exports` finding. The function is still called inside `grep.ts`.

- Un-export `buildArguments`. It has 0 importers anywhere (`git grep buildArguments -- src packages` finds only `grep.ts`).
- Drop its baseline row, plus three rows the ratchet reports as fixed since #12229: `StageStartEvent` ×2 and `CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT`.

## Verified
- `node scripts/check-dead-code-ratchet.mjs`: "244 combined vs 244 baselined … Dead-code ratchet OK" (exit 0).
- prettier on both files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
