### PR TITLE
refactor: warn on unparseable delegation replay, index-keyed question answers, O(1) subscription cleanup

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -129,8 +129,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
               ? repeat(
                   question.options,
                   (option) => option.label,
-                  (option) =>
-                    this.renderCheckboxOption(index, option, current),
+                  (option) => this.renderCheckboxOption(index, option, current),
                 )
               : html`
                   <wa-radio-group

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -44,8 +44,11 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
     userQuestionPanelStyles,
   ];
 
-  @state() private selections: Record<string, string[]> = {};
-  @state() private freeText: Record<string, string> = {};
+  // Indexed by question position (not `question.question`): two questions
+  // with identical wording would otherwise collide on a text key, both in
+  // Lit's `repeat` reconciliation and in these state maps.
+  @state() private selections: string[][] = [];
+  @state() private freeText: string[] = [];
 
   override render(): TemplateResult {
     const data = this.permission.data;
@@ -63,8 +66,8 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
         <div class="user-question-request__questions">
           ${repeat(
             data.questions,
-            (question) => question.question,
-            (question) => this.renderQuestion(question),
+            (_question, index) => index,
+            (question, index) => this.renderQuestion(question, index),
           )}
         </div>
         <div class="user-question-request__actions">
@@ -100,8 +103,11 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
     return true;
   }
 
-  private renderQuestion(question: UserQuestionPrompt): TemplateResult {
-    const current = this.selections[question.question] ?? [];
+  private renderQuestion(
+    question: UserQuestionPrompt,
+    index: number,
+  ): TemplateResult {
+    const current = this.selections[index] ?? [];
 
     return html`
       <fieldset class="user-question-request__question">
@@ -124,18 +130,16 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
                   question.options,
                   (option) => option.label,
                   (option) =>
-                    this.renderCheckboxOption(question, option, current),
+                    this.renderCheckboxOption(index, option, current),
                 )
               : html`
                   <wa-radio-group
                     label="Choose one answer"
                     .value=${
-                      this.freeText[question.question]?.trim()
-                        ? ''
-                        : (current[0] ?? '')
+                      this.freeText[index]?.trim() ? '' : (current[0] ?? '')
                     }
                     @change=${(event: Event) =>
-                      this.updateSingleSelection(question, event)}
+                      this.updateSingleSelection(index, event)}
                   >
                     ${repeat(
                       question.options,
@@ -160,8 +164,8 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
                 resize="vertical"
                 autocomplete="off"
                 spellcheck
-                .value=${this.freeText[question.question] ?? ''}
-                @input=${(event: Event) => this.updateFreeText(question, event)}
+                .value=${this.freeText[index] ?? ''}
+                @input=${(event: Event) => this.updateFreeText(index, event)}
               ></wa-textarea>`
             : nothing
         }
@@ -183,7 +187,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
   }
 
   private renderCheckboxOption(
-    question: UserQuestionPrompt,
+    index: number,
     option: UserQuestionPrompt['options'][number],
     current: string[],
   ): TemplateResult {
@@ -192,7 +196,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
         class="user-question-request__option"
         ?checked=${current.includes(option.label)}
         @change=${(event: Event) =>
-          this.updateSelection(question, option.label, event)}
+          this.updateSelection(index, option.label, event)}
       >
         ${this.renderOptionLabel(option)}
       </wa-checkbox>
@@ -209,39 +213,37 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
     `;
   }
 
-  private updateSelection(
-    question: UserQuestionPrompt,
-    label: string,
-    event: Event,
-  ): void {
+  private updateSelection(index: number, label: string, event: Event): void {
     const checked = (event.target as HTMLElement & { checked?: boolean })
       .checked;
-    const current = this.selections[question.question] ?? [];
+    const current = this.selections[index] ?? [];
     const next = checked
       ? [...current, label]
       : current.filter((item) => item !== label);
-    this.selections = { ...this.selections, [question.question]: next };
+    const nextSelections = [...this.selections];
+    nextSelections[index] = next;
+    this.selections = nextSelections;
   }
 
-  private updateSingleSelection(
-    question: UserQuestionPrompt,
-    event: Event,
-  ): void {
+  private updateSingleSelection(index: number, event: Event): void {
     const value =
       (event.target as HTMLElement & { value?: string }).value ?? '';
-    this.selections = {
-      ...this.selections,
-      [question.question]: value ? [value] : [],
-    };
-    if (value && this.freeText[question.question]) {
-      this.freeText = { ...this.freeText, [question.question]: '' };
+    const nextSelections = [...this.selections];
+    nextSelections[index] = value ? [value] : [];
+    this.selections = nextSelections;
+    if (value && this.freeText[index]) {
+      const nextFreeText = [...this.freeText];
+      nextFreeText[index] = '';
+      this.freeText = nextFreeText;
     }
   }
 
-  private updateFreeText(question: UserQuestionPrompt, event: Event): void {
+  private updateFreeText(index: number, event: Event): void {
     const value =
       (event.currentTarget as HTMLElement & { value?: string }).value ?? '';
-    this.freeText = { ...this.freeText, [question.question]: value };
+    const nextFreeText = [...this.freeText];
+    nextFreeText[index] = value;
+    this.freeText = nextFreeText;
   }
 
   private submitAnswers(): void {
@@ -255,35 +257,35 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
     }
     const answers: UserQuestionAnswers = {};
 
-    for (const question of data.questions) {
-      const custom = this.freeText[question.question]?.trim();
-      const selected = this.selections[question.question] ?? [];
+    data.questions.forEach((question, index) => {
+      const custom = this.freeText[index]?.trim();
+      const selected = this.selections[index] ?? [];
       if (question.multiSelect) {
         // The box is labelled "Another answer", so on a multi-select
         // question it adds to the checked options instead of replacing them.
         const merged = custom ? [...selected, custom] : selected;
         const answer = [...new Set(merged)];
-        if (answer.length === 0) continue;
+        if (answer.length === 0) return;
         answers[question.question] = answer;
-        continue;
+        return;
       }
       // Single-select holds one answer, so free text stays an override — it is
       // the escape hatch for "none of these options fit".
       if (custom) {
         answers[question.question] = custom;
-        continue;
+        return;
       }
-      if (selected.length === 0) continue;
+      if (selected.length === 0) return;
       answers[question.question] = selected[0];
-    }
+    });
 
     this.emitAction({ action: 'submit', answers });
   }
 
   private hasAnyAnswer(data: UserQuestionPermission): boolean {
-    return data.questions.some((question) => {
-      if (this.freeText[question.question]?.trim()) return true;
-      return (this.selections[question.question] ?? []).length > 0;
+    return data.questions.some((_question, index) => {
+      if (this.freeText[index]?.trim()) return true;
+      return (this.selections[index] ?? []).length > 0;
     });
   }
 }

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -254,9 +254,14 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
         ?.focus();
       return;
     }
+    // Submission itself still collapses onto `UserQuestionAnswersSchema`'s
+    // question-text keys (the AskUserQuestion wire vocabulary has no other
+    // id): two identically-worded questions answered independently above
+    // will silently collapse into one entry here. Pre-existing limitation,
+    // not introduced by the position-indexed state above.
     const answers: UserQuestionAnswers = {};
 
-    data.questions.forEach((question, index) => {
+    for (const [index, question] of data.questions.entries()) {
       const custom = this.freeText[index]?.trim();
       const selected = this.selections[index] ?? [];
       if (question.multiSelect) {
@@ -264,19 +269,19 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
         // question it adds to the checked options instead of replacing them.
         const merged = custom ? [...selected, custom] : selected;
         const answer = [...new Set(merged)];
-        if (answer.length === 0) return;
+        if (answer.length === 0) continue;
         answers[question.question] = answer;
-        return;
+        continue;
       }
       // Single-select holds one answer, so free text stays an override — it is
       // the escape hatch for "none of these options fit".
       if (custom) {
         answers[question.question] = custom;
-        return;
+        continue;
       }
-      if (selected.length === 0) return;
+      if (selected.length === 0) continue;
       answers[question.question] = selected[0];
-    });
+    }
 
     this.emitAction({ action: 'submit', answers });
   }

--- a/src/shared/schemas/proposalInput.ts
+++ b/src/shared/schemas/proposalInput.ts
@@ -72,12 +72,24 @@ export function extractionShorthandToolConfig(
   return overrides;
 }
 
-function warnProposalParseFailure(toolName: string, message: string): void {
+/**
+ * Parse `data` against `schema`, warning and returning `null` on failure
+ * instead of throwing. Shared by both delegation-tool branches below so a
+ * reconstruction failure is reported identically regardless of category.
+ */
+function parseOrWarn<T>(
+  schema: z.ZodType<T>,
+  data: unknown,
+  toolName: string,
+): T | null {
+  const result = schema.safeParse(data);
+  if (result.success) return result.data;
   console.warn(
     `[proposalInput] Could not reconstruct a proposal for delegation tool ` +
       `"${toolName}"; the "Restore setup" link will be unavailable for this ` +
-      `logged call: ${message}`,
+      `logged call: ${result.error.message}`,
   );
+  return null;
 }
 
 /**
@@ -96,25 +108,20 @@ export function parseDelegationToolInput(
   const spread = isObject(input) ? input : {};
 
   if (category === AgentCategory.ToolUse) {
-    const result = LenientToolUseProposalSchema.safeParse({
-      agentCategory: AgentCategory.ToolUse,
-      ...spread,
-    });
-    if (!result.success) {
-      warnProposalParseFailure(toolName, result.error.message);
-      return null;
-    }
-    return result.data;
+    return parseOrWarn(
+      LenientToolUseProposalSchema,
+      { agentCategory: AgentCategory.ToolUse, ...spread },
+      toolName,
+    );
   }
 
-  const result = LenientWorkflowProposalSchema.safeParse({
-    agentCategory: AgentCategory.Workflow,
-    ...spread,
-    toolConfig: extractionShorthandToolConfig(spread),
-  });
-  if (!result.success) {
-    warnProposalParseFailure(toolName, result.error.message);
-    return null;
-  }
-  return result.data;
+  return parseOrWarn(
+    LenientWorkflowProposalSchema,
+    {
+      agentCategory: AgentCategory.Workflow,
+      ...spread,
+      toolConfig: extractionShorthandToolConfig(spread),
+    },
+    toolName,
+  );
 }

--- a/src/shared/schemas/proposalInput.ts
+++ b/src/shared/schemas/proposalInput.ts
@@ -72,6 +72,14 @@ export function extractionShorthandToolConfig(
   return overrides;
 }
 
+function warnProposalParseFailure(toolName: string, message: string): void {
+  console.warn(
+    `[proposalInput] Could not reconstruct a proposal for delegation tool ` +
+      `"${toolName}"; the "Restore setup" link will be unavailable for this ` +
+      `logged call: ${message}`,
+  );
+}
+
 /**
  * Parse raw delegation/proposal tool input into a canonical {@link AgentProposal},
  * or `null` when the tool is not proposal-bearing or the input fails validation.
@@ -88,19 +96,25 @@ export function parseDelegationToolInput(
   const spread = isObject(input) ? input : {};
 
   if (category === AgentCategory.ToolUse) {
-    return LenientToolUseProposalSchema.nullable()
-      .catch(null)
-      .parse({
-        agentCategory: AgentCategory.ToolUse,
-        ...spread,
-      });
+    const result = LenientToolUseProposalSchema.safeParse({
+      agentCategory: AgentCategory.ToolUse,
+      ...spread,
+    });
+    if (!result.success) {
+      warnProposalParseFailure(toolName, result.error.message);
+      return null;
+    }
+    return result.data;
   }
 
-  return LenientWorkflowProposalSchema.nullable()
-    .catch(null)
-    .parse({
-      agentCategory: AgentCategory.Workflow,
-      ...spread,
-      toolConfig: extractionShorthandToolConfig(spread),
-    });
+  const result = LenientWorkflowProposalSchema.safeParse({
+    agentCategory: AgentCategory.Workflow,
+    ...spread,
+    toolConfig: extractionShorthandToolConfig(spread),
+  });
+  if (!result.success) {
+    warnProposalParseFailure(toolName, result.error.message);
+    return null;
+  }
+  return result.data;
 }

--- a/src/tools/github/RunSubscriptionRegistry.ts
+++ b/src/tools/github/RunSubscriptionRegistry.ts
@@ -70,6 +70,14 @@ export class RunSubscriptionRegistry<K extends string, Input> {
   private readonly logger: Pick<AgentTrace, 'info' | 'warn'>;
   private readonly perRun = new Map<RunId, Map<K, BoundSubscription>>();
   private readonly releaseHooks = new Map<SessionHandle, () => void>();
+  /**
+   * Live binding count per session, kept in lockstep with every place a
+   * `BoundSubscription.owner` is set or cleared (new binding, rebind-reassign,
+   * unbind, unbindAll, source-key prune, session release). Lets
+   * {@link detachReleaseHookIfUnused} answer "does this session still own
+   * anything" in O(1) instead of scanning every run's every binding.
+   */
+  private readonly bindingCountBySession = new Map<SessionHandle, number>();
 
   constructor(private readonly opts: RunSubscriptionRegistryOptions<K, Input>) {
     this.logger = opts.logger ?? createLog(opts.name);
@@ -102,6 +110,8 @@ export class RunSubscriptionRegistry<K extends string, Input> {
         const previousOwner = existing.owner;
         existing.owner = session;
         if (previousOwner !== session) {
+          this.decrementSessionRefCount(previousOwner);
+          this.incrementSessionRefCount(session);
           this.detachReleaseHookIfUnused(previousOwner);
         }
         this.opts.source.updateSubscription?.(input, existing.onEvent);
@@ -154,6 +164,7 @@ export class RunSubscriptionRegistry<K extends string, Input> {
           };
           bound.set(key, subscription);
           this.perRun.set(runId, bound);
+          this.incrementSessionRefCount(session);
           this.ensureReleaseHook(session);
           this.logger.info(`Bound subscription ${key} → stream ${runId}`);
           this.emitBindingsChanged();
@@ -167,9 +178,8 @@ export class RunSubscriptionRegistry<K extends string, Input> {
   unbind(runId: RunId, input: Input): boolean {
     const key = this.opts.keyOf(input);
     const bound = this.perRun.get(runId);
-    const binding = bound?.get(key);
+    const binding = bound && this.deleteBoundKey(runId, bound, key);
     if (!bound || !binding) return false;
-    this.removeBoundKey(runId, bound, key);
     this.detachReleaseHookIfUnused(binding.owner);
     binding.disposable.dispose();
     this.emitBindingsChanged();
@@ -186,11 +196,10 @@ export class RunSubscriptionRegistry<K extends string, Input> {
     const removedBindings: BoundSubscription[] = [];
     const owners = new Set<SessionHandle>();
     for (const [runId, bound] of [...this.perRun]) {
-      const binding = bound.get(canonicalKey);
+      const binding = this.deleteBoundKey(runId, bound, canonicalKey);
       if (!binding) continue;
       removedBindings.push(binding);
       owners.add(binding.owner);
-      this.removeBoundKey(runId, bound, canonicalKey);
     }
     if (removedBindings.length > 0) {
       for (const owner of owners) this.detachReleaseHookIfUnused(owner);
@@ -224,27 +233,24 @@ export class RunSubscriptionRegistry<K extends string, Input> {
     const detach = session.followUps.onRelease((runId) => {
       const bound = this.perRun.get(runId);
       if (!bound) return;
-      const owned = [...bound].filter(
-        ([, binding]) => binding.owner === session,
-      );
+      const owned = [...bound]
+        .filter(([, binding]) => binding.owner === session)
+        .map(([key]) => key);
       if (owned.length === 0) return;
-      for (const [key] of owned) bound.delete(key);
-      if (bound.size === 0) this.perRun.delete(runId);
+      const removed = owned
+        .map((key) => this.deleteBoundKey(runId, bound, key))
+        .filter(
+          (binding): binding is BoundSubscription => binding !== undefined,
+        );
       this.detachReleaseHookIfUnused(session);
-      for (const [, binding] of owned) {
-        binding.disposable.dispose();
-      }
+      for (const binding of removed) binding.disposable.dispose();
       this.emitBindingsChanged();
     });
     this.releaseHooks.set(session, detach);
   }
 
   private detachReleaseHookIfUnused(session: SessionHandle): void {
-    for (const bound of this.perRun.values()) {
-      for (const binding of bound.values()) {
-        if (binding.owner === session) return;
-      }
-    }
+    if ((this.bindingCountBySession.get(session) ?? 0) > 0) return;
     this.releaseHooks.get(session)?.();
     this.releaseHooks.delete(session);
   }
@@ -254,26 +260,48 @@ export class RunSubscriptionRegistry<K extends string, Input> {
     const removedOwners = new Set<SessionHandle>();
     let removed = false;
     for (const [runId, bound] of [...this.perRun]) {
-      for (const [key, binding] of [...bound]) {
-        if (!active.has(key)) {
-          removedOwners.add(binding.owner);
-          bound.delete(key);
-          removed = true;
-        }
+      for (const key of [...bound.keys()]) {
+        if (active.has(key)) continue;
+        const binding = this.deleteBoundKey(runId, bound, key);
+        if (!binding) continue;
+        removedOwners.add(binding.owner);
+        removed = true;
       }
-      if (bound.size === 0) this.perRun.delete(runId);
     }
     for (const owner of removedOwners) this.detachReleaseHookIfUnused(owner);
     if (removed) this.emitBindingsChanged();
   }
 
-  private removeBoundKey(
+  /**
+   * Remove one binding, decrementing its owner's ref count and pruning the
+   * run's map (and, once empty, `perRun` itself) in the same step. The
+   * single place every unbind path shrinks the (runId, key) → binding maps —
+   * callers still own disposing the returned binding's `disposable`.
+   */
+  private deleteBoundKey(
     runId: RunId,
     bound: Map<K, BoundSubscription>,
     key: K,
-  ): void {
+  ): BoundSubscription | undefined {
+    const binding = bound.get(key);
+    if (!binding) return undefined;
     bound.delete(key);
     if (bound.size === 0) this.perRun.delete(runId);
+    this.decrementSessionRefCount(binding.owner);
+    return binding;
+  }
+
+  private incrementSessionRefCount(session: SessionHandle): void {
+    this.bindingCountBySession.set(
+      session,
+      (this.bindingCountBySession.get(session) ?? 0) + 1,
+    );
+  }
+
+  private decrementSessionRefCount(session: SessionHandle): void {
+    const count = this.bindingCountBySession.get(session) ?? 0;
+    if (count <= 1) this.bindingCountBySession.delete(session);
+    else this.bindingCountBySession.set(session, count - 1);
   }
 
   private emitBindingsChanged(): void {


### PR DESCRIPTION
## Summary

Follow-up from a scheduled data-structure-complexity review. Fixes three of the genuine findings; the rest turned out to be intentional/already-solved on closer reading (see below).

1. **`parseDelegationToolInput`** (`src/shared/schemas/proposalInput.ts`) silently swallowed malformed persisted tool input via `.nullable().catch(null)` with no diagnostic trail — exactly the `.catch()`-on-persisted-data anti-pattern AGENTS.md calls out. It now `safeParse`s and warns on failure, mirroring the pattern `agentPresets.ts` already uses for the same class of bug.
2. **`UserQuestionPanel`** (`packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts`) keyed its `selections`/`freeText` state — and Lit's `repeat` reconciliation — by `question.question` (display text). Two questions with identical wording would collide during interaction. State is now keyed by question position; the wire-level `answers` object still keys by question text, since that's the `AskUserQuestion` schema's own vocabulary and out of this PR's scope.
3. **`RunSubscriptionRegistry`** (`src/tools/github/RunSubscriptionRegistry.ts`) tripled the "delete binding, prune the run entry once empty" cleanup logic across `unbind`/`unbindAll`/session-release/source-key-prune, and `detachReleaseHookIfUnused` did an O(total bindings) scan on every unbind just to check whether a session still owned anything. Consolidated into one `deleteBoundKey` helper and added a per-session ref count (`bindingCountBySession`) kept in lockstep with every owner assignment/removal, making that check O(1).

### Rejected on inspection (not included)

- **Google Interactions `PendingStepBuffer`** (untagged accumulator, kind derived from field presence): the surrounding comment documents that an earlier version *did* carry a mutable `.type` tag, and that caused a real bug (final kind depended on mutation order) this design deliberately moved away from. `seedPendingStep` also can't always know the kind upfront (some deltas arrive with no prior `step.start`). Reapplying a tag would risk recreating the bug it fixed for no complexity win.
- **`openRouter`/`openrouter` id-casing "mismatch"** in `src/shared/constants/providers.ts`: `providerConfig.ts:33-38` documents this as intentional and load-bearing until a already-tracked follow-up PR ("overdefensive-top10 #8: lowercase once at registry load") lands. A blind rename risks breaking persisted per-provider state keyed by the old casing.
- **`ExternalToolDef.probe: unknown`**: already solved by the existing `prerequisitesChecks<T>` factory (externalToolDefs.ts:294-308), which is exactly the generic wrapper a fix would add — the `unknown`→typed unwrap happens at one centralized `resolve` point per prerequisite kind, not per consumer.
- **`TokenCountOptions.tools: unknown[]`**: initially "fixed" to `ToolDefinition[]`, but reverted — this is a shared base-class contract (`ModelHandler.estimateTokenCount`) where different provider handlers pass genuinely different wire shapes through it (the OpenAI compaction coordinator passes already-provider-converted tools, not raw `ToolDefinition[]`). `unknown[]` is correct here; typecheck caught this on the first attempt.
- Several lower-severity findings (parallel timeout maps, `workflowScriptRun.ts`'s multi-map state, undated legacy-compat comments, `DesktopTaskShellState`) were left out as low-value/already-justified per the original survey.

## Issue acceptance gates

No tracked issue — this is follow-up work from an ad hoc scheduled review. Gates satisfied: the three fixes above compile, lint, and pass their existing/related test suites; no behavior change to the wire-level `AskUserQuestion` answers schema.

## Single source of truth

- `deleteBoundKey` is now the single place `RunSubscriptionRegistry` shrinks a (runId, key) → binding map and decrements a session's ref count.
- `warnProposalParseFailure` is the single place `parseDelegationToolInput` reports a reconstruction failure.

## Duplication and abstraction budget

Removed: the triplicated "delete key(s), then prune the run entry if empty" logic in `RunSubscriptionRegistry` (previously inlined in `removeBoundKey`, the `onRelease` callback, and `pruneMissingSourceKeys`). Added: one private helper (`deleteBoundKey`) plus a small ref-count map and its two one-line mutators — this is the O(n)→O(1) fix for `detachReleaseHookIfUnused`, not a pass-through layer. No new public/exported surface.

## Net elements (R6)

Files: 0 added/removed, 3 modified. Exported symbols: none added or removed (`git diff origin/main..HEAD -- src packages | grep -E '^[+-].*\bexport\b'` → empty). Classes/interfaces/enums: 0 added/removed. Net LoC: `git diff --stat origin/main..HEAD` → 3 files changed, 128 insertions(+), 84 deletions(-).

## Consumer counts (R8)

n/a — no export or emit path was deleted or re-routed; all changes are internal to their modules (private methods/fields, or a function's internal parsing strategy with an unchanged public signature).

## Host impact

Extension: `UserQuestionPanel` (progressView webview) behavior fix — no visible UI change except duplicate-worded questions now behave independently.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` (full workspace + all packages): clean.
- `npm run lint`: clean.
- `npm run test:pure` (215 files, 2434 tests): all pass.
- `npm run test:changed` (504 files, 5449 tests, reachable from this diff): all pass.
- Targeted suites also run individually: `ParseDelegationToolInput.vitest.ts`, `GitHubSubscriptionProgressEvents.vitest.ts`, `UserQuestionPanel.vitest.ts` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWLuQht8gapDghSDWtRAxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWLuQht8gapDghSDWtRAxm)_