### PR TITLE
consolidate: shared wa-details toggle guard, native toSorted over spread+sort

### DIFF
--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -190,9 +190,7 @@ export function mergeLocalNotices(
       next += 1;
     }
   };
-  for (const notice of [...runNotices].sort(
-    (a, b) => a.afterSeq - b.afterSeq,
-  )) {
+  for (const notice of runNotices.toSorted((a, b) => a.afterSeq - b.afterSeq)) {
     flushThrough(notice.afterSeq);
     const previous = out.at(-1);
     const seq = previous?.settlementSeqNo ?? previous?.seqNo;

--- a/packages/extension/src/progressView/frontend/components/CollapsiblePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/CollapsiblePanel.ts
@@ -9,6 +9,8 @@ import {
 } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
+import { isOwnDetailsToggle } from '@shared/litControllers/detailsToggle';
+
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/details/details.js';
 
@@ -54,13 +56,12 @@ export abstract class CollapsiblePanel extends LitElement {
   }
 
   private handleShow(e: Event): void {
-    // Ignore bubbled events from nested wa-details
-    if (e.target !== e.currentTarget) return;
+    if (!isOwnDetailsToggle(e)) return;
     this.open = true;
   }
 
   private handleHide(e: Event): void {
-    if (e.target !== e.currentTarget) return;
+    if (!isOwnDetailsToggle(e)) return;
     this.open = false;
   }
 }

--- a/packages/extension/src/progressView/frontend/utils.ts
+++ b/packages/extension/src/progressView/frontend/utils.ts
@@ -1,6 +1,7 @@
 // Shared utility functions for the progress view frontend.
 
 import type { RunId } from '@shared/schemas';
+import { isOwnDetailsToggle } from '@shared/litControllers/detailsToggle';
 import { SessionUiEvents } from '@shared/session/uiEvents';
 
 /**
@@ -34,7 +35,7 @@ export function dispatchGroupToggle(
   runId: RunId | null,
   key: string,
 ): void {
-  if (event.target !== event.currentTarget || runId === null) return;
+  if (!isOwnDetailsToggle(event) || runId === null) return;
   host.dispatchEvent(
     SessionUiEvents.surface({
       kind: 'group',

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -22,6 +22,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import type { MemoryViewItem } from '@shared/schemas';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
+import { isOwnDetailsToggle } from '@shared/litControllers/detailsToggle';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { getLightweightMd } from '@shared/highlighting/lightweightMd';
 import { renderIconActionButtonParts } from '@shared/wa/actionButtons';
@@ -131,13 +132,13 @@ export class MemoryItem extends LitElement {
   }
 
   private handleContentsShow(event: Event): void {
-    if (event.target !== event.currentTarget) return;
+    if (!isOwnDetailsToggle(event)) return;
     this.contentsOpened = true;
     this.requestPreviewIfNeeded();
   }
 
   private handleContentsHide(event: Event): void {
-    if (event.target !== event.currentTarget) return;
+    if (!isOwnDetailsToggle(event)) return;
     this.contentsOpened = false;
   }
 

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -28,6 +28,7 @@ import type {
   ToolDashboardItem,
   ToolInstallAction,
 } from '@shared/schemas';
+import { isOwnDetailsToggle } from '@shared/litControllers/detailsToggle';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
@@ -205,12 +206,12 @@ export class ToolCard extends LitElement {
   }
 
   private handleGuideShow(event: Event): void {
-    if (event.target !== event.currentTarget) return;
+    if (!isOwnDetailsToggle(event)) return;
     this.guideExpanded = true;
   }
 
   private handleGuideHide(event: Event): void {
-    if (event.target !== event.currentTarget) return;
+    if (!isOwnDetailsToggle(event)) return;
     this.guideExpanded = false;
   }
 

--- a/src/shared/litControllers/detailsToggle.ts
+++ b/src/shared/litControllers/detailsToggle.ts
@@ -1,0 +1,8 @@
+/**
+ * Whether a `wa-show`/`wa-hide` event on a `<wa-details>` originated from this
+ * element itself rather than bubbling up from a nested `<wa-details>` — unlike
+ * the native `<details>` `toggle` event, these bubble.
+ */
+export function isOwnDetailsToggle(event: Event): boolean {
+  return event.target === event.currentTarget;
+}

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -610,8 +610,8 @@ function sameCatalogSchemaKind(actual: unknown, expected: unknown): boolean {
     return false;
   }
   if (actual instanceof z.ZodEnum && expected instanceof z.ZodEnum) {
-    const actualOptions = [...actual.options].sort();
-    const expectedOptions = [...expected.options].sort();
+    const actualOptions = actual.options.toSorted();
+    const expectedOptions = expected.options.toSorted();
     return (
       actualOptions.length === expectedOptions.length &&
       actualOptions.every((option, index) => option === expectedOptions[index])

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -4,13 +4,13 @@
 import { strict as assert } from 'node:assert';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { setTimeout as sleep } from 'node:timers/promises';
 
 // Third-party imports
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 // Local imports
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { waitForCondition } from '@test/support/asyncTestUtils';
 import { createFakeHost, setupPlatform } from '@test/support/setupPlatform';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { executeCommand, executeCommandSync } from '@utils/system/execUtils';
@@ -20,18 +20,6 @@ import { BinaryResolverService } from '@utils/system/binaryResolver';
 // ---------------------------------------------------------------------------
 // execUtils
 // ---------------------------------------------------------------------------
-
-async function waitFor(
-  description: string,
-  check: () => boolean,
-  attempts = 50,
-): Promise<void> {
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    if (check()) return;
-    await sleep(20);
-  }
-  throw new Error(`Timed out waiting for ${description}`);
-}
 
 // Signal delivery to a whole process group, and the kernel reaping the members,
 // is not instant — and gets markedly slower when the suite is saturating every
@@ -45,8 +33,7 @@ async function waitFor(
 const PROCESS_EXIT_TEST_TIMEOUT_MS = 30_000;
 
 function waitForProcessExit(pid: number): Promise<void> {
-  return waitFor(
-    `process ${pid} to exit`,
+  return waitForCondition(
     () => {
       try {
         process.kill(pid, 0);
@@ -55,7 +42,11 @@ function waitForProcessExit(pid: number): Promise<void> {
         return true;
       }
     },
-    500,
+    {
+      timeoutMs: 10_000,
+      intervalMs: 20,
+      timeoutMessage: `Timed out waiting for process ${pid} to exit`,
+    },
   );
 }
 
@@ -90,7 +81,11 @@ describe('executeCommand', () => {
       env: { PID_FILE: pidFile },
     });
 
-    await waitFor(pidFile, () => existsSync(pidFile));
+    await waitForCondition(() => existsSync(pidFile), {
+      timeoutMs: 1000,
+      intervalMs: 20,
+      timeoutMessage: `Timed out waiting for ${pidFile}`,
+    });
     const childPid = Number.parseInt(readFileSync(pidFile, 'utf8'), 10);
     assert.ok(Number.isInteger(childPid) && childPid > 0);
     return { promise, childPid };
@@ -237,7 +232,11 @@ describe('executeCommand', () => {
         },
       );
 
-      await waitFor('child pid', () => childPid !== undefined);
+      await waitForCondition(() => childPid !== undefined, {
+        timeoutMs: 1000,
+        intervalMs: 20,
+        timeoutMessage: 'Timed out waiting for child pid',
+      });
       assert.ok(childPid && childPid > 0);
 
       controller.abort();


### PR DESCRIPTION
## Summary

A scheduled consolidation sweep surveyed the codebase for duplicated logic and hand-rolled reimplementations of native methods (survey covered `src/agent/modelHandlers/`, `src/tools/`, the PocketFlow flows, the three webview frontend trees, and general utility/native-method opportunities). Most of the codebase was already well-factored; this PR lands the candidates that were genuinely evidenced, small, and behavior-preserving. Two other candidates the survey found (an xAI reasoning-effort clamp that duplicates `support/reasoningEffort.ts`, and an `execFallback` shape shared by the reflection/tooluse cycle nodes) were investigated and deliberately **not** changed — see "Rejected candidates" below.

- **`isOwnDetailsToggle` (new, `src/shared/litControllers/detailsToggle.ts`)**: the `event.target !== event.currentTarget` bubble guard for `wa-show`/`wa-hide` on `<wa-details>` was hand-rolled character-for-character across two of the three webview trees, in 4 files / 7 handler invocations (2 each in `progressView/frontend/components/CollapsiblePanel.ts`, `settingsView/frontend/components/tools/ToolCard.ts`, and `settingsView/frontend/components/memory/MemoryItem.ts`; 1 in `progressView/frontend/utils.ts`'s `dispatchGroupToggle`). `progressView` had already factored it once into `CollapsiblePanel` but missed its own second use site; `settingsView` never adopted it and reinvented it twice. Factored into a plain function in `src/shared/litControllers/`, the existing home for cross-tree Lit helpers (`SortableController`, `TickerController`, …) already consumed by all three trees.
- **`.toSorted()` over `[...arr].sort()`** in the two places where the source was already an array and the spread existed only to avoid mutating it: `packages/cli/src/chat/tui/state/transcript.ts` (`mergeLocalNotices`, sorting `readonly LocalNotice[]`) and `src/shared/schemas/settingsViewMessages.ts` (`sameCatalogSchemaKind`, sorting `ZodEnum.options`, a live mutable array on the schema instance — `.toSorted()` is a safer no-mutation read than the old spread-then-sort). Left the several `[...aSet].sort()` sites alone: converting a `Set` to an array still needs the spread regardless of which array method sorts it, so `.toSorted()` there wouldn't remove anything.
- **Test-only poll-loop dedup**: `src/test-kernel/utils/system/SystemUtils.vitest.ts` had its own hand-rolled `waitFor` (for/sleep loop) duplicating the shared `waitForCondition` in `src/test-kernel/support/asyncTestUtils.ts`; the other "waitFor*"-named helpers in the suite already turned out to be thin `vi.waitFor` wrappers, not duplicates.

## Issue acceptance gates

No tracked issue — ad hoc consolidation sweep. Acceptance gate: no behavior change, all `isOwnDetailsToggle` call sites keep their pre-existing state semantics, `.toSorted()` swaps produce identical output ordering, and the test poll-loop swap keeps the same effective timeout/interval per call site (500 attempts × 20ms → `timeoutMs: 10000, intervalMs: 20`; 50 attempts × 20ms → `timeoutMs: 1000, intervalMs: 20`).

## Single source of truth

`isOwnDetailsToggle` in `src/shared/litControllers/detailsToggle.ts` now owns the "is this wa-show/wa-hide event mine, not bubbled from a nested `<wa-details>`" fact for all three webview trees.

## Duplication and abstraction budget

Removed: the same one-line DOM-event guard duplicated 7 times across 4 files down to 1 shared function with 4 importing files. No new class/controller — a plain predicate was enough, no state management was factored since each site's `open`/`guideExpanded`/`contentsOpened` state and surrounding `willUpdate` logic genuinely differ per component. No new abstraction layers; `src/shared/litControllers/` already exists as the intended location.

## Net elements (R6)

- Files: 8 changed (1 new, 7 modified) — `git diff --stat origin/main`: `8 files changed, 40 insertions(+), 31 deletions(-)`
- Exported symbols: +1 (`isOwnDetailsToggle`), 0 removed
- Classes/interfaces/enums: none added or removed
- Net LoC: +9

## Consumer counts (R8)

New export `isOwnDetailsToggle` has 4 importing files added in this same PR (`CollapsiblePanel.ts`, `progressView/frontend/utils.ts`, `ToolCard.ts`, `MemoryItem.ts`), 7 call sites total. No emit path or existing public symbol was deleted or re-routed.

## Host impact

Extension: `progressView` and `settingsView` webview frontends — no behavior change, same collapse/expand semantics for `CollapsiblePanel`/`TodoList`, the progress-view group toggle, `ToolCard`'s install guide, and `MemoryItem`'s content preview.

Desktop: none.

CLI: `packages/cli/src/chat/tui/state/transcript.ts` — `mergeLocalNotices` sort order unchanged.

## Scheduled refactoring

None. Two related findings were investigated and rejected rather than deferred:
- **xAI reasoning-effort clamp** (`src/agent/modelHandlers/openai/modelHandlerXAI.ts`) hand-rolls a low/medium/high check that superficially resembles `support/reasoningEffort.ts`'s `normalizeSupportedReasoningEffort`, already used by GLM and DeepSeek. Not changed: delegating would change clamp behavior for an out-of-vocabulary `'minimal'` input (nearest-tier algorithm lands on `'low'`, not xAI's current blanket `'high'` fallback) and drops the xAI-specific warning log message — a real behavior change to production model-request handling, not a safe refactor.
- **`execFallback` shape** in `ResponseCycleNode` (reflection flow) and `ToolUseCycleNode` (tooluse flow) both call `buildFailedRetryInfo` then log then return `{ outcome: 'failed', lastError }`, but the log call's message text and options differ at each site. Two callers with diverging content isn't enough real shared logic to justify a new `core/flows/` helper per the repo's abstraction-discipline bar.

## Validation

- `npm run typecheck` — all packages pass
- `npm run lint` — clean (2 import/order fixes auto-applied)
- `npm run format` — clean
- `npm run check:dead-code-ratchet` — no new findings
- `npm run test:changed` — 505 test files / 5450 tests passed, 1 skipped
- `npm run test:pure` — 215 test files / 2434 tests passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLFMrEck7UaJ5rQFU6qneb