### PR TITLE
fix: fail ALLOW_ORCHESTRATOR_KILL closed on a corrupt value

### DIFF
--- a/src/shared/config/settingsAccess.ts
+++ b/src/shared/config/settingsAccess.ts
@@ -90,7 +90,11 @@ export function readSetting(
   log.warn(
     `Ignoring invalid persisted value for setting "${entry.key}": ${toErrorMessage(result.error)}`,
   );
-  return settingDefault(entry);
+  // A row can fail closed on a present-but-invalid value when its absent
+  // default is permissive; everything else snaps to that default.
+  return entry.invalidPersistedFallback !== undefined
+    ? entry.invalidPersistedFallback
+    : settingDefault(entry);
 }
 
 /**

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -229,6 +229,13 @@ export interface StateSettingEntry {
    * Keep migration mappings in the domain parser referenced here, not the row.
    */
   readonly normalizePersisted?: (raw: unknown) => unknown;
+  /**
+   * What a present-but-invalid persisted value resolves to instead of the
+   * absent default. Only a permission gate whose default is permissive
+   * declares one: corruption of a deliberate denial must fail closed, not
+   * silently re-permit (#11797).
+   */
+  readonly invalidPersistedFallback?: unknown;
   /** Short label for compact settings UIs; falls back to the stripped key. */
   readonly title?: string;
   /** Human-readable description, shared across every host that renders it. */
@@ -1139,6 +1146,9 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   surfacedSetting({
     key: GlobalStateKey.ALLOW_ORCHESTRATOR_KILL,
     schema: z.boolean().prefault(true),
+    // The permissive default applies only when the key is absent: a stored
+    // value that no longer parses resolves to denied (#11797).
+    invalidPersistedFallback: false,
     title: 'Allow orchestrator cancellation',
     description:
       'Allow the orchestrator to stop subagents that are no longer needed.',

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -575,4 +575,22 @@ describe('settingsAccess', () => {
       warn.mockRestore();
     }
   });
+
+  // #11797: the kill gate's permissive default is the absent value's; a
+  // present-but-corrupt one fails closed.
+  it('denies orchestrator kills on a corrupt ALLOW_ORCHESTRATOR_KILL value', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const entry = entryByKey(GlobalStateKey.ALLOW_ORCHESTRATOR_KILL);
+    try {
+      const absent = makeFakeSettingsStores();
+      assert.equal(readSetting(entry, absent.stores, 'vscode'), true);
+
+      const { stores, globalState } = makeFakeSettingsStores();
+      void globalState.update(entry.key, 'false');
+      assert.equal(readSetting(entry, stores, 'vscode'), false);
+      assert.equal(warn.mock.calls.length, 1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Three triaged low-risk follow-ups. Two of them turned out to be obsolete on
current `main` — the persistence cutover (#11881, #11972, and
3d8b07e628 "fold snapshots and commit deletion ownership") deleted the
mechanisms both issues cite. The third, #11797, still stands and is fixed
here.

### #11839 — CLI workflow popup never hydrated run facts (obsolete, no code)

The defect was `subscribeStreamArtifacts.ts` re-hydrating run facts only on
`activeStreamId` changes, so a workflow popup opened through
`foregroundReader` never triggered `hydrateFocusedStreamRunFacts`. Both files
and the entire row-open hydration mechanism were deleted by #11881
(`git log --diff-filter=D -- **/subscribeStreamArtifacts.ts **/sessionSignalsAdapter.ts`
→ 47b7e8522a; `git log -S hydrateFocusedStreamRunFacts` → added in #11836,
removed in #11881).

On current main there is no hydration gap to close: the session fold replays
the cold listing at open (`sessionInputs.ts:45-56`), and the listing carries
the latest `status` / `run.end` / `run.workflow` row per aggregate
(`Database.ts:141-149`, `listingTypeOf` in `sessionEvent.ts`), so a restored
workflow's phase is resident in `SessionView` before any surface opens. The
TUI additionally subscribes the transcript tier of *every* run in the view,
not just the active one (`runChatTui.tsx:328-344`), and `WorkflowPopup` reads
the fold directly. `Refs #11839` — closing it there is a maintainer call.

### #11834 — leftover-stream sweep delay and late publication (obsolete, no code)

Both complaints target code deleted by 3d8b07e628 and #11972
(`git log --diff-filter=D -- **/SessionStores.ts **/scheduleLeftoverStreamSweep.ts`
→ 3d8b07e628; `git log -S onPersistentOpenFailure -- packages/cli/src/runtime/transcriptSession.ts`
→ removed in 4ea15ba8a8):

1. *Interactive resume gets the zero-delay sweep*: the
   `onPersistentOpenFailure === 'fail'` → `delayMs: 0` plumbing no longer
   exists. The replacement `sweepLeftoverRuns`
   (`src/controllers/session/sweepLeftoverRuns.ts`) is `forkScoped` at session
   build (`sessionLayer.ts:434`) and iterates the already-read initial
   listing — the multi-second whole-storage-root filesystem scan the delay
   was protecting against is gone, so there is no delay decision to get
   wrong.
2. *Shell removals publish late*: the old sweep deleted shells, ran the
   orphan/executions scan, then returned the list for publication. The new
   sweep issues `session.requests.removeRun(runId, ...)` per shell as it
   walks the listing; each removal commits its own `run.removed` event
   through the normal event pipeline. There is no trailing orphan scan
   gating publication (no `orphan` scan remains in the session sweep path;
   pending file deletions are handled separately by `collectPendingDeletions`
   on a 30 s retry schedule).

`Refs #11834` — closing it there is a maintainer call.

### #11797 — ALLOW_ORCHESTRATOR_KILL fails open on a corrupt value (fixed)

The issue asks for option (1): resolve present-but-invalid values for this
key to `false` (deny) while keeping the absent default at `true`.

- `StateSettingEntry` gains an optional `invalidPersistedFallback`, declared
  only by permission gates whose absent default is permissive
  (`src/shared/schemas/stateSettings.ts`).
- `readSetting` resolves a stored value that fails the schema to that
  fallback instead of the absent default; the `log.warn` from #11787 is
  unchanged (`src/shared/config/settingsAccess.ts`).
- The `ALLOW_ORCHESTRATOR_KILL` row declares `invalidPersistedFallback:
  false`. Its single runtime reader (`ExecutionsTool.ts` `handleKill`) now
  denies kills when the persisted value is corrupt. The
  `DETACH_SUBAGENTS_ON_STOP` row needs nothing (default already `false`).

One regression test in the existing `stateSettings.vitest.ts` suite: absent
key resolves `true`, stored `'false'` (string) resolves `false`. Verified
red without the `settingsAccess` change, green with it.

## Issue acceptance gates

Closes #11797. Refs #11839, Refs #11834 (premise code deleted by later
merges; evidence above).

## Single source of truth

`readSetting` (`src/shared/config/settingsAccess.ts`) remains the one read
path; the fail-closed policy lives on the catalog row, not at the read site.

## Duplication and abstraction budget

One optional catalog field consumed by one branch in `readSetting`; no new
read path or per-call-site special case.

## Host impact

Extension: settings UI shows "off" for a corrupt kill-toggle value, matching
what the runtime honors.

Desktop: same (shared catalog read).

CLI: same; `/config` reads go through the same path.

## Scheduled refactoring

None.

## Validation

- `npm run format` (no changes needed)
- `npm run lint` — clean
- `npm run typecheck:workspace`, `npm run typecheck:test-kernel` — clean
- New regression test red without the fix, green with it
- `npm run test:changed` — 498 files, 5386 passed / 1 skipped
