### PR TITLE
refactor(shared): drop the dead activate/open/close arms of ShellAction

### DIFF
--- a/src/shared/session/shell.ts
+++ b/src/shared/session/shell.ts
@@ -17,40 +17,14 @@ export interface Shell {
   readonly collapsed: readonly string[];
 }
 
-export type ShellAction =
-  | { readonly kind: 'activate'; readonly session: string }
-  | { readonly kind: 'open'; readonly session: string }
-  | { readonly kind: 'close'; readonly session: string }
-  | {
-      readonly kind: 'collapse';
-      readonly session: string;
-      readonly collapsed: boolean;
-    };
+export type ShellAction = {
+  readonly kind: 'collapse';
+  readonly session: string;
+  readonly collapsed: boolean;
+};
 
 export function applyShellAction(shell: Shell, action: ShellAction): Shell {
   switch (action.kind) {
-    case 'activate':
-      return shell.open.includes(action.session)
-        ? { ...shell, active: action.session }
-        : {
-            ...shell,
-            active: action.session,
-            open: [...shell.open, action.session],
-          };
-    case 'open':
-      return shell.open.includes(action.session)
-        ? shell
-        : { ...shell, open: [...shell.open, action.session] };
-    case 'close': {
-      const open = shell.open.filter((key) => key !== action.session);
-      if (open.length === 0) return shell;
-      return {
-        ...shell,
-        open,
-        collapsed: shell.collapsed.filter((key) => key !== action.session),
-        active: shell.active === action.session ? open[0] : shell.active,
-      };
-    }
     case 'collapse': {
       const without = shell.collapsed.filter((key) => key !== action.session);
       return {


### PR DESCRIPTION
## Summary

`applyShellAction` has exactly one caller in the repo — `packages/desktop/src/renderer/main.ts:705`, `onToggleProjectCollapsed` — and it passes only `kind: 'collapse'`. The desktop's project open/close paths never go through this reducer: `main.ts` constructs the next `Shell` object directly and project selection travels over postMessage (`SELECT_PROJECT`). Repo-wide grep (double-quoted/template-literal forms included) finds zero producers of the `'activate'`, `'open'`, or `'close'` action kinds — they existed only as definitions in `src/shared/session/shell.ts`.

Delete the three orphaned union members and their switch cases; `ShellAction` narrows to the single `collapse` member and the exhaustive switch keeps the surviving branch compiler-checked. The one caller is unchanged. Net −26 lines, 1 file.

Adversarially verified at HEAD before implementation (caller recount, behavior read, ratchet safety, PRD lanes, dynamic references). No test file imports `@shared/session/shell`; no ratchet baseline names the file.

## Verification

- `tsc --noEmit` repo-root workspace project + `tsconfig.test-kernel.json` (direct binaries, gate-serialized)
- `check-dead-code-ratchet` + `check-effect-migration-ratchet` (no baseline interaction — file is unbaselined)
- ESLint (src + test-kernel) + vitest pure tier
- Note: the sole consumer is in the desktop scope, whose per-package typecheck needs a real install locally — it is compiler-trivial there (the caller's only literal is `'collapse'`, the surviving member); CI's real-install desktop typecheck is the authoritative confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
