### PR TITLE
fix(cli): settle resume Deferred on lost root-run slot race

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -646,6 +646,10 @@ export function createChatSessionController(
         effectRuntime().runPromise(Deferred.await(claimedRun)),
       )
     ) {
+      // The slot went to another run: nothing will ever complete this
+      // Deferred, so settle it here or the awaiting fiber parks until
+      // shutdown.
+      Deferred.doneUnsafe(claimedRun, Effect.void);
       appendLocalAssistantTranscript(
         'Finish the active chat before resuming a previous session.',
       );
@@ -825,6 +829,10 @@ export function createChatSessionController(
     // any `await` below, see tryClaimRootRunSlot and the matching comment
     // in resume().
     if (!session.tryClaimRootRunSlot(runPromise.then(() => undefined))) {
+      // The slot went to another run: nothing will ever complete this
+      // Deferred, so settle it here or the awaiting fiber parks until
+      // shutdown.
+      Deferred.doneUnsafe(autoResumeRun, Effect.succeed(false));
       return Promise.resolve(false);
     }
     const attemptCancellation = { cancellationRequested: false };


### PR DESCRIPTION
## Summary

Two triaged follow-up bug fixes were requested; one of them turned out already fixed on `main`, so this PR carries one code change.

**#12230 — leaked Effect fiber on a lost root-run-slot race.** PR #12221 converted the chat controller's `p-defer` promise to Effect's `Deferred`. `effectRuntime().runPromise(Deferred.await(claimedRun))` forks its fiber eagerly. In both `resume()` and `tryResumeRun()` (the current name of the issue's `tryResumeStream`), that fiber is forked and passed into `tryClaimRootRunSlot()`; when the slot is already claimed, the call returned early without ever completing the Deferred, parking the fiber until CLI shutdown. Both lost-race paths now settle their Deferred before returning: `Deferred.doneUnsafe(claimedRun, Effect.void)` in `resume()`, `Deferred.doneUnsafe(autoResumeRun, Effect.succeed(false))` in `tryResumeRun()`. `startRootRun()` needs no change (no early return between fork and completion). Closes #12230.

**#12201 — gitignore matcher cache not keyed by workspace root.** Verified stale: the `sharedLoad` module-level cache described in the issue no longer exists. #12220 (`c4ea13953c`, merged today) removed the cache entirely — `getGitignoreMatcher` in `src/tools/gitignore.ts` now reads the policy files and builds the matcher on every call, so a second workspace root in the same process can no longer be filtered by the first project's `.gitignore`, and `.gitignore` edits are always seen. No change needed here; the issue is resolved on `main`. Closes #12201.

## Issue acceptance gates

- #12230: both lost-race early returns in `packages/cli/src/chat/chatSessionController.ts` settle their Deferred; no parked fiber remains. `startRootRun()` audited — no early return between fork and completion, unchanged.
- #12201: premise stale — defect already removed by #12220; no acceptance gate left to satisfy.

## Single source of truth

The root-run slot claim stays owned by `TuiSession.tryClaimRootRunSlot()` (`packages/cli/src/chat/tui/state/sessionRunState.ts`); the Deferred settlement moves into the two callers that own the fork.

## Duplication and abstraction budget

No new abstraction; the same two-line settlement appears at the two lost-race sites, matching the existing settlement style already used in both functions' success/failure paths.

## Host impact

Extension: none.

Desktop: none.

CLI: resume/auto-resume paths no longer leak an awaiting fiber when the root-run slot is already claimed.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/cli/chatSessionController.vitest.ts` — 38 passed.
- `npx vitest run src/test-kernel/tools/GitignoreMatcher.vitest.ts` — 5 passed (unchanged module, run to confirm the #12201 regression coverage from #12220 still holds).
- `npm run test:changed` — 13 files, 211 passed, 1 skipped.
- `npm run typecheck:cli` — passed.
- `npm run lint` — passed.
- `npm run format` — no changes needed.
- No new test: the defect is a parked fiber inside the shared Effect runtime, not observable at the suite's boundary; per the testing discipline the fix is the deliverable.
