### PR TITLE
fix(edge): restore the relay usageRoute enum member in log-usage validation

### DIFF
--- a/supabase/functions/log-usage/usageValidation.ts
+++ b/supabase/functions/log-usage/usageValidation.ts
@@ -16,6 +16,11 @@ const UsageRouteSchema = z.enum([
   'kimi-code-subscription',
   'xai-subscription',
   'api-key',
+  // LEGACY: relay wire tolerance. Released 0.40.x clients still post
+  // `usageRoute: 'relay'` alongside `usedRelay: true`. Retirement is owned
+  // by #10921: after 2026-11, and only once the ops drain (#10920) has
+  // completed.
+  'relay',
 ]);
 
 const UsageLogEntryInputSchema = z.object({

--- a/supabase/functions/log-usage/usageValidation_test.ts
+++ b/supabase/functions/log-usage/usageValidation_test.ts
@@ -107,6 +107,18 @@ Deno.test('rejects invalid present optional fields', () => {
   );
 });
 
+Deno.test('accepts a mixed batch with a legacy relay entry', () => {
+  const parsed = UsageBatchSchema.safeParse({
+    batchId: VALID_BATCH_ID,
+    entries: [
+      usageEntry(),
+      { ...usageEntry(), usageRoute: 'relay', usedRelay: true },
+    ],
+  });
+
+  equal(parsed.success, true);
+});
+
 Deno.test('rejects a whole batch when any entry is invalid', () => {
   const parsed = UsageBatchSchema.safeParse({
     batchId: VALID_BATCH_ID,


### PR DESCRIPTION
## Summary

Closes #12161.

`UsageRouteSchema` in `supabase/functions/log-usage/usageValidation.ts` lost its `'relay'` member in #12144. A currently-installed 0.40.x client that routes usage through the relay still posts `usageRoute: 'relay'` together with `usedRelay: true`. Because `'relay'` fails the enum check, the whole batch — including non-relay entries alongside it — is rejected with `BATCH_REJECTED (retryable: false)` before `usedRelay` is ever read, and that client's usage goes unlogged.

This PR adds `'relay'` back to the enum as documented wire tolerance (retirement owned by #10921, gated on the #10920 drain — mirroring the LEGACY comment on the `usedRelay` field), plus one regression test.

## Issue acceptance gates

- #12161: batches containing entries with `usageRoute: 'relay'` validate successfully again — covered by the new mixed-batch regression test.

## Single source of truth

`UsageRouteSchema` in `supabase/functions/log-usage/usageValidation.ts` remains the single owner of the accepted `usageRoute` wire values.

## Duplication and abstraction budget

None added or removed — one enum member and one test. No new abstraction.

## Net elements (R6)

n/a — bug fix, not a refactor/simplify PR. Net diff: +17/-0 across 2 files, no new exported symbols.

## Consumer counts (R8)

n/a — no emit path or export deleted or re-routed; the restored enum member is consumed only by the existing `subscriptionSourceForUsage` `default: undefined` arm.

## Host impact

Extension: none (fixes acceptance of batches sent by released 0.40.x clients).

Desktop: none.

CLI: none.

## Scheduled refactoring

Retirement of the `'relay'` tolerance is owned by #10921, gated on the #10920 ops drain completing (after 2026-11).

## Validation

- `npm run format` — clean (only the two intended files modified).
- Confirmed `index.ts` needs no `'relay'` arm: routing goes through `subscriptionSourceForUsage`, whose `default: undefined` arm sends relay entries to `usage_logs`; `used_relay` is written from `entry.usedRelay ?? false` (`index.ts:151`).
- **Not run locally:** `deno check` / `deno lint` / `deno test` — Deno is not installed on this machine. CI's edge-function validation step (`.github/workflows/ci.yml`, per-function `deno check`/`deno lint`/`deno test --allow-env`) covers it; the change is one enum member plus a schema-level test that mirrors the existing tests.