### PR TITLE
refactor: drop the invariant run-finalize params (1.0 clean slate)

### DIFF
--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -50,9 +50,7 @@ import {
   type AgentFlowResult,
 } from './AgentFlowResult';
 import type { SessionHandle } from './SessionHandle';
-import type { RunRegistry } from './runRegistry';
 import type { AgentLaunchContext } from './AgentLaunchContext';
-import type { RunStatusMachine } from './RunStatusService';
 
 const logger = createChannelTrace('agentRunLifecycle');
 
@@ -103,13 +101,16 @@ export interface FlowLifecycleControl {
 }
 
 interface FinalizeRunTerminalParams {
+  /**
+   * Owns the registry tracking the handle (untracked after the delivery
+   * hook), the status machine holding this run's in-memory phase
+   * (terminalized last), and the display sidecars drained before the
+   * `run.end` row is written — so a waiter that opens the completed-run
+   * archive does not race the final transcript or work-plan write.
+   */
   readonly session: SessionHandle;
   /** Live handle for this terminal attempt; its settled flag is the exactly-once guard. */
   readonly handle: RunHandle;
-  /** Registry tracking the handle; untracked after the delivery hook runs. */
-  readonly runs: Pick<RunRegistry, 'untrack'>;
-  /** Status machine owning this run's in-memory phase; terminalized last. */
-  readonly runStatus: RunStatusMachine;
   /**
    * The exiting run's own report. The `run.end` row is the run's terminal
    * fact; the in-memory run phase only supplies stop precedence, so this
@@ -135,13 +136,6 @@ interface FinalizeRunTerminalParams {
   readonly stage?: Pick<StageHandle, 'end'>;
   /** The flow-record policy the storage finalizer applies beside the row. */
   readonly flowRecord: FlowRecordRetention;
-  /**
-   * Drain display sidecars before the `run.end` row is written. This keeps
-   * a waiter that immediately opens the completed-run archive from racing the
-   * final transcript or work-plan write. Failures are logged here and retried
-   * by the run-ownership release boundary.
-   */
-  readonly flushArtifacts?: () => Promise<void>;
   /**
    * Delivery hook (subagent onError) run after the result settles and before
    * untrack, so the parent still sees this child as active while the
@@ -173,7 +167,7 @@ interface FinalizeRunTerminalResult {
 export const finalizeRunTerminal = Effect.fn('finalizeRunTerminal')(function* (
   params: FinalizeRunTerminalParams,
 ): Effect.fn.Return<FinalizeRunTerminalResult | undefined, Error> {
-  const { handle } = params;
+  const { session, handle } = params;
   if (!handle.claimTerminalFinalize()) return undefined;
   // The `run.end` row written below is the run's terminal fact; the
   // in-memory run phase supplies the stop precedence read here, so
@@ -183,7 +177,7 @@ export const finalizeRunTerminal = Effect.fn('finalizeRunTerminal')(function* (
   // arrived after it. Resolving once here is what lets every projection below
   // (stage end, the `run.end` row, terminal phase) read one value, so no
   // caller has to cross-check the phase for itself.
-  const observedPhase = params.runStatus.get(handle.runId);
+  const observedPhase = session.status.get(handle.runId);
   const outcome = isTerminalOutcomePhase(observedPhase)
     ? observedPhase
     : params.outcome;
@@ -206,20 +200,20 @@ export const finalizeRunTerminal = Effect.fn('finalizeRunTerminal')(function* (
       ),
     );
   }
-  if (params.flushArtifacts) {
-    yield* Effect.tryPromise({
-      try: params.flushArtifacts,
-      catch: ensureError,
-    }).pipe(
-      Effect.catch((artifactError) =>
-        Effect.sync(() => {
-          logger.warn('Failed to persist pre-terminal display artifacts', {
-            data: { runId: handle.runId, error: artifactError },
-          });
-        }),
-      ),
-    );
-  }
+  // A drain failure is logged here and retried by the run-ownership release
+  // boundary.
+  yield* Effect.tryPromise({
+    try: () => session.flushArtifacts(),
+    catch: ensureError,
+  }).pipe(
+    Effect.catch((artifactError) =>
+      Effect.sync(() => {
+        logger.warn('Failed to persist pre-terminal display artifacts', {
+          data: { runId: handle.runId, error: artifactError },
+        });
+      }),
+    ),
+  );
   // Write the terminal row BEFORE untrack so the registry's terminal listener
   // event never precedes it, and settle the handle's `result` promise with
   // the same fact (F-2: per-run control handle). The row carries the
@@ -234,7 +228,7 @@ export const finalizeRunTerminal = Effect.fn('finalizeRunTerminal')(function* (
     output,
   };
   const { flowRecord } = params;
-  const finalization = yield* finalizeRun(params.session, {
+  const finalization = yield* finalizeRun(session, {
     runId: handle.runId,
     outcome,
     error,
@@ -274,13 +268,13 @@ export const finalizeRunTerminal = Effect.fn('finalizeRunTerminal')(function* (
   // escape past an already-settled result.
   yield* Effect.try({
     try: () => {
-      params.runs.untrack(handle.runId);
+      session.runs.untrack(handle.runId);
       // Refused only when the phase turned terminal after the resolution above,
       // i.e. a stop that landed across this function's own awaits. The phase
       // keeps its own value; the divergence from the written row is real and
       // must stay loud.
       if (
-        !params.runStatus.transitionToTerminal(
+        !session.status.transitionToTerminal(
           handle.runId,
           outcome,
           RUN_TRANSITION_CAUSE.LIFECYCLE,
@@ -537,11 +531,8 @@ export const runFlowWithLifecycle = Effect.fn('runFlowWithLifecycle')(
       finalizeRunTerminal({
         session,
         handle,
-        runs: session.runs,
-        runStatus: session.status,
         usage: ctx.usageMonitor.lastTotals(),
         stage: ctx.parentStage,
-        flushArtifacts: () => session.flushArtifacts(),
         // Tool-use flows report the exact recovery decision through the
         // private lifecycle control. Other flows retain the historical
         // policy, read against the outcome finalization resolves rather

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -1151,8 +1151,6 @@ export function startChildRunLoop<TTurn>(
               yield* finalizeRunTerminal({
                 session: runSession,
                 handle,
-                runs: runSession.runs,
-                runStatus: runSession.status,
                 outcome,
                 error:
                   sawTurnFailure && lastTurnErr !== undefined
@@ -1161,7 +1159,6 @@ export function startChildRunLoop<TTurn>(
                         message: toErrorMessage(lastTurnErr),
                       }
                     : undefined,
-                flushArtifacts: () => runSession.flushArtifacts(),
                 flowRecord: retainFlowRecordUnlessCompleted,
               });
             }

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -12,7 +12,10 @@ import {
 } from '@agent/storage/runLease';
 import { RunStatusMachine } from '@agent/runtime/RunStatusService';
 import { RunHandle, type AgentRunHandle } from '@agent/runtime/RunHandle';
-import { defaultSession } from '@agent/runtime/SessionHandle';
+import {
+  defaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import {
   finalizeRunTerminal,
   runFlowWithLifecycle,
@@ -1127,28 +1130,39 @@ describe('runFlowWithLifecycle', () => {
   });
 });
 
-/** The handle, status machine, and untrack spy every finalize test drives. */
+/** The session fake, handle, status machine, and spies every finalize test drives. */
 function finalizeFixture(): {
   runId: RunId;
+  session: SessionHandle;
   runStatus: RunStatusMachine;
   handle: ReturnType<typeof testRunHandle>;
   untrack: Mock<(runId: RunId) => void>;
+  flushArtifacts: Mock<() => Promise<void>>;
 } {
   const runId =
     `f${(finalizeFixtureCounter++).toString(16).padStart(5, '0')}` as RunId;
+  const runStatus = new RunStatusMachine(
+    () => {},
+    () => {},
+  );
+  const untrack = vi.fn<(runId: RunId) => void>();
+  const flushArtifacts = vi.fn(async () => {});
   return {
     runId,
-    runStatus: new RunStatusMachine(
-      () => {},
-      () => {},
-    ),
+    session: {
+      runs: { untrack },
+      status: runStatus,
+      flushArtifacts,
+    } as unknown as SessionHandle,
+    runStatus,
+    untrack,
+    flushArtifacts,
     handle: testRunHandle({
       runId,
       parent: PARENT_RUN_ID,
       agent: 'test-agent',
       trace: noopTrace,
     }),
-    untrack: vi.fn<(runId: RunId) => void>(),
   };
 }
 
@@ -1161,7 +1175,7 @@ describe('finalizeRunTerminal', () => {
   // handle) would otherwise both pass the check before the first settles and
   // double-publish persist/emit/settle/untrack.
   it('finalizes exactly once when two callers race across the persist await', async () => {
-    const { runId, runStatus, handle, untrack } = finalizeFixture();
+    const { runId, session, runStatus, handle, untrack } = finalizeFixture();
     // Park the first caller at its persist await so the second caller arrives
     // while the first has not yet emitted or settled anything.
     const parked = parkNextFinalize();
@@ -1171,10 +1185,8 @@ describe('finalizeRunTerminal', () => {
         phase: RUN_PHASE.RUNNING,
       });
       const params = {
-        session: defaultSession(),
+        session,
         handle,
-        runs: { untrack },
-        runStatus,
         outcome: RUN_OUTCOME.COMPLETED,
         flowRecord: 'delete',
       } as const;
@@ -1209,9 +1221,10 @@ describe('finalizeRunTerminal', () => {
   });
 
   it('flushes display artifacts before publishing and untracking', async () => {
-    const { runId, runStatus, handle, untrack } = finalizeFixture();
+    const { runId, session, runStatus, handle, untrack, flushArtifacts } =
+      finalizeFixture();
     let releaseFlush: (() => void) | undefined;
-    const flushArtifacts = vi.fn(
+    flushArtifacts.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
           releaseFlush = resolve;
@@ -1228,13 +1241,10 @@ describe('finalizeRunTerminal', () => {
       });
       const finalization = Effect.runPromise(
         finalizeRunTerminal({
-          session: defaultSession(),
+          session,
           handle,
-          runs: { untrack },
-          runStatus,
           outcome: RUN_OUTCOME.COMPLETED,
           flowRecord: 'preserve',
-          flushArtifacts,
         }),
       );
 
@@ -1254,7 +1264,7 @@ describe('finalizeRunTerminal', () => {
   });
 
   it('settles and untracks once while reporting terminal metadata failure', async () => {
-    const { runId, runStatus, handle, untrack } = finalizeFixture();
+    const { runId, session, runStatus, handle, untrack } = finalizeFixture();
     const durabilityError = new Error('metadata disk write failed');
     storageMocks.finalizeRun.mockReturnValueOnce(
       Effect.succeed({
@@ -1271,10 +1281,8 @@ describe('finalizeRunTerminal', () => {
 
       const event = await Effect.runPromise(
         finalizeRunTerminal({
-          session: defaultSession(),
+          session,
           handle,
-          runs: { untrack },
-          runStatus,
           outcome: RUN_OUTCOME.FAILED,
           flowRecord: 'preserve',
         }),
@@ -1313,7 +1321,7 @@ describe('finalizeRunTerminal', () => {
   // killed then reports its own non-zero exit as a failure — so the phase, not
   // the report, has to decide, and no caller may cross-check it for itself.
   it('resolves the terminal outcome from an already-cancelled stream phase', async () => {
-    const { runId, runStatus, handle, untrack } = finalizeFixture();
+    const { runId, session, runStatus, handle } = finalizeFixture();
     const stage = { end: vi.fn() };
 
     try {
@@ -1323,10 +1331,8 @@ describe('finalizeRunTerminal', () => {
 
       const finalized = await Effect.runPromise(
         finalizeRunTerminal({
-          session: defaultSession(),
+          session,
           handle,
-          runs: { untrack },
-          runStatus,
           outcome: RUN_OUTCOME.FAILED,
           error: { kind: 'unexpected', message: 'exited with code 143' },
           stage,
@@ -1347,7 +1353,7 @@ describe('finalizeRunTerminal', () => {
       );
       expect(stage.end).toHaveBeenCalledExactlyOnceWith(RUN_OUTCOME.CANCELLED);
       expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
-        defaultSession(),
+        session,
         expect.objectContaining({
           outcome: RUN_OUTCOME.CANCELLED,
         }),
@@ -1365,7 +1371,7 @@ describe('finalizeRunTerminal', () => {
   // published FAILED is a terminal fact a later stop cannot rewrite, so a
   // caller reporting `cancelled` does not get to relabel it.
   it('keeps an already-failed stream phase over a later cancelled report', async () => {
-    const { runId, runStatus, handle, untrack } = finalizeFixture();
+    const { runId, session, runStatus, handle } = finalizeFixture();
 
     try {
       seedRunStatusForTest(runStatus, runId, {
@@ -1374,10 +1380,8 @@ describe('finalizeRunTerminal', () => {
 
       const finalized = await Effect.runPromise(
         finalizeRunTerminal({
-          session: defaultSession(),
+          session,
           handle,
-          runs: { untrack },
-          runStatus,
           outcome: RUN_OUTCOME.CANCELLED,
           flowRecord: 'preserve',
         }),

--- a/src/test-kernel/agent/runtime/RunRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunRegistry.vitest.ts
@@ -796,12 +796,15 @@ describe('runRegistry', () => {
         cleanup: teardown,
       });
 
+      const session = {
+        runs: registry,
+        status: runStatus,
+        flushArtifacts: async () => {},
+      } as unknown as SessionHandle;
       const finalized = Effect.runPromise(
         finalizeRunTerminal({
-          session: defaultSession(),
+          session,
           handle,
-          runs: registry,
-          runStatus,
           outcome: RUN_OUTCOME.COMPLETED,
           flowRecord: 'delete',
         }),
@@ -817,7 +820,7 @@ describe('runRegistry', () => {
         outcome: RUN_OUTCOME.COMPLETED,
       });
       expect(storageMocks.finalizeRun).toHaveBeenCalledExactlyOnceWith(
-        defaultSession(),
+        session,
         expect.objectContaining({
           runId,
           outcome: RUN_OUTCOME.COMPLETED,

--- a/src/tools/delegation/childRun.ts
+++ b/src/tools/delegation/childRun.ts
@@ -278,12 +278,9 @@ const finalizeChildRun = Effect.fn('finalizeChildRun')(function* (
   yield* finalizeRunTerminal({
     session,
     handle,
-    runs: session.runs,
-    runStatus: session.status,
     outcome,
     error,
     stage: options.stage,
-    flushArtifacts: () => session.flushArtifacts(),
     flowRecord: options.flowRecord ?? 'preserve',
   });
   disposeTrace();


### PR DESCRIPTION
## Summary

Implements the finalize-params part of **coauthor-2c:agent-runtime#7** (runtime janitorial batch).

`FinalizeRunTerminalParams` carried `runs`, `runStatus` and `flushArtifacts` beside `session`. All three production callers pass the same projections of that session: `runFlowWithLifecycle` (AgentRunLifecycle.ts), the between-turn finalize in `childRunLoop.ts`, and `finalizeChildRun` (`src/tools/delegation/childRun.ts`). Each passes `runs: session.runs`, `runStatus: session.status` and `flushArtifacts: () => session.flushArtifacts()`. S2 (#12246) renamed `executions`/`streamStatus` to `runs`/`runStatus` but kept the fields. The finalizer now reads all three from `params.session`. The artifact drain becomes unconditional, which it already was on every production path. Only tests varied these fields. They now build one session fake: the `AgentRunLifecycle.vitest.ts` fixture plus a local fake in `RunRegistry.vitest.ts`. No tests were added or deleted. The flush-ordering test still covers the drain, now through the session.

**Not in this PR: the `clearHold` reduction.** It needs `RunStatusService.ts` (the `discardRetainedPhase` option) and its caller `resumeRun.ts`. Both files are in open PR #12268 and are claimed pr-open in the coordination ledger. The title keeps the dispatched wording. That half should follow once #12268 lands. At `origin/main`, every production `clearHold` caller still passes `{ discardRetainedPhase: true }`: `resumeRun.ts:288` and `ToolUseFollowUp.ts:243` and `:246`.

## Net elements (R6)

- Production: 3 files, +26 / −41 (net −15). Tests: 2 files, +41 / −34 (net +7). Total: 5 files, net −8.
- Deleted: 3 interface fields (`runs`, `runStatus`, `flushArtifacts`), 9 call-site arguments (3 per caller), 2 type-only imports (`RunRegistry`, `RunStatusMachine`), the `if (params.flushArtifacts)` guard, and 2 per-field doc comments.
- Added: 1 `session` destructure and 1 consolidated doc comment on `session`, which says what the finalizer reads from it. No new abstractions.

## Consumer counts (R8)

- `finalizeRunTerminal({…})`: 3 production callers, all updated. There are 7 test calls (6 in `AgentRunLifecycle.vitest.ts`, 1 in `RunRegistry.vitest.ts`).
- The removed fields had 0 production callers passing a value other than the session's own projection.
- `SessionHandle.flushArtifacts()` is untouched; `SessionHandle.ts` is in #12268. It now has 11 production call sites; the finalizer's is 1 of them.

## Verified

Run in a real-install worktree at `047c88cf6e`, after the rebase. The files this PR touches did not change between the gated base and `047c88cf6e`.

- `npx prettier --check .`: exit 0
- `npx eslint <changed files>`: exit 0
- `env CI=true npm run typecheck` (all per-package tsconfigs): GATE_EXIT=0
- `vitest run --changed origin/main`: 97 files / 1424 tests passed, GATE_EXIT=0
- `vitest run --project pure`: 213 files / 2425 tests passed, GATE_EXIT=0
- `node scripts/check-dead-code-ratchet.mjs`: exit 0 (no new findings)
- `node scripts/check-effect-migration-ratchet.mjs`: exit 0 (no count grew)
- The node_modules symlink check prints nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
