### PR TITLE
refactor: delete RunHandle.result's unawaited Deferred; clearHold always discards the retained phase (1.0 clean slate)

### DIFF
--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -240,10 +240,10 @@ export function recordRunRefusal(
       );
       return 'not_resumable';
     case 'finished':
-      session.status.clearHold(runId, { discardRetainedPhase: true });
+      session.status.clearHold(runId);
       return 'finished';
     case 'resumable':
-      session.status.clearHold(runId, { discardRetainedPhase: true });
+      session.status.clearHold(runId);
       return 'not_resumable';
     case 'unclassified':
       return 'not_resumable';

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -154,9 +154,8 @@ interface FinalizeRunTerminalResult {
  * The single owner of terminal run choreography, shared by the run lifecycle
  * arms below, the agent-CLI session loop, and child runs
  * (`finalizeChildRun`): transcript stage end, the artifact drain, the
- * `run.end` row (through `finalizeRun`, its one writer), the in-memory
- * result settle, the delivery hook, then registry untrack + terminal run
- * phase — in that order. Exactly-once
+ * `run.end` row (through `finalizeRun`, its one writer), the delivery hook,
+ * then registry untrack + terminal run phase — in that order. Exactly-once
  * per handle: the claim below flips synchronously in the same tick as the
  * check, so a second call (e.g. the lifecycle catch arm after the success arm
  * already finalized, or a concurrent finalize racing across this function's
@@ -215,10 +214,9 @@ export const finalizeRunTerminal = Effect.fn('finalizeRunTerminal')(function* (
     ),
   );
   // Write the terminal row BEFORE untrack so the registry's terminal listener
-  // event never precedes it, and settle the handle's `result` promise with
-  // the same fact (F-2: per-run control handle). The row carries the
-  // classified error `kind` (when any), the run usage totals (present once a
-  // round recorded usage, including on failures), and the flow's output.
+  // event never precedes it. The row carries the classified error `kind`
+  // (when any), the run usage totals (present once a round recorded usage,
+  // including on failures), and the flow's output.
   const event: ResultEvent = {
     type: 'run.end',
     outcome,
@@ -247,7 +245,6 @@ export const finalizeRunTerminal = Effect.fn('finalizeRunTerminal')(function* (
       },
     });
   }
-  handle.settleResult(event);
   if (params.deliver) {
     const deliver = params.deliver;
     yield* Effect.tryPromise({
@@ -504,8 +501,8 @@ export const runFlowWithLifecycle = Effect.fn('runFlowWithLifecycle')(
     if (options?.onRun) {
       const onRun = options.onRun;
       // Start observation at the same time as invocation. The callback may
-      // run handle.result to completion, so its observer must not hold up
-      // the flow that settles it.
+      // run as long as the run does, so its observer must not hold up the
+      // flow.
       yield* Effect.tryPromise({
         try: async () => onRun(handle),
         catch: ensureError,

--- a/src/agent/runtime/RunHandle.ts
+++ b/src/agent/runtime/RunHandle.ts
@@ -138,7 +138,7 @@ export class RunHandle<
   constructor(
     /**
      * The run's birth facts, the same object its `run.start` published and its
-     * terminal `result` reports. Held whole rather than copied field by field,
+     * `run.end` row closes. Held whole rather than copied field by field,
      * so the handle and the event plane cannot describe the run differently.
      */
     readonly run: RunFacts,

--- a/src/agent/runtime/RunHandle.ts
+++ b/src/agent/runtime/RunHandle.ts
@@ -6,9 +6,7 @@
  * terminal settlement. Termination policy lives with the owning registry.
  */
 
-import { Deferred, Effect } from 'effect';
-
-import type { AgentTrace, ResultEvent } from '@agent/trace';
+import type { AgentTrace } from '@agent/trace';
 import type { ToolUseFlowContext } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import type {
   AgentCategory,
@@ -17,6 +15,7 @@ import type {
   RunPhase,
 } from '@shared/schemas';
 import { runIdentityName } from '@shared/schemas';
+import type { Effect } from 'effect';
 
 export interface RunStatusInfo {
   status: RunPhase | 'unknown';
@@ -65,17 +64,6 @@ export interface RunInterruptHandler {
 type RunSuspension =
   | { readonly state: 'parked'; readonly teardown: Effect.Effect<void, Error> }
   | { readonly state: 'terminating' };
-
-/**
- * How far the run's exactly-once terminal outcome has progressed.
- *
- * `claimed` is the window between a caller winning {@link
- * RunHandle.claimTerminalFinalize} and the result actually
- * settling; `settled` is reachable directly for the non-lifecycle child runs
- * that settle without claiming. Both refuse a further claim, which is why
- * this is one ordered state rather than two independent flags.
- */
-type TerminalState = 'open' | 'claimed' | 'settled';
 
 /**
  * The projection of the flow's {@link ToolUseFlowContext} that a run handle
@@ -144,20 +132,8 @@ export class RunHandle<
    */
   workflowPhase?: string;
 
-  /**
-   * The run's terminal outcome, settled exactly once (by the run lifecycle, or
-   * by `finalizeChildRun` for non-lifecycle child runs) BEFORE the run is
-   * untracked. It always succeeds — it has no error channel — so a failed run
-   * reports through the `ResultEvent`'s own outcome rather than through a
-   * rejection nobody is required to observe, and a consumer that never awaits
-   * it costs nothing. Awaiting it is a fiber parked on the `Deferred`, so an
-   * interrupted consumer detaches with its fiber. SDK consumers awaiting a
-   * specific run's outcome use this; the host-wide stream is
-   * `session.onResult`.
-   */
-  private readonly _terminal = Deferred.makeUnsafe<ResultEvent>();
-  readonly result: Effect.Effect<ResultEvent> = Deferred.await(this._terminal);
-  private terminalState: TerminalState = 'open';
+  /** Whether a caller has claimed the run's exactly-once terminal outcome. */
+  private terminalClaimed = false;
 
   constructor(
     /**
@@ -191,12 +167,6 @@ export class RunHandle<
     return this.run.category;
   }
 
-  /** Settle {@link result} with the terminal outcome (idempotent). */
-  settleResult(event: ResultEvent): void {
-    this.terminalState = 'settled';
-    Deferred.doneUnsafe(this._terminal, Effect.succeed(event));
-  }
-
   /**
    * Atomically claim the exactly-once terminal finalization of this handle.
    * Returns true for exactly one caller — the flag flips synchronously in the
@@ -207,8 +177,8 @@ export class RunHandle<
    * registry cannot both publish a terminal outcome for one run.
    */
   claimTerminalFinalize(): boolean {
-    if (this.terminalState !== 'open') return false;
-    this.terminalState = 'claimed';
+    if (this.terminalClaimed) return false;
+    this.terminalClaimed = true;
     return true;
   }
 
@@ -345,7 +315,6 @@ export type AgentRunHandle = Pick<
   | 'agentName'
   | 'startedAt'
   | 'trace'
-  | 'result'
   | 'deliveryTarget'
   | 'interrupt'
 >;

--- a/src/agent/runtime/RunStatusService.ts
+++ b/src/agent/runtime/RunStatusService.ts
@@ -237,29 +237,19 @@ export class RunStatusMachine {
   }
 
   /**
-   * Drop a hold, restoring the phase it retained. The callers that open a run
-   * for write call this when they finish without writing a phase — a resume
-   * that reattaches, and a follow-up the session refuses; a `transition` that
-   * does write replaces the hold with the phase it lands on.
+   * Drop a hold together with the phase it retained. The callers that open a
+   * run for write call this when they finish without writing a phase — a
+   * resume that reattaches, and a follow-up the session refuses; a
+   * `transition` that does write replaces the hold with the phase it lands on.
    *
-   * `discardRetainedPhase` drops that retained phase with the hold. A hold
-   * written after a failed tool-use resume carries the WAITING its rollback
-   * left, and a caller that has just re-read the run and found it finished or
-   * merely resumable has disproved that phase: restoring it would show a live
-   * run this process does not have. A caller that learned nothing new about
-   * the phase keeps the default.
+   * A hold written after a failed tool-use resume carries the WAITING its
+   * rollback left, and every caller has just re-read the run and found it
+   * finished or merely resumable, which disproves that phase: restoring it
+   * would show a live run this process does not have.
    */
-  clearHold(
-    runId: RunId,
-    options: { discardRetainedPhase?: boolean } = {},
-  ): void {
-    const entry = this.runs.get(runId);
-    if (entry?.kind !== 'hold') return;
-    if (entry.state && !options.discardRetainedPhase) {
-      this.runs.set(runId, { kind: 'phase', state: entry.state });
-    } else {
-      this.runs.delete(runId);
-    }
+  clearHold(runId: RunId): void {
+    if (this.runs.get(runId)?.kind !== 'hold') return;
+    this.runs.delete(runId);
     this.publishHoldChanged(runId);
   }
 

--- a/src/agent/runtime/resumeRun.ts
+++ b/src/agent/runtime/resumeRun.ts
@@ -285,7 +285,7 @@ const resumeRunWithRecoveryProvenance = Effect.fn(
           catch: ensureError,
         }).pipe(Effect.onError(() => Effect.sync(releaseQueue)))
       : undefined;
-  session.status.clearHold(runId, { discardRetainedPhase: true });
+  session.status.clearHold(runId);
   if (lease?.status === 'held') {
     releaseQueue();
     session.status.markUnavailable(runId, runHeldMessage(lease.owner.pid));

--- a/src/agent/runtime/waitingTermination.ts
+++ b/src/agent/runtime/waitingTermination.ts
@@ -2,13 +2,13 @@
  * Termination cascade for suspended runs.
  *
  * Tears down an `RunHandle` parked at WAITING with no live
- * interrupt context: writes the `run.end` row, settles `handle.result`, and
- * releases the run lease, all on behalf of `RunRegistry.terminate`.
+ * interrupt context: writes the `run.end` row and releases the run lease,
+ * both on behalf of `RunRegistry.terminate`.
  */
 
 import { Cause, Effect, Exit } from 'effect';
 
-import { createChannelTrace, type ResultEvent } from '@agent/trace';
+import { createChannelTrace } from '@agent/trace';
 import { RunLeaseLostError } from '@agent/storage/runLease';
 import {
   type FinalizeRunInput,
@@ -63,43 +63,27 @@ export class WaitingTermination {
    *
    * This path bypasses `runFlowWithLifecycle`'s own terminal handling (the
    * flow never resumes to produce one), so it writes the `run.end` row through
-   * `finalizeRun` and settles `handle.result` itself — otherwise session
-   * subscribers would miss the stop, a consumer awaiting `handle.result` (F-2)
-   * would hang forever, and the run's history would keep a non-terminal
-   * status. Unlike `finalizeRunTerminal`, no usage totals ride the row: the
-   * flow is suspended, so there is no live usage monitor to read.
+   * `finalizeRun` itself — otherwise session subscribers would miss the stop
+   * and the run's history would keep a non-terminal status. Unlike
+   * `finalizeRunTerminal`, no usage totals ride the row: the flow is
+   * suspended, so there is no live usage monitor to read.
    */
   terminateWaitingHandle(handle: RunHandle): Effect.Effect<void> | undefined {
     const teardown = handle.beginSuspendedTermination();
     if (!teardown) return undefined;
-    const cancelledResult: ResultEvent = {
-      type: 'run.end',
-      outcome: RUN_OUTCOME.CANCELLED,
-      runId: handle.runId,
-      output: emptyRunEndOutput(handle.category),
-    };
     return this.context.lanes.holdLive(
       handle.runId,
-      this.finishWaitingTermination(handle, teardown, cancelledResult).pipe(
+      this.finishWaitingTermination(handle, teardown).pipe(
         Effect.catchCause((cause) =>
           Effect.gen({ self: this }, function* () {
             const error = Cause.squash(cause);
             // Durable finalization never ran, so recovery only settles what this
             // generation privately owns. Each step is guarded on its own: a failure
-            // in one must not cost the others. A former generation owns only its
-            // private result, it must not mark, release, untrack, or cancel a
-            // locally reacquired successor, which is what `untrackIfCurrent` gates.
+            // in one must not cost the others. A former generation must not mark,
+            // release, untrack, or cancel a locally reacquired successor, which
+            // is what `untrackIfCurrent` gates.
             const recoveryFailures: unknown[] = [error];
             let untracked = false;
-            const settled = yield* Effect.exit(
-              Effect.try({
-                try: () => handle.settleResult(cancelledResult),
-                catch: ensureError,
-              }),
-            );
-            if (Exit.isFailure(settled)) {
-              recoveryFailures.push(Cause.squash(settled.cause));
-            }
             const untracking = yield* Effect.exit(
               Effect.try({
                 try: () => {
@@ -146,7 +130,6 @@ export class WaitingTermination {
     this: WaitingTermination,
     handle: RunHandle,
     teardown: Effect.Effect<void, Error>,
-    cancelledResult: ResultEvent,
   ) {
     yield* teardown.pipe(
       Effect.catchCause((cause) =>
@@ -164,21 +147,19 @@ export class WaitingTermination {
 
     if (this.context.getHandle(handle.runId) !== handle) {
       // `track` transfers the pending stop to a resumed successor. The old
-      // handle still needs its private result settled, but it no longer owns
-      // the shared stream, run metadata, or lease.
-      handle.settleResult(cancelledResult);
+      // handle no longer owns the shared stream, run metadata, or lease.
       return;
     }
 
     // Cleanup closes the suspended run's transcript group. Write the terminal
     // row only after that owned artifact is settled so every host observes
     // one coherent cancellation boundary, and in one fixed order: write the
-    // row, settle the envelope, drop the handle, cancel the stream.
+    // row, drop the handle, cancel the stream.
     const finalize = Effect.gen({ self: this }, function* () {
       const finalization = yield* this.context.finalizeRun({
         runId: handle.runId,
         outcome: RUN_OUTCOME.CANCELLED,
-        output: cancelledResult.output,
+        output: emptyRunEndOutput(handle.category),
         // A stopped WAITING run is exactly what a user resumes. Deleting its
         // checkpoint here was the #11304 invariant's first violation (#11315).
         flowRecord: retainFlowRecordUnlessCompleted(RUN_OUTCOME.CANCELLED),
@@ -192,7 +173,6 @@ export class WaitingTermination {
           },
         });
       }
-      handle.settleResult(cancelledResult);
       this.context.untrackHandle(handle);
       this.context.cancelRunStatus(handle.runId);
     });

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -53,7 +53,7 @@ export type StatusEvent = TraceArm<'status'> & { readonly runId: RunId };
 
 /**
  * The terminal fact as the runtime hands it to in-process consumers
- * (`RunHandle.result`, `SessionHandle.onResult`): the `run.end` row named by
+ * (`SessionHandle.onResult`): the `run.end` row named by
  * its run. Not an {@link AgentEvent} arm: the row is written once by the
  * storage finalizer (`finalizeRun`), never emitted on a trace.
  */

--- a/src/test-kernel/agent/followUp/ChildRunProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildRunProgressEvents.vitest.ts
@@ -508,7 +508,6 @@ describe('child run progress events', () => {
         const recorded = recordSessionEvents(session);
         let childRun: ChildRun | undefined;
         let childRunId: RunId | undefined;
-        let handle: ReturnType<typeof session.runs.getHandle>;
 
         try {
           // `reraiseAgentCliCallFailure` re-raises the loop's throw as a
@@ -525,7 +524,6 @@ describe('child run progress events', () => {
                 startLoop: (context) => {
                   childRun = context.childRun;
                   childRunId = context.runId;
-                  handle = session.runs.getHandle(context.childRun.childRunId);
                   throw setupError;
                 },
                 summary: 'unreachable',
@@ -538,21 +536,16 @@ describe('child run progress events', () => {
 
           expect(childRun).toBeDefined();
           expect(childRunId).toBeDefined();
-          expect(handle).toBeDefined();
-          if (!childRun || !childRunId || !handle) {
+          if (!childRun || !childRunId) {
             throw new Error('expected the failed child launch to be captured');
           }
           expect(session.runs.getHandle(childRunId)).toBeUndefined();
           expect(session.status.get(childRun.childRunId)).toBe(
             RUN_PHASE.FAILED,
           );
-          const failedHandle = handle;
-          const result = yield* failedHandle.result;
-          expect(result).toMatchObject({
-            type: 'run.end',
-            outcome: 'failed',
-            runId: childRunId,
-          });
+          expect(
+            yield* getRunRecords(session, childRunId).readRunEnd(),
+          ).toMatchObject({ outcome: 'failed' });
         } finally {
           if (childRun) {
             clearRunStatusForTest(session.status, childRun.childRunId);
@@ -566,8 +559,7 @@ describe('child run progress events', () => {
       loopRunId,
       'Run a long-lived Codex child loop',
     );
-    const handle = defaultSession().runs.getHandle(loopRunId);
-    expect(handle).toBeDefined();
+    expect(defaultSession().runs.getHandle(loopRunId)).toBeDefined();
     // From here on: the launch's own facts are not the loop's.
     const recorded = recordSessionEvents(defaultSession());
     const rosters = recordChildRosters(defaultSession().runs);
@@ -589,8 +581,11 @@ describe('child run progress events', () => {
       parentRunId,
       items: [],
     });
-    await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
-      type: 'run.end',
+    await expect(
+      Effect.runPromise(
+        getRunRecords(defaultSession(), loopRunId).readRunEnd(),
+      ),
+    ).resolves.toMatchObject({
       outcome: 'failed',
       error: {
         kind: 'unexpected',
@@ -608,8 +603,7 @@ describe('child run progress events', () => {
       stoppedRunId,
       'Run a stopped Codex child loop',
     );
-    const handle = defaultSession().runs.getHandle(stoppedRunId);
-    expect(handle).toBeDefined();
+    expect(defaultSession().runs.getHandle(stoppedRunId)).toBeDefined();
     seedRunStatusForTest(defaultSession().status, stoppedRunId, {
       phase: RUN_PHASE.CANCELLED,
     });
@@ -628,11 +622,11 @@ describe('child run progress events', () => {
           event.aggregateId === qualifyAggregateId('run', stoppedRunId),
       ),
     ).toHaveLength(0);
-    await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
-      type: 'run.end',
-      outcome: 'cancelled',
-      runId: stoppedRunId,
-    });
+    await expect(
+      Effect.runPromise(
+        getRunRecords(defaultSession(), stoppedRunId).readRunEnd(),
+      ),
+    ).resolves.toMatchObject({ outcome: 'cancelled' });
   });
 
   it('settles failed child handle results with error details', async () => {
@@ -640,8 +634,7 @@ describe('child run progress events', () => {
       failedRunId,
       'Run a failing Codex child loop',
     );
-    const handle = defaultSession().runs.getHandle(failedRunId);
-    expect(handle).toBeDefined();
+    expect(defaultSession().runs.getHandle(failedRunId)).toBeDefined();
 
     await Effect.runPromise(
       childRun.finalize({
@@ -651,10 +644,12 @@ describe('child run progress events', () => {
     );
 
     expect(defaultSession().status.get(failedRunId)).toBe(RUN_PHASE.FAILED);
-    await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
-      type: 'run.end',
+    await expect(
+      Effect.runPromise(
+        getRunRecords(defaultSession(), failedRunId).readRunEnd(),
+      ),
+    ).resolves.toMatchObject({
       outcome: 'failed',
-      runId: failedRunId,
       error: {
         kind: 'unexpected',
         message: 'child process exited 1',

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -11,7 +11,7 @@ import {
   releaseOwnedRunLease,
 } from '@agent/storage/runLease';
 import { RunStatusMachine } from '@agent/runtime/RunStatusService';
-import { RunHandle, type AgentRunHandle } from '@agent/runtime/RunHandle';
+import { RunHandle } from '@agent/runtime/RunHandle';
 import {
   defaultSession,
   type SessionHandle,
@@ -579,7 +579,6 @@ describe('runFlowWithLifecycle', () => {
   // its own verdict and drop its abort facts.
   it('does not adopt a previous run terminal phase when a stop lands before start', async () => {
     const { runId, runStatus, ctx } = lifecycleFixture();
-    let terminalResult: AgentRunHandle['result'] | undefined;
 
     try {
       seedRunStatusForTest(runStatus, runId, {
@@ -594,8 +593,7 @@ describe('runFlowWithLifecycle', () => {
             throw new DOMException('Request aborted', 'AbortError');
           },
           {
-            onRun: async (handle) => {
-              terminalResult = handle.result;
+            onRun: async () => {
               const stop = defaultSession().runs.kill(runId);
               expect(stop.accepted).toBe(true);
               await Effect.runPromise(stop.settlement);
@@ -610,13 +608,10 @@ describe('runFlowWithLifecycle', () => {
         defaultSession(),
         expect.objectContaining({
           outcome: RUN_OUTCOME.CANCELLED,
+          error: expect.objectContaining({ kind: 'abort' }),
           flowRecord: 'preserve',
         }),
       );
-      await expect(Effect.runPromise(terminalResult!)).resolves.toMatchObject({
-        outcome: RUN_OUTCOME.CANCELLED,
-        error: { kind: 'abort' },
-      });
     } finally {
       clearRunStatusForTest(runStatus, runId);
     }
@@ -762,7 +757,7 @@ describe('runFlowWithLifecycle', () => {
       expect(followUpsTerminalize).not.toHaveBeenCalled();
       expect(storageMocks.finalizeRun).not.toHaveBeenCalled();
 
-      const waitingHandle = takeWaitingHandle(runId);
+      takeWaitingHandle(runId);
 
       // runToolUseFlow's finally detaches this stream's interrupt handler but
       // preserves the follow-up queue for WAITING — it does not dispose the
@@ -775,20 +770,12 @@ describe('runFlowWithLifecycle', () => {
       expect(stop.accepted).toBe(true);
       await Effect.runPromise(stop.settlement);
 
-      // The bypassed runFlowWithLifecycle can't settle the terminal row, so
-      // terminateWaitingHandle must — a waiter on the handle would otherwise
-      // miss the stop entirely.
-      await expect(
-        Effect.runPromise(waitingHandle.result),
-      ).resolves.toMatchObject({
-        type: 'run.end',
-        outcome: RUN_OUTCOME.CANCELLED,
-        runId,
-      });
-
       expect(defaultSession().runs.getHandle(runId)).toBeUndefined();
       expect(defaultSession().status.get(runId)).toBe(RUN_PHASE.CANCELLED);
       expect(followUpsTerminalize).toHaveBeenCalledWith(runId);
+      // The bypassed runFlowWithLifecycle can't write the terminal row, so
+      // terminateWaitingHandle must — session subscribers would otherwise
+      // miss the stop entirely.
       await vi.waitFor(() =>
         expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
           defaultSession(),
@@ -833,14 +820,13 @@ describe('runFlowWithLifecycle', () => {
         }),
       );
       expect(result.outcome).toBe(RUN_PHASE.WAITING);
-      const waitingHandle = takeWaitingHandle(runId);
+      takeWaitingHandle(runId);
 
       const stop = defaultSession().runs.kill(runId);
 
       expect(stop.accepted).toBe(true);
 
       await Effect.runPromise(stop.settlement);
-      await Effect.runPromise(waitingHandle.result);
 
       expect(stopSessionsForRun).toHaveBeenCalledWith(runId);
     } finally {
@@ -1211,9 +1197,6 @@ describe('finalizeRunTerminal', () => {
       // writer, so writing it once is what "exactly once" means here.
       expect(storageMocks.finalizeRun).toHaveBeenCalledTimes(1);
       expect(untrack).toHaveBeenCalledTimes(1);
-      await expect(Effect.runPromise(handle.result)).resolves.toBe(
-        event?.event,
-      );
       expect(runStatus.get(runId)).toBe(RUN_PHASE.COMPLETED);
     } finally {
       clearRunStatusForTest(runStatus, runId);
@@ -1230,11 +1213,6 @@ describe('finalizeRunTerminal', () => {
           releaseFlush = resolve;
         }),
     );
-    let resultSettled = false;
-    void Effect.runPromise(handle.result).then(() => {
-      resultSettled = true;
-    });
-
     try {
       seedRunStatusForTest(runStatus, runId, {
         phase: RUN_PHASE.RUNNING,
@@ -1249,13 +1227,13 @@ describe('finalizeRunTerminal', () => {
       );
 
       await vi.waitFor(() => expect(flushArtifacts).toHaveBeenCalledOnce());
-      expect(resultSettled).toBe(false);
+      expect(storageMocks.finalizeRun).not.toHaveBeenCalled();
       expect(untrack).not.toHaveBeenCalled();
 
       releaseFlush?.();
       await finalization;
 
-      expect(resultSettled).toBe(true);
+      expect(storageMocks.finalizeRun).toHaveBeenCalledOnce();
       expect(untrack).toHaveBeenCalledExactlyOnceWith(runId);
       expect(runStatus.get(runId)).toBe(RUN_PHASE.COMPLETED);
     } finally {
@@ -1295,9 +1273,6 @@ describe('finalizeRunTerminal', () => {
           runId,
         },
       });
-      await expect(Effect.runPromise(handle.result)).resolves.toBe(
-        event?.event,
-      );
       expect(untrack).toHaveBeenCalledExactlyOnceWith(runId);
       expect(runStatus.get(runId)).toBe(RUN_PHASE.FAILED);
       expect(channelTraceMocks.warn).toHaveBeenCalledExactlyOnceWith(
@@ -1348,9 +1323,6 @@ describe('finalizeRunTerminal', () => {
       // Error facts classified for a failure that the phase says never
       // happened must not ride the cancelled result.
       expect(finalized?.event.error).toBeUndefined();
-      await expect(Effect.runPromise(handle.result)).resolves.toBe(
-        finalized?.event,
-      );
       expect(stage.end).toHaveBeenCalledExactlyOnceWith(RUN_OUTCOME.CANCELLED);
       expect(storageMocks.finalizeRun).toHaveBeenCalledWith(
         session,

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -861,11 +861,6 @@ describe('childRunLoop E2E fixtures', () => {
 
     await waitForLoopEnd(runId);
 
-    // Settled: handle.result resolves instead of hanging forever.
-    await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
-      outcome: 'cancelled',
-      runId,
-    });
     // Untracked: no longer resumable — a later delegate_agent(execution_id=…)
     // would correctly report "not found" instead of finding a ghost handle.
     expect(session.runs.getHandle(runId)).toBeUndefined();
@@ -1019,18 +1014,21 @@ describe('childRunLoop E2E fixtures', () => {
 
     await waitForLiveOwner(runId);
 
-    const handle = trackChildHandle(runId, PARENT_RUN_ID, RUN_PHASE.WAITING);
+    trackChildHandle(runId, PARENT_RUN_ID, RUN_PHASE.WAITING);
 
     await resolveTurn(1, { kind: 'error-turn', value: 'oops' });
 
     await waitForLoopEnd(runId);
-    await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
-      outcome: 'failed',
-      runId,
-      error: expect.objectContaining({
-        message: expect.stringContaining('reported a failed turn'),
+    expect(mocks.finalizeRun).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        runId,
+        outcome: RUN_OUTCOME.FAILED,
+        error: expect.objectContaining({
+          message: expect.stringContaining('reported a failed turn'),
+        }),
       }),
-    });
+    );
     expect(session.runs.getHandle(runId)).toBeUndefined();
   });
 
@@ -1046,7 +1044,6 @@ describe('childRunLoop E2E fixtures', () => {
       }),
     );
     trackedRunIds.add(runId);
-    const handle = session.runs.getHandle(runId);
     const { strategy, rejectTurn } = createFakeStrategy();
     // Fires between the turn failure landing FAILED on the stream phase and
     // the loop's finalize, so the loop reports an interrupted run for a stream
@@ -1071,16 +1068,15 @@ describe('childRunLoop E2E fixtures', () => {
     await Promise.all(stopSettlements);
     expect(interruptAfterFailure).toHaveBeenCalledOnce();
     expect(session.status.get(runId)).toBe(RUN_PHASE.FAILED);
-    await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
-      outcome: 'failed',
-      runId,
-      error: expect.objectContaining({
-        message: expect.stringContaining('turn blew up'),
-      }),
-    });
     expect(mocks.finalizeRun).toHaveBeenCalledWith(
       session,
-      expect.objectContaining({ outcome: RUN_OUTCOME.FAILED }),
+      expect.objectContaining({
+        runId,
+        outcome: RUN_OUTCOME.FAILED,
+        error: expect.objectContaining({
+          message: expect.stringContaining('turn blew up'),
+        }),
+      }),
     );
   });
 

--- a/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
@@ -4,7 +4,6 @@ import '@test/support/defaultSessionTestSetup';
 import { describe, expect, it, vi } from 'vitest';
 
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
-import type { RunHandle } from '@agent/runtime/RunHandle';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import {
@@ -107,13 +106,13 @@ describe('run lifecycle host-interaction cancel', () => {
 
   it('settles and untracks the run after native interruption joins the active flow', async () => {
     const { session, ctx, runId } = lifecycleCase();
-    const started = createDeferred<RunHandle>();
+    const started = createDeferred();
     const aborted = createDeferred();
     const released = createDeferred();
     const stopped = createDeferred();
     const fiber = Effect.runFork(
-      runFlowWithLifecycle(ctx, async (handle) => {
-        started.resolve(handle);
+      runFlowWithLifecycle(ctx, async () => {
+        started.resolve();
         ctx.runScope.signal.addEventListener('abort', () => aborted.resolve(), {
           once: true,
         });
@@ -123,7 +122,7 @@ describe('run lifecycle host-interaction cancel', () => {
         return toolUseRun(runId, RUN_OUTCOME.CANCELLED);
       }),
     );
-    const handle = await started.promise;
+    await started.promise;
     const interrupted = Effect.runPromise(Fiber.interrupt(fiber));
     await aborted.promise;
     expect(ctx.disposeTrace).not.toHaveBeenCalled();
@@ -133,9 +132,7 @@ describe('run lifecycle host-interaction cancel', () => {
     expect(Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)).toBe(true);
     await stopped.promise;
     expect(session.runs.getHandle(runId)).toBeUndefined();
-    await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
+    expect(session.status.get(runId)).toBe(RUN_PHASE.CANCELLED);
     expect(ctx.disposeTrace).toHaveBeenCalledOnce();
     session.dispose();
   });

--- a/src/test-kernel/agent/runtime/RunRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunRegistry.vitest.ts
@@ -397,14 +397,15 @@ describe('runRegistry', () => {
       // No handle interrupt target: mirrors a suspended subagent whose live
       // tool-use session has already been disposed. The run phase follows
       // the same suspension, as it does in production.
-      const handle = trackSuspendedWaitingHandle(registry, runStatus, {
+      trackSuspendedWaitingHandle(registry, runStatus, {
         runId,
         parent: parentRunId,
         cleanup,
       });
 
-      expect(killRegistry(registry, runId)).toBe(true);
-      await Effect.runPromise(handle.result);
+      const stop = registry.kill(runId);
+      expect(stop.accepted).toBe(true);
+      await Effect.runPromise(stop.settlement);
 
       expect(cleanup).toHaveBeenCalledOnce();
       expect(runStatus.get(runId)).toBe(RUN_PHASE.CANCELLED);
@@ -418,27 +419,23 @@ describe('runRegistry', () => {
     // terminateWaitingHandle bypasses runFlowWithLifecycle (the flow never
     // resumes), so it writes the terminal row itself — otherwise session
     // subscribers silently miss a user-initiated stop of a suspended native
-    // subagent even though handle.result itself resolved. The turn's own
-    // trace is already torn down by the time a kill runs, so the row, not an
-    // emit, is what reaches them.
+    // subagent. The turn's own trace is already torn down by the time a kill
+    // runs, so the row, not an emit, is what reaches them.
     storageMocks.finalizeRun.mockClear();
     const { runStatus, registry } = createRegistry();
     const parentRunId = generateRunId();
     const runId = generateRunId();
 
     try {
-      const handle = trackSuspendedWaitingHandle(registry, runStatus, {
+      trackSuspendedWaitingHandle(registry, runStatus, {
         runId,
         parent: parentRunId,
       });
 
-      expect(killRegistry(registry, runId)).toBe(true);
+      const stop = registry.kill(runId);
+      expect(stop.accepted).toBe(true);
+      await Effect.runPromise(stop.settlement);
 
-      await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
-        type: 'run.end',
-        outcome: RUN_OUTCOME.CANCELLED,
-        runId,
-      });
       expect(storageMocks.finalizeRun).toHaveBeenCalledExactlyOnceWith(
         defaultSession(),
         {
@@ -477,17 +474,16 @@ describe('runRegistry', () => {
         },
       });
 
-      expect(killRegistry(registry, runId)).toBe(true);
+      const stop = registry.kill(runId);
+      expect(stop.accepted).toBe(true);
+      const settled = Effect.runPromise(stop.settlement);
       await Promise.resolve();
       expect(storageMocks.finalizeRun).not.toHaveBeenCalled();
       expect(registry.getHandle(runId)).toBe(handle);
       expect(runStatus.get(runId)).toBe(RUN_PHASE.WAITING);
 
       finishCleanup();
-      await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
-        type: 'run.end',
-        outcome: RUN_OUTCOME.CANCELLED,
-      });
+      await settled;
       expect(order).toEqual(['cleanup', 'finalize']);
       expect(registry.getHandle(runId)).toBeUndefined();
       expect(runStatus.get(runId)).toBe(RUN_PHASE.CANCELLED);
@@ -507,13 +503,15 @@ describe('runRegistry', () => {
     });
 
     try {
-      const previous = trackSuspendedWaitingHandle(registry, runStatus, {
+      trackSuspendedWaitingHandle(registry, runStatus, {
         runId,
         parent: parentRunId,
         cleanup: () => cleanupGate,
       });
 
-      expect(killRegistry(registry, runId)).toBe(true);
+      const stop = registry.kill(runId);
+      expect(stop.accepted).toBe(true);
+      const settled = Effect.runPromise(stop.settlement);
 
       const successorInterrupt = vi.fn();
       const successor = trackInterruptibleHandle(
@@ -524,10 +522,7 @@ describe('runRegistry', () => {
 
       expect(successorInterrupt).toHaveBeenCalledOnce();
       finishCleanup();
-      await expect(Effect.runPromise(previous.result)).resolves.toMatchObject({
-        type: 'run.end',
-        outcome: RUN_OUTCOME.CANCELLED,
-      });
+      await settled;
 
       expect(registry.getHandle(runId)).toBe(successor);
       expect(storageMocks.finalizeRun).not.toHaveBeenCalled();
@@ -545,16 +540,14 @@ describe('runRegistry', () => {
     const runId = generateRunId();
 
     try {
-      const handle = trackSuspendedWaitingHandle(registry, runStatus, {
+      trackSuspendedWaitingHandle(registry, runStatus, {
         runId,
         parent: generateRunId(),
       });
 
-      expect(killRegistry(registry, runId)).toBe(true);
-      await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
-        type: 'run.end',
-        outcome: RUN_OUTCOME.CANCELLED,
-      });
+      const stop = registry.kill(runId);
+      expect(stop.accepted).toBe(true);
+      await Effect.runPromise(stop.settlement);
       expect(registry.getHandle(runId)).toBeUndefined();
       expect(runStatus.get(runId)).toBe(RUN_PHASE.CANCELLED);
     } finally {
@@ -577,18 +570,15 @@ describe('runRegistry', () => {
     channelTraceMocks.warn.mockClear();
 
     try {
-      const handle = trackSuspendedWaitingHandle(registry, runStatus, {
+      trackSuspendedWaitingHandle(registry, runStatus, {
         runId,
         parent: parentRunId,
       });
 
-      expect(killRegistry(registry, runId)).toBe(true);
+      const stop = registry.kill(runId);
+      expect(stop.accepted).toBe(true);
+      await Effect.runPromise(stop.settlement);
 
-      await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
-        type: 'run.end',
-        outcome: RUN_OUTCOME.CANCELLED,
-        runId,
-      });
       expect(registry.getHandle(runId)).toBeUndefined();
       expect(runStatus.get(runId)).toBe(RUN_PHASE.CANCELLED);
       await vi.waitFor(() => {
@@ -789,9 +779,6 @@ describe('runRegistry', () => {
       releasePersist?.();
       await finalized;
       expect(teardown).not.toHaveBeenCalled();
-      await expect(Effect.runPromise(handle.result)).resolves.toMatchObject({
-        outcome: RUN_OUTCOME.COMPLETED,
-      });
       expect(storageMocks.finalizeRun).toHaveBeenCalledExactlyOnceWith(
         session,
         expect.objectContaining({
@@ -844,8 +831,9 @@ describe('runRegistry', () => {
         substate: RUN_SUBSTATE.RESUMING,
       });
 
-      expect(killRegistry(registry, runId)).toBe(true);
-      await Effect.runPromise(handle.result);
+      const stop = registry.kill(runId);
+      expect(stop.accepted).toBe(true);
+      await Effect.runPromise(stop.settlement);
 
       expect(cleanup).toHaveBeenCalledOnce();
       expect(registry.getHandle(runId)).toBeUndefined();

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -6,7 +6,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { TraceEmitter, type ResultEvent } from '@agent/trace';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
-import type { AgentRunHandle } from '@agent/runtime/RunHandle';
 import { RunStatusMachine } from '@agent/runtime/RunStatusService';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
@@ -164,34 +163,6 @@ describe('terminal result event', () => {
       ).rejects.toThrow('model exploded');
 
       expectSingleResult(results, ctx, { outcome: 'failed' });
-    } finally {
-      clearRunStatusForTest(runStatus, ctx.runScope.runId);
-    }
-  });
-
-  it('settles handle.result as failed on a thrown run (always resolves)', async () => {
-    const { ctx, runStatus } = setupResultCase();
-    let handle: AgentRunHandle | undefined;
-    try {
-      await expect(
-        Effect.runPromise(
-          runFlowWithLifecycle(
-            ctx,
-            async () => {
-              throw new Error('boom');
-            },
-            {
-              onRun: (h) => {
-                handle = h;
-              },
-            },
-          ),
-        ),
-      ).rejects.toThrow('boom');
-      await expect(Effect.runPromise(handle!.result)).resolves.toMatchObject({
-        type: 'run.end',
-        outcome: 'failed',
-      });
     } finally {
       clearRunStatusForTest(runStatus, ctx.runScope.runId);
     }


### PR DESCRIPTION
## Summary

Two small 1.0 clean-slate deletions in `src/agent/runtime/`. Both became possible once #12268 (one run model S4+S5) merged.

- **coauthor-97:D03-6: delete `RunHandle.result`.** `RunHandle` kept a terminal `Deferred<ResultEvent>` (`_terminal`) and exposed it as `result`. Nothing in production awaits it. A run's result already has two owners: the durable `run.end` row (`finalizeRun`, which reaches hosts through `session.onResult`) and, for the SDK, the launching fiber's exit (`Fiber.join` in `packages/agent`). This PR deletes `_terminal`, `result`, the `Deferred` import, and `'result'` from the `AgentRunHandle` pick. `settleResult` goes too. Once the Deferred is gone it has nothing left to do: its only other effect set `terminalState = 'settled'`, and every one of its four callers had already won `claimTerminalFinalize()` (`finalizeRunTerminal` claims on its first line, and `waitingTermination` claims through `beginSuspendedTermination`). The `'claimed'` and `'settled'` states were never told apart, because the only check is `!== 'open'`. So the three-state `TerminalState` becomes one `terminalClaimed` flag. `waitingTermination` also loses the `cancelledResult` object it built only to settle the Deferred, including the settle step in its recovery arm.
- **coauthor-2c:agent-runtime#7 (clearHold remainder): `clearHold` always discards the retained phase.** All three production callers passed `{ discardRetainedPhase: true }`: `resumeRun.ts`, and `ToolUseFollowUp.ts` twice. So the restore-the-retained-phase branch never ran. This PR deletes the option, its doc and the dead branch, and updates the callers. The change to `resumeRun.ts` is only the call site the new signature forces. No test passed `false` or relied on the default; the one other reference is a no-op mock.

Tests that used `handle.result` as an observation point now read what production reads:
- the `finalizeRun` input (the `run.end` row) where storage is mocked;
- `getRunRecords(...).readRunEnd()` where storage is real;
- `stop.settlement` from `registry.kill()` / `runs.kill()` as the sync point for waiting-run teardown;
- the session's terminal run phase in the one suite whose barrel mock never intercepts the lifecycle's leaf import of `finalizeRun`.

The one test whose only subject was the Deferred ("settles handle.result as failed on a thrown run") is deleted. The `onResult` cases in the same suite already cover the failed-result path. No new test API was added to `RunHandle`.

## Net elements (R6)

- Deleted: the `_terminal` field, the `result` property, the `settleResult` method, the `TerminalState` type with its doc, the `Deferred` import, `ResultEvent` imports (`RunHandle.ts`, `waitingTermination.ts`), the `'result'` pick member, the `discardRetainedPhase` option with its doc and restore branch, the `cancelledResult` object and parameter in `waitingTermination`, the settle step in the waiting-termination recovery arm, and 1 test case.
- Added: one `terminalClaimed` boolean.
- Lines: production +42 / −104 (net −62), tests +84 / −165 (net −81), total **−145** across 13 files.

## Consumer counts (R8)

- `RunHandle.result` / `AgentRunHandle['result']`: **0 production readers.** With the member removed, `npm run typecheck` failed only in tests (26 sites in 7 suites), and every production project compiled. Checked with grep as well: the `run.result` reads in `packages/agent/src/index.ts`, `agentsRun.ts` and `multiAgent.ts` are other types (the SDK `AgentRun` and the CLI execution result).
- `settleResult`: 4 production callers (`AgentRunLifecycle.ts` ×1, `waitingTermination.ts` ×3). Every one runs after a successful `claimTerminalFinalize()`.
- `clearHold`: 3 production callers, all passing `discardRetainedPhase: true`. 0 pass `false` or omit it. Tests pinning the restore branch: 0.

## Verified

Run in a fresh worktree on `origin/main` @ 1aa0491dc9 (after #12273), with a real `pnpm install`:

| Gate | Exit |
| --- | --- |
| `npx prettier --check .` | 0 |
| eslint on the 13 changed files | 0 |
| `env CI=true npm run typecheck` | 0 |
| `vitest run --changed origin/main` | 0 (181 files, 2221 passed, 1 skipped) |
| `vitest run --project pure` | 0 (210 files, 2389 passed) |
| `node scripts/check-dead-code-ratchet.mjs` | 0 |
| `node scripts/check-effect-migration-ratchet.mjs` | 0 (no rows touched) |
| `npm run check:guidance-refs` | 0 |

ChildRunLoop, a known flake, failed once in an early combined 7-suite run on the "keeps the failing turn diagnosis" case. It then passed 3 of 3 runs alone and passed inside the `--changed` run. The retargeted assertion checks the same `error` value the old `handle.result` event carried: `finalizeRunTerminal` builds the row input and the event from one variable.

The dead-code ratchet reports 5 stale baseline entries in `packages/cli/src/chat/tui/forms/`. They are unrelated to this change and left for their owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
