### PR TITLE
chore(ci): drop stale merge_group trigger, trim get-agent-config response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  merge_group:
   schedule:
     - cron: '17 3 * * *'
   workflow_dispatch:
@@ -216,7 +215,7 @@ jobs:
 
   test:
     # Keep the pre-existing `linux` / `windows` labels rather than the raw
-    # runner image: these strings are the check names branch protection pins.
+    # runner image: these strings are the historical check names.
     name: kernel tests (${{ matrix.os == 'windows-latest' && 'windows' || 'linux' }}, shard ${{ matrix.shard }}/2)
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name != 'schedule'
@@ -348,7 +347,7 @@ jobs:
   runtime-validation:
     name: runtime validation (linux)
     # Runs on push to main, the nightly schedule (whose whole purpose is this
-    # timing run), merge groups, and manual dispatch; never on PRs.
+    # timing run), and manual dispatch; never on PRs.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/supabase/functions/get-agent-config/index.ts
+++ b/supabase/functions/get-agent-config/index.ts
@@ -67,7 +67,7 @@ Deno.serve(async (req: Request) => {
     // Description comes from YAML (parsed client-side), not DB
     const { data: agent, error: agentError } = await userClient
       .from('remote_agents')
-      .select('name, storage_path, visibility, agent_category')
+      .select('storage_path')
       .eq('name', body.agentName)
       .single();
 
@@ -88,16 +88,7 @@ Deno.serve(async (req: Request) => {
     // 6. Return config (client parses YAML and extracts description)
     const yamlContent = await fileData.text();
 
-    return jsonResponse(
-      req,
-      {
-        config: yamlContent,
-        name: agent.name,
-        visibility: agent.visibility,
-        agentCategory: agent.agent_category,
-      },
-      200,
-    );
+    return jsonResponse(req, { config: yamlContent }, 200);
   } catch (err) {
     console.error('[GET_AGENT_CONFIG] Error:', err);
     return errorResponse(req, 'Internal server error', 500);


### PR DESCRIPTION
Closes #12286

## Summary

Two deferred cleanups from #12274:

1. **`ci.yml`: drop the stale `merge_group:` trigger and its now-inaccurate comments.** Merge queues are not enabled on this repository (0 `merge_group` runs ever, no branch protection, the only ruleset is disabled), so the trigger can never fire. Removed the trigger, reworded the `test` job comment that claimed branch protection pins the `linux`/`windows` check names, and dropped "merge groups" from the `runtime-validation` trigger comment.

2. **`get-agent-config`: trim the dead response fields.** The edge function returned `name`, `visibility`, and `agentCategory` alongside `config`, but the only client (`EdgeFunctionResponseSchema` in `src/agent/remote/types.ts`, consumed by `remoteAgentConfigClient.ts`) reads just `config`. The response now returns only `config`, and the DB select is narrowed to `storage_path` (the only column still used; the `name` filter in `.eq()` is unaffected). No other behavior change; nothing deployed.

## Issue acceptance gates

- #12286 item 1: `merge_group:` trigger and both stale comments removed from `ci.yml`.
- #12286 item 2: `name`/`visibility`/`agentCategory` removed from the `get-agent-config` response; client verified to read only `config`.

## Single source of truth

`EdgeFunctionResponseSchema` (`src/agent/remote/types.ts`) already owns the response contract; the edge function now emits exactly that shape. No branch-protection check-name contract exists anymore.

## Duplication and abstraction budget

No new abstraction. Removed dead response fields and a dead CI trigger — 14 lines deleted, 4 added.

## Net elements (R6)

- Files: 2 changed (`.github/workflows/ci.yml`, `supabase/functions/get-agent-config/index.ts`), +4/-14
- Exported symbols: none added or deleted
- Classes/interfaces/enums: none

## Consumer counts (R8)

- `get-agent-config` response fields `name` / `visibility` / `agentCategory`: 0 consumers — the sole client schema (`EdgeFunctionResponseSchema`, grep-confirmed at `src/agent/remote/remoteAgentConfigClient.ts:23`) reads only `.config`.
- `merge_group` CI trigger: 0 runs ever per #12286; no workflow depends on it.

## Host impact

Extension: none

Desktop: none

CLI: none

## Scheduled refactoring

None.

## Validation

- `npm run format`: clean (no rewrites needed).
- `npm run lint`: passes.
- `ci.yml` parses: `python3 -c "yaml.safe_load(...)"` OK.
- Edge function: `deno` is not installed locally, so `deno check`/`deno lint` were not run; the change removes three fields from a JSON literal and narrows a `.select()` string, both covered by CI's "Validate edge functions" step.
- TS typecheck not applicable to either change (workflow YAML, Deno edge function); no `src/` code touched.
