### PR TITLE
fix(cli): resolve remote workflow default outputs from the loaded agent definition

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -12,6 +12,7 @@ import {
   missingAgentMessage,
   parseCliAgentCategoryFilter,
   resolveCliAgent,
+  resolveCliDefaultOutputFiles,
   type CliAgentListOptions,
 } from '../runtime/agents';
 import { CliExitCode } from '../runtime/exitCodes';
@@ -71,10 +72,19 @@ export async function showAgent(
     return CliExitCode.Usage;
   }
 
+  // A failed remote-definition load (the loader logs it) must not take down a
+  // display command that otherwise has catalog data to show.
+  const defaultOutputFiles = await resolveCliDefaultOutputFiles(entry).catch(
+    () => entry.defaultOutputFiles ?? [],
+  );
+  const details = defaultOutputFiles.length
+    ? { ...entry, defaultOutputFiles: [...defaultOutputFiles] }
+    : entry;
+
   emitCliResult(context, {
-    json: entry,
-    ndjson: { kind: 'agent', agent: entry },
-    text: formatCliAgentDetails(entry),
+    json: details,
+    ndjson: { kind: 'agent', agent: details },
+    text: formatCliAgentDetails(entry, defaultOutputFiles),
   });
   return CliExitCode.Success;
 }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -35,6 +35,7 @@ import {
   selectCliRunModel,
 } from '../runtime/runModel';
 import {
+  resolveCliDefaultOutputFiles,
   resolveCliLaunchAgent,
   WORKFLOW_AGENT_NAME_DESCRIPTION,
 } from '../runtime/agents';
@@ -148,8 +149,17 @@ export const runWorkflowAgent = Effect.fn('runWorkflowAgent')(function* (
           catch: ensureError,
         });
         const runContext = buildHeadlessRunContext(context);
+        // The catalog entry carries declared defaults for local agents only;
+        // remote agents need their definition loaded to resolve them.
         const expectedOutputFiles = init.outputDir
-          ? expectedOutputFilesForOutputDir(agent, inputFiles, stdinInputPath)
+          ? expectedOutputFilesForOutputDir(
+              yield* Effect.tryPromise({
+                try: () => resolveCliDefaultOutputFiles(agent),
+                catch: ensureError,
+              }),
+              inputFiles,
+              stdinInputPath,
+            )
           : undefined;
         // Persist CLI destinations absolutely so resumption has one path
         // representation and never reconstructs output locations.

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -205,6 +205,23 @@ export async function resolveCliLaunchAgent(
   );
 }
 
+/**
+ * Read the default output files declared by an agent's current definition.
+ * Remote catalog entries come from the agent listing, which carries no
+ * `defaultOutputFiles`; load the remote definition to resolve them. Local
+ * entries already carry the scanned value, and a remote entry refreshed by an
+ * earlier load this session skips the fetch.
+ */
+export async function resolveCliDefaultOutputFiles(
+  entry: AgentEntry,
+): Promise<readonly string[]> {
+  if (entry.source !== 'remote' || entry.defaultOutputFiles?.length) {
+    return entry.defaultOutputFiles ?? [];
+  }
+  const { loadRemoteAgent } = await import('@agent/remote/RemoteAgentLoader');
+  return (await loadRemoteAgent(entry.name)).settings.defaultOutputFiles;
+}
+
 export async function loadCliAgentList(
   options: CliAgentListOptions = {},
 ): Promise<CliAgentListResult> {
@@ -246,7 +263,10 @@ export function formatCliAgentList(
     .join('\n');
 }
 
-export function formatCliAgentDetails(entry: AgentEntry): string {
+export function formatCliAgentDetails(
+  entry: AgentEntry,
+  defaultOutputFiles: readonly string[],
+): string {
   const lines: string[] = [
     `name: ${entry.name}`,
     `category: ${entry.category}`,
@@ -259,7 +279,7 @@ export function formatCliAgentDetails(entry: AgentEntry): string {
   }
   const metadataFields: readonly [string, readonly string[] | undefined][] = [
     ['tools', entry.tools],
-    ['defaultOutputFiles', entry.defaultOutputFiles],
+    ['defaultOutputFiles', defaultOutputFiles],
   ];
   const metadataLines = metadataFields.flatMap(([label, values]) =>
     values?.length ? [`${label}: ${values.join(', ')}`] : [],

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -1,7 +1,6 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
-import type { AgentEntry } from '@agent/index';
 import type { AgentConfigPayload, WorkflowFlowResult } from '@agent/runtime';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import type {
@@ -229,14 +228,14 @@ function expectedInputOutputFiles(
 }
 
 export function expectedOutputFilesForOutputDir(
-  agent: AgentEntry | undefined,
+  defaultOutputFiles: readonly string[] | undefined,
   inputFiles: readonly string[],
   /** The path this run materialized stdin to, when it read stdin. */
   stdinInputPath?: string,
 ): readonly string[] {
-  const defaultOutputFiles = (agent?.defaultOutputFiles ?? []).filter(Boolean);
-  return defaultOutputFiles.length > 0
-    ? defaultOutputFiles
+  const declaredOutputFiles = (defaultOutputFiles ?? []).filter(Boolean);
+  return declaredOutputFiles.length > 0
+    ? declaredOutputFiles
     : expectedInputOutputFiles(inputFiles, stdinInputPath);
 }
 

--- a/src/test-kernel/cli/AgentsCommand.vitest.ts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.ts
@@ -14,11 +14,16 @@ import { createRunCommandCliContext } from '@test/cli/fixtures/cliContext';
 
 const mocks = vi.hoisted(() => ({
   resolveCliAgent: vi.fn(),
+  loadRemoteAgent: vi.fn(),
 }));
 
 vi.mock('@cli/runtime/agents', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@cli/runtime/agents')>()),
   resolveCliAgent: mocks.resolveCliAgent,
+}));
+
+vi.mock('@agent/remote/RemoteAgentLoader', () => ({
+  loadRemoteAgent: mocks.loadRemoteAgent,
 }));
 
 // Import the modules under test after the mock factories above are registered
@@ -96,6 +101,8 @@ describe('CLI agents command', () => {
     vi.clearAllMocks();
     agentCatalogMock.getAgentsByCategory.mockReturnValue([]);
     agentCatalogMock.getVisibleAgents.mockReturnValue([]);
+    // Show falls back to catalog data when the remote definition cannot load.
+    mocks.loadRemoteAgent.mockRejectedValue(new Error('not signed in'));
   });
 
   it('parses agent category filter spellings', () => {

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => {
     finalizeRun: vi.fn(),
     withExpandedRunInputs: vi.fn(),
     resolveCliLaunchAgent: vi.fn(),
+    loadRemoteAgent: vi.fn(),
     selectCliRunModel: vi.fn(),
     deriveResumability: vi.fn(),
     writeResultMeta: vi.fn(),
@@ -87,6 +88,10 @@ vi.mock('@cli/commands/_helpers/output', async (importOriginal) => ({
 vi.mock('@cli/runtime/agents', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@cli/runtime/agents')>()),
   resolveCliLaunchAgent: mocks.resolveCliLaunchAgent,
+}));
+
+vi.mock('@agent/remote/RemoteAgentLoader', () => ({
+  loadRemoteAgent: mocks.loadRemoteAgent,
 }));
 
 vi.mock('@cli/runtime/transcriptSession', () => ({
@@ -545,6 +550,51 @@ describe('CLI workflow run command', () => {
           compileFailures: [],
         }),
       );
+    });
+  });
+
+  it('resolves declared default outputs from the remote agent definition', async () => {
+    await withTempDir('texra-workflow-', async (root) => {
+      // A remote catalog entry comes from the agent listing, which carries no
+      // defaultOutputFiles; the run must load the definition to resolve them
+      // (#12162).
+      mocks.resolveCliLaunchAgent.mockResolvedValue({
+        name: 'remote-polish',
+        category: AgentCategory.Workflow,
+        source: 'remote',
+        path: '',
+      });
+      mocks.loadRemoteAgent.mockResolvedValue({
+        settings: { defaultOutputFiles: ['build/paper.tex'] },
+        prompts: {},
+      });
+      const generated = await writeGeneratedOutput(root);
+      const outputSummary = runOutputSummary(
+        generated,
+        path.join(root, 'build', 'paper.tex'),
+      );
+      mockWorkflowRun(
+        workflowRun('exec-remote', { outputs: [outputSummary] }),
+        true,
+      );
+
+      const exitCode = await runWorkflow(
+        { agent: 'remote-polish', outputDir: 'out' },
+        createRunCommandCliContext({ cwd: root }),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mocks.loadRemoteAgent).toHaveBeenCalledWith('remote-polish');
+      expect(mocks.executeCliConfig.mock.calls[0]?.[0]).toMatchObject({
+        cli: {
+          outputFile: undefined,
+          outputDirectory: path.join(root, 'out'),
+          expectedOutputFiles: ['build/paper.tex'],
+        },
+      });
+      await expect(
+        fs.readFile(path.join(root, 'out', 'build', 'paper.tex'), 'utf8'),
+      ).resolves.toBe('polished');
     });
   });
 


### PR DESCRIPTION
## Summary

#12157 deleted the persisted remote-agent metadata cache and its `cached?.defaultOutputFiles` fallback in `loadRemoteAgents()`. In-band delegation was unaffected (it resolves defaults from a freshly prepared definition via `prepareInBandDefinition`), but the CLI's two `AgentEntry.defaultOutputFiles` readers both run against the plain catalog listing — which carries no `defaultOutputFiles` for remote agents — before any YAML load:

- `texra run <remote-workflow-agent> --output-dir <dir>` computed input-derived expected output names instead of the agent's declared defaults, which could spuriously fail with "workflow completed without expected output" or copy results under unexpected relative paths.
- `texra agents show <remote-workflow-agent>` omitted the `defaultOutputFiles` line.

Both reads now resolve against the current, freshly loaded agent definition. No persisted cache is reintroduced.

Closes #12162

## Issue acceptance gates

- `expectedOutputFilesForOutputDir` no longer reads `defaultOutputFiles` off the catalog entry; `runWorkflowAgent` resolves defaults through the loaded remote definition (`loadRemoteAgent`, the same loader the launch path uses) before computing expected `--output-dir` outputs. Done.
- `texra agents show` resolves declared defaults from the loaded remote definition for both text and JSON output. Done.
- Local (YAML-scanned and inline) agents pay no extra loading cost: their catalog entries already carry the scanned value and return early. Done.
- No persisted metadata cache reintroduced. Done.

## Single source of truth

`resolveCliDefaultOutputFiles` (`packages/cli/src/runtime/agents.ts`) owns the CLI read of declared default outputs: local entries return their scanned value; remote entries load their current definition via `loadRemoteAgent` (which also refreshes the live registry entry, so a repeat read in the same session skips the fetch).

## Duplication and abstraction budget

One new helper replaces two divergent read sites; the loader is the existing `loadRemoteAgent`, not a new path. `expectedOutputFilesForOutputDir` lost its `AgentEntry` parameter in favor of the resolved list, so the pure function no longer depends on the catalog shape. No new abstraction layers.

## Net elements (R6)

n/a — bug fix, not a refactor/simplify PR.

## Consumer counts (R8)

`expectedOutputFilesForOutputDir` signature change: 1 production caller (`packages/cli/src/commands/workflow.ts`) + 3 test call sites, all updated. `formatCliAgentDetails` signature change: 1 caller (`packages/cli/src/commands/agents.ts`).

## Host impact

Extension: none.
Desktop: none.
CLI: `texra run --output-dir` and `texra agents show` now resolve remote workflow agents' declared default outputs from the loaded definition. `agents show` falls back to catalog data if the remote definition cannot load (the loader logs the failure); `run` surfaces the load error, which the run itself would hit moments later anyway.

## Scheduled refactoring

None.

## Validation

- `npm run format` — clean
- `npm run lint` — clean
- `npm run typecheck:cli` — clean; `npm run typecheck:test-kernel` — clean
- `npm run test:changed` — 26 files, 482 passed / 1 skipped
- Directly affected suites: `WorkflowRunCommand` (33, incl. new regression test), `AgentsCommand` (10), `WorkflowOutputResolution` (15) — all pass
- Regression test verified to fail with the source fix stashed (expected `['build/paper.tex']`, got input-derived `['paper.tex']`) and pass with it applied

One regression test added (site 1, the user-visible run failure), extending `WorkflowRunCommand.vitest.ts` per testing discipline. Site 2 gets no dedicated test: reproducing it needs the same loader mock and exercises only a formatting line, below the bar for a second test; `AgentsCommand.vitest.ts` gained the loader mock so its existing remote-agent case stays deterministic against the new fallback.