### PR TITLE
fix: workflow-script agent() exposes .structured again after the one-terminal-fact move

### DIFF
--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -75,8 +75,12 @@ return await parallel(
   not-reached. Hosts must not present plan entries as resolved calls, nor
   infer parallelism or dependencies from shared phase membership — the run
   snapshot's `queued`/`running` calls are the only source of real concurrency.
-- `agent(prompt, opts?)` — one subagent run; resolves to the host runner's
-  typed result, `null` on failure, or the truthy
+- `agent(prompt, opts?)` — one subagent run; resolves to the host's
+  script-facing envelope (the host's `toScriptValue` over the runner's typed
+  result: in production the child's output plus `outcome` and `cost`, so a
+  workflow call reads `{ category, outcome, outputs, diffs, compileFailures,
+cost }` and a tool-use call `{ category, outcome, response, files,
+structured, cost }`), `null` on failure, or the truthy
   `'__WORKFLOW_SKIPPED__'` sentinel when an interactive user skips it. Exclude
   both non-results before synthesis.
   Set `opts.model` to an available model short name when a call needs a
@@ -103,7 +107,9 @@ return await parallel(
   `runAgent` callback. The production adapter in
   `src/tools/delegation/workflowScriptAgentRunner.ts` uses the in-band
   subagent execution path, so the engine consumes the run's `RunEnd`
-  (`run.end` payload) — never the XML follow-up delivery string. It
+  (`run.end` payload) — never the XML follow-up delivery string. The journal
+  records that `RunEnd`; the strategy's `toScriptValue` flattens it into the
+  documented `agent()` envelope at the one script-facing boundary. It
   also verifies task-run inputs against persisted child lineage and result
   manifests before passing them to a later workflow step.
 - **Restart-safe checkpoints**: one strict, versioned execution-KV record per

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -295,6 +295,7 @@ export async function runWorkflowScript(
 ): Promise<WorkflowScriptRunResult> {
   const {
     runAgent,
+    toScriptValue,
     fingerprintAgentDependencies,
     onEvent,
     onJournalEntry,
@@ -637,21 +638,27 @@ export async function runWorkflowScript(
     };
 
     // Serialize (and round-trip deserialize) a result value for the journal,
-    // failing the call if it isn't bridge-safe. Shared by the cached-replay
-    // and live-call paths below, which differ only in the source value — a
-    // cached replay's call is still PLANNED here, which is exactly the case
-    // `failCall` keeps `finish()` from reclassifying as not-reached.
+    // failing the call if it or its script-facing projection isn't
+    // bridge-safe. Shared by the cached-replay and live-call paths below,
+    // which differ only in the source value — a cached replay's call is still
+    // PLANNED here, which is exactly the case `failCall` keeps `finish()`
+    // from reclassifying as not-reached.
     const journalValue = (
       value: unknown,
       valueLabel: string,
     ): { payload: string | undefined; normalizedResult: unknown } => {
       try {
-        const payload = serializeBridgeValue(value, valueLabel);
-        return {
-          payload,
-          normalizedResult:
-            payload === undefined ? undefined : JSON.parse(payload),
-        };
+        const journalPayload = serializeBridgeValue(value, valueLabel);
+        const normalizedResult =
+          journalPayload === undefined ? undefined : JSON.parse(journalPayload);
+        // The journal keeps the runner's result; the script sees the host's
+        // projection of that same normalized value, so a replay resolves
+        // exactly like the live call it caches.
+        const payload =
+          toScriptValue === undefined
+            ? journalPayload
+            : serializeBridgeValue(toScriptValue(normalizedResult), valueLabel);
+        return { payload, normalizedResult };
       } catch (error) {
         const fault = failRun(
           error instanceof WorkflowRunAbortError

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -293,8 +293,9 @@ export interface WorkflowAttemptFacts {
 /**
  * Host-provided executor for one `agent()` call. Tests use a fake; a
  * production host wires this to the in-band subagent run path so the
- * engine receives the typed `RunEnd` envelope, never the XML
- * follow-up delivery string.
+ * engine receives the typed `RunEnd`, never the XML follow-up delivery
+ * string. The journal records that result; the script sees
+ * {@link WorkflowScriptRunOptions.toScriptValue} of it.
  */
 export type WorkflowAgentRunner = (
   invocation: WorkflowAgentInvocation,
@@ -359,6 +360,14 @@ export interface WorkflowScriptRunOptions {
   /** Exposed to the script as the immutable global `files` object. */
   files?: WorkflowScriptFiles;
   runAgent: WorkflowAgentRunner;
+  /**
+   * Host projection from a runner result (live, or replayed from the journal)
+   * to the value `agent()` resolves to in the script. The journal keeps the
+   * runner's own result, so resume and cost accounting read one shape while
+   * the script sees the host's documented envelope. Omitted: the script sees
+   * the runner result unchanged.
+   */
+  toScriptValue?: (result: unknown) => unknown;
   /**
    * Host-owned fingerprint for external file dependencies referenced by one
    * agent() call. Required when the call carries file options: the engine

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -143,6 +143,53 @@ describe('createWorkflowScriptStrategy', () => {
     );
   });
 
+  it('resolves a structured tool-use agent() call to the documented envelope', async () => {
+    // Regression: #12246 moved the child's result under `RunEnd.output`, and
+    // agent() handed scripts the RunEnd itself, so `.structured` read undefined.
+    const structuredEnd: RunEnd = {
+      outcome: 'completed',
+      usage: RunUsageTotalsSchema.parse({ totalCost: 0.1 }),
+      output: {
+        category: 'toolUse',
+        response: 'Solved.',
+        files: [],
+        structured: { answer: '(±23,±22)' },
+      },
+    };
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'structured-envelope',
+        script: `export const meta = {
+  name: 'structured-envelope',
+  description: 'reads the structured envelope',
+}
+return await agent('Solve.', {
+  agentName: 'prover',
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['answer'],
+    properties: { answer: { type: 'string' } },
+  },
+})`,
+        createRunAgent: () => async () => structuredEnd,
+      }),
+    );
+
+    const turn = await Effect.runPromise(
+      strategy.launch(fakePorts(), new AbortController().signal),
+    );
+
+    expect(turn.result).toEqual({
+      category: 'toolUse',
+      outcome: 'completed',
+      response: 'Solved.',
+      files: [],
+      structured: { answer: '(±23,±22)' },
+      cost: 0.1,
+    });
+  });
+
   it('settles zero for a pure checkpoint replay', async () => {
     await runPersistedWorkflowScript({
       store: getRunStore(runId),
@@ -397,7 +444,7 @@ throw new Error('current revision failed')`,
     expect(errText).toContain('"taskTotal":0');
   });
 
-  it('retains live spend when the completed journal result is malformed', async () => {
+  it('retains live spend when the agent() result is malformed', async () => {
     const malformedScript = `export const meta = {
   name: 'malformed-cost',
   description: 'tests malformed journal cost settlement',
@@ -417,8 +464,10 @@ return await agent('saved call')`;
 
     await expect(
       Effect.runPromise(strategy.launch(ports, new AbortController().signal)),
-    ).rejects.toThrow('Workflow journal entry 0 is not a run result.');
-    expect(ports.recordCost.mock.calls).toEqual([[0.2]]);
+    ).rejects.toThrow('Workflow agent() result is not a run result');
+    // The live candidate, then the failure path's settlement of that same
+    // retained spend: the malformed result never reached the journal.
+    expect(ports.recordCost.mock.calls).toEqual([[0.2], [0.2]]);
   });
 });
 
@@ -567,8 +616,9 @@ describe('createWorkflowScriptStrategy interactive controls', () => {
     const turn = await launch;
     // The second attempt settles with the real result, and the call ran twice.
     expect(turn.result).toMatchObject({
-      output: { category: 'workflow' },
-      usage: { totalCost: 0.42 },
+      category: 'workflow',
+      outcome: 'completed',
+      cost: 0.42,
     });
     expect(fake.attempts()).toBe(2);
     expect(completedTaskCosts).toHaveLength(1);

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -468,6 +468,27 @@ return await agent('saved call')`;
     // The live candidate, then the failure path's settlement of that same
     // retained spend: the malformed result never reached the journal.
     expect(ports.recordCost.mock.calls).toEqual([[0.2], [0.2]]);
+
+    // A well-formed but failed RunEnd fails the same way, naming its outcome
+    // and error, rather than resolving an `{ outcome: 'failed' }` envelope.
+    const failedStrategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'failed-outcome',
+        script: malformedScript.replaceAll('malformed-cost', 'failed-outcome'),
+        createRunAgent: () => async () => ({
+          ...finalResult,
+          outcome: 'failed',
+          error: { kind: 'unexpected', message: 'prover crashed' },
+        }),
+      }),
+    );
+    await expect(
+      Effect.runPromise(
+        failedStrategy.launch(fakePorts(), new AbortController().signal),
+      ),
+    ).rejects.toThrow(
+      'Workflow agent() result ended with failed outcome: prover crashed.',
+    );
   });
 });
 

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -312,7 +312,16 @@ export function createWorkflowScriptStrategy(
                         { cause: parsed.error },
                       );
                     }
-                    const { outcome, usage, output } = parsed.data;
+                    const { outcome, error, usage, output } = parsed.data;
+                    // agent() resolves only a completed child. Any other outcome
+                    // is a failure, never an envelope a script could mistake
+                    // for a result.
+                    if (outcome !== 'completed') {
+                      throw new Error(
+                        `Workflow agent() result ended with ${outcome} outcome${error?.message ? `: ${error.message}` : ''}.`,
+                        error ? { cause: error } : undefined,
+                      );
+                    }
                     return { ...output, outcome, cost: usage?.totalCost ?? 0 };
                   },
                   fingerprintAgentDependencies:

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -301,6 +301,20 @@ export function createWorkflowScriptStrategy(
                   // once": the engine's own default is a library fallback only.
                   concurrency: resolveChildRunConcurrencyBudget(),
                   runAgent,
+                  // The one place a child's terminal fact becomes the documented
+                  // agent() envelope: its output, flattened, beside the outcome and
+                  // cost. The journal keeps the `RunEnd` itself.
+                  toScriptValue: (value) => {
+                    const parsed = RunEndSchema.safeParse(value);
+                    if (!parsed.success) {
+                      throw new Error(
+                        `Workflow agent() result is not a run result: ${toErrorMessage(parsed.error)}`,
+                        { cause: parsed.error },
+                      );
+                    }
+                    const { outcome, usage, output } = parsed.data;
+                    return { ...output, outcome, cost: usage?.totalCost ?? 0 };
+                  },
                   fingerprintAgentDependencies:
                     params.fingerprintAgentDependencies,
                   onActivity: runLog.add,


### PR DESCRIPTION
## Summary

**Symptom.** In the `validate-run` workflow-script scenario (`packages/cli/scripts/validate-run.mjs`, ~:1031), all three structured prover children finish, but the script report is `{"solutions": [null, null, null]}`. The fixture follows the documented contract: `results.map((result) => result?.structured ?? null)`. `WorkflowScriptTool`'s description promises that tool-use `agent()` calls "resolve to a structured JSON result via agent().structured". So every user script that follows that contract got `null`/`undefined`.

**Root cause: 4bc68a85c3 (#12246, one run model S2a+S2b).** That PR changed `createWorkflowScriptAgentRunner` (`src/tools/delegation/workflowScriptAgentRunner.ts`) to return the child's `RunEnd` (`{ outcome, usage, output: { category, structured, … } }`) instead of the flat `AgentFinalResult`. The engine (`src/agent/workflowScript/runWorkflowScript.ts`, `journalValue`) forwards the runner value to the script unchanged. So every documented field moved one level down, under `.output`. #12240 is not involved: at c789469685 the runner still returned `AgentFinalResult`. The main-only runtime-validation job hid this, because since #12246 it had been failing earlier, at :795 (fixed by #12289).

**Fix, at one boundary.** The engine gets a host `toScriptValue` option. It runs where the engine builds the script-facing payload, the same `journalValue` step that both live calls and cached replays go through.
- The journal still stores the `RunEnd`. It is the one stored shape, and `workflowJournalEntryCost` and the delivery file summary already read it, so no second copy of the terminal fact is added.
- The production projection is in `workflowScriptStrategy.ts`: `{ ...output, outcome, cost: usage?.totalCost ?? 0 }`.

Documented `agent()` fields restored, all at that boundary:
- workflow calls: `category`, `outcome`, `outputs`, `diffs`, `compileFailures` (plus `diffsUnavailable` and `structured` when present), `cost`
- tool-use calls: `category`, `outcome`, `response`, `files`, `structured`, `cost`

Notes:
- `error` is not projected. The runner throws on any non-completed outcome, so a resolved value never carries one.
- A runner result that is not a `RunEnd` now fails the run at the projection, before it can reach the journal.
- Journals written between #12246 and this fix hold `RunEnd`s, so they replay correctly: the projection also applies to cached entries.
- `workflowScriptAgentRunner.ts` is untouched, because it overlaps open PR #12281.

## Regression test

One new test in `src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts`: "resolves a structured tool-use agent() call to the documented envelope". A structured tool-use `RunEnd` child must resolve `agent()` to `{ category, outcome, response, files, structured, cost }`.
- **Negative control:** with main's `workflowScriptStrategy.ts` restored, it fails. It receives `{ outcome, usage, output }`.

Two existing tests in the same suite changed:
- The retry test's `turn.result` expectation had pinned the broken `RunEnd` shape; it now expects the envelope.
- The malformed-result test now expects the new boundary error. Its cost expectation is now `[[0.2], [0.2]]`: live spend is still retained and settled on the failure path.

## Verified

All on the rebased branch (origin/main 1dd790a72a):
- `npx prettier --check .`: exit 0
- eslint on the 4 changed TS files: exit 0
- `env CI=true npm run typecheck`: GATE_EXIT=0
- `vitest run --changed origin/main`: GATE_EXIT=0 (84 files, 1370 passed, 1 skipped)
- `vitest run --project pure`: GATE_EXIT=0 (208 files, 2385 passed)
- `node scripts/check-dead-code-ratchet.mjs`: GATE_EXIT=0 (no new findings)
- `node scripts/check-effect-migration-ratchet.mjs`: exit 0
- `npm run check:guidance-refs`: exit 0
- Focused workflow-script suites (Strategy, Engine, Persistence, Cost, ProgressBridge, RunObservability): 213 passed
- **End to end:** `node packages/cli/scripts/validate-run.mjs` builds its own validation bundle with the internal validation model. It ran in full, including #12289's :795 fix: GATE_EXIT=0, "CLI run validation passed". So the :1031 workflow-script assertion now passes: the child report contains all three structured answers (`(±23,±22)`, `det(I+A)=4`, `1/4`) where it used to be `[null, null, null]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
