### PR TITLE
docs: fix embedded session initialization example

### DIFF
--- a/docs/architecture/2026-07-26-embedding-the-agent-runtime.md
+++ b/docs/architecture/2026-07-26-embedding-the-agent-runtime.md
@@ -150,7 +150,7 @@ required.
 
 Two ways out:
 
-- `initializeDefaultSession({ transcripts: await StreamLogStore.open() })` —
+- `initializeDefaultSession({ transcriptMode: { kind: 'ephemeral', reason: 'embedded host' } })` —
   the process-default session (`src/agent/runtime/SessionHandle.ts:445-452`,
   called once; a second call throws). This is what the CLI
   (`packages/cli/src/runtime/transcriptSession.ts:45`) and the extension
@@ -207,7 +207,6 @@ import { nodeProcesses } from '@platform/defaults/nodeProcesses';
 import { effectRuntime } from '@platform/processRuntime';
 import { loadAgents } from '@agent/index/agentRegistry';
 import { initializeDefaultSession } from '@agent/runtime/SessionHandle';
-import { StreamLogStore } from '@transcript';
 import { runAgent } from '@agent/runtime/runAgent';
 import { validateRunRequest } from '@agent/core/state/runRequests';
 import { AgentCategory } from '@shared/schemas/agent';
@@ -227,7 +226,7 @@ installProcessRuntime(await nodeProcesses.selfIdentity()); // Step 3 needs it
 await effectRuntime().runPromise(bootstrapNodeAgentDirectories({/* … */})); // Step 3
 
 const session = initializeDefaultSession({
-  transcripts: await StreamLogStore.open(),
+  transcriptMode: { kind: 'ephemeral', reason: 'embedded host' },
 });
 const detachHostInteractions = session.interactions.use({
   cancel: () => {},


### PR DESCRIPTION
## Summary

Replace the broken `await StreamLogStore.open()` embedding examples with the current `initializeDefaultSession` API and an explicit ephemeral transcript mode.

## Issue acceptance gates

Closes #12236. Both broken examples now initialize a working process-default session without omitting a database argument or awaiting an Effect.

## Single source of truth

`initializeDefaultSession` owns session construction and transcript-store initialization.

## Duplication and abstraction budget

No new abstraction or duplication.

## Net elements (R6)

One documentation file changed; no exported symbols or code constructs; net -1 line.

## Consumer counts (R8)

n/a — documentation-only correction.

## Host impact

Extension: None.

Desktop: None.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `git diff --check` passed.
- Dependency installation was attempted with frozen pnpm lockfile; registry socket/download failures prevented the Prettier command from completing.
