### PR TITLE
simplify: drop two unused session-tier imports

### DIFF
--- a/src/shared/session/sessionFold.ts
+++ b/src/shared/session/sessionFold.ts
@@ -79,7 +79,6 @@ import {
   type FoldInput,
   type ExistenceReconciliation,
   type LocalRuntimeState,
-  type RoundIndexed,
   type DisplaySessionEvent,
   type StreamLogEntry,
   type RunId,

--- a/src/shared/session/traceFold.ts
+++ b/src/shared/session/traceFold.ts
@@ -28,7 +28,6 @@ import type {
   StreamLogAppendInput,
   StreamLogUpdatePatch,
 } from '@shared/session/traceEntries';
-import { isObject } from '@utils/core';
 import { redactLogData } from './traceRedaction';
 
 const KNOWN_MESSAGE_TYPES = new Set<string>(Object.values(MESSAGE_TYPES));


### PR DESCRIPTION
Closes #12182.

## Summary

The issue surveyed the session tier on main @ 98afef5a7a. On current main,
every item had already been resolved by later merges except two unused import
bindings, which this PR removes:

- `type RoundIndexed` in `src/shared/session/sessionFold.ts` — imported from
  `@shared/schemas`, never referenced in the file.
- `isObject` in `src/shared/session/traceFold.ts` — imported from
  `@utils/core`, never referenced in the file.

### Per-item verification against current main

**Exports with no consumer at all — all already removed:**

- `Database.aggregatesAfterCommit`: zero references in `src/` (repo-wide grep
  finds only `.agents/docs` mentions); the contract, implementation, vitest
  assertion, and private `after` SQL constant are all gone.
- `SessionHandle.hasStream`: no occurrence in `src/agent/runtime/SessionHandle.ts`
  or anywhere in `src/`.
- `Session.events` on the SDK interface (`packages/agent/src/effect/sessions.ts`):
  the `Session` interface no longer has an `events` field; `events` now lives on
  `Run` where it is consumed.

**Exports that should be file-local — all already demoted:**
`SessionBridgeOptions`, `SessionPort` (SessionBridge.ts), `HostRunActions`
(hostRunActions.ts), `HostSnapshotSourceOptions` (hostSnapshotSource.ts),
`WebviewRuntime` (webviewSessionLayer.ts), `TraceStamp` (traceFold.ts) are all
non-exported on current main.

**Ratchet shrinks — already done:** `RoundKeyStringSchema` (roundIndexed.ts)
and `cleanSessionDescription` (sessionDescription.ts) are file-local, and
neither appears in `config/ratchets/knip-baseline.json`.

**Invisible dead imports — 9 of 11 already gone; 2 fixed here:**
`src/shared/schemas/streamState.ts` (8 bindings) was deleted outright, and
`RunOutcomeSchema` is no longer imported by `sessionEvent.ts`. The remaining
two (`RoundIndexed`, `isObject`) are removed in this PR.

**Comments naming types that no longer exist — all already fixed:**
`StreamMetadata`, `StreamExecutionState`, and `buildStreamTabInfo` have zero
occurrences anywhere in `src/` or `packages/`. The `sessionLayer.ts` header
(:9, :16-20, :104) and the `openSync` hazard comment (:757-764) have both been
rewritten; the current text describes only what the file does.

**Same-process re-validation — already fixed:** `redactLogData`
(`src/shared/session/traceRedaction.ts:82`) is now generic (`<T>(data: T): T`),
every arm returns a spread literal, and there is no full-union re-parse.

**Single-consumer test support module — already inlined:**
`src/test-kernel/support/executionLeaseFixtures.ts` no longer exists.

## Issue acceptance gates

Every enumerated item in #12182 is resolved on main after this PR: verified by
per-item grep on current main, with the two surviving items fixed here.

## Single source of truth

n/a — pure deletion of unused import bindings; no fact or decision moves.

## Duplication and abstraction budget

n/a — no abstraction added; two unused bindings removed.

## Net elements (R6)

- Files: 2 changed, 2 deletions, 0 additions
- Exported symbols: 0 added, 0 removed (both removals are import bindings, not exports)
- Classes/interfaces/enums: 0
- Net LoC: −2

## Consumer counts (R8)

- `type RoundIndexed` in `src/shared/session/sessionFold.ts`: 1 occurrence
  repo-wide (the import itself) — 0 consumers.
- `isObject` in `src/shared/session/traceFold.ts`: 1 occurrence in the file
  (the import itself) — 0 consumers. (`@utils/core` still exports `isObject`
  for its other consumers; only this file's unused binding is dropped.)

## Host impact

Extension: none
Desktop: none
CLI: none

## Scheduled refactoring

None.

## Validation

- `npm run format` — clean (unchanged)
- `npm run lint` — clean
- `npm run typecheck:workspace` — clean (`typecheck:test-kernel` not run: no test files changed)
- `npm run check:dead-code-ratchet` — OK, no new findings (228 findings vs 228 baselined)
- `npm run test:changed` — 184 files, 2269 passed, 1 skipped
