### PR TITLE
refactor: browser state gets a synchronous KeyValueStore; delete the Promise.resolve() StateStore fakes (1.0 clean slate)

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -19,7 +19,6 @@ import { repeat } from 'lit/directives/repeat.js';
 import { z } from 'zod';
 import '@progressView/frontend/ProgressApp';
 import './TexraDiffView';
-import type { StateStore } from '@platform/interfaces';
 import type { ProgressApp } from '@progressView/frontend/ProgressApp';
 import { createSessionSurfaces } from '@progressView/frontend/sessionSurfaces';
 import '@settingsView/frontend';
@@ -27,7 +26,10 @@ import { hostBridge, postMessage } from '@shared/hostBridge';
 import { DESKTOP_THEME_KIND } from '@shared/schemas';
 import { resolvePostMessageTargetOrigin } from '@shared/postMessageOrigin';
 import { applyShellAction, type Shell } from '@shared/session/shell';
-import { PersistedState } from '@shared/state/PersistedState';
+import {
+  PersistedState,
+  type KeyValueStore,
+} from '@shared/state/PersistedState';
 
 import { formatDesktopAccelerator } from '@shared/commands/accelerators';
 
@@ -149,7 +151,7 @@ const startupTeamPanel = createStartupTeamPanel({
 
 // The renderer's own interaction state survives a reload in
 // `localStorage`; the preload bridge's `getState` is in-memory only.
-const rendererState: StateStore = {
+const rendererState: KeyValueStore = {
   get<T>(key: string, defaultValue?: T): T {
     const raw = window.localStorage.getItem(key);
     if (raw === null) return defaultValue as T;
@@ -158,7 +160,6 @@ const rendererState: StateStore = {
   update(key, value) {
     if (value === undefined) window.localStorage.removeItem(key);
     else window.localStorage.setItem(key, JSON.stringify(value));
-    return Promise.resolve();
   },
 };
 // The one Shell of this window (PRD 9): which projects are open and which one

--- a/packages/extension/src/progressView/frontend/sessionSurfaces.ts
+++ b/packages/extension/src/progressView/frontend/sessionSurfaces.ts
@@ -11,7 +11,6 @@
  */
 import { signal, type Signal } from '@lit-labs/signals';
 
-import type { StateStore } from '@platform/interfaces';
 import type { SessionType, RunId } from '@shared/schemas';
 import { subscribeToSignalChanges } from '@shared/signals';
 import { LAUNCH_FILE_LISTS } from '@shared/launcher/fileSelectConfigs';
@@ -33,7 +32,10 @@ import {
   type Surface,
   type SurfaceAction,
 } from '@shared/session/surface';
-import { PersistedState } from '@shared/state/PersistedState';
+import {
+  PersistedState,
+  type KeyValueStore,
+} from '@shared/state/PersistedState';
 
 import { playCompletionSound } from './audioNotification';
 import {
@@ -87,7 +89,7 @@ function withPickedPaths(
 }
 
 export function createSessionSurfaces(options: {
-  readonly storage: StateStore;
+  readonly storage: KeyValueStore;
   /** Desktop requests present through their host session. The extension
    *  surface owns its request notices. Choose the owner when wiring a shell. */
   readonly hostRequestFailureOwner: 'host' | 'surface';

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -1,15 +1,15 @@
 import { z } from 'zod';
 
-import type { StateStore } from '@platform/interfaces';
+/** A renderer's synchronous key-value store; `undefined` removes a key. */
+export interface KeyValueStore {
+  get<T>(key: string, defaultValue?: T): T;
+  update(key: string, value: unknown): void;
+}
 
 /**
- * Create a {@link StateStore} over webview host state. All keys share a single
- * state object, cached in memory to avoid repeated getState() calls on rapid
- * updates.
- *
- * A key is removed by updating it to `undefined`, as with a Memento. `update`
- * returns an already-resolved promise because `setState` is synchronous and
- * cannot fail — that is not a dropped write.
+ * Create a {@link KeyValueStore} over webview host state. All keys share a
+ * single state object, cached in memory to avoid repeated getState() calls on
+ * rapid updates.
  *
  * @example
  * import { hostBridge } from '@shared/hostBridge';
@@ -18,7 +18,7 @@ import type { StateStore } from '@platform/interfaces';
 export function createWebviewStorage(hostBridge: {
   getState(): unknown;
   setState(state: unknown): void;
-}): StateStore {
+}): KeyValueStore {
   // Cache full state - read once, update in memory
   const cache = (hostBridge.getState() as Record<string, unknown>) ?? {};
 
@@ -34,13 +34,12 @@ export function createWebviewStorage(hostBridge: {
         cache[key] = value;
       }
       hostBridge.setState(cache);
-      return Promise.resolve();
     },
   };
 }
 
 /**
- * Renderer UI state persisted under one key of a `StateStore`, validated by a
+ * Renderer UI state persisted under one key of a `KeyValueStore`, validated by a
  * Zod schema. Two renderers use it: the Progress-View surfaces over
  * `createWebviewStorage(hostBridge)`, and the desktop shell's collapsed-group
  * set over localStorage.
@@ -62,7 +61,7 @@ export class PersistedState<T extends Record<string, unknown>> {
   private state: T;
 
   constructor(
-    private readonly storage: StateStore,
+    private readonly storage: KeyValueStore,
     private readonly key: string,
     private readonly schema: z.ZodType<T>,
   ) {
@@ -90,25 +89,8 @@ export class PersistedState<T extends Record<string, unknown>> {
       },
     );
     const defaults = this.schema.parse({});
-    this.persist(defaults);
+    this.storage.update(this.key, defaults);
     return defaults;
-  }
-
-  /**
-   * Write through to storage. The promise is deliberately not awaited — every
-   * caller is a synchronous UI path — but a rejection must not escape as an
-   * unhandled rejection, which on the desktop main process is an uncaught
-   * error with no attribution to the failing key. Warn loudly instead.
-   */
-  private persist(value: T): void {
-    void Promise.resolve(this.storage.update(this.key, value)).catch(
-      (error: unknown) => {
-        console.warn(
-          `[PersistedState] Failed to persist ${this.key}; the in-memory value is now ahead of storage.`,
-          error,
-        );
-      },
-    );
   }
 
   /** Get current state (shallow copy) */
@@ -119,7 +101,7 @@ export class PersistedState<T extends Record<string, unknown>> {
   /** Replace entire state */
   setState(state: T): void {
     this.state = { ...state };
-    this.persist(this.state);
+    this.storage.update(this.key, this.state);
   }
 }
 

--- a/src/test-kernel/shared/PersistedState.vitest.ts
+++ b/src/test-kernel/shared/PersistedState.vitest.ts
@@ -20,7 +20,7 @@ const StateSchema = z.object({
 describe('PersistedState loading', () => {
   const storage = {
     get: vi.fn(),
-    update: vi.fn<(key: string, value: unknown) => Promise<void>>(),
+    update: vi.fn<(key: string, value: unknown) => void>(),
   };
 
   let warn: MockInstance<typeof console.warn>;


### PR DESCRIPTION
## Summary

coauthor-48 found this: `StateStore` (`src/platform/interfaces.ts`) mirrors `vscode.Memento`, so its `update` returns a promise. Both browser stores behind `PersistedState` are synchronous and matched that interface only by faking the async half:

- `createWebviewStorage` (`src/shared/state/PersistedState.ts`) returned `Promise.resolve()`. Its doc comment admitted that "`setState` is synchronous and cannot fail — that is not a dropped write".
- The desktop renderer's localStorage `rendererState` (`packages/desktop/src/renderer/main.ts`) did the same.

`PersistedState` now takes a narrower `KeyValueStore { get; update(): void }`, declared next to it in `src/shared/state`. Changes:

- Both `Promise.resolve()` fakes are deleted, along with the comment excusing them.
- The `void Promise.resolve(this.storage.update(...)).catch(warn)` wrapper in `PersistedState.persist` is gone, and so is the `persist` method: both call sites now call `storage.update` directly.

This doesn't change behavior. A synchronous throw, such as a full localStorage, was already thrown before `Promise.resolve` could catch it, and neither browser store ever rejected.

The method keeps the name `update`, so the test double `FakeStateStore` (whose `update` returns a promise) still satisfies `KeyValueStore`. `SessionSurfaces.vitest.ts` therefore needs no change.

## Net elements (R6)

- 4 files, +24 / −39, **−15 LOC net**.
- Removed:
  - 2 `return Promise.resolve()` fakes
  - 1 comment excusing them
  - the `persist` method: its promise wrapper, its `.catch` warn path and its 6-line doc
  - 2 `@platform/interfaces` imports from browser zones (`sessionSurfaces.ts`, `renderer/main.ts`)
  - 1 `@platform/interfaces` import from `src/shared/state/PersistedState.ts`
- Added: 1 four-line type (`KeyValueStore`). No other abstraction.

## Consumer counts (R8)

`KeyValueStore`:
- 2 implementers: `createWebviewStorage` and the desktop renderer's `rendererState`.
- 2 consumers: `PersistedState` and the `storage` option of `createSessionSurfaces`.
- 1 test double: `FakeStateStore`, which is structurally compatible.

No browser-zone consumer needed the async signature. At origin/main, the webview and settings-view frontends import `StateStore` nowhere. The Progress-View frontend and the desktop renderer used it only to feed `PersistedState` or `createSessionSurfaces`.

## Scope

Deliberately untouched:
- the host `StateStore` interface
- `platform().globalState`
- `jsonStore.ts`, `memoryState.ts` and `AppState`
- `tryGlobalState`, which is queued behind #12281
- every file in open PR #12281. I checked its paginated file list for overlap right before pushing.

`packages/desktop/src/renderer/main.ts` is in coauthor-97's slice. 97 has finished and released its claims. The file is also under coauthor-2c's planned batch-b claim. **coauthor-2c OK'd this edit through the coordinator**: its batch hasn't started, doesn't touch `rendererState`, and will rebase over this PR. The edit is small and mechanical: the type import moves and one `return Promise.resolve()` line is deleted.

## Verified

Run in the worktree at the pushed SHA, after a real `pnpm install` (lockfile left unmodified, no node_modules symlink):

| Gate | Exit |
| --- | --- |
| `npx prettier --check .` | 0 |
| eslint on the 4 changed files | 0 |
| `env CI=true npm run typecheck` (all per-package tsconfigs, desktop renderer included) | 0 |
| `vitest run --changed origin/main` (2 files, 11 tests) | 0 |
| `vitest run --project pure` (210 files, 2389 tests) | 0 |
| `node scripts/check-dead-code-ratchet.mjs` | 0 |
| `node scripts/check-effect-migration-ratchet.mjs` | 0 |
| `npm run check:guidance-refs` | 0 |
| `node scripts/check-browser-safe-utils.mjs` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
