### PR TITLE
fix(desktop): stop split-panel emitting NaN workbench width on relaunch

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -553,21 +553,37 @@ function recordLayoutMeasurement(next: DesktopTaskShellState): void {
   projectWorkbenches.get(shell.active)?.updateState(next);
 }
 
+/**
+ * Read the split handle's measured size from a `wa-reposition` event.
+ *
+ * A panel that has not been laid out yet has `size === 0`, so the component's
+ * pixels↔percent conversion produces NaN/Infinity and the first reposition
+ * event can carry a non-finite `positionInPixels`. Skip that emission; the
+ * panel's resize observer re-fires with the real measurement after layout.
+ */
+function measuredSplitPosition(event: Event): number | undefined {
+  const value = (event.currentTarget as SplitPanelElement).positionInPixels;
+  return Number.isFinite(value) ? value : undefined;
+}
+
 function rememberSidebarWidth(event: Event): void {
   if (shellState().sidebarCollapsed) return;
-  const width = (event.currentTarget as SplitPanelElement).positionInPixels;
+  const width = measuredSplitPosition(event);
+  if (width == null) return;
   recordLayoutMeasurement(setSidebarWidth(shellState(), width));
 }
 
 function rememberBottomPanelHeight(event: Event): void {
   if (!activeWorkbenchTab(shellState(), 'bottom')) return;
-  const height = (event.currentTarget as SplitPanelElement).positionInPixels;
+  const height = measuredSplitPosition(event);
+  if (height == null) return;
   recordLayoutMeasurement(setBottomPanelHeight(shellState(), height));
 }
 
 function rememberWorkbenchWidth(event: Event): void {
   if (!activeWorkbenchTab(shellState(), 'right')) return;
-  const width = (event.currentTarget as SplitPanelElement).positionInPixels;
+  const width = measuredSplitPosition(event);
+  if (width == null) return;
   recordLayoutMeasurement(setWorkbenchWidth(shellState(), width));
 }
 


### PR DESCRIPTION
## Summary

On relaunch with a persisted right workbench tab open, the desktop renderer
crashed with `ZodError: received NaN, path ["workbenchWidth"]` and subsequent
rendering failed (the settingsPersistence e2e then could not dismiss onboarding
or open the workbench).

Root cause: `wa-split-panel` measures its `size` from its bounding rect, which
is `0` before first layout. When the restored shell template applies
`position-in-pixels` in that window, the component's pixels↔percent conversion
computes `value / 0 * 100` (`Infinity`, or `NaN` for `0 / 0`), the `position`
watcher then computes `0 * Infinity = NaN` for `positionInPixels`, and the
component dispatches `wa-reposition` carrying `NaN`. The renderer's
`rememberWorkbenchWidth` handler stored that measurement through
`setWorkbenchWidth` (`clamp` passes `NaN` through), and the shell state schema
rejected it on the next read. The same pre-layout event can carry non-finite
values on the sidebar and bottom-panel splits.

Fix: at the producer of the layout update (the `wa-reposition` handlers in
`packages/desktop/src/renderer/main.ts`), skip the emission when
`positionInPixels` is not finite. No measurement is lost: the panel's own
ResizeObserver re-reads the attribute and re-fires `wa-reposition` with the
real pixel value once the panel is laid out. The schema is unchanged and still
rejects `NaN`; there is no timeout or retry.

Closes #12148

## Issue acceptance gates

- Fix the source of the invalid layout update or its lifecycle ordering: the
  layout update is no longer emitted from the pre-measurement `wa-reposition`
  event.
- No `.catch()` / silent schema default: `DesktopTaskShellStateSchema`
  untouched.
- No timeout/self-repair workaround, no test expectation change.

## Single source of truth

`DesktopTaskShellStateSchema` / the setters in
`packages/desktop/src/shared/desktopTaskShell.ts` remain the sole owners of
shell layout state; the renderer handler now only forwards finite measurements.

## Duplication and abstraction budget

One file-local helper `measuredSplitPosition` replaces the identical
`positionInPixels` read in the three split-panel handlers; it owns the "only
finite measurements update stored layout" invariant.

## Net elements (R6)

n/a — bug fix, not a refactor (1 file, +19/−3, one new file-local function, no
new exports).

## Consumer counts (R8)

n/a — no emit path or export deleted or re-routed.

## Host impact

Extension: none.

Desktop: renderer no longer persists NaN layout measurements on relaunch; the
settingsPersistence e2e passes.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run format` — pass
- `npm run lint` — pass
- `pnpm --filter @texra/desktop build` (includes the desktop `typecheck`, same
  as `npm run typecheck:desktop`) — pass
- `npm run test:changed` — no suites selected (renderer entry module is not in
  the kernel module graph); no existing kernel suite covers
  `packages/desktop/src/renderer/main.ts`, so no regression test was added per
  testing discipline — the Electron e2e is the coverage.
- `pnpm --filter @texra/desktop test:e2e settingsPersistence.spec.ts`:
  - unfixed renderer (fix stashed, renderer rebuilt): **fails** on the second
    launch at onboarding dismissal; a temporary pageerror probe (launch → open
    settings memory tab → relaunch) captured the exact
    `ZodError: received NaN, path ["workbenchWidth"]` renderer crash, matching
    the issue. Probe deleted after use.
  - fixed renderer: **1 passed**.
