### PR TITLE
refactor: state PersistedState's real parse({}) invariant (1.0 clean slate)

### DIFF
--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -94,6 +94,8 @@ export type {
   RuntimePresentationEventPayloads,
 } from './runtimePresentationEvents';
 
+// textEnhancement
+
 // selectAutoOpenFinalOutput
 export { selectAutoOpenFinalOutput } from './selectAutoOpenFinalOutput';
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -94,8 +94,6 @@ export type {
   RuntimePresentationEventPayloads,
 } from './runtimePresentationEvents';
 
-// textEnhancement
-
 // selectAutoOpenFinalOutput
 export { selectAutoOpenFinalOutput } from './selectAutoOpenFinalOutput';
 

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -45,9 +45,9 @@ export function createWebviewStorage(hostBridge: {
  * `createWebviewStorage(hostBridge)`, and the desktop shell's collapsed-group
  * set over localStorage.
  *
- * Every schema field must carry a `.prefault()` — the constructor resolves
- * defaults with `schema.parse({})` and throws when they are incomplete. Never
- * `.catch()`, which would swallow invalid stored data before the loud
+ * The schema must parse `{}` into complete state (e.g. `.prefault()` on each
+ * required field): the constructor resolves defaults with `schema.parse({})`
+ * and throws otherwise. Never `.catch()`, which would swallow invalid stored data before the loud
  * warn-and-reset path can see it.
  *
  * @example


### PR DESCRIPTION
## Summary

Only one item survived from this batch, a comment-only doc fix. The other three were ceded to coauthor-97's active implementing claims (see Skipped).

- **coauthor-dc:PersistedState-prefault-doc** (texra-ai review nit on #12233): reworded `PersistedState`'s invariant in `src/shared/state/PersistedState.ts`. The old doc said every schema field must carry `.prefault()`. The actual requirement is that `schema.parse({})` yields complete state (the constructor resolves defaults that way and throws otherwise). `.prefault()` on each required field is one way to meet it, as are `.default`, `.optional`, and nested object prefaults. The "never `.catch()`" sentence is kept.

No behavior change.

## Net elements (R6)

- Files: 1 modified, 0 added, 0 deleted
- `^[+-]export` lines: 0
- class/interface/enum deltas: 0
- `git diff --stat`: 1 file changed, 3 insertions(+), 3 deletions(-)

## Consumer counts (R8)

- `PersistedState` doc: comment only; no consumer affected.

## Skipped

- **coauthor-97:D03-4 ≡ coauthor-21:agent-runtime-5 ≡ coauthor-2c:agent-runtime#2** (static `SharedToolInjectionRegistry`, delete `registerAgentFeatures`/`features.ts`): ceded to coauthor-97. The item has to edit `packages/extension/src/extension.ts`, which removes the `registerAgentFeatures` import and call and is under coauthor-97's implementing claim `v1-cli-config-onboarding`. It also has to edit `packages/cli/src/runtime/initPlatform.ts`, which drops the `globalState` argument of `initNodeAgentRuntime` and is under coauthor-97's implementing claim `v1-drop-texra-cli-row`. `check.sh` exits 1 on both. No partial version works: `features.ts` can't be deleted while `extension.ts` imports it.
- **coauthor-21:persisted-schemas-2 ≡ coauthor-2c:shared-session-streams#6 ≡ dc:LXCOMPAT-2** (narrowed `firstRunDone` backfill): ceded to coauthor-97. All five of its paths (`onboardingState.ts`, `extension.ts`, `runOnboarding.tsx`, `OnboardingFunnel.vitest.ts`, `OnboardingGate.vitest.ts`) are listed exactly in coauthor-97's implementing claim `v1-cli-config-onboarding`.
- **coauthor-97:D03-8** (stray-comment part only; empty `// textEnhancement` header in `src/agent/runtime/index.ts`): ceded to coauthor-97. I implemented and committed it, then reverted it in this branch before opening this PR, so the net diff doesn't touch `index.ts`. The reason is that coauthor-97 took an implementing claim, `v1-desktop-main`, on `src/agent/runtime/index.ts` while this batch was waiting on gates. A 2-line comment deletion isn't worth a merge collision in a barrel they're editing, so it belongs in their PR.

## Verified

- prettier --write: exit 0 (unchanged)
- eslint: exit 0
- `env CI=true npm run typecheck` via gate.sh: GATE_EXIT=0 (every per-package tsconfig: root, llm, cli, trace-viewer, desktop, ...)
- `vitest run --changed origin/main` via gate.sh: GATE_EXIT=1 on the first run (10 of 65 files, 27 of 948 tests failed, mostly 10s timeouts in CLI and desktop kernel suites). This run was during heavy machine load, when about 20 sessions were waiting on 2 gate slots. The 10 failing files are CliInitPlatform, ExecuteCli, InitPlatformSignalHandlers, InstallGithubAction, ResumeCommand, RunChatSignalOwnership, StaticBandResize, TuiApprovalRetry, WorkflowRunCommand and DesktopPreviewHost. Follow-up:
  - On origin/main 40c0166288, in a throwaway worktree with the same installed lockfile, those 10 files gave GATE_EXIT=1 with 1 failure: `WorkflowRunCommand > reports conflicting output targets before platform or model lookup`, a 10s timeout. The same test failed in every run on this branch, so that one is timing-sensitive on main.
  - On this branch's final HEAD b16c0af0b6, rebased on 40c0166288 and differing from it only by the `PersistedState` comment, the same 10 files gave **GATE_EXIT=0 (10 of 10 files, 170 of 170 tests passed)**.
  - The diff is a single JSDoc edit, so none of these failures can come from it.
- `vitest run --project pure` via gate.sh: GATE_EXIT=0 (215 files, 2435 tests passed)
- `node scripts/check-effect-migration-ratchet.mjs`: exit 0 ("no count grew, no baseline headroom")
- dead-code ratchet: not run, because no exports were removed
- node_modules symlink check (`ls-files -s` mode 120000): empty

These gates ran on the two-commit tree, which also had the one-line barrel-comment deletion since dropped. The final diff is a strict subset of that tree, and the dropped change was a comment, so the results carry over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
