### PR TITLE
simplify(desktop): one agent-failure presentation, required desktop ports (1.0 clean slate)

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-09-host-shared-controllers-on-effect.md
+++ b/.agents/docs/proposed/architecture/2026-09-09-host-shared-controllers-on-effect.md
@@ -111,7 +111,8 @@ refresh is written twice —
 `ProgressViewProvider.ts:397-431` and `desktopOnboardingIpc.ts:100-132` are
 the same five steps in the same order (probe in a try with a near-identical
 "Credential probe failed; treating as no credential" warning, plan the
-transition, store it, publish, `clearDeclined`, `selectSetupAgent`), both
+transition, store it, publish, `clearDeclined`, and on the extension
+`selectSetupAgent`; desktop discards that transition), both
 holding a private `previousFunnelState` and both wrapped in the same shared
 `OnboardingRefreshQueue`. Three small credential paths are written three
 times: [`providerApiKey.ts`](../../../../packages/cli/src/runtime/providerApiKey.ts)
@@ -432,7 +433,8 @@ and `shutdownExtension`'s re-activation idempotency.
 the Electron quit path with its renderer veto, per-project session scoping,
 `DesktopPromptController`'s correlated renderer prompts, the N-sessions
 registry, the `hasAuthoritativeStream` pre-check in resume, and
-`selectSetupAgent` as a documented no-op. It loses the `toolEditAction`
+discarding the `selectSetupAgent` transition, as the CLI does
+(`runOnboarding.tsx`). It loses the `toolEditAction`
 pass-through.
 
 **CLI.** Rendering, terminal ownership, and everything the study confirmed is

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -2,9 +2,12 @@ import { Cause, Effect, Exit } from 'effect';
 
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
-import { runInSession, type SessionHandle } from '@agent/runtime';
 import {
-  agentErrorPresentation,
+  presentAgentFailure,
+  runInSession,
+  type SessionHandle,
+} from '@agent/runtime';
+import {
   classifyAgentError,
   primaryAgentError,
 } from '@common/errors/agentErrorClassification';
@@ -110,21 +113,14 @@ export class DesktopProcessResumeOwner {
       data: toLogData(error),
     });
     const primaryError = primaryAgentError(error);
-    const presentation = agentErrorPresentation({
-      kind: classifyAgentError(primaryError),
-      message: `Resume failed: ${toErrorMessage(primaryError)}`,
-    });
-    if (presentation?.type === 'instruction') {
-      session.interactions.emit(
-        'requestShowInstruction',
-        presentation.payload,
-        { replayWhenAttached: true },
-      );
-    } else if (presentation?.type === 'error') {
-      session.interactions.emit('requestShowError', presentation.payload, {
-        replayWhenAttached: true,
-      });
-    }
+    presentAgentFailure(
+      session.interactions,
+      {
+        kind: classifyAgentError(primaryError),
+        message: `Resume failed: ${toErrorMessage(primaryError)}`,
+      },
+      { replayWhenAttached: true },
+    );
     return false;
   }
 }

--- a/packages/desktop/src/main/desktopBrowserViews.ts
+++ b/packages/desktop/src/main/desktopBrowserViews.ts
@@ -32,7 +32,7 @@ interface DesktopBrowserViewsOptions {
   onBlockedExternalUrl(error: unknown): void;
   /** Records a failure after the host has already surfaced the user-facing error. */
   onExternalOpenError(error: unknown): void;
-  onError?(error: unknown): void;
+  onError(error: unknown): void;
 }
 
 export interface DesktopBrowserViews {
@@ -71,7 +71,7 @@ export function createDesktopBrowserViews(
   const views = new Map<string, WebContentsView>();
   let attachedTabId: string | undefined;
 
-  const reportError = (error: unknown) => options.onError?.(error);
+  const reportError = (error: unknown) => options.onError(error);
 
   function openAllowedExternalUrl(url: string): void {
     if (!isHandOffableUrl(url)) {

--- a/packages/desktop/src/main/desktopHostRequests.ts
+++ b/packages/desktop/src/main/desktopHostRequests.ts
@@ -9,9 +9,8 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { Cause, Effect, Exit, SubscriptionRef } from 'effect';
-import type { SessionHandle } from '@agent/runtime';
+import { presentAgentFailure, type SessionHandle } from '@agent/runtime';
 import {
-  agentErrorPresentation,
   classifyAgentError,
   primaryAgentError,
 } from '@common/errors/agentErrorClassification';
@@ -193,25 +192,14 @@ export function createDesktopHostRequests(
                   data: toLogData(error),
                 });
                 const primaryError = primaryAgentError(error);
-                const presentation = agentErrorPresentation({
-                  kind: classifyAgentError(primaryError),
-                  message: `Merge failed: ${toErrorMessage(primaryError)}`,
-                });
-                if (presentation?.type === 'instruction') {
-                  session.interactions.emit(
-                    'requestShowInstruction',
-                    presentation.payload,
-                    { replayWhenAttached: true },
-                  );
-                } else if (presentation?.type === 'error') {
-                  session.interactions.emit(
-                    'requestShowError',
-                    presentation.payload,
-                    {
-                      replayWhenAttached: true,
-                    },
-                  );
-                }
+                presentAgentFailure(
+                  session.interactions,
+                  {
+                    kind: classifyAgentError(primaryError),
+                    message: `Merge failed: ${toErrorMessage(primaryError)}`,
+                  },
+                  { replayWhenAttached: true },
+                );
               }),
             ),
           ),
@@ -763,29 +751,18 @@ export function createDesktopHostRequests(
       // Request-scoped operations do not present. Every rejection, including
       // a capability refusal, reaches this one dialog before the response.
       const primaryError = primaryAgentError(error);
-      const presentation = agentErrorPresentation({
-        kind: classifyAgentError(primaryError),
-        message:
-          primaryError instanceof Rejected ||
-          primaryError instanceof Unavailable
-            ? primaryError.reason
-            : toErrorMessage(primaryError),
-      });
-      if (presentation?.type === 'instruction') {
-        await session.interactions.emit(
-          'requestShowInstruction',
-          presentation.payload,
-          { replayWhenAttached: true },
-        );
-      } else if (presentation?.type === 'error') {
-        await session.interactions.emit(
-          'requestShowError',
-          presentation.payload,
-          {
-            replayWhenAttached: true,
-          },
-        );
-      }
+      await presentAgentFailure(
+        session.interactions,
+        {
+          kind: classifyAgentError(primaryError),
+          message:
+            primaryError instanceof Rejected ||
+            primaryError instanceof Unavailable
+              ? primaryError.reason
+              : toErrorMessage(primaryError),
+        },
+        { replayWhenAttached: true },
+      );
       throw error;
     },
     closePort: draftRequests.closePort,

--- a/packages/desktop/src/main/desktopIpcTypes.ts
+++ b/packages/desktop/src/main/desktopIpcTypes.ts
@@ -1,5 +1,3 @@
-import { UnsupportedCommandError } from '@shared/utils/dispatcher';
-
 export type DesktopCommandMessage = { command: string } & Record<
   string,
   unknown
@@ -54,31 +52,4 @@ export function isDesktopCommandMessage(
     'command' in message &&
     typeof message.command === 'string'
   );
-}
-
-/**
- * Wraps a dispatcher's `onError` callback so an {@link UnsupportedCommandError}
- * (a registry entry declared `unsupported(...)`) is routed to `onUnsupported`
- * — the host's visible-feedback surface (e.g. a native info dialog) — instead
- * of the generic error reporter. Every desktop dispatcher call site shares
- * this so "command deliberately unsupported here" always produces visible
- * feedback rather than a console-only log.
- */
-export function createDesktopErrorReporter(
-  onError?: (error: unknown) => void,
-  onUnsupported?: (error: UnsupportedCommandError) => void,
-): (error: unknown) => void {
-  const reportError = onError ?? defaultReportError;
-  if (!onUnsupported) return reportError;
-  return (error: unknown) => {
-    if (error instanceof UnsupportedCommandError) {
-      onUnsupported(error);
-      return;
-    }
-    reportError(error);
-  };
-}
-
-function defaultReportError(error: unknown): void {
-  console.error(error);
 }

--- a/packages/desktop/src/main/desktopLogIpc.ts
+++ b/packages/desktop/src/main/desktopLogIpc.ts
@@ -1,26 +1,24 @@
 import {
-  createDesktopErrorReporter,
-  type DesktopCommandMessage,
-  type DesktopMessageHandler,
-  type DesktopRenderer,
-} from './desktopIpcTypes.js';
-import {
   DESKTOP_LOG_COMMANDS,
   type DesktopLogSnapshot,
 } from '../shared/desktopLogMessages.js';
+import type {
+  DesktopCommandMessage,
+  DesktopMessageHandler,
+  DesktopRenderer,
+} from './desktopIpcTypes.js';
 
 export interface DesktopLogIpcOptions {
   readLog(): DesktopLogSnapshot;
   copyLog(text: string): Promise<void>;
   exportLog(text: string): Promise<void>;
-  onAsyncError?: (error: unknown) => void;
+  onAsyncError: (error: unknown) => void;
 }
 
 export function createDesktopLogIpc(
   renderer: DesktopRenderer,
   options: DesktopLogIpcOptions,
 ): DesktopMessageHandler {
-  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
   function postSnapshot(): DesktopLogSnapshot {
     const log = options.readLog();
     renderer.postToRenderer({
@@ -37,10 +35,10 @@ export function createDesktopLogIpc(
           postSnapshot();
           return true;
         case DESKTOP_LOG_COMMANDS.COPY_LOG:
-          options.copyLog(postSnapshot().text).catch(reportAsyncError);
+          options.copyLog(postSnapshot().text).catch(options.onAsyncError);
           return true;
         case DESKTOP_LOG_COMMANDS.EXPORT_LOG:
-          options.exportLog(postSnapshot().text).catch(reportAsyncError);
+          options.exportLog(postSnapshot().text).catch(options.onAsyncError);
           return true;
         default:
           return false;

--- a/packages/desktop/src/main/desktopNavigationPolicy.ts
+++ b/packages/desktop/src/main/desktopNavigationPolicy.ts
@@ -1,8 +1,6 @@
 import { shell, type WebContents } from 'electron';
 import { tryParseUrl } from '@utils/core';
 
-import { createDesktopErrorReporter } from './desktopIpcTypes.js';
-
 const ALLOWED_HTTPS_HOSTS = new Set<string>([
   'github.com',
   'www.github.com',
@@ -31,17 +29,15 @@ function routeOrDeny(
 }
 
 interface DesktopNavigationPolicyOptions {
-  onAsyncError?: (error: unknown) => void;
+  onAsyncError: (error: unknown) => void;
 }
 
 export function installDesktopNavigationPolicy(
   webContents: WebContents,
-  options: DesktopNavigationPolicyOptions = {},
+  { onAsyncError }: DesktopNavigationPolicyOptions,
 ): void {
-  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
-
   webContents.setWindowOpenHandler(({ url }) => {
-    routeOrDeny(url, reportAsyncError);
+    routeOrDeny(url, onAsyncError);
     return { action: 'deny' };
   });
 
@@ -51,7 +47,7 @@ export function installDesktopNavigationPolicy(
     url: string,
   ): void => {
     event.preventDefault();
-    routeOrDeny(url, reportAsyncError);
+    routeOrDeny(url, onAsyncError);
   };
   webContents.on('will-navigate', denyAndRoute);
   webContents.on('will-redirect', denyAndRoute);

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -14,11 +14,10 @@ import {
   DESKTOP_ONBOARDING_COMMANDS,
   DESKTOP_ONBOARDING_DISMISSED_STATE_KEY,
 } from '../shared/desktopOnboardingMessages.js';
-import {
-  createDesktopErrorReporter,
-  type DesktopCommandMessage,
-  type DesktopMessageHandler,
-  type DesktopRenderer,
+import type {
+  DesktopCommandMessage,
+  DesktopMessageHandler,
+  DesktopRenderer,
 } from './desktopIpcTypes.js';
 
 const logger = createLog('DesktopOnboarding');
@@ -31,13 +30,11 @@ interface DesktopOnboardingIpcOptions {
    * provider API key). Async because the secrets read can involve disk I/O.
    */
   hasCredential: () => boolean | Promise<boolean>;
-  /** Put the setup agent in the launcher when entering State 1. */
-  selectSetupAgent: () => Promise<void>;
   /** Launch the setup conversation when the user clicks "Run Setup". */
   kickoffSetup: () => Promise<void>;
   /** Run ChatGPT sign-in flow from the welcome card. */
   signInWithChatGpt: () => Promise<void>;
-  onAsyncError?: (error: unknown) => void;
+  onAsyncError: (error: unknown) => void;
 }
 
 /**
@@ -56,7 +53,7 @@ export interface DesktopOnboardingIpc extends DesktopMessageHandler {
   skipOnboarding(): Promise<void>;
   /** The setup card's skip: marks the first run done and refreshes. */
   skipSetup(): Promise<void>;
-  /** The setup card's Run Setup: selects the setup agent and launches. */
+  /** The setup card's Run Setup: launches the setup conversation. */
   runSetup(): Promise<void>;
   signInWithChatGpt(): Promise<void>;
 }
@@ -66,7 +63,6 @@ export function createDesktopOnboardingIpc(
   options: DesktopOnboardingIpcOptions,
 ): DesktopOnboardingIpc {
   const state = options.state;
-  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
   let previousFunnelState: OnboardingFunnelState | undefined;
   let setupKickoffStarted = false;
   const funnelListeners = new Set<(state: OnboardingFunnelState) => void>();
@@ -117,12 +113,10 @@ export function createDesktopOnboardingIpc(
     if (transition.clearDeclined) {
       await setOnboardingDeclined(state, false);
     }
-    if (transition.selectSetupAgent) {
-      await options.selectSetupAgent();
-    }
-    // Entering State 1 only selects the setup agent and paints the setup card;
-    // it never auto-starts the setup conversation. The user launches setup
-    // explicitly via the card's "Run Setup" button (ONBOARDING_RUN_SETUP).
+    // Entering State 1 only paints the setup card (the launcher's agent
+    // selection is the surface's); it never auto-starts the setup
+    // conversation. The user launches setup explicitly via the card's
+    // "Run Setup" button (ONBOARDING_RUN_SETUP).
   }
 
   // Single guarded entry point for launching setup. The explicit "Run Setup"
@@ -171,7 +165,6 @@ export function createDesktopOnboardingIpc(
   }
 
   async function runSetup(): Promise<void> {
-    await options.selectSetupAgent();
     // Route through the shared guard so a double-click of "Run Setup" can't
     // launch a second concurrent run.
     startSetupKickoff();
@@ -190,7 +183,7 @@ export function createDesktopOnboardingIpc(
           postCurrentState();
           return true;
         case DESKTOP_ONBOARDING_COMMANDS.DISMISS:
-          dismiss().catch(reportAsyncError);
+          dismiss().catch(options.onAsyncError);
           return true;
         default:
           return false;

--- a/packages/desktop/src/main/desktopPtyHost.ts
+++ b/packages/desktop/src/main/desktopPtyHost.ts
@@ -62,7 +62,7 @@ export interface DesktopPtyHostOptions {
   onData(sessionId: string, data: string): void;
   /** Reports process exit so the UI can mark the session finished. */
   onExit(sessionId: string, exitCode: number): void;
-  onError?(error: unknown): void;
+  onError(error: unknown): void;
   /** Overrides native-module loading for a controlled host environment. */
   loadPty?: () => Promise<NodePtyModule>;
 }
@@ -225,7 +225,7 @@ export function createDesktopPtyHost(
           } catch (error) {
             // Resizing a pty whose process already exited throws; the exit
             // handler has cleaned up, so this is not actionable.
-            options.onError?.(error);
+            options.onError(error);
           }
         },
         dispose: () => {
@@ -233,7 +233,7 @@ export function createDesktopPtyHost(
           try {
             child.kill();
           } catch (error) {
-            options.onError?.(error);
+            options.onError(error);
           }
         },
       };

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -26,7 +26,11 @@ import {
   applyStateSettingUpdate,
   type SettingsSnapshotPosters,
 } from '@shared/settingsView/handlers/stateSettingWrite';
-import { unsupported, unsupportedCommands } from '@shared/utils/dispatcher';
+import {
+  unsupported,
+  unsupportedCommands,
+  UnsupportedCommandError,
+} from '@shared/utils/dispatcher';
 import { buildSettingsSnapshotMessage } from '@shared/settingsView/handlers/settingsSnapshot';
 import type { SettingsStores } from '@shared/config/settingsAccess';
 import { loadRuntimeSkillDisplay } from '@skills/runtimeSkills';
@@ -42,12 +46,11 @@ import {
   resolveGitHubTokenSource,
 } from '@tools/github/githubAuth';
 import { StorageFS } from '@utils/files/storageFS';
-import {
-  createDesktopErrorReporter,
-  type DesktopCommandMessage,
-  type DesktopMessageHandler,
-} from './desktopIpcTypes.js';
 import { subscribeDesktopGoalChanges } from './desktopGoalSubscription.js';
+import type {
+  DesktopCommandMessage,
+  DesktopMessageHandler,
+} from './desktopIpcTypes.js';
 import type { DesktopAgentSettingsController } from './desktopAgentSettingsController.js';
 import type { DesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import type { DesktopToolingSettingsController } from './desktopToolingSettingsController.js';
@@ -127,11 +130,15 @@ export function createDesktopSettingsIpc(
   const { workspaceState, config } = options.session.roots;
   // Commands declared `unsupported(...)` in settingsHandlers below surface as
   // a visible info dialog instead of a console-only error log.
-  const onError = createDesktopErrorReporter(options.ui.onError, (error) => {
+  const onError = (error: unknown): void => {
+    if (!(error instanceof UnsupportedCommandError)) {
+      options.ui.onError(error);
+      return;
+    }
     void Promise.resolve(options.ui.showInfoMessage(error.reason)).catch(
       options.ui.onError,
     );
-  });
+  };
   const settingsHost = new SettingsViewHost({
     state: { workspaceState, globalState },
     respond: options.postToRenderer,

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -7,18 +7,17 @@ import {
 } from '../shared/desktopShellMessages.js';
 import { buildDesktopOnboardingSetStateMessage } from '../shared/desktopOnboardingMessages.js';
 import {
-  createDesktopErrorReporter,
-  type DesktopCommandMessage,
-  type DesktopMessageHandler,
-  type DesktopRenderer,
-} from './desktopIpcTypes.js';
-import {
   DESKTOP_DOCS_URL,
   DESKTOP_SHELL_IPC_COMMANDS,
   dispatchDesktopCommand,
   postDesktopSettingsView,
   type DesktopCommandActions,
 } from '../shared/desktopCommandSurface.js';
+import type {
+  DesktopCommandMessage,
+  DesktopMessageHandler,
+  DesktopRenderer,
+} from './desktopIpcTypes.js';
 
 interface DesktopShellActionFactoryOptions extends Pick<
   MessageHost,
@@ -30,7 +29,7 @@ interface DesktopShellActionFactoryOptions extends Pick<
   openPath(filePath: string): Promise<void>;
   openWorkspaceFolder(): Promise<void>;
   signIn(): Promise<void>;
-  onAsyncError?: (error: unknown) => void;
+  onAsyncError: (error: unknown) => void;
 }
 
 /**
@@ -47,7 +46,7 @@ export function createDesktopShellActions(
   renderer: DesktopRenderer,
   options: DesktopShellActionFactoryOptions,
 ): DesktopShellActions {
-  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
+  const reportAsyncError = options.onAsyncError;
 
   function openWorkbench(kind: DesktopWorkbenchKind) {
     renderer.postToRenderer({

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -29,8 +29,6 @@ type DesktopToolEditApprovalUi = Pick<
 
 interface DesktopToolEditApprovalHostOptions {
   ui: DesktopToolEditApprovalUi;
-  /** Parent directory for per-request temp directories; defaults to the OS temp dir. */
-  tempRoot?: string;
 }
 
 export class DesktopToolEditApprovalHost implements ToolEditApprovalHost {
@@ -44,10 +42,7 @@ export class DesktopToolEditApprovalHost implements ToolEditApprovalHost {
     request: ToolEditApprovalRequest,
     context: ToolEditPreviewContext,
   ): Promise<ToolEditPreview> {
-    const tempDir = await createTexraTempDir(
-      'texra-tool-edit-',
-      this.options.tempRoot,
-    );
+    const tempDir = await createTexraTempDir('texra-tool-edit-');
     const { originalPath, proposedPath } = await effectRuntime().runPromise(
       writeApprovalTempFiles({
         directory: tempDir,

--- a/packages/desktop/src/main/desktopWorkspaceIpc.ts
+++ b/packages/desktop/src/main/desktopWorkspaceIpc.ts
@@ -55,8 +55,8 @@ interface DesktopWorkspaceIpcOptions {
    * session; the window's own paper is what a re-list decision compares to.
    */
   getWorkspacePath(): string | undefined;
-  getEnvironmentSummary?(): Promise<DesktopEnvironmentSummary>;
-  onAsyncError?(error: unknown): void;
+  getEnvironmentSummary(): Promise<DesktopEnvironmentSummary>;
+  onAsyncError(error: unknown): void;
 }
 
 interface DesktopWorkspaceIpc extends DesktopMessageHandler {
@@ -176,7 +176,7 @@ export function createDesktopWorkspaceIpc(
   renderer: DesktopRenderer,
   options: DesktopWorkspaceIpcOptions,
 ): DesktopWorkspaceIpc {
-  const reportError = (error: unknown) => options.onAsyncError?.(error);
+  const reportError = (error: unknown) => options.onAsyncError(error);
 
   // Accepted run outputs and accepted LaTeX diffs write straight to disk, past
   // the editor's own write path, and the file tree caches its listing — so
@@ -413,10 +413,6 @@ export function createDesktopWorkspaceIpc(
               command: DESKTOP_WORKSPACE_COMMANDS.ENVIRONMENT_STATE,
               environment,
             });
-          if (!options.getEnvironmentSummary) {
-            postEnvironment(EMPTY_DESKTOP_ENVIRONMENT_SUMMARY);
-            return true;
-          }
           void options
             .getEnvironmentSummary()
             .then(postEnvironment)

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -15,7 +15,7 @@ import {
 
 import { Cause, Effect, Exit, SubscriptionRef } from 'effect';
 import { z } from 'zod';
-import { runInSession } from '@agent/runtime';
+import { presentAgentFailure, runInSession } from '@agent/runtime';
 import {
   computeAgentOptionsData,
   getAgentsByCategory,
@@ -26,7 +26,6 @@ import {
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { hostPort } from '@common/hostPort';
 import {
-  agentErrorPresentation,
   classifyAgentError,
   primaryAgentError,
 } from '@common/errors/agentErrorClassification';
@@ -1243,10 +1242,6 @@ function createWindow(options: {
       // logic can't drift between them.
       hasCredential: () =>
         hasUsableSetupCredential(options.secrets, credentialLog.warn),
-      // The setup card launches its own request (`kickoffSetup` below), so
-      // the launcher's agent selection, which is the surface's (PRD 9),
-      // is not moved from here.
-      selectSetupAgent: async () => {},
       // Launch the setup conversation when the user clicks "Run Setup" on the
       // setup card, mirroring the extension's `launchSetupAssistant` →
       // launch path: resolve a model the user's credentials can call,
@@ -1294,31 +1289,23 @@ function createWindow(options: {
                 if (error instanceof Cancelled) return;
                 // Setup continues after its initiating request has completed.
                 const primaryError = primaryAgentError(error);
-                const presentation = agentErrorPresentation({
-                  kind: classifyAgentError(primaryError),
-                  message:
-                    primaryError instanceof Rejected
-                      ? primaryError.reason
-                      : toErrorMessage(primaryError),
-                });
-                if (
-                  presentation?.type === 'instruction' ||
-                  presentation?.type === 'error'
-                ) {
-                  yield* Effect.tryPromise({
-                    try: () =>
-                      Promise.resolve(
-                        setupSession.interactions.emit(
-                          presentation.type === 'instruction'
-                            ? 'requestShowInstruction'
-                            : 'requestShowError',
-                          presentation.payload,
-                          { replayWhenAttached: true },
-                        ),
+                yield* Effect.tryPromise({
+                  try: () =>
+                    Promise.resolve(
+                      presentAgentFailure(
+                        setupSession.interactions,
+                        {
+                          kind: classifyAgentError(primaryError),
+                          message:
+                            primaryError instanceof Rejected
+                              ? primaryError.reason
+                              : toErrorMessage(primaryError),
+                        },
+                        { replayWhenAttached: true },
                       ),
-                    catch: (emitError) => emitError,
-                  });
-                }
+                    ),
+                  catch: (emitError) => emitError,
+                });
                 return yield* Effect.fail(error);
               }),
             ),

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -75,6 +75,7 @@ export { classifyRun } from './runClassification';
 // terminalResultToast
 export {
   attachTerminalResultToast,
+  presentAgentFailure,
   trackTerminalResultPresentation,
 } from './terminalResultToast';
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -95,8 +95,6 @@ export type {
   RuntimePresentationEventPayloads,
 } from './runtimePresentationEvents';
 
-// textEnhancement
-
 // selectAutoOpenFinalOutput
 export { selectAutoOpenFinalOutput } from './selectAutoOpenFinalOutput';
 

--- a/src/agent/runtime/terminalResultToast.ts
+++ b/src/agent/runtime/terminalResultToast.ts
@@ -50,6 +50,24 @@ export function trackTerminalResultPresentation(
   };
 }
 
+/**
+ * Present a classified failure on a host: its instruction (a missing API key)
+ * or its error toast. An abort presents nothing. Returns what the host's emit
+ * returned, so a caller can await a host that settles once it is on screen.
+ */
+export function presentAgentFailure(
+  interactions: SessionHostInteractions,
+  error: Parameters<typeof agentErrorPresentation>[0],
+  options: { replayWhenAttached?: boolean } = {},
+): unknown {
+  const toast = agentErrorPresentation(error);
+  if (toast?.type === 'instruction')
+    return interactions.emit('requestShowInstruction', toast.payload, options);
+  if (toast?.type === 'error')
+    return interactions.emit('requestShowError', toast.payload, options);
+  return undefined;
+}
+
 /** Returns a detach disposer; callers detach when the run/host tears down. */
 export function attachTerminalResultToast(
   session: SessionHandle,
@@ -58,11 +76,6 @@ export function attachTerminalResultToast(
 ): () => void {
   return session.onResult((event) => {
     if (!event.error || isChildResult(session, event)) return;
-    const toast = agentErrorPresentation(event.error);
-    if (toast?.type === 'instruction') {
-      interactions.emit('requestShowInstruction', toast.payload, options);
-    } else if (toast?.type === 'error') {
-      interactions.emit('requestShowError', toast.payload, options);
-    }
+    presentAgentFailure(interactions, event.error, options);
   });
 }

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
@@ -234,10 +234,9 @@ describe('desktop IPC adapters', () => {
 
   it('serializes overlapping funnel refreshes to one consistent terminal state', async () => {
     // A credential probe that resolves on the next macrotask, so two refreshes
-    // started back-to-back genuinely overlap in flight. If they interleaved,
-    // both would compute against `previous === undefined` and each report a
-    // change. Serialized, the second refresh sees `previous === 'setup'` and
-    // reports none.
+    // started back-to-back genuinely overlap in flight. Serialized, the
+    // second refresh sees `previous === 'setup'` and reports no change. (The
+    // assertion pins the terminal state; it is not a strict interleave probe.)
     let credentialPresent = false;
     const hasCredential = vi.fn(
       () =>
@@ -257,8 +256,7 @@ describe('desktop IPC adapters', () => {
     await Promise.all([first, second]);
     await flushAsync();
 
-    // One change, to setup: proof the refreshes did not interleave and
-    // clobber `previousFunnelState`.
+    // One change, to setup.
     expect(funnelStates).toEqual(['setup']);
   });
 });

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
@@ -54,6 +54,7 @@ async function createShellHarness(
       openWorkspaceFolder: vi.fn(async () => {}),
       signIn: vi.fn(async () => {}),
       showInfoMessage: vi.fn(),
+      onAsyncError: vi.fn(),
       ...overrides,
     },
   );
@@ -83,9 +84,9 @@ async function createOnboardingHarness({
     { postToRenderer },
     {
       hasCredential: () => false,
-      selectSetupAgent: async () => {},
       kickoffSetup: async () => {},
       signInWithChatGpt: async () => {},
+      onAsyncError: vi.fn(),
       ...options,
       state,
     },
@@ -174,18 +175,14 @@ describe('desktop IPC adapters', () => {
   });
 
   it('derives State 1 (setup) when hasCredential is true on fresh install', async () => {
-    const selectSetupAgent = vi.fn(async () => {});
     const { onboarding } = await createOnboardingHarness({
       hasCredential: () => true,
-      selectSetupAgent,
     });
 
     await onboarding.refreshOnboardingFunnel();
     await flushAsync();
     // Credential present, firstRunDone not set: State 1 (setup card).
     expectFunnelState(onboarding, 'setup');
-    // selectSetupAgent callback fires on State 1 entry.
-    expect(selectSetupAgent).toHaveBeenCalled();
   });
 
   it('derives State 2 (done) for backfilled veterans with firstRunDone set', async () => {
@@ -220,39 +217,27 @@ describe('desktop IPC adapters', () => {
   });
 
   it('runs the real kickoff path on runSetup and refreshes after', async () => {
-    const callOrder: string[] = [];
-    const selectSetupAgent = vi.fn(async () => {
-      callOrder.push('select');
-    });
-    const kickoffSetup = vi.fn(async () => {
-      callOrder.push('kickoff');
-    });
+    const kickoffSetup = vi.fn(async () => {});
     const { onboarding } = await createOnboardingHarness({
       hasCredential: () => true,
-      selectSetupAgent,
       kickoffSetup,
     });
 
     await onboarding.runSetup();
     await flushAsync();
 
-    // Real run-setup path: `runSetup` selects the setup agent and kicks off the
-    // conversation, then recomputes the funnel. The follow-up refresh enters
-    // State 1 (credential present) so it also selects the setup agent — hence
-    // `select` fires twice, framing `kickoff`. The terminal state is 'setup'.
+    // Real run-setup path: `runSetup` kicks off the conversation, then
+    // recomputes the funnel, which enters State 1 (credential present).
     expect(kickoffSetup).toHaveBeenCalledOnce();
-    expect(selectSetupAgent).toHaveBeenCalledTimes(2);
-    expect(callOrder).toEqual(['select', 'kickoff', 'select']);
     expectFunnelState(onboarding, 'setup');
   });
 
   it('serializes overlapping funnel refreshes to one consistent terminal state', async () => {
     // A credential probe that resolves on the next macrotask, so two refreshes
-    // started back-to-back genuinely overlap in flight. `selectSetupAgent`
-    // would only fire when `previous !== 'setup'`; if the two refreshes
-    // interleaved and both computed against `previous === undefined`, it would
-    // be called twice. Serialized, the second refresh sees `previous === 'setup'`
-    // and does not re-select.
+    // started back-to-back genuinely overlap in flight. If they interleaved,
+    // both would compute against `previous === undefined` and each report a
+    // change. Serialized, the second refresh sees `previous === 'setup'` and
+    // reports none.
     let credentialPresent = false;
     const hasCredential = vi.fn(
       () =>
@@ -260,26 +245,20 @@ describe('desktop IPC adapters', () => {
           setTimeout(() => resolve(credentialPresent), 0);
         }),
     );
-    const selectSetupAgent = vi.fn(async () => {});
-    const { onboarding } = await createOnboardingHarness({
-      hasCredential,
-      selectSetupAgent,
-    });
+    const { onboarding } = await createOnboardingHarness({ hasCredential });
     const funnelStates: string[] = [];
     onboarding.onFunnelChange((state) => funnelStates.push(state));
 
-    // First refresh: no credential yet, needs-credential. Second refresh: a
-    // credential lands, setup. Fire them overlapping (no await between).
+    // Fire them overlapping (no await between); the credential lands before
+    // either probe resolves.
     const first = onboarding.refreshOnboardingFunnel();
     credentialPresent = true;
     const second = onboarding.refreshOnboardingFunnel();
     await Promise.all([first, second]);
     await flushAsync();
 
-    // The terminal state is consistent (setup), and the State 0 to 1
-    // transition selected the setup agent exactly once: proof the refreshes
-    // did not interleave and clobber `previousFunnelState`.
-    expect(funnelStates.at(-1)).toBe('setup');
-    expect(selectSetupAgent).toHaveBeenCalledOnce();
+    // One change, to setup: proof the refreshes did not interleave and
+    // clobber `previousFunnelState`.
+    expect(funnelStates).toEqual(['setup']);
   });
 });

--- a/src/test-kernel/desktop/DesktopPtyHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopPtyHost.vitest.ts
@@ -49,6 +49,7 @@ function createHost(
   return createDesktopPtyHost({
     onData: vi.fn(),
     onExit: vi.fn(),
+    onError: vi.fn(),
     ...overrides,
   });
 }

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -53,13 +53,6 @@ async function pathExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-/** Polls until `dir` is empty; fails the test if cleanup never completes. */
-async function waitForEmptyDir(dir: string): Promise<void> {
-  await vi.waitFor(async () => {
-    expect(await readdir(dir)).toEqual([]);
-  });
 }
 
 async function loadApprovalModules(workspacePath = '/workspace') {
@@ -178,12 +171,10 @@ async function createApprovalFixture(
     workspacePath?: string;
   } = {},
 ) {
-  const tempRoot = await createTempRoot();
   const modules = await loadApprovalModules(options.workspacePath);
   const session = disposeAfterTest(createTestSession());
   const host = new modules.desktopModule.DesktopToolEditApprovalHost({
     ui: options.ui ?? createStubDesktopAgentRunHost(),
-    tempRoot,
   });
   const stagePreview = vi.spyOn(host, 'stagePreview');
   const controller = disposeAfterTest(
@@ -201,7 +192,18 @@ async function createApprovalFixture(
     ...modules,
     controller,
     session,
-    tempRoot,
+    /** Waits until every staged preview's directory has been removed. */
+    async waitForStagedCleanup() {
+      await vi.waitFor(async () => {
+        const previews = await Promise.all(
+          stagePreview.mock.results.map(({ value }) => value),
+        );
+        for (const preview of previews)
+          await expect(
+            pathExists(path.dirname(preview.proposedPath)),
+          ).resolves.toBe(false);
+      });
+    },
     async waitForPreviews(count = 1) {
       await vi.waitFor(() => expect(stagePreview).toHaveBeenCalledTimes(count));
       await Promise.all(stagePreview.mock.results.map(({ value }) => value));
@@ -553,7 +555,7 @@ describe('desktop tool edit approval', () => {
   approvalTest(
     'cleans up a run approval cancelled during initialization',
     async () => {
-      const { requestToolEditApproval, controller, tempRoot } =
+      const { requestToolEditApproval, controller, waitForStagedCleanup } =
         await createApprovalFixture();
 
       const resultPromise = requestToolEditApproval({
@@ -573,14 +575,14 @@ describe('desktop tool edit approval', () => {
         action: 'reject',
         cause: 'Owning run ended.',
       });
-      await waitForEmptyDir(tempRoot);
+      await waitForStagedCleanup();
     },
   );
 
   approvalTest(
     'cleans up an approval when disposed during initialization',
     async () => {
-      const { requestToolEditApproval, controller, tempRoot } =
+      const { requestToolEditApproval, controller, waitForStagedCleanup } =
         await createApprovalFixture();
 
       const resultPromise = requestToolEditApproval({
@@ -596,15 +598,19 @@ describe('desktop tool edit approval', () => {
         action: 'reject',
         cause: SESSION_DISPOSED_CAUSE,
       });
-      await waitForEmptyDir(tempRoot);
+      await waitForStagedCleanup();
     },
   );
 
   approvalTest(
     'cancels only tool-edit approvals selected for the owning run',
     async () => {
-      const { requestToolEditApproval, controller, waitForPreviews, tempRoot } =
-        await createApprovalFixture();
+      const {
+        requestToolEditApproval,
+        controller,
+        waitForPreviews,
+        waitForStagedCleanup,
+      } = await createApprovalFixture();
 
       const cancelledPromise = requestToolEditApproval({
         path: '/workspace/cancelled.tex',
@@ -651,7 +657,7 @@ describe('desktop tool edit approval', () => {
         action: 'reject',
         feedback: 'Retained request resolved normally.',
       });
-      await waitForEmptyDir(tempRoot);
+      await waitForStagedCleanup();
     },
   );
 
@@ -663,7 +669,7 @@ describe('desktop tool edit approval', () => {
         controller,
         waitForPreviews,
         session,
-        tempRoot,
+        waitForStagedCleanup,
       } = await createApprovalFixture();
       session.interactions.use({
         requestToolEditApproval: (request) =>
@@ -691,8 +697,7 @@ describe('desktop tool edit approval', () => {
         action: 'reject',
         cause: 'Stream resources released.',
       });
-      await waitForEmptyDir(tempRoot);
-      expect(await readdir(tempRoot)).toEqual([]);
+      await waitForStagedCleanup();
     },
   );
 });

--- a/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.ts
@@ -61,6 +61,8 @@ function createIpc(
     browserViews: createBrowserViews(),
     toWindowBounds: (bounds) => bounds,
     getWorkspacePath: () => workspacePath,
+    getEnvironmentSummary: async () => EMPTY_DESKTOP_ENVIRONMENT_SUMMARY,
+    onAsyncError: vi.fn(),
     ...overrides,
   };
   const ipc = createDesktopWorkspaceIpc({ postToRenderer }, options);

--- a/src/utils/files/tempDir.ts
+++ b/src/utils/files/tempDir.ts
@@ -2,10 +2,7 @@ import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-/** Create a fresh temp directory under `root` (default OS tmpdir) with `prefix`. */
-export async function createTexraTempDir(
-  prefix: string,
-  root?: string,
-): Promise<string> {
-  return mkdtemp(path.join(root ?? tmpdir(), prefix));
+/** Create a fresh temp directory under the OS tmpdir with `prefix`. */
+export async function createTexraTempDir(prefix: string): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), prefix));
 }


### PR DESCRIPTION
## Summary

**D01-6: one agent-failure presentation.** `presentAgentFailure(interactions, { kind, message }, options)` in `src/agent/runtime/terminalResultToast.ts` turns a classified failure into its instruction or error toast and emits it. It is exported through the existing `@agent/runtime` barrel, so hosts gain no new deep-import specifier. It returns what the host's `emit` returned, so a caller can await it. `attachTerminalResultToast` calls it, and so do the four hand-rolled desktop classify-then-emit forks:
- the merge-run failure and the request failure in `desktopHostRequests.ts`;
- the resume failure in `desktopAgentResume.ts`;
- the setup kickoff in `main/index.ts`.

Each site still builds its own message (a Rejected/Unavailable reason, or `Merge failed:` / `Resume failed:` plus the error message).

**D17-5: optional or no-op desktop ports that production always passes or never uses.**
- **Now required:** `onAsyncError` / `onError` on the log, navigation-policy, onboarding, shell, browser-view, pty and workspace IPCs, and `getEnvironmentSummary` on the workspace IPC. Their absence branches and `?.` calls are gone.
- **`createDesktopErrorReporter`:** deleted, along with its unreachable `defaultReportError` console fallback. Settings, the one caller that routes `UnsupportedCommandError` to an info dialog, inlines that check. The other callers use their sink directly.
- **`selectSetupAgent`:** the no-op onboarding option and its two awaits are deleted. The shared funnel's `transition.selectSetupAgent` stays because the extension reads it. Desktop now discards that transition, as the CLI does. The host-shared-controllers proposal is updated to match.
- **`tempRoot`:** the test-only option on `DesktopToolEditApprovalHost` is gone, and so is `createTexraTempDir`'s `root` parameter, which no longer has a caller. The suite now checks cleanup through each staged preview's directory, `dirname(proposedPath)`.

**D03-8 (remaining part): delete the stray barrel comment.** The `// textEnhancement` comment in `src/agent/runtime/index.ts` labels nothing. coauthor-dc handed this part over because this branch already holds the file.

**Skipped, with reasons:**
- **D17-1 (no-workspace fallback session):** the premise is false. The renderer creates a workbench for the fallback's `activeKey`, so the full shell renders around the conversation-pane placeholder. Settings, the command palette, logs, terminal and the startup panel are all reachable before a folder opens. Deleting the fallback would be a behavior change.
- **D17-6:** cosmetic, and scoped to land only alongside D17-1.
- **Desktop `projects.close` → owner `closeSession`:** not behavior-preserving. The owner's close is budgeted to `SHUTDOWN_PHASE_DEADLINE_MS` (5 s) and releases an overrunning session later. Desktop's stop is deliberately unbounded, so the project stays stoppable and visible until its runs end.

## Net elements (R6)
- **Files:** 21. That is 13 desktop main files, 2 in `src/agent/runtime`, 1 in `src/utils/files`, 4 test-kernel suites adapted (no new tests), and 1 proposed-doc correction.
- **Exported symbols** (`^[+-]export` lines): −2 / +2.
  - Deleted: `createDesktopErrorReporter`.
  - Added: `presentAgentFailure`.
  - `createTexraTempDir` changed signature (the `root` parameter is gone), which accounts for the other −1/+1 line.
- **Class/interface/enum declarations:** 0 added, 0 removed.
- **Net LOC** (`git diff --shortstat origin/main...HEAD`): 21 files changed, +174 / −261 (net −87).

## Consumer counts (R8)
| Symbol | Consumers before | Consumers after |
|---|---|---|
| `createDesktopErrorReporter` | 5 production callers (desktopLogIpc, desktopNavigationPolicy, desktopOnboardingIpc, desktopSettingsIpc, desktopShellIpc) | 0 (settings inlines the unsupported-command routing) |
| `defaultReportError` | 1 (reached only when `onError` was omitted, which no production caller did) | 0 |
| `DesktopOnboardingIpcOptions.selectSetupAgent` | 1 production value (`async () => {}` in index.ts) and 2 awaits | 0 |
| `DesktopToolEditApprovalHost` `tempRoot` | 0 in production; 2 sites in DesktopToolEditApproval.vitest | 0 |
| `createTexraTempDir(prefix, root)` `root` argument | 1 caller passed it (desktopToolEditApproval) | 0 (all 5 production callers pass only the prefix) |
| `agentErrorPresentation(` desktop call sites | 4 | 0 |
| `presentAgentFailure` (new) | n/a | 5 (desktopHostRequests ×2, desktopAgentResume, main/index.ts, `attachTerminalResultToast`) |

No emit path or command was deleted.

## Gates
All gates ran through the coordination gate on base `7f23e2c92b`, after reinstalling for main's Effect 4.0.0-rc.113 and vitest 5.0.0 bumps.
- **`npm run typecheck`** (`CI=true`): PASS, `GATE_EXIT=0`, every per-package tsconfig.
- **`npm run lint`** (repo-wide): PASS, `GATE_EXIT=0`.
- **`vitest run --changed origin/main`** (`FORCE_COLOR=0`): PASS. 135/135 files, 1862 passed, 1 skipped.
- **`npm run check:dead-code-ratchet`**: PASS, "no new findings" (239 vs 239 baselined). The baseline did not change.
- **`npm run format` + `npx prettier --check .`**: PASS, no files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Re-gated after rebase
The full local gate set in **Gates** above passed on the pre-rebase base. The branch then rebased onto origin/main `6a60507630` without conflicts (HEAD `beeb3b638a`,  21 files changed, 174 insertions(+), 263 deletions(-)). After the rebase, the Effect migration ratchet and `prettier --check` over the changed files were re-run locally and pass. The post-rebase typecheck, lint and tests are left to CI: local re-runs were killed by machine memory pressure (about ten concurrent sessions). **Opened as a draft; it is marked ready only once CI is green.**
Open PRs touching the same files: #12265 
