### PR TITLE
simplify(tools): drop the TeXRA CLI coming-soon row (1.0 clean slate)

### DIFF
--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -35,9 +35,6 @@ function formatToolDetectionForTui(
 }
 
 function formatToolDescriptionForTui(tool: CliToolStatusRecord): string {
-  // "Coming soon" already says the tool is off and cannot run, so the
-  // enablement and status parts would only repeat it.
-  if (tool.comingSoon) return 'coming soon';
   return [
     formatToolEnablementForTui(tool),
     formatToolDetectionForTui(tool.detected),
@@ -59,7 +56,7 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
           value: tool.id,
           label: tool.name,
           description: formatToolDescriptionForTui(tool),
-          disabled: !tool.toggleable || tool.comingSoon,
+          disabled: !tool.toggleable,
         }))
       }
       availableRows={props.availableRows}

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -175,18 +175,6 @@ export function readCliEntrypointPath(): string {
   return process.argv[1] ?? '';
 }
 
-const CLI_ENTRYPOINT_NAMES: ReadonlySet<string> = new Set([
-  'texra',
-  'texra-local',
-  'texra.js',
-  'texra.mjs',
-  'texra.ts',
-]);
-
-export function isTexraCliEntrypointPath(entrypointPath: string): boolean {
-  return CLI_ENTRYPOINT_NAMES.has(path.basename(entrypointPath).toLowerCase());
-}
-
 export function resolveCliCommandName(entrypointPath: string): string {
   return path.basename(entrypointPath).toLowerCase() === 'texra-local'
     ? 'texra-local'

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -39,7 +39,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 // Local file imports
 import { installCliProcessRuntime } from './cliProcessRuntime';
 import { getCliSecrets } from './cliSecrets';
-import { isTexraCliEntrypointPath, readCliEntrypointPath } from './cliContext';
 import {
   flushNdjsonStdout,
   flushTextStderr,
@@ -326,10 +325,6 @@ export async function initCliPlatform(
           (await cliResumeHandler?.(runId, recovery)) ?? false,
       },
       agentDirectories,
-      toolAvailability: {
-        isTexraCliEntrypoint: () =>
-          isTexraCliEntrypointPath(readCliEntrypointPath()),
-      },
     });
     initPlatform(services);
     // One process, one paper: the process roots are the `--cwd` workspace.

--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -18,7 +18,6 @@ export interface CliToolStatusRecord {
   readonly statusLabel?: string;
   readonly statusDetail?: string;
   readonly toggleable: boolean;
-  readonly comingSoon: boolean;
   readonly installCommand?: string;
   readonly authCommand?: string;
   readonly note?: string;
@@ -35,7 +34,6 @@ function getCliToolDefs(): ExternalToolDef[] {
   return EXTERNAL_TOOL_DEFS.filter(
     (def) =>
       !def.hideFromDashboard &&
-      !def.hideFromCli &&
       !(
         def.tools.length > 0 &&
         def.tools.every((name) => isDefaultToolUnavailableOnHost(name, 'cli'))
@@ -66,10 +64,9 @@ export async function readCliToolStatuses(): Promise<CliToolStatusRecord[]> {
   return getCliToolDefs().map((def) => {
     // `runProbes` maps over the same EXTERNAL_TOOL_DEFS this filters, so the
     // lookup always hits; the `??` arms are shape-level defaults, not reachable
-    // states. The probe already decides coming-soon (`status`) and the raw
-    // dependency outcome (`detected`), so neither is re-derived here.
+    // states. The probe already decides `status` and the raw dependency
+    // outcome (`detected`), so neither is re-derived here.
     const check = checks.get(def.id);
-    const comingSoon = def.comingSoon === true;
     const toggleable = def.toggleable === true;
     const status = check?.status ?? 'unknown';
     const detected = check?.detected ?? null;
@@ -83,7 +80,6 @@ export async function readCliToolStatuses(): Promise<CliToolStatusRecord[]> {
       statusLabel: check?.statusLabel,
       statusDetail: check?.statusDetail,
       toggleable,
-      comingSoon,
       installCommand: def.installCommand,
       authCommand: def.authCommand,
       note: noteForTool(def, detected, check?.statusLabel),

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -237,7 +237,6 @@ export class ToolCard extends LitElement {
     available: 'check',
     'not-found': 'triangle-exclamation',
     unknown: 'circle-question',
-    'coming-soon': 'clock',
   };
 
   private renderAvailableStatusIcon(): TemplateResult {

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -218,12 +218,10 @@ export class AIAgentsTab extends LitElement {
       available: 0,
       'not-found': 0,
       unknown: 0,
-      'coming-soon': 0,
     };
     for (const item of items) {
       counts[item.status] += 1;
     }
-    const pending = counts.unknown + counts['coming-soon'];
 
     return html`
       <ul class="ai-agents-status" aria-label="Integration status">
@@ -241,10 +239,10 @@ export class AIAgentsTab extends LitElement {
             : nothing
         }
         ${
-          pending > 0
+          counts.unknown > 0
             ? html`
                 <li class="ai-agents-status-stat ai-agents-status-neutral">
-                  ${waIcon('clock')} Pending: ${pending}
+                  ${waIcon('clock')} Pending: ${counts.unknown}
                 </li>
               `
             : nothing

--- a/src/platform/interfaces.ts
+++ b/src/platform/interfaces.ts
@@ -213,14 +213,10 @@ export interface LifecycleHost {
 export interface ToolAvailabilityHost {
   /** True when a VS Code extension is installed in the active extension host. */
   isVscodeExtensionInstalled(extensionId: string): boolean;
-
-  /** True when the current process already is the TeXRA CLI entrypoint. */
-  isTexraCliEntrypoint(): boolean;
 }
 
 export const NO_TOOL_AVAILABILITY_HOST: ToolAvailabilityHost = Object.freeze({
   isVscodeExtensionInstalled: () => false,
-  isTexraCliEntrypoint: () => false,
 });
 
 // ---------------------------------------------------------------------------

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -406,7 +406,6 @@ const ToolDependencyStatusSchema = z.enum([
   'available',
   'not-found',
   'unknown',
-  'coming-soon',
 ]);
 export type ToolDependencyStatus = z.infer<typeof ToolDependencyStatusSchema>;
 

--- a/src/shared/tools/toolDependencyStatusLabels.ts
+++ b/src/shared/tools/toolDependencyStatusLabels.ts
@@ -6,7 +6,6 @@ const TOOL_DEPENDENCY_STATUS_FALLBACK_LABELS = {
   available: 'Ready',
   'not-found': 'Needs setup',
   unknown: 'Not checked',
-  'coming-soon': 'Coming soon',
 } satisfies Record<ToolDependencyStatus, string>;
 
 export function toolDependencyStatusLabel(

--- a/src/test-kernel/cli/CliContext.vitest.ts
+++ b/src/test-kernel/cli/CliContext.vitest.ts
@@ -9,7 +9,6 @@ import { Effect } from 'effect';
 import {
   buildCliContext,
   CliUsageError,
-  isTexraCliEntrypointPath,
   readCliBugsUrl,
   readCliEnv,
   readCliVersion,
@@ -68,18 +67,6 @@ async function workspaceWithConfig(config: string): Promise<string> {
 }
 
 describe('CLI entrypoint detection', () => {
-  it('recognizes published and local TeXRA launchers', () => {
-    expect(isTexraCliEntrypointPath('/usr/local/bin/texra')).toBe(true);
-    expect(isTexraCliEntrypointPath('/tmp/bin/texra-local')).toBe(true);
-    expect(
-      isTexraCliEntrypointPath('/repo/packages/cli/dist/bin/texra.js'),
-    ).toBe(true);
-    expect(
-      isTexraCliEntrypointPath('/repo/packages/cli/src/bin/texra.ts'),
-    ).toBe(true);
-    expect(isTexraCliEntrypointPath('/usr/local/bin/vitest')).toBe(false);
-  });
-
   it('uses the local launcher name in user-facing command hints', () => {
     expect(resolveCliCommandName('/usr/local/bin/texra')).toBe('texra');
     expect(resolveCliCommandName('/tmp/bin/texra-local')).toBe('texra-local');

--- a/src/test-kernel/settings/PlanToolTerminalAction.vitest.ts
+++ b/src/test-kernel/settings/PlanToolTerminalAction.vitest.ts
@@ -100,7 +100,7 @@ const CASES: Array<{
   },
   {
     name: 'does not ask the handler to open a terminal without a command',
-    input: { toolId: 'texra-cli', commandKind: 'auth' },
+    input: { toolId: 'wolfram', commandKind: 'auth' },
     expected: { kind: 'none', reason: 'missingCommand' },
   },
   {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -104,14 +104,10 @@ export interface ExternalToolDef {
   readonly configNotes?: string;
   /** When true, the tool is checked for availability but not shown in the Tools tab dashboard. */
   readonly hideFromDashboard?: boolean;
-  /** Explicit CLI visibility for tool-less integrations; tool-backed rows derive it from the registry. */
-  readonly hideFromCli?: boolean;
   /** Short auth/billing note shown as a badge (e.g. "Uses ChatGPT subscription"). */
   readonly authNote?: string;
   /** When true, the dashboard shows an enable/disable toggle for this tool group. */
   readonly toggleable?: boolean;
-  /** When true, detect setup but show the integration as not yet enabled. */
-  readonly comingSoon?: boolean;
 }
 
 // ============================================================
@@ -170,12 +166,6 @@ function resolveGitHubPRPrerequisites(
     ? getGitHubPRPrerequisites()
     : Effect.succeed(probeResult as GitHubPRPrerequisites);
 }
-
-const probeTexraCli = Effect.fn('probeTexraCli')(function* () {
-  if (platform().toolAvailability.isTexraCliEntrypoint()) return true;
-  if (yield* hostPort(() => checkToolInstalled('texra', false))) return true;
-  return yield* hostPort(() => checkToolInstalled('texra-local', false));
-});
 
 interface Lean4Prerequisites {
   extensionAvailable: boolean;
@@ -567,42 +557,6 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     authNote: 'Uses your premium chat subscription',
     toggleable: true,
     check: () => Effect.succeed(true),
-  },
-
-  {
-    id: 'texra-cli',
-    tools: [],
-    name: 'TeXRA CLI',
-    category: 'ai-agents',
-    description:
-      'Local TeXRA command-line app integration. Detection is shown now; activation is coming soon.',
-    installGuide:
-      'Run the same agents on your .tex projects without an editor. This works well for scripts, CI, and remote machines.\n\n' +
-      `Install globally from npm (requires Node.js ${TEXRA_CLI_SUPPORTED_NODE_RANGE}):\n` +
-      '  npm install -g @texra-ai/cli\n\n' +
-      'The CLI also ships with the TeXRA package. Make sure the `texra` command is on the PATH visible to VS Code or the desktop app.\n\n' +
-      'Check from a terminal:\n' +
-      '  texra --version',
-    installUrl: 'https://www.npmjs.com/package/@texra-ai/cli',
-    installCommand: 'npm install -g @texra-ai/cli',
-    configNotes:
-      'Coming soon. This entry only checks whether the local CLI is visible.',
-    comingSoon: true,
-    hideFromCli: true,
-    ...prerequisitesChecks<boolean | undefined>({
-      probe: probeTexraCli,
-      resolve: (probeResult) =>
-        Effect.succeed(
-          typeof probeResult === 'boolean' ? probeResult : undefined,
-        ),
-      check: (detected) => detected ?? false,
-      statusLabel: (detected) =>
-        detected ? 'Detected; integration coming soon' : undefined,
-      detailCheck: (detected) =>
-        detected
-          ? 'TeXRA CLI detected on PATH. This integration is not enabled for agent runs yet.'
-          : 'TeXRA CLI not detected on PATH. This integration is not enabled for agent runs yet.',
-    }),
   },
 
   {

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -42,8 +42,8 @@ export interface ExternalToolCheckResult {
   readonly id: string;
   readonly tools: readonly RegisteredToolName[];
   readonly name: string;
-  readonly status: 'available' | 'not-found' | 'unknown' | 'coming-soon';
-  /** Raw external dependency probe result, independent of presentation-only statuses. */
+  readonly status: 'available' | 'not-found' | 'unknown';
+  /** Raw external dependency probe result; null when the probe failed. */
   readonly detected: boolean | null;
   /** Short status label for the dashboard badge, when the default is too generic. */
   readonly statusLabel?: string;
@@ -171,7 +171,6 @@ const probeToolGroup = Effect.fn('probeToolGroup')(function* ({
   check,
   statusLabel: getStatusLabel,
   detailCheck,
-  comingSoon,
 }: ExternalToolDef): Effect.fn.Return<ExternalToolCheckResult, never> {
   // Run check/status/detail from one shared probe result. Some groups
   // (Codex, Zotero, GitHub PR) touch async local state, so running the
@@ -189,7 +188,7 @@ const probeToolGroup = Effect.fn('probeToolGroup')(function* ({
     ),
   );
   const detectedStatus = probed.available ? 'available' : 'not-found';
-  const probedStatus: 'available' | 'not-found' | 'unknown' = probed.failure
+  const status: ExternalToolCheckResult['status'] = probed.failure
     ? 'unknown'
     : detectedStatus;
   const statusDetail = probed.failure
@@ -212,8 +211,8 @@ const probeToolGroup = Effect.fn('probeToolGroup')(function* ({
     id,
     tools,
     name,
-    status: comingSoon ? 'coming-soon' : probedStatus,
-    detected: probedStatus === 'unknown' ? null : probedStatus === 'available',
+    status,
+    detected: status === 'unknown' ? null : status === 'available',
     statusLabel,
     statusDetail,
   };

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -143,14 +143,6 @@ const TOOL_CONFIGS: Record<string, ToolConfig> = {
 
   // Document conversion tools
   pandoc: withDocs(featureTool('pandoc', PANDOC_INSTRUCTIONS), { docs: false }),
-
-  // TeXRA's own CLI entrypoints
-  texra: withDocs('TeXRA CLI is not installed or not on PATH.', {
-    docs: false,
-  }),
-  'texra-local': withDocs('TeXRA local CLI is not installed or not on PATH.', {
-    docs: false,
-  }),
 };
 
 /** Whether a probe result carries a version-like pattern (e.g., "3.7.1"). */


### PR DESCRIPTION
## Summary

**D06-4: drop the texra-cli coming-soon placeholder row.**

Owner ruling: the maintainer approved dropping this placeholder on 2026-09-11. It was one of the four rulings asked in §4 of the 1.0 clean-slate survey synthesis ("D06-4: Drop the texra-cli coming-soon placeholder row?").

The `texra-cli` external-tool row had `tools: []` and only checked whether a `texra` binary was on PATH ("activation is coming soon"). It had not changed since afc5bd2858 (2026-05-18). The only host that computed a true value, the CLI, hid the row via `hideFromCli`, so no user ever saw a positive result. This PR deletes the row and everything that existed only for it:
- the `EXTERNAL_TOOL_DEFS` `texra-cli` entry and `probeTexraCli` (`src/tools/externalToolDefs.ts`)
- `ExternalToolDef.comingSoon` / `hideFromCli`
- the `'coming-soon'` tool-dependency status, which appeared in:
  - `ExternalToolCheckResult` and `probeToolGroup` (`src/tools/toolAvailability.ts`)
  - `ToolDependencyStatusSchema`
  - the fallback label (`toolDependencyStatusLabels.ts`)
  - the `ToolCard` icon
  - the `AIAgentsTab` summary count ("Pending" now counts only `unknown`)
- `ToolAvailabilityHost.isTexraCliEntrypoint` (the interface method, its frozen default, and the CLI implementation), plus `CLI_ENTRYPOINT_NAMES` and `isTexraCliEntrypointPath` (`packages/cli/src/runtime/cliContext.ts`)
- the CLI record's `comingSoon` field, the `hideFromCli` filter, and the `/tools` form branch
- the `texra` and `texra-local` install hints in `toolUtils.ts`, whose only caller was the probe

**User-visible changes:**
- Extension and desktop AI Agents tab: the "TeXRA CLI" row is gone, and the "Pending" count drops by one.
- CLI JSON output (changelog): `texra tools list --output-format json|ndjson` records no longer carry the `comingSoon` key. The value was `false` on every row the CLI showed.

`TEXRA_CLI_SUPPORTED_NODE_RANGE` stays because `texra doctor` uses it; moving it into packages/cli is a natural follow-up. `resolveCliCommandName` and `readCliEntrypointPath` also stay, since other code uses both.

**coauthor-21:tools-core-6 / domain-tools-4**: the texra-cli half of these findings is done. The Zotero probe dedupe, the id renames, and moving the Node range constant are out of scope.

**Not done (hand-off):** `packages/cli/scripts/validate-run.mjs:378` still has the `record.comingSoon !== true` conjunct. That file is under coauthor-3d claims (p4-release-build and p5-lint-ci-ratchets). With the field gone the conjunct is always true, so behavior is unchanged. The holder of those claims should delete the one line. It is the only live reference left to any symbol this PR deletes.

Tests: removed the one `isTexraCliEntrypointPath` test (`CliContext.vitest.ts`). `PlanToolTerminalAction.vitest.ts` switched its missing-auth-command fixture from `texra-cli` to `wolfram`, which also has no auth command. No new tests.

## Net elements (R6)
- Files: 14 changed (0 added, 0 deleted)
- `^[+-]export` lines: -1 (`isTexraCliEntrypointPath`), +0
- class/interface/enum declarations: 0 added, 0 removed. Members removed: `ToolAvailabilityHost.isTexraCliEntrypoint`, `ExternalToolDef.comingSoon`, `ExternalToolDef.hideFromCli`, `CliToolStatusRecord.comingSoon`, and one `z.enum` member (`'coming-soon'`).
- LOC (`git diff --stat origin/main...HEAD`): +11 / -112, net -101

## Consumer counts (R8)
Counts are production consumers at origin/main before this change; tests are excluded unless noted.
- `ToolAvailabilityHost.isTexraCliEntrypoint`: 1 reader (`probeTexraCli`); 1 non-default implementation (CLI `initPlatform.ts`) plus the frozen default.
- `isTexraCliEntrypointPath`: 1 caller (`initPlatform.ts`); 1 test (deleted).
- `CLI_ENTRYPOINT_NAMES`: 1 (`isTexraCliEntrypointPath`).
- `probeTexraCli`: 1 (the `texra-cli` row).
- `ExternalToolDef.comingSoon`: 1 writer (the row); 2 readers (`probeToolGroup` and CLI `tools.ts`).
- `CliToolStatusRecord.comingSoon`: 2 readers in `ToolsListForm.tsx`, plus 1 in `validate-run.mjs` (left in place, handed off above).
- `ExternalToolDef.hideFromCli`: 1 writer (the row); 1 reader (CLI `tools.ts`).
- `'coming-soon'` status: 1 producer (`probeToolGroup`). Other sites: the schema member, the label, the ToolCard icon, and 2 lines in the AIAgentsTab count.
- `'texra-cli'` id: 1 production site (the row); 1 test fixture.
- `toolUtils` `texra` / `texra-local` hints: 2 lookups, both via `checkToolInstalled` inside `probeTexraCli`.
- Emit paths, commands, and subscribers deleted: none.

## Gates
All gates ran on `71f0156ae3`, rebased onto origin/main `d719637662`, through the machine-wide gate semaphore with FORCE_COLOR=0.
- `CI=true npm run typecheck`: exit 0
- `npx vitest run --changed origin/main`: exit 0. 502/502 files passed, 5434 tests passed, 1 skipped.
- `npm run lint` (repo-wide): exit 0
- `npm run check:dead-code-ratchet`: exit 0. "no new findings", 239 findings vs 239 baselined.
- `npm run format && npx prettier --check .` (repo-wide): exit 0. Formatting changed no files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)