### PR TITLE
fix(model): apply Astra long-context pricing tier past 272K

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -105,6 +105,7 @@ import {
   uploadToolAttachments,
   type UploadedOpenAIResponseAttachment,
 } from './openAIResponseFileUploads';
+import type { StandardPricingConfig } from '../support/priceUtils';
 import type { AssistantTextAppendOptions } from '../ModelHandler';
 import type { BackgroundRunLifecycle } from '../support/BackgroundRunLifecycle';
 
@@ -1950,6 +1951,25 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     return this.config.provider === ModelProvider.OPENAI
       ? 'openai-response'
       : (this.config.provider as NormalizedUsage['provider']);
+  }
+
+  /**
+   * Astra's documented long-context tier: once a request's prompt reaches
+   * 272K input tokens, the whole request bills at 2x input/cache and 1.5x
+   * output (docs/guide/models.md). The registry catalogs only the standard
+   * rates, so the tier derives from them.
+   */
+  protected override standardPricingConfig(): StandardPricingConfig {
+    const base = super.standardPricingConfig();
+    if (this.config.fullName !== 'gpt-6-astra') return base;
+    return {
+      ...base,
+      longContextTier: {
+        thresholdTokens: 272_000,
+        inputPrice: base.inputPrice * 2,
+        outputPrice: base.outputPrice * 1.5,
+      },
+    };
   }
 
   /** Normalizes OpenAI Responses API usage data into a unified format. */

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -1483,6 +1483,40 @@ describe('ModelHandlerOpenAIResponse.normalizeUsage', () => {
 
     assert.equal(normalized.cacheCreationTokens, undefined);
   });
+
+  it('bills gpt-6-astra at the long-context tier past 272K prompt tokens', () => {
+    const handler = createHandler({ ...MODEL_CONFIGS.gpt6 });
+    const usage: ResponseUsage = {
+      input_tokens: 300_000,
+      output_tokens: 10_000,
+      total_tokens: 310_000,
+      input_tokens_details: { cached_tokens: 100_000 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    } as ResponseUsage;
+
+    const normalized = handler.normalizeUsage(usage, 0);
+
+    // Tier rates: 2x input/cache and 1.5x output on the catalog's $10/$50
+    // with the 0.1 cache factor — 300K*20 + 10K*75 − 100K*20*0.9, per 1M.
+    assert.ok(normalized.cost != null);
+    assert.ok(
+      Math.abs(normalized.cost - 4.95) < 1e-9,
+      `cost=${normalized.cost}`,
+    );
+
+    const shortContext = handler.normalizeUsage(
+      { ...usage, input_tokens: 271_999, total_tokens: 281_999 },
+      0,
+    );
+    // Flat catalog rates below the threshold.
+    assert.ok(
+      Math.abs(
+        (shortContext.cost ?? NaN) -
+          (271_999 * 10 + 10_000 * 50 - 100_000 * 10 * 0.9) / 1e6,
+      ) < 1e-9,
+      `cost=${shortContext.cost}`,
+    );
+  });
 });
 
 describe('ModelHandlerOpenAIResponse background abort handling', () => {


### PR DESCRIPTION
## Summary

One code change, two triaged issues:

- **#11878 (verified defect 1):** `ModelHandlerOpenAIResponse.standardPricingConfig()` never populated `longContextTier`, so `gpt-6-astra` requests over 272K prompt tokens were billed at flat catalog rates — underreporting cost by up to 2x on input/cache and 1.5x on output for a mainline use of a 1M-context model. The handler now attaches the documented tier, mirroring the xAI pattern through the existing `LongContextPricingTier` mechanism in `src/agent/modelHandlers/support/priceUtils.ts`. Tier rates derive from the catalog prices via the documented multipliers (2x input/cache, 1.5x output); no new pricing numbers are invented. The existing cache rebate follows the tier switch, matching the documented 2x cached rate.
- **#11878 (defect 2, does not verify):** the claim that the `minimal`-effort clamp misses short-name substitution does not hold. Astra's llm-zoo entry has `shortName === fullName === 'gpt-6-astra'` (verified against both the installed llm-zoo 1.36.0 and the 1.35.0 npm tarball), so `applyShortModelNamePreference` (`src/agent/runtime/ModelFactory.ts:218-229`) returns the config unchanged and the `fullName` clamp at `modelHandlerOpenAIResponse.ts:1109` always fires. No other code path rewrites `fullName` for an OpenAI model (the only rewriters are the Kimi-subscription router and the short-name preference). Left as-is with this evidence.
- **#11790 (stale):** the two failing tests (`presents a merge failure that occurs before lifecycle startup`, `presents a terminal merge failure exactly once from its result`) no longer exist on `main`. #11883 (`ae723ad489`, "the conversation shell and both hosts on the fold") deleted `packages/desktop/src/main/desktopAgentExecution.ts` (1377 LoC) and its entire suite `src/test-kernel/desktop/DesktopAgentExecution.vitest.ts` (4126 LoC) plus harness; the merge-failure surface moved to `packages/desktop/src/main/desktopHostRequests.ts:213` under the new host-request arms. Nothing to fix or re-scope — the module the tests pinned was retired. Close with this evidence.

## Issue acceptance gates

- #11878 defect 1: satisfied — tier applied at the documented threshold and rates, regression test pins both sides of the boundary.
- #11878 defect 2: gate not applicable — claim disproven against the code and both llm-zoo versions; no change made.
- #11790: gate not applicable — named tests and the module under test no longer exist on `main`; evidence above.

## Single source of truth

`standardPricingConfig()` on the handler remains the one place Responses-API pricing config is assembled; the tier rides the existing `LongContextPricingTier` mechanism in `src/agent/modelHandlers/support/priceUtils.ts` rather than a new pricing path.

## Duplication and abstraction budget

No new abstraction: the fix reuses the `longContextTier` field and `computeStandardPrice` tier switch that `ModelHandlerXAI` already exercises. Astra is a single model, so the tier derives inline from the catalog rates instead of growing a documented-pricing table module like xAI's (which exists only because xAI's cache factor also needs overriding).

## Net elements (R6)

n/a — bug fix, not a refactor/simplify PR.

## Consumer counts (R8)

n/a — no emit path or export deleted or re-routed; `standardPricingConfig` gains one override on a class that previously inherited the base implementation.

## Host impact

Extension: usage/cost totals for `gpt-6-astra` prompts over 272K tokens now reflect the tier.

Desktop: same shared handler.

CLI: same shared handler.

## Scheduled refactoring

None.

## Validation

- `npm run format` — clean
- `npx eslint` on both touched files — clean
- `npm run typecheck:workspace` — pass
- `npm run typecheck:test-kernel` — pass
- `npm run test:changed` — 105 files, 1465 passed / 1 skipped
- `npx vitest run --project kernel src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts` — 44 passed, including the new regression test
- `npx vitest run --project pure src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts src/test-kernel/agent/modelHandlers/support/priceUtils.vitest.ts` — 12 passed
- New regression test discriminates: without the tier the same usage computes $2.60 flat vs the asserted $4.95
- #11790 staleness evidence: `git show ae723ad489 --stat` shows both the production module and suite deleted; grep for the test names and `merge failure` in `src/test-kernel` finds nothing on current `main`

Closes #11878
Refs #11790
