### PR TITLE
refactor(tools): hoist the pollOne→PollHookRejected wrap into PollingSourceBase

### DIFF
--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -6,7 +6,6 @@ import { afterEach, describe, expect, vi, type Mock } from 'vitest';
 // Local imports - tools
 import type { PRSubscriptionState } from '@tools/github/PRPollingSource';
 import type { GhCheckRun, GhPullRequest } from '@tools/github/prTypes';
-import type { PollHookRejected } from '@tools/github/PollingSourceBase';
 
 // Local imports - test support
 import { mockGitHubClient } from '../support/githubClientMock';
@@ -19,7 +18,7 @@ interface CiStartedSource {
   pollOne(
     key: string,
     state: PRSubscriptionState,
-  ): Effect.Effect<void, PollHookRejected>;
+  ): Effect.Effect<void, unknown>;
 }
 
 const SHA = 'abcdef1234567890';

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -14,7 +14,7 @@
  * file only owns the per-issue endpoint set and the dedup state.
  */
 
-import { Cause, Effect } from 'effect';
+import { Effect } from 'effect';
 
 import type { Disposable } from '@platform/interfaces';
 import {
@@ -32,7 +32,6 @@ import {
   dedupeComments,
   type DedupedResource,
   type PollEventListener,
-  PollHookRejected,
   PollingSourceBase,
 } from './PollingSourceBase';
 import {
@@ -111,14 +110,8 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
   protected pollOne(
     _key: string,
     state: SubscriptionState,
-  ): Effect.Effect<void, PollHookRejected> {
-    return this.pollIssue(state).pipe(
-      Effect.catchCause((cause) =>
-        Effect.failCause(
-          Cause.map(cause, (error) => new PollHookRejected({ cause: error })),
-        ),
-      ),
-    );
+  ): Effect.Effect<void, unknown> {
+    return this.pollIssue(state);
   }
 
   private readonly pollIssue = Effect.fn('IssuePollingSource.pollIssue')(

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -276,14 +276,8 @@ export class PRPollingSource extends PollingSourceBase<
   protected pollOne(
     key: string,
     state: PRSubscriptionState,
-  ): Effect.Effect<void, PollHookRejected> {
-    return this.pollPr(key, state).pipe(
-      Effect.catchCause((cause) =>
-        Effect.failCause(
-          Cause.map(cause, (error) => new PollHookRejected({ cause: error })),
-        ),
-      ),
-    );
+  ): Effect.Effect<void, unknown> {
+    return this.pollPr(key, state);
   }
 
   private readonly pollPr = Effect.fn('PRPollingSource.pollPr')(function* (

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -230,11 +230,12 @@ export abstract class PollingSourceBase<
     this.logger = createChannelTrace(config.name);
   }
 
-  /** Subclass: poll the endpoints for one subscription and emit any new events. */
-  protected abstract pollOne(
-    key: K,
-    state: S,
-  ): Effect.Effect<void, PollHookRejected>;
+  /**
+   * Subclass: poll the endpoints for one subscription and emit any new
+   * events. The base wraps every hook failure in `PollHookRejected` before
+   * classifying it, so implementations may fail with the raw endpoint error.
+   */
+  protected abstract pollOne(key: K, state: S): Effect.Effect<void, unknown>;
 
   /** Optional subclass hook that runs after all subscription polls settle. */
   protected afterTick(
@@ -644,6 +645,11 @@ export abstract class PollingSourceBase<
     function* (this: PollingSourceBase<K, S>, key: K, state: S, now: number) {
       if (state.skipPollUntilMs > now) return;
       yield* this.pollOne(key, state).pipe(
+        Effect.catchCause((cause) =>
+          Effect.failCause(
+            Cause.map(cause, (error) => new PollHookRejected({ cause: error })),
+          ),
+        ),
         Effect.flatMap(() =>
           Effect.map(Clock.currentTimeMillis, (completedAt) => {
             state.lastSuccessAt = completedAt;
@@ -656,7 +662,12 @@ export abstract class PollingSourceBase<
             return Effect.failCause(cause);
           }
           return Effect.flatMap(Clock.currentTimeMillis, (failedAt) =>
-            this.handleFailure(key, state, reason.error.cause, failedAt),
+            this.handleFailure(
+              key,
+              state,
+              (reason.error as PollHookRejected).cause,
+              failedAt,
+            ),
           );
         }),
         Effect.catchCause((cause) => {

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -34,7 +34,7 @@
  * - **CI / check-run status and inline annotations.** Per-PR by design.
  */
 
-import { Cause, Effect, Exit } from 'effect';
+import { Effect, Exit } from 'effect';
 import { LRUCache } from 'lru-cache';
 
 import type { Disposable } from '@platform/interfaces';
@@ -56,7 +56,6 @@ import {
   dedupeComments,
   type DedupedResource,
   type PollEventListener,
-  PollHookRejected,
   PollingSourceBase,
 } from './PollingSourceBase';
 import {
@@ -184,14 +183,8 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
   protected pollOne(
     _key: RepoKey,
     state: SubscriptionState,
-  ): Effect.Effect<void, PollHookRejected> {
-    return this.pollRepo(state).pipe(
-      Effect.catchCause((cause) =>
-        Effect.failCause(
-          Cause.map(cause, (error) => new PollHookRejected({ cause: error })),
-        ),
-      ),
-    );
+  ): Effect.Effect<void, unknown> {
+    return this.pollRepo(state);
   }
 
   private readonly pollRepo = Effect.fn('RepoPollingSource.pollRepo')(


### PR DESCRIPTION
## Summary

All three GitHub polling sources (`IssuePollingSource`, `PRPollingSource`, `RepoPollingSource`) wrapped their `pollOne` hook in the character-identical pipe stage:

```ts
Effect.catchCause((cause) =>
  Effect.failCause(Cause.map(cause, (error) => new PollHookRejected({ cause: error }))))
```

`PollingSourceBase.pollEntry` is `pollOne`'s only production caller, so the wrap belongs there once. Widen the abstract hook's error channel to `unknown`, apply the wrap at the head of `pollEntry`'s pipe, and read the classified cause through a `PollHookRejected` narrowing in the Fail branch.

**Semantics unchanged**: `Cause.map` touches only Fail reasons — Die and Interrupt causes pass through exactly as before, so the Fail/Die/interrupt classification branches below the wrap see identical shapes. `PRPollingSource`'s `afterTick`/`drainAnnotationQueues` path fails with `PollHookRejected` natively and is untouched.

**Subclass shape**: each source keeps a 5-line `pollOne` delegate returning its inner effect (`pollIssue(state)` / `pollPr(key, state)` / `pollRepo(state)`) — deleting the override outright leaves the abstract member unimplemented (TS2515), so the delegate is the minimal correct form. `Cause`/`PollHookRejected` imports shrink in Issue- and RepoPollingSource; PR keeps both (still used by `afterTick` and the drain path). One test-local interface (`PRPollingSourceCiStarted`) widens its error type to `unknown`; the two base-class test stubs need no change (`Effect<void, PollHookRejected>` satisfies the widened signature by covariance). Net −10 lines across 5 files.

## Verification

- `tsc --noEmit` repo-root workspace project + `tsconfig.test-kernel.json` (direct binaries, gate-serialized)
- Targeted vitest: `PollingSourceBase`, `PRPollingSource`, `PRPollingSourceAnnotationPages`, `PRPollingSourceCiStarted`, `GitHubSubscriptionTool`, `GitHubSubscriptionProgressEvents` (`FORCE_COLOR=0`)
- `check-dead-code-ratchet` + `check-effect-migration-ratchet` (no baseline change: `Effect.catchCause` is not a counted catch clause; no new exports)
- ESLint (src + test-kernel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
