### PR TITLE
docs: update landing slogan to "do good work"

### DIFF
--- a/docs/.vitepress/components/LandingHero.vue
+++ b/docs/.vitepress/components/LandingHero.vue
@@ -54,7 +54,7 @@ async function copyCli() {
     <p class="lh-eyebrow">Open-source multi-agent AI for theorists</p>
     <h1 class="lh-headline">
       Derive it, check it,<br />
-      write it into your paper.
+      do good work.
     </h1>
     <p class="lh-tagline">
       You direct an orchestrator. It delegates to specialist agents that search

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -83,7 +83,7 @@ const baseConfig = {
   title: 'TeXRA',
   base,
   description:
-    'An AI theorist for advancing theoretical science. A team of specialist agents derives results, checks derivations in Wolfram, formalizes proofs in Lean 4, and writes them into your paper, in VS Code and the terminal.',
+    'An AI theorist for advancing theoretical science. A team of specialist agents derives results, checks derivations in Wolfram, formalizes proofs in Lean 4, and helps you do good work, in VS Code and the terminal.',
   head: [
     ['link', { rel: 'icon', href: `${base}favicon.svg` }],
     [


### PR DESCRIPTION
## Summary

Updates the website landing hero headline and site description slogan to emphasize doing good, rigorous research rather than writing text into papers:

- **Headline** in [LandingHero.vue](file:///Users/siruilu/Local/AI-Projects/coauthor/docs/.vitepress/components/LandingHero.vue):
  - Before: `Derive it, check it, / write it into your paper.`
  - After: `Derive it, check it, / do good work.`
- **Site description** in [config.js](file:///Users/siruilu/Local/AI-Projects/coauthor/docs/.vitepress/config.js):
  - Updates the closing clause from `writes them into your paper` to `helps you do good work`.

This clarifies TeXRA's positioning as an AI theorist for rigorous derivations, verification, and proofs, avoiding phrasing that could be interpreted as an automated paper-writing tool.