### PR TITLE
fix(cli): coalesce session wakeups and reconcile TUI transcript inline

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -266,13 +266,17 @@ export function App(props: AppProps): React.JSX.Element {
   const childListAvailable = childListValues.length > 0;
   const selectedChild = runViewOf(view, selectedChildValue);
   const selectedChildKillable = killableRunId(selectedChild) !== undefined;
-  useEffect(() => {
-    dispatchChildListSelection({
-      kind: 'reconcile',
-      activeRunId,
-      values: childListValues,
-    });
-  }, [activeRunId, childListValues]);
+  const reconcileSelection = {
+    kind: 'reconcile' as const,
+    activeRunId,
+    values: childListValues,
+  };
+  if (
+    reduceChildListSelection(childListSelection, reconcileSelection) !==
+    childListSelection
+  ) {
+    dispatchChildListSelection(reconcileSelection);
+  }
   // Stream focus can also move through lifecycle completion or a numeric
   // accelerator. Align the selected row before the changed frame is painted;
   // ordinary row reconciliation still preserves manual list selection.

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -6,7 +6,7 @@
 
 import path from 'node:path';
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Box, Static, Text } from 'ink';
 
 import { COLOR_HINT } from '@cli/tui/ui/colors';
@@ -1122,37 +1122,20 @@ export function StaticConversationTranscript({
       width: normalizedWidth,
     }),
   );
-  const items =
-    state.ownerKey === ownerKey
-      ? state.items
-      : buildStaticTranscriptItems({
-          source,
-          runLabels: subagentRunLabels,
-          meta: sessionMeta,
-          maxRows,
-          width: normalizedWidth,
-        }).items;
-  useEffect(() => {
-    setState((current) =>
-      advanceStaticTranscriptState(current, {
-        eraseRequest,
-        runLabels: subagentRunLabels,
-        maxRows,
-        meta: sessionMeta,
-        ownerKey,
-        source,
-        width: normalizedWidth,
-      }),
-    );
-  }, [
+  // Reconcile before committing the render. Updating derived transcript state
+  // in an effect commits stale rows first and schedules another React update
+  // for every source change, even when only the scan position has advanced.
+  const nextState = advanceStaticTranscriptState(state, {
     eraseRequest,
+    runLabels: subagentRunLabels,
     maxRows,
+    meta: sessionMeta,
     ownerKey,
-    sessionMeta,
     source,
-    subagentRunLabels,
-    normalizedWidth,
-  ]);
+    width: normalizedWidth,
+  });
+  if (nextState !== state) setState(nextState);
+  const items = nextState.items;
   const repaintKey = `${renderKey}:${state.repaintEpoch}`;
   const previousRenderKey = useRef<string | undefined>(undefined);
   useLayoutEffect(() => {

--- a/src/controllers/session/sessionInputs.ts
+++ b/src/controllers/session/sessionInputs.ts
@@ -4,6 +4,10 @@
  * then the log ordinal, and drains that finite prefix before yielding text.
  * Thus a committed run.start has reached this reader before its first chunk.
  */
+// Node imports
+import { isDeepStrictEqual } from 'node:util';
+
+// Third-party imports
 import { Effect, Layer, Stream, SubscriptionRef } from 'effect';
 
 import {
@@ -69,8 +73,9 @@ export const sessionInputsLayer = Layer.effect(
             checked = new Set(
               replayExistence.claims.map(({ aggregateId }) => aggregateId),
             );
+            const initialLocal = yield* SubscriptionRef.get(local.ref);
             replay.push(
-              { _tag: 'local', local: yield* SubscriptionRef.get(local.ref) },
+              { _tag: 'local', local: initialLocal },
               { _tag: 'replay.complete', existence: replayExistence },
             );
             // Every level replays on subscribe; changes during the cold read
@@ -90,8 +95,19 @@ export const sessionInputsLayer = Layer.effect(
               { concurrency: 3 },
             );
             const tail = wakes.pipe(
+              // Wakeups carry no data: the next read captures every source's
+              // current level. Retain one pending read, not a backlog of reads
+              // of the same state after a burst of text chunks.
+              Stream.buffer({ capacity: 1, strategy: 'dropping' }),
               Stream.mapAccumEffect(
-                () => ({ cursor: anchor, text: new Map() as InflightText }),
+                () => ({
+                  cursor: anchor,
+                  text: new Map() as InflightText,
+                  local: initialLocal,
+                  // The first drain must publish the anchor: replay.complete
+                  // reconciles existence but does not advance the view cursor.
+                  existence: undefined as ExistenceReconciliation | undefined,
+                }),
                 (previous) =>
                   Effect.gen(function* () {
                     const nextText = yield* SubscriptionRef.get(text.ref);
@@ -138,10 +154,19 @@ export const sessionInputsLayer = Layer.effect(
                       };
                       inputs.push(chunk);
                     }
-                    inputs.push(
-                      { _tag: 'local', local: snapshot },
-                      { _tag: 'drained', cursor, existence },
-                    );
+                    if (!isDeepStrictEqual(previous.local, snapshot)) {
+                      inputs.push({ _tag: 'local', local: snapshot });
+                    }
+                    if (
+                      inputs.length > 0 ||
+                      rows.length > 0 ||
+                      cursor !== previous.cursor ||
+                      !isDeepStrictEqual(previous.existence, existence)
+                    ) {
+                      // Every nonempty batch needs its closing marker so the
+                      // webview decoder can release it as one complete read.
+                      inputs.push({ _tag: 'drained', cursor, existence });
+                    }
                     const batch: FoldInput[] = [
                       ...rows
                         .filter(isDisplaySessionEvent)
@@ -152,7 +177,10 @@ export const sessionInputsLayer = Layer.effect(
                         })),
                       ...inputs,
                     ];
-                    return [{ cursor, text: nextText }, [batch]] as const;
+                    return [
+                      { cursor, text: nextText, local: snapshot, existence },
+                      batch.length === 0 ? [] : [batch],
+                    ] as const;
                   }),
               ),
             );

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -328,6 +328,35 @@ afterEach(() => {
 });
 
 describe('App foreground Escape ownership', () => {
+  it('renders the latest transcript after a burst of microtask updates', async () => {
+    seedRootRun();
+    const { instance, stdout } = await renderWithInterrupt();
+    try {
+      // Successive snapshots must not trigger effects that schedule another
+      // state update after every render. Those follow-up commits exhausted
+      // React's nested-update limit during a microtask burst.
+      for (let index = 0; index < 150; index += 1) {
+        seedRun(ROOT, {
+          transcript: {
+            rows: [
+              textRowFixture(
+                'streaming',
+                'assistant',
+                `stream update ${index}`,
+              ),
+            ],
+            settledRows: 0,
+            taskGroups: [],
+            run: null,
+          },
+        });
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+      }
+      await waitFor(() => stdout.output.includes('stream update 149'));
+    } finally {
+      instance.unmount();
+    }
+  });
   it('lets a foreground information pane own Escape before child back', async () => {
     seedChildHierarchy();
     focusRun(CHILD);

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -231,6 +231,54 @@ beforeAll(() => {
 });
 
 describe('session events and view', () => {
+  it.effect(
+    'does not publish unchanged views for a burst of source wakeups',
+    () =>
+      Effect.gen(function* () {
+        const view = yield* SessionViewService;
+        const text = yield* TextChunkSource;
+        const events = yield* SessionEvents;
+        yield* settle(
+          view.ref,
+          (state) => state.runs.has(RUN) && state.cursor === 1,
+        );
+        const initial = yield* SubscriptionRef.get(view.ref);
+        const observed: SessionView[] = [];
+        const finished = yield* Deferred.make<void>();
+        yield* Effect.forkScoped(
+          view.changes.pipe(
+            Stream.drop(1),
+            Stream.runForEach((state) =>
+              Effect.gen(function* () {
+                observed.push(state);
+                if (state.cursor > initial.cursor) {
+                  yield* Deferred.succeed(finished, undefined);
+                }
+              }),
+            ),
+          ),
+        );
+        yield* Effect.yieldNow;
+        // A level notification can arrive after an earlier read has already
+        // consumed its data. Repeating it must neither publish another view nor
+        // prevent the next committed event from reaching the reader.
+        const held = yield* SubscriptionRef.get(text.ref);
+        for (let index = 0; index < 150; index += 1) {
+          yield* SubscriptionRef.set(text.ref, held);
+        }
+        yield* TestClock.adjust('1 second');
+        expect(yield* SubscriptionRef.get(view.ref)).toBe(initial);
+        expect(observed).toHaveLength(0);
+        yield* events.publish([waiting]);
+        yield* Deferred.await(finished);
+        expect(observed.length).toBeGreaterThan(0);
+        expect(observed.every((state) => state.cursor > initial.cursor)).toBe(
+          true,
+        );
+        expect(observed.at(-1)?.runs.get(RUN)?.status).toBe(RUN_PHASE.WAITING);
+      }).pipe(Effect.provide(graph([runStart]))),
+  );
+
   it.effect('keeps an inquiry independent of the run it was asked under', () =>
     Effect.gen(function* () {
       const events = yield* SessionEvents;


### PR DESCRIPTION
## Summary

Fixes React nested-update exhaustion during streaming bursts and avoids redundant view emissions on session input wakeups.

### Key Changes
1. **Session Inputs Wakeup Coalescing ()**:
   - Added a dropping buffer of capacity 1 () on wakeup notifications so rapid text arrivals don't queue an unbounded backlog of redundant drains when the reader is already reading current levels.
   - Deduped local snapshot emissions via .
   - Only emits `drained` markers when items or cursors/existence have changed, and drops empty batch emissions.

2. **Inline TUI Transcript Reconciliation ()**:
   - Reconciles derived static transcript state inline during render rather than in a `useEffect`.
   - Updating derived state in `useEffect` committed stale rows first and scheduled another React update for each source change, triggering React's `Maximum update depth exceeded` error during microtask update bursts.

3. **Child Selection Reconciliation Guard ()**:
   - Reconciles child list selection during render only when `reduceChildListSelection` produces a changed selection, preventing unnecessary dispatches.

4. **Regression Tests**:
   - Added `renders the latest transcript after a burst of microtask updates` to `AppEscapeRouting.vitest.ts` (150 streaming updates in microtask loop).
   - Added `does not publish unchanged views for a burst of source wakeups` to `sessionEvents.vitest.ts`.