### PR TITLE
simplify(cli,onboarding): delete the firstRunDone backfill and fold the /config props factory (1.0 clean slate)

### DIFF
--- a/config/ratchets/host-agent-mock-baseline.json
+++ b/config/ratchets/host-agent-mock-baseline.json
@@ -72,11 +72,6 @@
       "specifier": "@agent/index"
     },
     {
-      "file": "src/test-kernel/cli/OnboardingGate.vitest.ts",
-      "form": "mock",
-      "specifier": "@agent/storage"
-    },
-    {
       "file": "src/test-kernel/cli/ResumeCommand.vitest.ts",
       "form": "mock",
       "specifier": "@agent/runtime/SessionResumeRetrieval"

--- a/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
@@ -18,13 +18,12 @@ import {
   type SettingsStores,
 } from '@shared/config/settingsAccess';
 import { applyStateSettingUpdate } from '@shared/settingsView/handlers/stateSettingWrite';
-import { GlobalStateKey } from '@shared/state/stateKeys';
 import { platformSettingsStores } from '@utils/config/platformSettings';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { bumpCodexPreferenceVersion } from '../state/cliState';
 import { AgentRosterForm } from './AgentRosterForm';
-import { ConfigForm, type ConfigFormProps } from './ConfigForm';
+import { ConfigForm } from './ConfigForm';
 import {
   formatGitHubTokenSummary,
   GitHubTokenForm,
@@ -49,16 +48,6 @@ export interface CliConfigFormProps {
    * Omitted by `texra config edit`, whose process holds no session to update.
    */
   readonly onApprovalPolicyChanged?: (policy: TexraApprovalPolicy) => void;
-}
-
-interface CreateCliConfigFormPropsInput extends CliConfigFormProps {
-  readonly stores: SettingsStores;
-  readonly apiKeyStatusView?: ProviderApiKeyStatusView;
-  readonly markProviderApiKeySet?: (provider: ApiProvider) => void;
-  readonly refreshApiKeyStatuses?: () => void | Promise<void>;
-  readonly githubTokenStatusView?: GitHubTokenStatusView;
-  readonly markGitHubTokenSet?: () => void;
-  readonly refreshGitHubTokenStatus?: () => void | Promise<void>;
 }
 
 type StatusViewBase = { readonly loading: boolean; readonly error: boolean };
@@ -138,19 +127,36 @@ const buildGitHubTokenStatusView = (
 ): GitHubTokenStatusView => ({ status, loading: false, error: false });
 
 /**
- * Construct the canonical CLI configuration interface. Both the standalone
- * command and the in-chat form use this function, so persistence and runtime
- * side effects cannot diverge between entry points.
+ * Canonical CLI configuration form. Both `texra config` and `/config` mount
+ * it, so persistence and runtime side effects cannot diverge between them.
  */
-export function createCliConfigFormProps(
-  props: CreateCliConfigFormPropsInput,
-): ConfigFormProps {
-  const { stores } = props;
-  const apiKeyStatusView =
-    props.apiKeyStatusView ?? (INITIAL_STATUS_VIEW as ProviderApiKeyStatusView);
-  const githubTokenStatusView =
-    props.githubTokenStatusView ??
-    (INITIAL_STATUS_VIEW as GitHubTokenStatusView);
+export function CliConfigForm(props: CliConfigFormProps): React.JSX.Element {
+  const [stores] = useState(() => props.stores ?? platformSettingsStores());
+  const onError = useRef(props.onError);
+  onError.current = props.onError;
+
+  const {
+    view: apiKeyStatusView,
+    refresh: refreshApiKeyStatuses,
+    mark: markApiKey,
+  } = useAsyncStatusView({
+    initial: INITIAL_STATUS_VIEW as ProviderApiKeyStatusView,
+    load: loadProviderApiKeyStatuses,
+    buildView: buildApiKeyStatusView,
+    onErrorRef: onError,
+  });
+
+  const {
+    view: githubTokenStatusView,
+    refresh: refreshGitHubTokenStatus,
+    mark: markGitHubToken,
+  } = useAsyncStatusView({
+    initial: INITIAL_STATUS_VIEW as GitHubTokenStatusView,
+    load: loadGitHubTokenStatus,
+    buildView: buildGitHubTokenStatusView,
+    onErrorRef: onError,
+  });
+
   // The one CLI write path for a `/config` row: the same
   // `applyStateSettingUpdate` the extension and desktop settings views call, so
   // a row that carries a live side effect (approval policy) cannot be persisted
@@ -191,136 +197,84 @@ export function createCliConfigFormProps(
       bumpCodexPreferenceVersion();
     }
   };
-  return {
-    availableRows: props.availableRows,
-    entries: CLI_STATE_SETTINGS,
-    readValue: (entry) => readSetting(entry, stores, 'cli'),
-    writeValue: (entry, value) => applyUpdate(entry, value),
-    resetValue: (entry) => applyUpdate(entry, null),
-    formLinks: [
-      {
-        name: 'agents',
-        label: 'Agents',
-        description: 'workspace roster and user default team',
-      },
-      {
-        name: 'api-keys',
-        label: 'API keys',
-        description: formatProviderApiKeySummary(apiKeyStatusView),
-      },
-      {
-        name: 'github-token',
-        label: 'GitHub token',
-        description: formatGitHubTokenSummary(githubTokenStatusView),
-      },
-    ],
-    formRenderers: {
-      agents: (onBack) => (
-        <AgentRosterForm
-          availableRows={props.availableRows}
-          onClose={onBack}
-          onError={props.onError}
-        />
-      ),
-      'api-keys': (onBack) => (
-        <ProviderApiKeyForm
-          availableRows={props.availableRows}
-          statusView={apiKeyStatusView}
-          onSave={async (provider, key) => {
-            await saveProviderApiKey(provider, key);
-            props.markProviderApiKeySet?.(provider);
-            await props.refreshApiKeyStatuses?.();
-          }}
-          onDone={onBack}
-          onCancel={onBack}
-        />
-      ),
-      'github-token': (onBack) => (
-        <GitHubTokenForm
-          availableRows={props.availableRows}
-          statusView={githubTokenStatusView}
-          onSave={async (token) => {
-            await saveGitHubToken(token);
-            props.markGitHubTokenSet?.();
-            await props.refreshGitHubTokenStatus?.();
-          }}
-          onRemove={async () => {
-            await removeGitHubToken();
-            await props.refreshGitHubTokenStatus?.();
-          }}
-          onDone={onBack}
-          onCancel={onBack}
-        />
-      ),
-      tools: (onBack) => (
-        <ToolsListForm availableRows={props.availableRows} onClose={onBack} />
-      ),
-      skills: (onBack) => (
-        <SkillsSettingsForm
-          availableRows={props.availableRows}
-          stores={stores}
-          onClose={onBack}
-        />
-      ),
-    },
-    onClose: props.onClose,
-    onError: props.onError,
-  };
-}
-
-/** Canonical CLI configuration form, shared by `texra config` and `/config`. */
-export function CliConfigForm(props: CliConfigFormProps): React.JSX.Element {
-  const [stores] = useState(() => props.stores ?? platformSettingsStores());
-  const onError = useRef(props.onError);
-  onError.current = props.onError;
-
-  const {
-    view: apiKeyStatusView,
-    refresh: refreshApiKeyStatuses,
-    mark: markApiKey,
-  } = useAsyncStatusView({
-    initial: INITIAL_STATUS_VIEW as ProviderApiKeyStatusView,
-    load: loadProviderApiKeyStatuses,
-    buildView: buildApiKeyStatusView,
-    onErrorRef: onError,
-  });
-
-  const {
-    view: githubTokenStatusView,
-    refresh: refreshGitHubTokenStatus,
-    mark: markGitHubToken,
-  } = useAsyncStatusView({
-    initial: INITIAL_STATUS_VIEW as GitHubTokenStatusView,
-    load: loadGitHubTokenStatus,
-    buildView: buildGitHubTokenStatusView,
-    onErrorRef: onError,
-  });
-
-  const markProviderApiKeySet = useCallback(
-    (provider: ApiProvider) => {
-      markApiKey((current) => ({
-        statuses: { ...current.statuses, [provider]: 'set' },
-      }));
-    },
-    [markApiKey],
-  );
-
-  const markGitHubTokenSet = useCallback(() => {
-    markGitHubToken(() => ({ status: 'secret' }));
-  }, [markGitHubToken]);
 
   return (
     <ConfigForm
-      {...createCliConfigFormProps({
-        ...props,
-        stores,
-        apiKeyStatusView,
-        markProviderApiKeySet,
-        refreshApiKeyStatuses,
-        githubTokenStatusView,
-        markGitHubTokenSet,
-        refreshGitHubTokenStatus,
-      })}
+      availableRows={props.availableRows}
+      entries={CLI_STATE_SETTINGS}
+      readValue={(entry) => readSetting(entry, stores, 'cli')}
+      writeValue={(entry, value) => applyUpdate(entry, value)}
+      resetValue={(entry) => applyUpdate(entry, null)}
+      formLinks={[
+        {
+          name: 'agents',
+          label: 'Agents',
+          description: 'workspace roster and user default team',
+        },
+        {
+          name: 'api-keys',
+          label: 'API keys',
+          description: formatProviderApiKeySummary(apiKeyStatusView),
+        },
+        {
+          name: 'github-token',
+          label: 'GitHub token',
+          description: formatGitHubTokenSummary(githubTokenStatusView),
+        },
+      ]}
+      formRenderers={{
+        agents: (onBack) => (
+          <AgentRosterForm
+            availableRows={props.availableRows}
+            onClose={onBack}
+            onError={props.onError}
+          />
+        ),
+        'api-keys': (onBack) => (
+          <ProviderApiKeyForm
+            availableRows={props.availableRows}
+            statusView={apiKeyStatusView}
+            onSave={async (provider, key) => {
+              await saveProviderApiKey(provider, key);
+              markApiKey((current) => ({
+                statuses: { ...current.statuses, [provider]: 'set' },
+              }));
+              await refreshApiKeyStatuses();
+            }}
+            onDone={onBack}
+            onCancel={onBack}
+          />
+        ),
+        'github-token': (onBack) => (
+          <GitHubTokenForm
+            availableRows={props.availableRows}
+            statusView={githubTokenStatusView}
+            onSave={async (token) => {
+              await saveGitHubToken(token);
+              markGitHubToken(() => ({ status: 'secret' }));
+              await refreshGitHubTokenStatus();
+            }}
+            onRemove={async () => {
+              await removeGitHubToken();
+              await refreshGitHubTokenStatus();
+            }}
+            onDone={onBack}
+            onCancel={onBack}
+          />
+        ),
+        tools: (onBack) => (
+          <ToolsListForm availableRows={props.availableRows} onClose={onBack} />
+        ),
+        skills: (onBack) => (
+          <SkillsSettingsForm
+            availableRows={props.availableRows}
+            stores={stores}
+            onClose={onBack}
+          />
+        ),
+      }}
+      onClose={props.onClose}
+      onError={props.onError}
     />
   );
 }

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -100,18 +100,18 @@ export function isConfigResetInput(
   return isCtrlInput(input, key, 'r');
 }
 
-export function formatSettingValue(value: unknown): string {
+function formatSettingValue(value: unknown): string {
   if (typeof value === 'boolean') return value ? 'on' : 'off';
   if (value === '' || value == null) return '(empty)';
   return String(value);
 }
 
 /** The store the CLI reads/writes this setting from (`entry.slots.cli`). */
-export function settingStoreLabel(entry: SurfacedSettingEntry): string {
+function settingStoreLabel(entry: SurfacedSettingEntry): string {
   return settingSlot(entry, 'cli');
 }
 
-export function settingDisplayName(entry: SurfacedSettingEntry): string {
+function settingDisplayName(entry: SurfacedSettingEntry): string {
   return entry.title ?? stripPrefix(entry.key);
 }
 
@@ -136,7 +136,7 @@ export function buildConfigListItems(
   });
 }
 
-export function buildEnumItems(
+function buildEnumItems(
   entry: SurfacedSettingEntry,
 ): Array<SelectItem<string>> {
   const values = settingEnumOptions(entry) ?? [];
@@ -148,7 +148,7 @@ export function buildEnumItems(
   }));
 }
 
-export interface ConfigFormProps {
+interface ConfigFormProps {
   readonly entries: readonly SurfacedSettingEntry[];
   readonly readValue: (entry: SurfacedSettingEntry) => unknown;
   readonly writeValue: (

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -165,8 +165,9 @@ async function runOrchestration(context: CliContext): Promise<number> {
   // State 1 continuation (.agents/docs/archived/feature/2026-06-11-agent-native-onboarding.md): on a true
   // first run the picker hands straight to a chat session owned by the setup
   // agent instead of the launcher. Existing users (firstRunDone set) and users
-  // who pinned an agent via env land on the launcher as before. `orchestrate` has no `--agent` flag here; the env override is the
-  // only explicit agent pin this entry point honors.
+  // who pinned an agent via env land on the launcher as before. `orchestrate`
+  // has no `--agent` flag here; the env override is the only explicit agent
+  // pin this entry point honors.
   const setupAgentOverride = firstRunSetupAgentOverride({
     onboardingConfigured: onboarding.configured,
     firstRunDone: getFirstRunDone(services.globalState),

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -164,9 +164,8 @@ async function runOrchestration(context: CliContext): Promise<number> {
   }
   // State 1 continuation (.agents/docs/archived/feature/2026-06-11-agent-native-onboarding.md): on a true
   // first run the picker hands straight to a chat session owned by the setup
-  // agent instead of the launcher. Existing users (firstRunDone backfilled or
-  // earned) and users who pinned an agent via env land on the launcher as
-  // before. `orchestrate` has no `--agent` flag here; the env override is the
+  // agent instead of the launcher. Existing users (firstRunDone set) and users
+  // who pinned an agent via env land on the launcher as before. `orchestrate` has no `--agent` flag here; the env override is the
   // only explicit agent pin this entry point honors.
   const setupAgentOverride = firstRunSetupAgentOverride({
     onboardingConfigured: onboarding.configured,

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -14,8 +14,6 @@ import { Cause, Effect } from 'effect';
 import { Box, Text, useApp } from 'ink';
 import { useState } from 'react';
 
-import { listRuns } from '@agent/storage';
-import { initializeCliTranscriptSession } from '@cli/runtime/transcriptSession';
 import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
 import { LoadingIndicator } from '@cli/tui/ui/LoadingIndicator';
 import { useCancellableEffect } from '@cli/tui/useCancellableEffect';
@@ -40,12 +38,10 @@ import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import type { StateStore } from '@platform/interfaces';
 import { effectRuntime } from '@platform/processRuntime';
 import {
-  backfillFirstRunDone,
   readOnboardingFlags,
   setOnboardingDeclined,
 } from '@shared/state/onboardingState';
 import { providerDisplayName } from '@shared/constants/providers';
-import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import {
   ONBOARDING_CARD_TITLE,
@@ -101,8 +97,7 @@ const credentialLog = createLog('Setup Credentials');
 /**
  * The gate degrades to "not configured yet" when a state read or write fails,
  * which at worst re-prompts. Say why in the log so a read-only home directory
- * or an unreadable history store is diagnosable rather than looking like the
- * gate's normal behavior.
+ * is diagnosable rather than looking like the gate's normal behavior.
  */
 function warnOnboardingFailure(action: string, error: unknown): void {
   logWarning(LOG_CHANNEL, `${action} failed: ${toErrorMessage(error)}`);
@@ -148,60 +143,6 @@ export const maybeRunCliOnboarding = Effect.fn('maybeRunCliOnboarding')(
       try: () => hasUsableSetupCredential(services.secrets, credentialLog.warn),
       catch: ensureError,
     });
-    // Onboarding-funnel backfill (PRD: agent-native onboarding): a CLI user
-    // with run history never enters State 0/1. Credential presence alone
-    // does not prove this is an upgrader: fresh installs can inherit env keys.
-    // One-shot and best-effort: if a credential appears after a previous skip,
-    // the stale skip is cleared below so a later sign-out re-enters State 0.
-    const needsFirstRunBackfill =
-      (yield* Effect.try({
-        try: () =>
-          globalState.get<boolean | undefined>(
-            GlobalStateKey.ONBOARDING_FIRST_RUN_DONE,
-          ),
-        catch: ensureError,
-      })) === undefined;
-    const hasRunHistory = needsFirstRunBackfill
-      ? yield* Effect.tryPromise({
-          try: () => initializeCliTranscriptSession(),
-          catch: ensureError,
-        }).pipe(
-          Effect.flatMap((session) => listRuns(session)),
-          Effect.map((entries) => entries.length > 0),
-          Effect.catch((error) =>
-            Effect.sync(() => {
-              warnOnboardingFailure('Run-history check', error);
-              return false;
-            }),
-          ),
-        )
-      : false;
-    // LAST_KNOWN_VERSION is stamped by desktop/extension startup and is the
-    // reliable prior-install signal shared across hosts.
-    const hasPriorInstall =
-      needsFirstRunBackfill &&
-      (yield* Effect.try({
-        try: () =>
-          globalState.get<string | undefined>(
-            GlobalStateKey.LAST_KNOWN_VERSION,
-          ),
-        catch: ensureError,
-      })) !== undefined;
-    yield* Effect.tryPromise({
-      try: () =>
-        backfillFirstRunDone(globalState, {
-          hasCredential,
-          hasPriorInstall,
-          hasRunHistory,
-        }),
-      catch: ensureError,
-    }).pipe(
-      Effect.catch((error) =>
-        Effect.sync(() =>
-          warnOnboardingFailure('First-run backfill write', error),
-        ),
-      ),
-    );
     // Route through the same funnel-transition planner the extension/desktop
     // hosts use, rather than a hand-copied precedence ladder. `selectSetupAgent`
     // is discarded: the CLI has no launcher agent list to steer. Clearing a

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -7,7 +7,7 @@ import PQueue from 'p-queue';
 
 // Local imports
 import { loadAgents } from '@agent/index';
-import { clearStoreCache, listRuns } from '@agent/storage';
+import { clearStoreCache } from '@agent/storage';
 import { registerAgentFeatures } from '@agent/features';
 import {
   agentResponseTextConnector,
@@ -99,7 +99,6 @@ import {
 } from '@shared/approvalPolicy';
 import type { CommandId } from '@shared/commands/catalog';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import { backfillFirstRunDone } from '@shared/state/onboardingState';
 import { UsageLogService } from '@telemetry/UsageLogService';
 import { registerRuntimeShutdownHandlers } from '@tools/agentCliSessionStores';
 import { setSetupPlatform } from '@tools/setup';
@@ -567,44 +566,6 @@ async function activateExtension(context: vscode.ExtensionContext) {
       GlobalStateKey.LAST_KNOWN_VERSION,
     ),
   );
-
-  // Onboarding-funnel backfill (PRD: agent-native onboarding): upgraders who
-  // already have a credential or run history must never see the welcome card
-  // or the preselected setup agent, so firstRunDone is backfilled once when
-  // the flag first appears. Awaited: the main view's funnel derivation reads this flag
-  // at webview-ready, and awaiting here closes the only read-before-backfill
-  // window. One-shot in practice — once the key exists the probes are skipped.
-  if (
-    context.globalState.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE) ===
-    undefined
-  ) {
-    try {
-      const hasPriorInstall =
-        context.globalState.get<string>(GlobalStateKey.LAST_KNOWN_VERSION) !==
-        undefined;
-      // Neither probe is masked: a failed probe must not be recorded as
-      // "false" in a one-shot key. A rejection lands in the catch below,
-      // which logs the cause and leaves the key unset so the next
-      // activation re-evaluates.
-      const [hasCredential, hasRunHistory] = await Promise.all([
-        // Same non-blank provider-key/server-side-key check used by the
-        // funnel and setup launch preflight.
-        hasAnyUsableSetupCredential(),
-        effectRuntime()
-          .runPromise(listRuns(defaultSession()))
-          .then((entries) => entries.length > 0),
-      ]);
-      await backfillFirstRunDone(context.globalState, {
-        hasCredential,
-        hasPriorInstall,
-        hasRunHistory,
-      });
-    } catch (err) {
-      log.warn(
-        `Onboarding firstRunDone backfill failed: ${toErrorMessage(err)}`,
-      );
-    }
-  }
 
   // The following startup steps touch independent state, so they run
   // concurrently to shorten activation. Within the agent branch the order

--- a/src/shared/state/onboardingState.ts
+++ b/src/shared/state/onboardingState.ts
@@ -60,28 +60,3 @@ export function readOnboardingFlags(state: StateStore): {
     firstRunDone: getFirstRunDone(state),
   };
 }
-
-/**
- * One-shot migration: upgraders keep their normal product. A prior install
- * with a credential, or any install with run history, never sees first-run
- * onboarding. The key is written on the first call, even when the value is
- * false, so the backfill never re-evaluates.
- */
-export async function backfillFirstRunDone(
-  state: StateStore,
-  signals: {
-    hasCredential: boolean;
-    hasPriorInstall?: boolean;
-    hasRunHistory: boolean;
-  },
-): Promise<void> {
-  const existing = state.get<boolean | undefined>(
-    GlobalStateKey.ONBOARDING_FIRST_RUN_DONE,
-  );
-  if (existing !== undefined) return;
-  await setFirstRunDone(
-    state,
-    signals.hasRunHistory ||
-      (signals.hasPriorInstall === true && signals.hasCredential),
-  );
-}

--- a/src/test-kernel/cli/ConfigForm.vitest.ts
+++ b/src/test-kernel/cli/ConfigForm.vitest.ts
@@ -6,23 +6,12 @@ import { z } from 'zod';
 
 import {
   buildConfigListItems,
-  buildEnumItems,
   coerceSettingInput,
-  formatSettingValue,
   isConfigResetInput,
-  settingDisplayName,
   settingEditKind,
-  settingStoreLabel,
   validateSettingInput,
 } from '@cli/chat/tui/forms/ConfigForm';
-import {
-  buildConfigCategoryItems,
-  configCategoryLabel,
-} from '@cli/chat/tui/forms/configCategories';
-import {
-  CliConfigForm,
-  createCliConfigFormProps,
-} from '@cli/chat/tui/forms/CliConfigForm';
+import { CliConfigForm } from '@cli/chat/tui/forms/CliConfigForm';
 import {
   buildProviderApiKeyItems,
   formatProviderApiKeySummary,
@@ -86,6 +75,26 @@ vi.mock('@cli/runtime/githubToken', () => ({
   saveGitHubToken: githubTokenRuntime.save,
   removeGitHubToken: githubTokenRuntime.remove,
 }));
+
+type ConfigFormProps = Parameters<
+  typeof import('@cli/chat/tui/forms/ConfigForm').ConfigForm
+>[0];
+const configFormProps = vi.hoisted(() => ({
+  current: undefined as ConfigFormProps | undefined,
+}));
+// Record the props `/config` hands the real form, so the wiring tests can call
+// its read/write/reset callbacks without walking the menus keypress by keypress.
+vi.mock('@cli/chat/tui/forms/ConfigForm', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@cli/chat/tui/forms/ConfigForm')>();
+  return {
+    ...actual,
+    ConfigForm: (props: ConfigFormProps) => {
+      configFormProps.current = props;
+      return actual.ConfigForm(props);
+    },
+  };
+});
 
 function apiKeyStatuses(
   overrides: Partial<Record<ApiProvider, ApiKeyStatus>> = {},
@@ -182,50 +191,22 @@ async function submitGitHubToken(
   stdin.write('\r');
 }
 
-interface RenderedConfigFormProps {
-  entries?: readonly SurfacedSettingEntry[];
-  readValue?: (entry: SurfacedSettingEntry) => unknown;
-  writeValue?: (
-    entry: SurfacedSettingEntry,
-    value: unknown,
-  ) => void | Promise<void>;
-  resetValue?: (entry: SurfacedSettingEntry) => void | Promise<void>;
-  onError?: (error: unknown) => void;
-  formRenderers?: Readonly<
-    Record<string, (onBack: () => void) => React.JSX.Element>
-  >;
-  formLinks?: readonly {
-    readonly name: string;
-    readonly label: string;
-    readonly description: string;
-  }[];
-  availableRows?: number;
+/** Mount the open `/config` form once and return the props it gave ConfigForm. */
+async function renderConfigFormProps(): Promise<ConfigFormProps> {
+  configFormProps.current = undefined;
+  const rendered = await renderInkElement(
+    activeForm.get()?.render(() => undefined, 20),
+  );
+  rendered.instance.unmount();
+  if (!configFormProps.current) {
+    throw new TypeError('Expected /config to render ConfigForm');
+  }
+  return configFormProps.current;
 }
 
-function renderConfigFormProps(): RenderedConfigFormProps {
-  const node = activeForm.get()?.render(() => {}, 20) as {
-    type?: (props: unknown) => unknown;
-    props?: unknown;
-  };
-  if (typeof node?.type !== 'function') {
-    throw new TypeError('Expected /config form adapter element');
-  }
-  const rendered = node.type(node.props) as {
-    type?: unknown;
-    props?: ReturnType<typeof Object>;
-  };
-  if (rendered.type === CliConfigForm) {
-    const props = rendered.props as Parameters<typeof CliConfigForm>[0];
-    if (!props.stores) throw new TypeError('Expected /config stores');
-    // The spread narrows `stores` from optional to required for the input type.
-    return createCliConfigFormProps({ ...props, stores: props.stores });
-  }
-  return (rendered.props ?? {}) as RenderedConfigFormProps;
-}
-
-function openConfigFormProps(
+async function openConfigFormProps(
   stores = makeFakeSettingsStores().stores,
-): RenderedConfigFormProps {
+): Promise<ConfigFormProps> {
   registerBuiltinSlashCommands({ getConfigStores: () => stores });
   openCliSlashCommandForm('config', '');
   return renderConfigFormProps();
@@ -499,7 +480,7 @@ describe('CliConfigForm API-key status lifecycle', () => {
 });
 
 describe('/config slash command wiring', () => {
-  it('wires the roster and reads through the injected CLI stores', () => {
+  it('wires the roster and reads through the injected CLI stores', async () => {
     const { stores, config } = makeFakeSettingsStores();
     // Seed the git-author config slot the CLI reads from.
     void config.update(WorkspaceStateKey.GIT_MARK_COMMITS, false);
@@ -508,13 +489,13 @@ describe('/config slash command wiring', () => {
     expect(openCliSlashCommandForm('config', '')).toBe(true);
     expect(activeForm.get()?.commandName).toBe('config');
 
-    const props = renderConfigFormProps();
-    expect(props.entries?.map((entry) => entry.key)).toEqual(
+    const props = await renderConfigFormProps();
+    expect(props.entries.map((entry) => entry.key)).toEqual(
       CLI_STATE_SETTINGS.map((entry) => entry.key),
     );
 
     const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
-    expect(props.readValue?.(markCommits)).toBe(false);
+    expect(props.readValue(markCommits)).toBe(false);
   });
 
   // Regression: `/config` used to persist `texra.approvalPolicy` with a bare
@@ -530,9 +511,9 @@ describe('/config slash command wiring', () => {
       },
     });
     openCliSlashCommandForm('config', '');
-    const props = renderConfigFormProps();
+    const props = await renderConfigFormProps();
 
-    await props.writeValue?.(
+    await props.writeValue(
       entryByKey(TEXRA_APPROVAL_POLICY_CONFIG_KEY),
       'yolo',
     );
@@ -543,12 +524,12 @@ describe('/config slash command wiring', () => {
 
   it('persists writes through the accessor to the CLI store', async () => {
     const { stores, config } = makeFakeSettingsStores();
-    const props = openConfigFormProps(stores);
+    const props = await openConfigFormProps(stores);
     const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
-    await props.writeValue?.(markCommits, false);
+    await props.writeValue(markCommits, false);
 
     expect(isStored(config, WorkspaceStateKey.GIT_MARK_COMMITS)).toBe(true);
-    expect(props.readValue?.(markCommits)).toBe(false);
+    expect(props.readValue(markCommits)).toBe(false);
   });
 
   it('emits a deferred command echo before a configuration error', async () => {
@@ -562,41 +543,43 @@ describe('/config slash command wiring', () => {
     });
     openCliSlashCommandForm('config', '', () => events.push('echo'));
 
-    await renderConfigFormProps().onError?.(new Error('write failed'));
-    await renderConfigFormProps().onError?.(new Error('write failed again'));
+    await (await renderConfigFormProps()).onError?.(new Error('write failed'));
+    await (
+      await renderConfigFormProps()
+    ).onError?.(new Error('write failed again'));
 
     expect(events).toEqual(['echo', 'error', 'error']);
   });
 
   it('resets a git setting by deleting the stored key', async () => {
     const { stores, config } = makeFakeSettingsStores();
-    const props = openConfigFormProps(stores);
+    const props = await openConfigFormProps(stores);
     const authorName = entryByKey(WorkspaceStateKey.GIT_AUTHOR_NAME);
 
-    await props.writeValue?.(authorName, 'someone-else');
+    await props.writeValue(authorName, 'someone-else');
     expect(isStored(config, WorkspaceStateKey.GIT_AUTHOR_NAME)).toBe(true);
 
-    await props.resetValue?.(authorName);
+    await props.resetValue(authorName);
     // The key is deleted, so reads fall back to the default identity.
     expect(isStored(config, WorkspaceStateKey.GIT_AUTHOR_NAME)).toBe(false);
-    expect(props.readValue?.(authorName)).toBe(DEFAULT_GIT_AUTHOR_NAME);
+    expect(props.readValue(authorName)).toBe(DEFAULT_GIT_AUTHOR_NAME);
   });
 
   it('turns OpenRouter off when Prefer Kimi Code is enabled', async () => {
     const { stores, globalState } = makeFakeSettingsStores();
     await globalState.update(GlobalStateKey.USE_OPENROUTER, true);
-    const props = openConfigFormProps(stores);
+    const props = await openConfigFormProps(stores);
     const preferKimiCode = entryByKey(GlobalStateKey.KIMI_CODE_PREFER);
-    await props.writeValue?.(preferKimiCode, true);
+    await props.writeValue(preferKimiCode, true);
 
     expect(globalState.get(GlobalStateKey.KIMI_CODE_PREFER)).toBe(true);
-    expect(props.readValue?.(entryByKey(GlobalStateKey.USE_OPENROUTER))).toBe(
+    expect(props.readValue(entryByKey(GlobalStateKey.USE_OPENROUTER))).toBe(
       false,
     );
 
     // Disabling the preference leaves the OpenRouter toggle untouched.
     await globalState.update(GlobalStateKey.USE_OPENROUTER, true);
-    await props.writeValue?.(preferKimiCode, false);
+    await props.writeValue(preferKimiCode, false);
     expect(globalState.get(GlobalStateKey.USE_OPENROUTER)).toBe(true);
   });
 });

--- a/src/test-kernel/cli/OnboardingGate.vitest.ts
+++ b/src/test-kernel/cli/OnboardingGate.vitest.ts
@@ -9,20 +9,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   hasUsableSetupCredential: vi.fn(),
-  listRuns: vi.fn(),
 }));
 
 vi.mock('@model/setupCredentialAccess', () => ({
   hasUsableSetupCredential: mocks.hasUsableSetupCredential,
 }));
 
-vi.mock('@agent/storage', () => ({
-  listRuns: () => Effect.tryPromise(() => mocks.listRuns()),
-}));
-
-vi.mock('@cli/runtime/transcriptSession', () => ({
-  initializeCliTranscriptSession: vi.fn(async () => ({})),
-}));
 vi.mock('@platform/processRuntime', () => ({
   effectRuntime: () => ({ runPromise: Effect.runPromise }),
 }));
@@ -52,7 +44,6 @@ describe('maybeRunCliOnboarding gate', () => {
 
   beforeEach(() => {
     mocks.hasUsableSetupCredential.mockReset().mockResolvedValue(false);
-    mocks.listRuns.mockReset().mockResolvedValue([]);
     services = createFakePlatform();
     originalIsTty = process.stdout.isTTY;
     Object.defineProperty(process.stdout, 'isTTY', {
@@ -80,41 +71,6 @@ describe('maybeRunCliOnboarding gate', () => {
       }),
   );
 
-  effectIt.effect(
-    'marks prior installs with credentials as first-run done',
-    () =>
-      Effect.gen(function* () {
-        yield* Effect.promise(() =>
-          services.globalState.update(
-            GlobalStateKey.LAST_KNOWN_VERSION,
-            '1.2.3',
-          ),
-        );
-        mocks.hasUsableSetupCredential.mockResolvedValue(true);
-
-        expect(yield* maybeRunCliOnboarding(services, INTERACTIVE)).toEqual(
-          SKIPPED,
-        );
-        expect(
-          services.globalState.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE),
-        ).toBe(true);
-      }),
-  );
-
-  effectIt.effect(
-    'backfills a credentialed fresh install as NOT done (env keys)',
-    () =>
-      Effect.gen(function* () {
-        // Credential alone proves nothing, fresh installs can inherit env keys.
-        mocks.hasUsableSetupCredential.mockResolvedValue(true);
-
-        yield* maybeRunCliOnboarding(services, INTERACTIVE);
-        expect(
-          services.globalState.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE),
-        ).toBe(false);
-      }),
-  );
-
   effectIt.effect('skips when onboarding was previously declined', () =>
     Effect.gen(function* () {
       yield* Effect.promise(() =>
@@ -134,12 +90,6 @@ describe('maybeRunCliOnboarding gate', () => {
         yield* Effect.promise(() =>
           services.globalState.update(GlobalStateKey.ONBOARDING_DECLINED, true),
         );
-        yield* Effect.promise(() =>
-          services.globalState.update(
-            GlobalStateKey.ONBOARDING_FIRST_RUN_DONE,
-            false,
-          ),
-        );
         mocks.hasUsableSetupCredential.mockResolvedValue(true);
 
         // `configured` stays false: only the picker actually configuring a
@@ -151,21 +101,6 @@ describe('maybeRunCliOnboarding gate', () => {
         expect(
           services.globalState.get(GlobalStateKey.ONBOARDING_DECLINED),
         ).toBe(false);
-      }),
-  );
-
-  effectIt.effect(
-    'skips onboarding for credential-less users with prior run history',
-    () =>
-      Effect.gen(function* () {
-        mocks.listRuns.mockResolvedValue([{ id: 'previous-run' }]);
-
-        expect(yield* maybeRunCliOnboarding(services, INTERACTIVE)).toEqual(
-          SKIPPED,
-        );
-        expect(
-          services.globalState.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE),
-        ).toBe(true);
       }),
   );
 
@@ -203,8 +138,7 @@ describe('firstRunSetupAgentOverride', () => {
       expected: undefined,
     },
     {
-      scenario:
-        'does nothing once the first run is done (backfilled or earned)',
+      scenario: 'does nothing once the first run is done',
       input: { onboardingConfigured: true, firstRunDone: true },
       expected: undefined,
     },

--- a/src/test-kernel/controllers/OnboardingFunnel.vitest.ts
+++ b/src/test-kernel/controllers/OnboardingFunnel.vitest.ts
@@ -7,14 +7,7 @@ import {
   type OnboardingFunnelTransition,
 } from '@controllers/onboarding/onboardingFunnel';
 import type { OnboardingFunnelState } from '@shared/schemas';
-import {
-  backfillFirstRunDone,
-  getDefaultTeamId,
-  getFirstRunDone,
-  readOnboardingFlags,
-  setDefaultTeamId,
-  setFirstRunDone,
-} from '@shared/state/onboardingState';
+import { getDefaultTeamId } from '@shared/state/onboardingState';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { FakeStateStore } from '@test/support/FakePlatform';
 
@@ -134,56 +127,4 @@ describe('onboarding flags', () => {
       ).toBeUndefined();
     },
   );
-});
-
-describe('backfillFirstRunDone', () => {
-  it.each<[string, Parameters<typeof backfillFirstRunDone>[1], boolean]>([
-    [
-      'marks prior installs with a credential as done',
-      { hasCredential: true, hasPriorInstall: true, hasRunHistory: false },
-      true,
-    ],
-    [
-      'does not mark fresh credential-only installs as done',
-      { hasCredential: true, hasRunHistory: false },
-      false,
-    ],
-    [
-      'marks upgraders with run history as done',
-      { hasCredential: false, hasRunHistory: true },
-      true,
-    ],
-  ])('%s', async (_name, signals, expected) => {
-    const state = new FakeStateStore();
-    await backfillFirstRunDone(state, signals);
-    expect(getFirstRunDone(state)).toBe(expected);
-  });
-
-  it('writes false for a fresh install so the backfill never re-evaluates', async () => {
-    const state = new FakeStateStore();
-    await backfillFirstRunDone(state, {
-      hasCredential: false,
-      hasRunHistory: false,
-    });
-    expect(state.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE)).toBe(false);
-
-    // A later credential must not flip the backfilled value: a fresh install
-    // that signs in minutes after activation still enters State 1.
-    await backfillFirstRunDone(state, {
-      hasCredential: true,
-      hasRunHistory: false,
-    });
-    expect(getFirstRunDone(state)).toBe(false);
-  });
-
-  it('never overwrites an existing flag', async () => {
-    const state = new FakeStateStore({
-      [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true,
-    });
-    await backfillFirstRunDone(state, {
-      hasCredential: false,
-      hasRunHistory: false,
-    });
-    expect(getFirstRunDone(state)).toBe(true);
-  });
 });

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
@@ -188,7 +188,7 @@ describe('desktop IPC adapters', () => {
     expect(selectSetupAgent).toHaveBeenCalled();
   });
 
-  it('derives State 2 (done) for backfilled veterans with firstRunDone set', async () => {
+  it('derives State 2 (done) for veterans with firstRunDone set', async () => {
     const { onboarding } = await createOnboardingHarness({
       seed: { [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true },
       hasCredential: () => true,

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
@@ -196,7 +196,7 @@ describe('desktop IPC adapters', () => {
 
     await onboarding.refreshOnboardingFunnel();
     await flushAsync();
-    // Backfilled veteran: State 2 (done), no onboarding UI shown.
+    // Veteran with firstRunDone set: State 2 (done), no onboarding UI shown.
     expectFunnelState(onboarding, 'done');
   });
 


### PR DESCRIPTION
## Summary

**D13-2: delete the one-shot firstRunDone backfill.** `backfillFirstRunDone` was an upgrader migration. Three live writers already own `firstRunDone`: `AgentRunLifecycle` on run completion, `desktopOnboardingIpc`, and `extensionHostRequests`. Under the 1.0 fresh-state premise no profile predates those writers, so the backfill could only ever write `false`. In a fresh store it could also wrongly flip the flag to `true` for a credentialed desktop user who then launches the CLI.

This PR deletes the helper, the CLI gate block in `runOnboarding.tsx`, the extension activation block in `extension.ts`, and their test cases. CLI onboarding no longer imports `listRuns`, and it no longer opens the transcript session before the picker. Every reader still goes through `getFirstRunDone`, which treats an absent key as "not done".

One behavior changes, as intended: a fresh-state profile with run history but no credential now reaches the picker. This assumes the 1.0 fresh-state premise (plan step A). The key is still `texra.onboarding.firstRunDone`, but every onboarding-era activation already writes it.

**LXCOMPAT-2: drop the dead CLI `LAST_KNOWN_VERSION` probe.** It lived inside the same CLI block. The CLI's `state.json` never carries that key; the CLI writes only `CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION`. The extension still writes and reads `LAST_KNOWN_VERSION`.

**D12-5: fold `createCliConfigFormProps` into `CliConfigForm`.** The `/config` form went CliConfigForm → createCliConfigFormProps → ConfigForm, and the factory's only other caller was the test. `CliConfigForm` now renders `ConfigForm` directly. That removes:
- the `CreateCliConfigFormPropsInput` bag and its optional-callback defaults
- the `useCallback` pass-through wrappers
- an unused import

`ConfigFormProps` is now file-local, as are the four helpers nothing imports (`formatSettingValue`, `settingStoreLabel`, `settingDisplayName`, `buildEnumItems`). The five helpers the suite still exercises stay exported, so coverage is unchanged. The wiring tests now capture the props `/config` actually hands the real `ConfigForm`, instead of rebuilding them through the factory. The mount sites are untouched.

Two review nits are fixed too: a stale "Backfilled veteran" test comment, and a comment line in `orchestrate.ts` that ran past 100 columns.

Not included: 5 stale `knip-baseline.json` entries (`createCliConfigFormProps`, `buildEnumItems`, `formatSettingValue`, `settingDisplayName`, `settingStoreLabel`). The ratchet passes with them. Drop them the next time the baseline is regenerated; another session holds that file.

## Net elements (R6)

From `git diff --stat origin/main`:
- Files: 10 (6 production, 4 test).
- Net LOC: +174 / -485 = **-311**.
  - Production: +116 / -285 (-169).
  - Test: +58 / -200 (-142).
- `^[+-]export` lines: +1 / -8, net -7.
  - Removed: `backfillFirstRunDone`, `createCliConfigFormProps`, `ConfigFormProps`, `formatSettingValue`, `settingStoreLabel`, `settingDisplayName`, `buildEnumItems`.
  - `CliConfigForm` moved (-1/+1).
- Class/interface/enum declarations: -2 net. `CreateCliConfigFormPropsInput` and the test's `RenderedConfigFormProps` are deleted, and the `ConfigFormProps` export is now local.

## Consumer counts (R8)

Grepped at origin/main:
- `backfillFirstRunDone`: 2 production callers (`runOnboarding.tsx`, `extension.ts`) and 1 test file (`OnboardingFunnel.vitest.ts`). All removed.
- `createCliConfigFormProps`: 1 production caller (`CliConfigForm.tsx`, now folded in) and 1 test caller (`ConfigForm.vitest.ts`, now replaced by prop capture).
- `formatSettingValue`, `settingStoreLabel`, `settingDisplayName`, `buildEnumItems`: 0 external callers. The only reference was an unused import in `ConfigForm.vitest.ts`.
- `ConfigFormProps`: 1 external consumer (`CliConfigForm.tsx`), gone after the fold. The test derives the type with `Parameters<typeof ConfigForm>[0]`.
- CLI `LAST_KNOWN_VERSION` read: 0 CLI writers.
- `listRuns`: the imports in `runOnboarding.tsx` and `extension.ts` are dropped. Other consumers remain.
- No emit paths, commands or settings were deleted.

## Gates

All at HEAD 10ebf22749 on origin/main 40c0166288, run through gate.sh:
- `env CI=true npm run typecheck`: **exit 0**. Covers all per-package tsconfigs.
- `env FORCE_COLOR=0 npx vitest run --changed origin/main`: **exit 0**. 135/135 files pass; 1861 tests pass and 1 is skipped (1862 total).
- `npm run lint` (repo-wide): **exit 0**.
- `npm run check:dead-code-ratchet`: **exit 0**, "no new findings", 239 combined vs 239 baselined.
- `npm run format`: exit 0, tree unchanged. `npx prettier --check .` (repo-wide): **all files formatted**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Re-gated after rebase
The full local gate set in **Gates** above passed on the pre-rebase base. The branch then rebased onto origin/main `6a60507630` without conflicts (HEAD `166b6bdad8`,  10 files changed, 174 insertions(+), 485 deletions(-)). After the rebase, the Effect migration ratchet (`node scripts/check-effect-migration-ratchet.mjs`) and `prettier --check` over the changed files were re-run locally and pass. The post-rebase typecheck, lint and tests are left to CI: three local re-runs were killed by machine memory pressure (about ten concurrent sessions). **Opened as a draft; it is marked ready only once CI is green.**


## Correction (from review)
The summary's account of what the deleted backfill could write is imprecise. The CLI backfill set `firstRunDone` when `hasRunHistory || (hasPriorInstall && hasCredential)`. The `hasPriorInstall` arm (the `LAST_KNOWN_VERSION` probe, LXCOMPAT-2) was dead in the CLI, because the CLI store never carries that key. The one live arm that could write `true` was `hasRunHistory`. It read the transcript store, which desktop and CLI can share, so it over-marked users whose history held no completed non-setup run as done. After this change such a user reaches the picker when no credential is present, and `firstRunDone` is written only by its three live writers. As the title says, the deletion assumes 1.0's fresh state: a pre-1.0 profile that predates those writers is no longer migrated.
