### PR TITLE
simplify(settings): one global streaming toggle; one OpenRouter provider-state id (1.0 clean slate)

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -21,7 +21,6 @@
       "src/tools/externalToolDefs.ts": 1,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/utils/config/platformSettings.ts": 1,
-      "src/utils/config/providerConfig.ts": 1,
       "src/utils/files/baseFS.ts": 13,
       "src/utils/files/storageFS.ts": 1,
       "src/utils/system/toolUtils.ts": 1

--- a/docs/.vitepress/components/ProviderConfigRow.vue
+++ b/docs/.vitepress/components/ProviderConfigRow.vue
@@ -1,8 +1,8 @@
 <script setup>
 // Frameless slice of one expanded "API Configuration" provider row from the
-// Models tab. Both the "Using OpenRouter" and "Streaming" sections narrate the
-// same interaction in prose — expand a provider row, then toggle streaming /
-// "Use OpenRouter for All Models" — but never show what expansion reveals.
+// Models tab. The "Using OpenRouter" section narrates this interaction in
+// prose — expand a provider row, then toggle "Use OpenRouter for All Models" —
+// but never shows what expansion reveals.
 // ApiKeysHero only renders these rows collapsed (chevron-right, no body); this
 // pulls a single row out, expanded (chevron-down), with the toggles + masked
 // key field it exposes. Reuses the .api-table provider-row vocab and the
@@ -10,7 +10,6 @@
 import { ref } from 'vue';
 import MockSwitch from './MockSwitch.vue';
 
-const streaming = ref(true);
 const openrouter = ref(false);
 </script>
 
@@ -43,7 +42,7 @@ const openrouter = ref(false);
       </div>
     </div>
 
-    <!-- Expanded body: masked key + the two per-provider toggles. -->
+    <!-- Expanded body: masked key + the per-provider toggle. -->
     <div class="pcr-body">
       <div class="pcr-field">
         <label class="pcr-flabel">API key</label>
@@ -51,14 +50,6 @@ const openrouter = ref(false);
           <wa-icon class="pcr-key-ic" library="texra" name="key"></wa-icon>
           <span class="pcr-key-mask">sk-••••••••••••••••••••••••</span>
         </div>
-      </div>
-
-      <div class="pcr-toggle">
-        <MockSwitch
-          v-model="streaming"
-          label="Enable streaming"
-          description="Long responses arrive incrementally"
-        />
       </div>
 
       <div class="pcr-toggle">

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -177,7 +177,7 @@ The Status column shows `Set` once the key is stored. To replace a key, set it a
 <p class="hero-caption">The Providers & Models tab's API configuration table: each provider shows its key status and Set / Get / Remove actions.</p>
 
 ::: tip Per-provider settings
-Expand a provider's row (select the chevron) to toggle streaming or, for providers that support it, point requests at a custom endpoint.
+Expand a provider's row (select the chevron) to point requests at a custom endpoint, for providers that support it.
 :::
 
 You can also place a `.env` file in your workspace with variables such as `OPENAI_API_KEY`. TeXRA loads it automatically, so you don't need to enter keys each time.
@@ -207,15 +207,15 @@ To access additional models or alternative pricing:
 2. Add it with the `TeXRA: Set API Key` command
 3. In the Dashboard → Providers & Models tab → API configuration, expand the OpenRouter row and turn on **Use OpenRouter for all models**
 
-Expanding any provider's row in **API Configuration** reveals its key field plus the per-provider toggles described here and under [Streaming](#streaming):
+Expanding any provider's row in **API Configuration** reveals its key field plus the per-provider toggles described here:
 
 <ProviderConfigRow />
 
-<p class="hero-caption">Expand a provider's <strong>API configuration</strong> row to reveal its masked key field, the per-provider <strong>Streaming</strong> switch (and <strong>Custom endpoint</strong> where supported); the OpenRouter row adds <strong>Use OpenRouter for all models</strong>.</p>
+<p class="hero-caption">Expand a provider's <strong>API configuration</strong> row to reveal its masked key field (and <strong>Custom endpoint</strong> where supported); the OpenRouter row adds <strong>Use OpenRouter for all models</strong>.</p>
 
 ## Streaming
 
-Streaming has a global default plus per-provider overrides. Open the **Dashboard → Providers & Models** tab: the **Enable streaming** toggle at the top of **API configuration** sets the default for all providers, and each expanded provider row has its own **Streaming** switch (shown in the [expanded provider row under Using OpenRouter](#using-openrouter)). When streaming is on, long responses
+Streaming is one switch for every provider: the **Enable streaming** toggle at the top of **API configuration** in the **Dashboard → Providers & Models** tab. When streaming is on, long responses
 arrive incrementally instead of in one large reply.
 
 ## Next steps

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -275,7 +275,7 @@ Opening VS Code from a configured terminal provides the most reliable environmen
 2. **Response timeout**:
    - For large documents, the model might time out
    - Try breaking the task into smaller chunks
-   - Enable streaming for the provider in the **Models** tab so long responses
+   - Turn on **Enable streaming** in the **Models** tab so long responses
      arrive incrementally instead of in a single large reply
 
 3. **Context length**:
@@ -370,7 +370,7 @@ Opening VS Code from a configured terminal provides the most reliable environmen
 
 1. **Incomplete generation**:
    - Check whether the AI reached the token limit
-   - Enable streaming for the provider in the **Models** tab for more reliable
+   - Turn on **Enable streaming** in the **Models** tab for more reliable
      completion of long outputs
 
 2. **XML parsing issues**:

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -8,10 +8,7 @@ import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import type { ProviderKeyStatus, ProviderSetting } from '@shared/schemas';
 import { DEFAULT_GLOBAL_STREAMING } from '@shared/schemas';
-import {
-  PROVIDER_STATE_ENTRIES,
-  type ProviderStateEntry,
-} from '@shared/constants/providers';
+import { PROVIDER_STATE_ENTRIES } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
@@ -55,20 +52,6 @@ export class ProviderKeyList extends LitElement {
   private toggleExpanded(provider: string): void {
     this.expandedProvider =
       this.expandedProvider === provider ? null : provider;
-  }
-
-  /**
-   * Catalog keys for a provider's streaming/endpoint writes. The lowercase
-   * fallback mirrors `providerConfig.entry()`: the API-key roster spells
-   * OpenRouter as `openRouter` while the state registry uses `openrouter`.
-   */
-  private providerStateKeys(provider: string): ProviderStateEntry | undefined {
-    return (
-      PROVIDER_STATE_ENTRIES.find((entry) => entry.id === provider) ??
-      PROVIDER_STATE_ENTRIES.find(
-        (entry) => entry.id === provider.toLowerCase(),
-      )
-    );
   }
 
   private renderActions(entry: ProviderKeyStatus): TemplateResult {
@@ -115,22 +98,6 @@ export class ProviderKeyList extends LitElement {
   }
 
   private renderDetails(entry: ProviderKeyStatus): TemplateResult {
-    const streamingToggle = html`
-      <div class="provider-setting">
-        <wa-switch
-          ?checked=${entry.streaming}
-          @change=${(e: Event) => {
-            const checked = (e.target as WaSwitch).checked;
-            const key = this.providerStateKeys(entry.provider)?.streamingKey;
-            if (key) postStateSetting(key, checked);
-          }}
-        >
-          Streaming
-          <span class="visually-hidden">for ${entry.displayName}</span>
-        </wa-switch>
-      </div>
-    `;
-
     const endpointInput = entry.supportsCustomEndpoint
       ? html`
           <div class="provider-setting">
@@ -148,7 +115,9 @@ export class ProviderKeyList extends LitElement {
               placeholder="Leave blank for default"
               @change=${(e: Event) => {
                 const value = (e.target as WaInput).value?.trim() ?? '';
-                const key = this.providerStateKeys(entry.provider)?.endpointKey;
+                const key = PROVIDER_STATE_ENTRIES.find(
+                  ({ id }) => id === entry.provider,
+                )?.endpointKey;
                 if (key) postStateSetting(key, value);
               }}
             ></wa-input>
@@ -158,7 +127,7 @@ export class ProviderKeyList extends LitElement {
 
     return html`
       <div class="settings-disclosure-content provider-settings">
-        ${streamingToggle} ${endpointInput}
+        ${endpointInput}
         ${entry.providerSettings.map((s) => this.renderProviderSetting(s))}
       </div>
     `;

--- a/packages/extension/src/settingsView/frontend/components/profile/providerKeyRows.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/providerKeyRows.ts
@@ -18,7 +18,6 @@ const DEFAULT_PROVIDER_KEY_STATUSES: readonly ProviderKeyStatus[] =
         displayName: PROVIDER_DISPLAY_NAMES[provider] ?? provider,
         status: 'not-set' as const,
         keyUrl: PROVIDER_URLS[provider] ?? '',
-        streaming: true,
         customEndpoint: '',
         supportsCustomEndpoint: false,
         providerSettings: [],

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -50,7 +50,6 @@ import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing'
 import { supportsReasoningLevel } from '@model/reasoningLevel';
 import {
   resolveDirectModelApiKeyProvider,
-  resolveModelSource,
   type ResolvedModelConfig,
 } from '@model/openRouterRouting';
 import { exposeApiKey, getApiKey, type ApiProvider } from '@model/apiProviders';
@@ -78,10 +77,7 @@ import { isObject } from '@utils/core';
 import { isImageMimeType } from '@utils/files/mimeUtils';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { extractScratchpad } from '@utils/text/xmlExtraction';
-import {
-  getProviderStreaming,
-  getGlobalStreaming,
-} from '@utils/config/providerConfig';
+import { getGlobalStreaming } from '@utils/config/providerConfig';
 import { getValidatedConfig } from '@utils/config/configUtils';
 
 // Local file imports
@@ -835,17 +831,9 @@ export abstract class ModelHandler<
     this.compactionRequested = false;
   }
 
-  /**
-   * Gets streaming configuration for the current model provider.
-   */
+  /** Whether requests stream: one global toggle covers every provider. */
   public getStreamingConfig(): boolean {
-    if (shouldUseOpenRouter(this.config))
-      return getProviderStreaming('openrouter');
-    if (this.config.provider === ModelProvider.OTHERS)
-      return getGlobalStreaming();
-    return getProviderStreaming(
-      resolveModelSource(this.config) ?? this.config.provider,
-    );
+    return getGlobalStreaming();
   }
 
   /**

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -17,7 +17,6 @@ import {
   getProviderDisplayName,
   getProviderEndpoint,
   getProviderKeyUrl,
-  getProviderStreaming,
   supportsCustomEndpoint,
 } from '@utils/config/providerConfig';
 
@@ -108,7 +107,6 @@ export class SettingsProfileController {
       displayName: this.getProviderDisplayName(provider),
       status: secretStatuses[provider] ?? 'not-set',
       keyUrl: getProviderKeyUrl(provider) ?? '',
-      streaming: getProviderStreaming(provider),
       customEndpoint: getProviderEndpoint(provider),
       supportsCustomEndpoint: supportsCustomEndpoint(provider),
       providerSettings: this.getProviderSettings(provider),

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -19,8 +19,6 @@ interface ProviderDef {
   readonly displayName: string;
   /** URL for obtaining API keys. undefined = no standalone key page. */
   readonly keyUrl?: string;
-  /** Global-state key for this provider's streaming toggle. */
-  readonly streamingKey?: GlobalStateKey;
   /** Global-state key for this provider's custom endpoint. */
   readonly endpointKey?: GlobalStateKey;
   /** Optional alternate-region metadata for endpoint/key-url derivation. */
@@ -38,7 +36,6 @@ interface ProviderRegionSetting {
 export interface ProviderStateEntry {
   readonly id: string;
   readonly displayName: string;
-  readonly streamingKey?: GlobalStateKey;
   readonly endpointKey?: GlobalStateKey;
   readonly region?: ProviderRegionSetting;
 }
@@ -64,42 +61,36 @@ const PROVIDER_REGISTRY = [
     id: ModelProvider.OPENAI,
     displayName: 'OpenAI',
     keyUrl: 'https://platform.openai.com/api-keys',
-    streamingKey: GlobalStateKey.STREAMING_OPENAI,
     endpointKey: GlobalStateKey.ENDPOINT_OPENAI,
   },
   {
     id: ModelProvider.ANTHROPIC,
     displayName: 'Anthropic',
     keyUrl: 'https://console.anthropic.com/',
-    streamingKey: GlobalStateKey.STREAMING_ANTHROPIC,
     endpointKey: GlobalStateKey.ENDPOINT_ANTHROPIC,
   },
   {
     id: ModelProvider.GOOGLE,
     displayName: 'Google',
     keyUrl: 'https://aistudio.google.com/app/apikey',
-    streamingKey: GlobalStateKey.STREAMING_GOOGLE,
     endpointKey: GlobalStateKey.ENDPOINT_GOOGLE,
   },
   {
     id: ModelProvider.XAI,
     displayName: 'xAI',
     keyUrl: 'https://console.x.ai/',
-    streamingKey: GlobalStateKey.STREAMING_XAI,
     endpointKey: GlobalStateKey.ENDPOINT_XAI,
   },
   {
     id: ModelProvider.DEEPSEEK,
     displayName: 'DeepSeek',
     keyUrl: 'https://platform.deepseek.com/api_keys',
-    streamingKey: GlobalStateKey.STREAMING_DEEPSEEK,
     endpointKey: GlobalStateKey.ENDPOINT_DEEPSEEK,
   },
   {
     id: ModelProvider.MOONSHOT,
     displayName: 'Moonshot',
     keyUrl: 'https://platform.moonshot.cn/console',
-    streamingKey: GlobalStateKey.STREAMING_MOONSHOT,
     endpointKey: GlobalStateKey.ENDPOINT_MOONSHOT,
     // China=true is the default since moonshot.cn is the primary platform;
     // when toggled off (international), keys come from platform.moonshot.ai.
@@ -114,7 +105,6 @@ const PROVIDER_REGISTRY = [
     id: ModelProvider.DASHSCOPE,
     displayName: 'Qwen',
     keyUrl: 'https://dashscope.aliyun.com/api-console/',
-    streamingKey: GlobalStateKey.STREAMING_DASHSCOPE,
     endpointKey: GlobalStateKey.ENDPOINT_DASHSCOPE,
     region: {
       key: GlobalStateKey.DASHSCOPE_USE_CHINA,
@@ -127,7 +117,6 @@ const PROVIDER_REGISTRY = [
     id: ModelProvider.MINIMAX,
     displayName: 'MiniMax',
     keyUrl: 'https://platform.minimax.io/',
-    streamingKey: GlobalStateKey.STREAMING_MINIMAX,
     endpointKey: GlobalStateKey.ENDPOINT_MINIMAX,
     region: {
       key: GlobalStateKey.MINIMAX_USE_CHINA,
@@ -139,7 +128,6 @@ const PROVIDER_REGISTRY = [
     id: ModelProvider.GLM,
     displayName: 'GLM',
     keyUrl: 'https://open.bigmodel.cn/',
-    streamingKey: GlobalStateKey.STREAMING_GLM,
     endpointKey: GlobalStateKey.ENDPOINT_GLM,
     // China=true is the default since bigmodel.cn is the primary platform;
     // when toggled off (international), the key URL is z.ai.
@@ -153,7 +141,6 @@ const PROVIDER_REGISTRY = [
     id: ModelProvider.META,
     displayName: 'Meta',
     keyUrl: 'https://dev.meta.ai/',
-    streamingKey: GlobalStateKey.STREAMING_META,
     endpointKey: GlobalStateKey.ENDPOINT_META,
   },
 ] as const satisfies readonly ProviderDef[];
@@ -209,25 +196,13 @@ export const PROVIDER_URLS: Record<string, string> = {
   kimiCode: 'https://www.kimi.com/code/console',
 };
 
-export const PROVIDER_STATE_ENTRIES: readonly ProviderStateEntry[] = [
-  ...PROVIDER_REGISTRY.map((provider) => ({
+export const PROVIDER_STATE_ENTRIES: readonly ProviderStateEntry[] =
+  PROVIDER_REGISTRY.map((provider) => ({
     id: provider.id,
     displayName: provider.displayName,
-    streamingKey: provider.streamingKey,
     endpointKey: provider.endpointKey,
     region: 'region' in provider ? provider.region : undefined,
-  })),
-  {
-    id: 'openrouter',
-    displayName: 'OpenRouter',
-    streamingKey: GlobalStateKey.STREAMING_OPENROUTER,
-  },
-  {
-    id: 'kimiCode',
-    displayName: 'Kimi Code',
-    streamingKey: GlobalStateKey.STREAMING_KIMI_CODE,
-  },
-];
+  }));
 
 function hasEndpoint(
   entry: ProviderStateEntry,

--- a/src/shared/schemas/profileViewMessages.ts
+++ b/src/shared/schemas/profileViewMessages.ts
@@ -43,7 +43,6 @@ const ProviderKeyStatusSchema = z.object({
   displayName: z.string(),
   status: z.enum(['set', 'env', 'not-set']),
   keyUrl: z.string(),
-  streaming: z.boolean().prefault(true),
   customEndpoint: z.string().prefault(''),
   supportsCustomEndpoint: z.boolean().prefault(false),
   providerSettings: z.array(ProviderSettingSchema).prefault([]),

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -16,7 +16,6 @@ import {
 import {
   DEFAULT_HELPER_MODEL,
   PROVIDER_ENDPOINT_STATE_ENTRIES,
-  PROVIDER_STATE_ENTRIES,
 } from '@shared/constants/providers';
 import {
   CLAUDE_AGENT_DEFAULT_EFFORT,
@@ -472,7 +471,7 @@ const CORE_SETTING_ROWS: Record<
     default: false,
     title: 'Google background responses',
     description:
-      'Run Google workflow generations as background Interactions (submit + poll). When this and the Google streaming toggle are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. The Google streaming toggle avoids that unary request; background responses also do when server-side conversation state is enabled and the selected model supports them. Off by default; unsupported models fall back automatically.',
+      'Run Google workflow generations as background Interactions (submit + poll). When this and the global streaming toggle (Enable streaming) are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. The global streaming toggle (Enable streaming) avoids that unary request; background responses also do when server-side conversation state is enabled and the selected model supports them. Off by default; unsupported models fall back automatically.',
     honoredBy: everyHost(
       'src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts',
     ),
@@ -480,7 +479,7 @@ const CORE_SETTING_ROWS: Record<
       provider: 'google',
       label: 'Background responses',
       description:
-        'Run workflow generations as background Interactions (submit + poll). When this and the Google streaming toggle are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. The Google streaming toggle avoids that unary request; background responses also do when server-side conversation state is enabled and the selected model supports them. Off by default; unsupported models fall back automatically.',
+        'Run workflow generations as background Interactions (submit + poll). When this and the global streaming toggle (Enable streaming) are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. The global streaming toggle (Enable streaming) avoids that unary request; background responses also do when server-side conversation state is enabled and the selected model supports them. Off by default; unsupported models fall back automatically.',
     },
   }),
   'model.useBackgroundResponses': modelProviderToggle({
@@ -1000,29 +999,6 @@ const PROVIDER_ENDPOINT_SETTINGS = PROVIDER_ENDPOINT_STATE_ENTRIES.map(
 );
 
 /**
- * Per-provider streaming toggles. Reads stay in `providerConfig`'s
- * `getProviderStreaming`, whose default-when-unset is the *global* streaming
- * toggle — the static `.prefault(true)` here matches that global default.
- */
-const PROVIDER_STREAMING_SETTINGS = PROVIDER_STATE_ENTRIES.flatMap(
-  ({ streamingKey, displayName }) =>
-    streamingKey
-      ? [
-          surfacedSetting({
-            key: streamingKey,
-            schema: z.boolean().prefault(true),
-            title: `${displayName} streaming`,
-            description: `Stream ${displayName} responses incrementally instead of waiting for the full completion.`,
-            category: 'model',
-            slots: sameSlot('globalState'),
-            honoredBy: everyHost(PROVIDER_CONFIG_READER),
-            surfaces: { settingsView: 'profile' },
-          }),
-        ]
-      : [],
-);
-
-/**
  * Region/routing toggles resolved by `ProxyConfigResolver`, each also a Models
  * tab control for its provider. The rows differ only in key, default, and
  * copy, so the shared fields are written once.
@@ -1452,7 +1428,6 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
 
   // --- Provider endpoints & streaming ---------------------------------------
   ...PROVIDER_ENDPOINT_SETTINGS,
-  ...PROVIDER_STREAMING_SETTINGS,
   surfacedSetting({
     key: GlobalStateKey.STREAMING_GLOBAL,
     schema: z.boolean().prefault(true),

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -84,18 +84,6 @@ export enum GlobalStateKey {
 
   // Streaming settings
   STREAMING_GLOBAL = 'texra.streaming.global',
-  STREAMING_OPENAI = 'texra.streaming.openai',
-  STREAMING_ANTHROPIC = 'texra.streaming.anthropic',
-  STREAMING_OPENROUTER = 'texra.streaming.openrouter',
-  STREAMING_GOOGLE = 'texra.streaming.google',
-  STREAMING_XAI = 'texra.streaming.xai',
-  STREAMING_DEEPSEEK = 'texra.streaming.deepseek',
-  STREAMING_MOONSHOT = 'texra.streaming.moonshot',
-  STREAMING_KIMI_CODE = 'texra.streaming.kimiCode',
-  STREAMING_DASHSCOPE = 'texra.streaming.dashscope',
-  STREAMING_MINIMAX = 'texra.streaming.minimax',
-  STREAMING_GLM = 'texra.streaming.glm',
-  STREAMING_META = 'texra.streaming.meta',
 
   // Agent settings (migrated from VS Code config)
   CUSTOM_AGENT_DIR = 'texra.customAgentDir',

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
@@ -254,7 +254,6 @@ function mockConfig(
       return originalGetConfig(key, defaultValue);
     },
   );
-  vi.spyOn(providerConfigModule, 'getProviderStreaming').mockReturnValue(false);
   vi.spyOn(providerConfigModule, 'getGlobalStreaming').mockReturnValue(false);
 }
 

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -50,7 +50,6 @@ import { buildSettingsSnapshotMessage } from '@shared/settingsView/handlers/sett
 import {
   DEFAULT_HELPER_MODEL,
   PROVIDER_ENDPOINT_STATE_ENTRIES,
-  PROVIDER_STATE_ENTRIES,
 } from '@shared/constants/providers';
 import {
   readSetting,
@@ -92,13 +91,6 @@ const CLASS_D_KEY_PATTERN = /migrated|version|onboarding|history|cache/i;
 const PROVIDER_ENDPOINT_DEFAULTS = Object.fromEntries(
   PROVIDER_ENDPOINT_STATE_ENTRIES.map(({ endpointKey }) => [endpointKey, '']),
 );
-// Per-provider streaming defaults mirror the global streaming default (true):
-// `getProviderStreaming` falls back to the global toggle when a key is unset.
-const PROVIDER_STREAMING_DEFAULTS = Object.fromEntries(
-  PROVIDER_STATE_ENTRIES.flatMap(({ streamingKey }) =>
-    streamingKey ? [[streamingKey, true]] : [],
-  ),
-);
 
 /** Expected default-when-absent for each catalog key, from the real getters. */
 const EXPECTED_DEFAULTS: Record<string, unknown> = {
@@ -137,7 +129,6 @@ const EXPECTED_DEFAULTS: Record<string, unknown> = {
   [WorkspaceStateKey.LATEX_FORMATTER]: LATEX_CONFIG_DEFAULTS.latexFormatter,
   [GlobalStateKey.WEBSOCKET_OPENAI]: false,
   ...PROVIDER_ENDPOINT_DEFAULTS,
-  ...PROVIDER_STREAMING_DEFAULTS,
   [GlobalStateKey.STREAMING_GLOBAL]: true,
   [GlobalStateKey.HELPER_MODEL]: DEFAULT_HELPER_MODEL,
   [GlobalStateKey.PREFER_SHORT_MODEL_NAMES]: false,

--- a/src/test-kernel/utils/config/ConfigUtils.vitest.ts
+++ b/src/test-kernel/utils/config/ConfigUtils.vitest.ts
@@ -12,7 +12,6 @@ import { getConfig, getValidatedConfig } from '@utils/config/configUtils';
 import {
   getProviderEndpoint,
   getProviderKeyUrl,
-  getProviderStreaming,
   getUseOpenRouter,
 } from '@utils/config/providerConfig';
 import { readPlatformSetting } from '@utils/config/platformSettings';
@@ -137,20 +136,5 @@ describe('getProviderEndpoint', () => {
       globalState: { [GlobalStateKey.ENDPOINT_OPENAI]: 42 },
     });
     expect(getProviderEndpoint('openai')).toBe('');
-  });
-});
-
-describe('OpenRouter streaming', () => {
-  it('uses the same setting for API-key and model-dispatch spellings', async () => {
-    await installPlatform({
-      globalState: { [GlobalStateKey.STREAMING_OPENROUTER]: false },
-    });
-
-    expect(getProviderStreaming('openRouter')).toBe(false);
-    await platform().globalState.update(
-      GlobalStateKey.STREAMING_OPENROUTER,
-      true,
-    );
-    expect(getProviderStreaming('openrouter')).toBe(true);
   });
 });

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -1,23 +1,16 @@
 /**
- * Provider-specific streaming, endpoint, and region configuration.
+ * Provider streaming, endpoint, and region configuration.
  *
  * The shared provider registry owns provider state keys and region metadata.
  * This module only reads/writes those keys through the active platform state.
  *
- * Canonical read path: keys registered in the state-setting catalog
- * (`src/shared/schemas/stateSettings.ts`) are read via `readPlatformSetting()`,
- * which resolves the default from the entry's schema and snaps an
- * invalid/stale stored value back to that default. The streaming toggles are
- * the deliberate exception: they are catalogued
- * (`PROVIDER_STREAMING_SETTINGS`, and the settings view writes them through
- * `UPDATE_STATE_SETTING`), but their reads stay on the local `read()` helper
- * so an unset per-provider key falls back to the *live* global streaming
- * toggle — `readPlatformSetting()` would instead resolve the entry schema's
- * static `.prefault(true)`. A key that genuinely has no catalog entry should
- * be catalogued, not given a fourth read path.
+ * Canonical read path: every key read here is registered in the state-setting
+ * catalog (`src/shared/schemas/stateSettings.ts`) and read via
+ * `readPlatformSetting()`, which resolves the default from the entry's schema
+ * and snaps an invalid/stale stored value back to that default. A key that
+ * has no catalog entry should be catalogued, not given another read path.
  */
 
-import { platform } from '@platform/platform';
 import {
   PROVIDER_STATE_ENTRIES,
   PROVIDER_URLS,
@@ -30,21 +23,8 @@ const PROVIDERS: ReadonlyMap<string, ProviderStateEntry> = new Map(
   PROVIDER_STATE_ENTRIES.map((provider) => [provider.id, provider]),
 );
 
-// The lowercase retry is load-bearing: the API-key spelling 'openRouter'
-// (EXTRA_API_KEY_PROVIDER_IDS, ModelHandler dispatch) and the registry id
-// 'openrouter' must resolve to the same entry until the carrier is retyped
-// (overdefensive-top10 #8's "lowercase once at registry load" is that PR).
-function entry(provider: string): ProviderStateEntry | undefined {
-  return PROVIDERS.get(provider) ?? PROVIDERS.get(provider.toLowerCase());
-}
-
-/** Deliberate raw read — see the module-level "Canonical read path" note. */
-function read<T>(key: GlobalStateKey, defaultValue: T): T {
-  return platform().globalState.get(key, defaultValue);
-}
-
 function regionSet(provider: string): boolean | undefined {
-  const region = entry(provider)?.region;
+  const region = PROVIDERS.get(provider)?.region;
   // Region keys are catalog-modeled, so the default comes from the entry's
   // schema (kept aligned with the registry's `region.default` by the
   // state-settings guardrail suite).
@@ -56,13 +36,7 @@ function regionSet(provider: string): boolean | undefined {
 // ---------------------------------------------------------------------------
 
 export function getGlobalStreaming(): boolean {
-  return read(GlobalStateKey.STREAMING_GLOBAL, true);
-}
-
-export function getProviderStreaming(provider: string): boolean {
-  const fallback = getGlobalStreaming();
-  const key = entry(provider)?.streamingKey;
-  return key ? read(key, fallback) : fallback;
+  return readPlatformSetting<boolean>(GlobalStateKey.STREAMING_GLOBAL);
 }
 
 // ---------------------------------------------------------------------------
@@ -70,13 +44,13 @@ export function getProviderStreaming(provider: string): boolean {
 // ---------------------------------------------------------------------------
 
 export function getProviderEndpoint(provider: string): string {
-  const key = entry(provider)?.endpointKey;
+  const key = PROVIDERS.get(provider)?.endpointKey;
   // Catalog-modeled (see PROVIDER_ENDPOINT_SETTINGS in stateSettings.ts).
   return key ? readPlatformSetting<string>(key) : '';
 }
 
 export function supportsCustomEndpoint(provider: string): boolean {
-  return entry(provider)?.endpointKey !== undefined;
+  return PROVIDERS.get(provider)?.endpointKey !== undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -87,7 +61,7 @@ export function getProviderDisplayName(
   provider: string,
   defaultName: string,
 ): string {
-  const region = entry(provider)?.region;
+  const region = PROVIDERS.get(provider)?.region;
   if (!region?.displayName) return defaultName;
   return regionSet(provider) ? region.displayName : defaultName;
 }
@@ -97,7 +71,7 @@ export function getProviderKeyUrl(provider: string): string | undefined {
   // string even for an unknown provider; the guard is what makes it honest.
   const defaultUrl = PROVIDER_URLS[provider];
   if (!defaultUrl) return undefined;
-  const region = entry(provider)?.region;
+  const region = PROVIDERS.get(provider)?.region;
   if (!region) return defaultUrl;
   const isSet = regionSet(provider);
   if (isSet === true && region.keyUrlWhenSet) return region.keyUrlWhenSet;


### PR DESCRIPTION
## Summary

This implements an owner ruling that the user approved directly on 2026-09-11 (audit item `coauthor-21:model-handlers-6`). It collapses the per-provider streaming knobs under the TeXRA 1.0 clean slate.

1. **Per-provider streaming toggles become one global toggle.** Deleted:
   - the 12 per-provider `GlobalStateKey.STREAMING_*` keys (`STREAMING_GLOBAL` stays);
   - the `streamingKey` registry field;
   - the `PROVIDER_STREAMING_SETTINGS` catalog rows;
   - `getProviderStreaming`;
   - the per-provider **Streaming** switch in each expanded provider row;
   - the `ProviderKeyStatus.streaming` wire field.

   `ModelHandler.getStreamingConfig()` now returns `getGlobalStreaming()`. That function reads `STREAMING_GLOBAL` through the settings catalog (`readPlatformSetting`, `.prefault(true)`) instead of the raw `globalState` read that existed only so per-provider keys could fall back to it. The global **Enable streaming** switch and its "Global default for all providers" copy are unchanged. Both `model.useGoogleBackgroundResponses` descriptions now point at the global streaming toggle ("Enable streaming") instead of the deleted Google streaming toggle.
2. **dc:SCHX-4 (folded in; approved by coauthor-dc).** Once `streamingKey` was gone, the provider-state rows `'openrouter'` and `'kimiCode'` carried only `id` and `displayName`. Nothing reads either field for those rows: they have no endpoint and no region. I deleted the two rows instead of renaming `'openrouter'` to `'openRouter'`. The lowercase-retry lookups (`providerConfig.entry()` and `ProviderKeyList.providerStateKeys()`) are deleted with them. A lookup for `'openRouter'` or `'kimiCode'` now misses the map, which returns exactly the same results as before: no endpoint, no custom-endpoint support, the default display name, and the default key URL.
   - **Persisted and wire check.** The row id was only ever a key for `providerConfig`'s `PROVIDERS` map and for the `ProviderKeyList` lookup. No state key, message schema, settings-view payload or host adapter is built from it. The one storage string tied to the row, `texra.streaming.openrouter`, is deleted with the per-provider streaming keys. No endpoint or region key string changes.
   - **Credential routes untouched.** The separate credential-route `'openrouter'` union (`ModelHandlerContracts.ts`, `sdkRequestEndpoint.ts`, `usage.ts`, the llm turn kinds) is not touched.
3. **Effect-migration baseline regenerated.** `providerConfig.ts` no longer calls `platform()`. I regenerated the baseline with `check-effect-migration-ratchet.mjs --update`; it drops that one row.

**`preferShortModelNames` is kept on owner feedback.** It is useful for some people. An earlier revision of this PR deleted it; everything related to it is now byte-identical to `main`.

Under the TeXRA 1.0 clean slate, old persisted state is not read. So there is no migration, the id deletion needs none either, and stale stored keys are simply never read.

**What the user gives up:** turning streaming off for one provider only.

**Docs:** `docs/guide/models.md` and `docs/guide/troubleshooting.md` now describe one streaming switch. The `ProviderConfigRow` mockup drops the per-provider switch. The shipped walkthrough image `api-key-setup.png` stays accurate: it shows the global switch with its unchanged copy, plus the short-names switch, which is kept.

## Net elements (R6)

- **Files:** 16 changed, 0 added, 0 deleted.
- **`^[+-]export` symbols:** net −1 (`getProviderStreaming`). `PROVIDER_STATE_ENTRIES` is still exported, reshaped from a spread array to a plain `map`.
- **class/interface/enum declarations:** 0 added, 0 removed. Members removed:
  - 12 `GlobalStateKey` enum members;
  - `streamingKey` from `ProviderDef` and from `ProviderStateEntry`;
  - `streaming` from `ProviderKeyStatusSchema`;
  - 2 provider-state rows.
- **Net LoC** (`git diff --stat origin/main`): 16 files, **+35 / −206 (−171)**.
  - production (`src`, `packages`, `scripts`, tests excluded): +25 / −160;
  - tests: −26;
  - docs: +10 / −19;
  - ratchet baseline: −1.

## Consumer counts (R8)

Counted with `git grep -w` at `origin/main` over `src packages scripts docs`, as files / hits:

| Deleted symbol | Files | Hits |
| --- | --- | --- |
| `STREAMING_OPENROUTER` | 3 | 4 |
| each of the other 11 `STREAMING_*` (OPENAI, ANTHROPIC, GOOGLE, XAI, DEEPSEEK, MOONSHOT, KIMI_CODE, DASHSCOPE, MINIMAX, GLM, META) | 2 | 2 |
| `streamingKey` | 5 | 22 |
| `PROVIDER_STREAMING_SETTINGS` | 2 | 3 |
| `getProviderStreaming` | 7 | 12 |
| `providerStateKeys` | 1 | 3 |
| lowercase-retry `toLowerCase()` sites (SCHX-4) | 2 | 2 |

After the change, none of these symbols appears anywhere in `src packages scripts docs config`.

## Tests

No new tests. The tests deleted here had the deleted behaviour as their only subject:
- the `ConfigUtils` "OpenRouter streaming" describe, which checked both spellings;
- the per-provider streaming rows in the `stateSettings` defaults table;
- the `getProviderStreaming` spy in `GoogleInteractionsBackground`.

## Checks

All of these ran on the final head, after the rebase onto `origin/main`:
- `CI=true npm run typecheck` (all projects, through the shared gate): **pass**.
- eslint on changed files: **clean**.
- `prettier --check` on changed files: **clean**.
- Targeted vitest, 23 suites covering every test-kernel suite that references the touched modules: **23 files / 410 tests pass**.
- `npm run check:guidance-refs`: **OK**.
- `npm run check:dead-code-ratchet`: **OK**, no new findings.
- `check-effect-migration-ratchet`: **OK** after `--update`. This fixes the red "static checks (linux)" run, which failed on `[platform()] src/utils/config/providerConfig.ts: 1 -> 0` stale headroom.
- The static-checks steps that CI skipped after that failure (extension package invariants, extension package contributions, NOTICE files, remote-agents catalog): run locally, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
