### PR TITLE
fix(latex): kill compile and clone subprocesses on interruption

### DIFF
--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -104,11 +104,15 @@ function buildOverleafClonePorts(
 
     runClone: (remoteUrl, cloneInto) =>
       Effect.tryPromise({
-        try: async () => {
+        try: async (signal) => {
           await mkdir(cloneInto, { recursive: true });
           canonicalWorkspacePath = await realpath(cloneInto);
           await execa('git', ['clone', remoteUrl, '.'], {
             cwd: canonicalWorkspacePath,
+            // Interrupting the fiber aborts `signal`, and execa's
+            // cancelSignal kills the git subprocess instead of letting the
+            // clone keep writing into the destination.
+            cancelSignal: signal,
             // extendEnv: false is required — makeMachineGitEnv omits the
             // helper-invoking keys, and execa's default merge re-adds them.
             env: makeMachineGitEnv(),

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -229,7 +229,7 @@ function buildOverleafClonePorts(
 
     runClone: (remoteUrl, workspacePath) =>
       Effect.tryPromise({
-        try: () =>
+        try: (signal) =>
           vscode.window.withProgress(
             {
               location: vscode.ProgressLocation.Notification,
@@ -238,6 +238,10 @@ function buildOverleafClonePorts(
             () =>
               execa('git', ['clone', remoteUrl, '.'], {
                 cwd: workspacePath,
+                // Interrupting the fiber aborts `signal`, and execa's
+                // cancelSignal kills the git subprocess instead of letting the
+                // clone keep writing into the workspace.
+                cancelSignal: signal,
                 // Same extended PATH as the executeCommandSync preflight
                 // above, so the probe can't pass while the clone misses git
                 // (bot review). extendEnv: false is required —

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -66,8 +66,16 @@ export interface LatexTrace {
   error(message: string, options?: LatexLogOptions): void;
 }
 
-/** Run `effect`, reading a filesystem promise as a typed failure. */
-const fsCall = <A>(thunk: () => Promise<A>): Effect.Effect<A, Error> =>
+/**
+ * Run `effect`, reading a filesystem promise as a typed failure. A thunk that
+ * declares the `signal` parameter receives the fiber's interruption signal
+ * (Effect allocates no AbortController for a zero-argument thunk), which the
+ * subprocess-spawning calls below pass to the compiler so cancellation kills
+ * it; the plain filesystem reads ignore it.
+ */
+const fsCall = <A>(
+  thunk: (signal: AbortSignal) => Promise<A>,
+): Effect.Effect<A, Error> =>
   Effect.tryPromise({ try: thunk, catch: ensureError });
 
 /**
@@ -164,8 +172,8 @@ export class LatexMediaManager {
     return Effect.gen({ self: this }, function* () {
       const buildDir = path.join(path.dirname(file.absolutePath), 'build');
       yield* fsCall(() => AbsoluteFS.ensureDir(buildDir));
-      const compiled = yield* fsCall(() =>
-        compileLatex2Pdf(file, { outputDirectory: buildDir }),
+      const compiled = yield* fsCall((signal) =>
+        compileLatex2Pdf(file, { outputDirectory: buildDir }, signal),
       );
       if (!compiled.ok) {
         this.logger.warn(
@@ -577,7 +585,7 @@ export class LatexMediaManager {
       const tikzResults = yield* Effect.forEach(
         files,
         (file) =>
-          fsCall(() => TikzPictureManager.compile(file)).pipe(
+          fsCall((signal) => TikzPictureManager.compile(file, signal)).pipe(
             // Silent skip: TikZ compilation failures are reported by the
             // TikzPictureManager itself; the fan-out must continue past
             // individual failures.

--- a/src/latex/README.md
+++ b/src/latex/README.md
@@ -23,7 +23,12 @@ consequences worth knowing before you touch a file here:
   and the latexdiff executors spawn their subprocess inside
   `Effect.tryPromise`, whose thunk receives the signal that aborts when the
   running fiber is interrupted. Do not add a `signal` parameter to a function
-  here so a caller can pass one down.
+  here so a caller can pass one down. The two Promise-shaped subprocess
+  helpers that remain (`compileLatex2Pdf`, and `TikzPictureManager.compile`
+  through it) are the exception: their `signal` parameter exists only so the
+  `tryPromise` thunk at the Effect boundary can hand the fiber's own signal
+  to the spawn — the signal always originates at the boundary, never from a
+  caller's own `AbortController`.
 
 - **Diagnostics are `Effect.log*`, not `createLog`.** A program names its
   channel once with `withLogChannel` from `@logger/effectLog` and every entry

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -91,9 +91,15 @@ export const TikzPictureManager = {
   /**
    * Extract and compile TikZ pictures from a LaTeX file
    * @param latexFile Location of the LaTeX file
+   * @param signal Aborts the in-flight pdflatex subprocess. Effect callers
+   * pass the signal their `Effect.tryPromise` thunk receives, so interrupting
+   * the fiber tears the compile down.
    * @returns Array of FileLocations for compiled PDF files
    */
-  async compile(latexFile: FileLocation): Promise<FileLocation[]> {
+  async compile(
+    latexFile: FileLocation,
+    signal?: AbortSignal,
+  ): Promise<FileLocation[]> {
     const inputName = path.parse(latexFile.absolutePath).name;
     const buildDir = path.join(
       path.dirname(latexFile.absolutePath),
@@ -122,10 +128,14 @@ export const TikzPictureManager = {
           buildDir,
           suffix,
         );
-        const compiled = await compileLatex2Pdf(texLocation, {
-          channel: CHANNEL,
-          compiler: 'pdflatex',
-        });
+        const compiled = await compileLatex2Pdf(
+          texLocation,
+          {
+            channel: CHANNEL,
+            compiler: 'pdflatex',
+          },
+          signal,
+        );
         if (!compiled.ok) {
           log.warn(
             `Failed to compile TikZ picture ${texLocation.absolutePath}:\n${compiled.logTail}`,

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -143,12 +143,16 @@ export type CompileLatex2PdfResult =
  * Compile a LaTeX file to PDF
  * @param latexLocation FileLocation for the LaTeX file
  * @param options Compilation options (channel defaults to module CHANNEL)
+ * @param signal Aborts the in-flight compiler subprocess. Effect callers pass
+ * the signal their `Effect.tryPromise` thunk receives, so interrupting the
+ * fiber tears the compile down.
  * @returns `{ ok: true, pdfPath } | { ok: false, logTail }` -- `pdfPath` is the
  * absolute path the engine wrote to; `logTail` is always populated on failure.
  */
 export async function compileLatex2Pdf(
   latexLocation: FileLocation,
   options: LaTeXCompileOptions = {},
+  signal?: AbortSignal,
 ): Promise<CompileLatex2PdfResult> {
   // Schema provides compiler default; channel defaults to module constant
   const parsed = LaTeXCompileOptionsSchema.parse(options);
@@ -210,6 +214,7 @@ export async function compileLatex2Pdf(
         channel,
         env,
         timeout,
+        signal,
         showError: true, // Show error if pdflatex fails
       });
     }
@@ -220,6 +225,7 @@ export async function compileLatex2Pdf(
         channel,
         env,
         timeout,
+        signal,
         showError: false, // Suppress error for latexmk to try pdflatex as fallback
       });
       if (!result) {

--- a/src/test-kernel/cli/OverleafCloneCommand.vitest.ts
+++ b/src/test-kernel/cli/OverleafCloneCommand.vitest.ts
@@ -124,6 +124,7 @@ describe('CLI Overleaf clone command', () => {
       ],
       {
         cwd: workspacePath,
+        cancelSignal: expect.any(AbortSignal),
         env: makeMachineGitEnv(),
         extendEnv: false,
       },
@@ -160,6 +161,7 @@ describe('CLI Overleaf clone command', () => {
       ],
       {
         cwd: destination,
+        cancelSignal: expect.any(AbortSignal),
         env: makeMachineGitEnv(),
         extendEnv: false,
       },

--- a/src/test-kernel/latex/TexTools.vitest.ts
+++ b/src/test-kernel/latex/TexTools.vitest.ts
@@ -169,6 +169,34 @@ describe('compileLatex2Pdf logger seam', () => {
   });
 });
 
+// #12193: cancelling the calling fiber must kill the compiler subprocess.
+// `compileLatex2Pdf` used to accept no signal at all, so the `AbortSignal`
+// `Effect.tryPromise` hands its thunk was dropped and latexmk/pdflatex kept
+// running after the tool call was reported cancelled.
+describe('compileLatex2Pdf cancellation', () => {
+  beforeEach(async () => {
+    mocks.runToolWithCheck.mockReset();
+    await installPlatform({ workspacePath });
+  });
+
+  it('hands its AbortSignal to the compiler subprocess spawn', async () => {
+    mocks.runToolWithCheck.mockResolvedValue(execResult(true));
+    const controller = new AbortController();
+
+    await compileLatex2Pdf(
+      pathToLocation(path.join(workspacePath, 'main.tex')),
+      { outputDirectory: path.join(workspacePath, 'build') },
+      controller.signal,
+    );
+
+    expect(mocks.runToolWithCheck).toHaveBeenCalledWith(
+      'latexmk',
+      expect.any(Array),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+});
+
 const D = path.delimiter;
 
 describe('buildKpathseaSearchPath', () => {

--- a/src/tools/latex/ExtractTikzFiguresTool.ts
+++ b/src/tools/latex/ExtractTikzFiguresTool.ts
@@ -65,7 +65,7 @@ const extractTikzFigures = Effect.fn('ExtractTikzFiguresTool.execute')(
     let attachments: ToolFileAttachment[] | undefined;
     if (compile) {
       const compiledPaths = yield* Effect.tryPromise({
-        try: () => TikzPictureManager.compile(location),
+        try: (signal) => TikzPictureManager.compile(location, signal),
         catch: ensureError,
       });
       if (compiledPaths.length > 0) {


### PR DESCRIPTION
## Summary

#12183 converted the LaTeX toolchain to Effect and correctly wired texcount/latexdiff cancellation: `Effect.tryPromise` hands its thunk an `AbortSignal` that aborts when the fiber is interrupted, and `executeCommand`/`runToolWithCheck` pass it to the subprocess. Three other call sites converted in that PR discarded the signal, so cancelling the run left the subprocess alive. This PR threads the fiber's signal through each of them, matching the established texcount/latexdiff pattern:

- **TikZ compile** — `ExtractTikzFiguresTool`'s `compile: true` path now passes the `tryPromise` signal to `TikzPictureManager.compile`, which forwards it to `compileLatex2Pdf`.
- **PDF auto-compile** — `compileLatex2Pdf` takes an optional `AbortSignal` passed to both `runToolWithCheck` calls (latexmk and the pdflatex fallback); `LatexMediaManager`'s `fsCall` thunk type declares the signal (zero-argument thunks still allocate no `AbortController`, so the plain filesystem calls are byte-for-byte unchanged), and `compileOnePdf` plus the TikZ compile fan-out declare it.
- **Overleaf/ShareLaTeX clone** — both host ports (extension `gitCommands.ts`, CLI `clone.ts`) pass the signal as execa's `cancelSignal`, the same mechanism `src/utils/system/execUtils.ts:340` uses.

`src/latex/README.md`'s cancellation rule is scoped to match: the signal originates at the Effect boundary's `tryPromise` thunk, never from a caller's own `AbortController`.

Closes #12193
Refs #11976 — verified already fixed on main by #12063 (`joinedStream` threads the signal into the fetch, body-write pipeline, tar-entry admission, and gunzip pipeline) and #12069 (staging-dir scope finalizer; verified Effect v4's `Effect.onError` matches interruption via `exitFilterCause`, so the partial-download cleanup already covers the interrupt path). Closed with the fixing-commit evidence.

## Issue acceptance gates

- #12193: all three named sites (TikZ compile, Overleaf/ShareLaTeX clone in both hosts, PDF auto-compile) now pass the fiber's `AbortSignal` to the subprocess spawn — the sites reduced to the same one-pattern change, so all three are done together.
- #11976: no delta required; each finding verified resolved on main with commit-level evidence (issue comment).

## Single source of truth

The fiber's `AbortSignal` from `Effect.tryPromise` remains the single cancellation source; `executeCommand`/`runToolWithCheck` (signal) and execa (`cancelSignal`) own subprocess teardown. No new cancellation mechanism introduced.

## Duplication and abstraction budget

No new abstraction: `compileLatex2Pdf` gains one optional parameter, `fsCall`'s thunk type widens to declare the signal it was already eligible to receive, and both clone ports set one execa option. Duplication avoided: the two `runToolWithCheck` calls share the one threaded signal rather than each growing a cancellation path.

## Net elements (R6)

n/a — bug fix, not a refactor/simplify PR.

## Consumer counts (R8)

`compileLatex2Pdf` callers grepped: 8 production call sites; 6 unchanged (the new parameter is optional), 2 (TikZ manager, media manager) now pass the signal. `TikzPictureManager.compile` callers: 2, both updated. `fsCall` callers: 13 in one file; 11 unchanged (zero-argument thunks keep identical runtime behavior — Effect allocates an `AbortController` only when the thunk declares the parameter).

## Host impact

Extension: Overleaf/ShareLaTeX clone (`texra.cloneOverleafProject`) kills `git clone` if the surrounding fiber is interrupted; TikZ compile tool calls cancel their pdflatex loop.

Desktop: none (no clone port; `compileLatex2Pdf` callers unchanged).

CLI: `texra clone` kills `git clone` on interruption.

## Scheduled refactoring

None.

## Validation

- `npm run format` — clean
- `npm run lint` — clean
- `npm run typecheck:workspace` — clean; `npm run typecheck:cli` — clean
- `npm run test:changed` — 80 files, 1103 passed, 1 skipped
- `npx vitest run src/test-kernel/latex src/test-kernel/cli src/test-kernel/tools` — 202 files, 2327 passed, 1 skipped
- New regression test (`TexTools.vitest.ts`, signal hand-off to the compiler spawn) verified failing without the fix, passing with it; the two existing `OverleafCloneCommand` execa assertions updated to expect `cancelSignal`