### PR TITLE
fix(cli): read run JSON under output in validate-run

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -791,10 +791,10 @@ function validateRunCommand() {
     assertSuccess(json, 'texra run JSON');
     const jsonResult = JSON.parse(json.stdout);
     assert(
-      jsonResult.category === 'workflow',
+      jsonResult.output?.category === 'workflow',
       'JSON run output should serialize the workflow result',
     );
-    const finalOutput = jsonResult.outputs.at(-1);
+    const finalOutput = jsonResult.output.outputs.at(-1);
     assert(
       outputPathPattern.test(finalOutput?.relativePath ?? ''),
       'JSON run output should report the run-storage output path',
@@ -882,11 +882,13 @@ function validateToolUseAgentRunCommand() {
 
     const jsonResult = JSON.parse(result.stdout);
     assert(
-      jsonResult.category === 'toolUse',
+      jsonResult.output?.category === 'toolUse',
       'JSON agent run output should serialize the tool-use result',
     );
     assert(
-      String(jsonResult.response ?? '').includes('Validated CLI Runtime'),
+      String(jsonResult.output?.response ?? '').includes(
+        'Validated CLI Runtime',
+      ),
       'tool-use agent run should return the validation model response',
     );
   } finally {
@@ -1030,7 +1032,7 @@ prompts:
       report.includes('(±23,±22)') &&
         report.includes('det(I+A)=4') &&
         report.includes('1/4'),
-      'workflow-script run should contain all structured mathematical results',
+      `workflow-script run should contain all structured mathematical results\nreport:\n${report}`,
     );
   } finally {
     rmSync(cwd, { recursive: true, force: true });
@@ -1085,11 +1087,11 @@ function validateMultiAgentRunCommand() {
       'multi-agent run should select an available preset root agent',
     );
     assert(
-      jsonResult.result?.category === 'toolUse',
+      jsonResult.result?.output?.category === 'toolUse',
       'multi-agent JSON output should serialize the tool-use result',
     );
     assert(
-      String(jsonResult.result?.response ?? '').includes(
+      String(jsonResult.result?.output?.response ?? '').includes(
         'Validated CLI Runtime',
       ),
       'multi-agent run should return the validation model response',
@@ -1121,11 +1123,11 @@ function validateMultiAgentRunCommand() {
       'instruction-only multi-agent JSON output should identify the preset',
     );
     assert(
-      inlineJsonResult.result?.category === 'toolUse',
+      inlineJsonResult.result?.output?.category === 'toolUse',
       'instruction-only multi-agent JSON output should serialize the tool-use result',
     );
     assert(
-      String(inlineJsonResult.result?.response ?? '').includes(
+      String(inlineJsonResult.result?.output?.response ?? '').includes(
         'Validated CLI Runtime',
       ),
       'instruction-only multi-agent run should return the validation model response',


### PR DESCRIPTION
## Summary
Runtime validation (the main-only `runtime validation (linux)` job) has been red on every main commit since 4bc68a85c3 (#12246, one run model S2b). That change moved `category`, `outputs` and `response` under `output` on the CLI run result (`CliWorkflowRunResult` / `CliToolUseRunResult`), a deliberate 1.0 break (D13-1), but `packages/cli/scripts/validate-run.mjs` still read the top-level fields.

- Workflow run JSON: `output.category`, `output.outputs`.
- `agents run` tool-use JSON: `output.category`, `output.response`.
- multi-agent JSON: `result.output.category`, `result.output.response`.
- The workflow-script report assertion now includes the report it received in its failure message.

## Known remaining failure
With these fixed, validation reaches :1031 and fails there: the workflow-script child report shows `{"solutions": [null, null, null]}`. `agent().structured` no longer reaches workflow scripts, although the `delegate_multi_agents` contract (WorkflowScriptTool.ts:194) documents it. That is a runtime regression, and coauthor-dc is restoring the contract in a separate PR. This PR makes the failure visible instead of masked by :795.

## Verified
- `npm --prefix packages/cli run validate:run` locally (same script CI runs): passes every run-JSON assertion, then fails at :1031 as described, printing the report.
- prettier --check on the changed file: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)