### PR TITLE
fix: lock in the Effect-ratchet headroom #12261 freed in externalToolDefs.ts

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -41,7 +41,7 @@
       "src/model/kimiCodeSubscriptionRouting.ts": 1,
       "src/model/runtimeModelRegistry.ts": 1,
       "src/tools/claudeAgentConfig.ts": 1,
-      "src/tools/externalToolDefs.ts": 3,
+      "src/tools/externalToolDefs.ts": 2,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/tools/github/githubAuth.ts": 1,
       "src/tools/setup/platform.ts": 7,


### PR DESCRIPTION
Fixes the red `static checks` on main after #12261.

#12261 deleted `probeTexraCli`, one of the three `platform()` sites in `src/tools/externalToolDefs.ts`. The Effect migration ratchet reports the freed headroom as a failure (`[platform()] src/tools/externalToolDefs.ts: 3 -> 2`), so the static checks on #12261's merge commit failed.

This regenerates `config/ratchets/effect-migration-baseline.json` through `node scripts/check-effect-migration-ratchet.mjs --update`. It changes one entry (3 → 2) and nothing else. `node scripts/check-effect-migration-ratchet.mjs` now passes.

If your branch fails on exactly this entry, rebase after this lands and regenerate, per the ledger's generated-baseline rule. Don't hand-merge it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
