### PR TITLE
feat(storage): stamp and enforce a database format version

### DIFF
--- a/src/controllers/session/Database.ts
+++ b/src/controllers/session/Database.ts
@@ -77,6 +77,18 @@ import { localDatabasePath } from './localDatabasePath';
 /** The database file of a session root, beside the stores it replaces. */
 const SESSION_DATABASE_FILE = 'texra.db';
 /**
+ * The one database format marker (issue #12251, 1.0 plan §6): a fresh
+ * database is stamped with this version in `PRAGMA user_version`, and an open
+ * whose stored version differs — including the unmarked 0 of pre-marker dev
+ * builds — is refused with one `DatabaseOpenFailed`, never a per-row parse
+ * failure and never a silent strip. 1.0 keeps no compatibility with earlier
+ * 1.0-dev builds, so there is deliberately no reader of any other version;
+ * bump this constant in the same PR as any persisted-shape change on main
+ * until 1.0 ships, after which it is the versioning hook the one-fold PRD
+ * anticipates.
+ */
+export const DATABASE_FORMAT_VERSION = 1;
+/**
  * Event history and bounded current application records.
  *
  * `commit` is a SQLite keyword, so the column is quoted at every site; the
@@ -240,7 +252,7 @@ export const databaseLayer = (
         disableWAL: mode === 'ephemeral',
         busyTimeout: '5 seconds',
       }).pipe(mapDatabaseFailure(openFailed));
-      yield* configure(sql, mode).pipe(mapDatabaseFailure(openFailed));
+      yield* configure(sql, mode, path).pipe(mapDatabaseFailure(openFailed));
       const level = yield* SubscriptionRef.make(0);
       const observedCommit = yield* SubscriptionRef.make(0);
       const highWater = "SELECT seq FROM sqlite_sequence WHERE name = 'event'";
@@ -1211,10 +1223,17 @@ function payloadOf(draft: {
  * Read cursors use sqlite_sequence's committed high-water mark. Wake levels
  * are separate counters, since a claim-only change must wake readers even
  * when the event ordinal does not change.
+ *
+ * One open-time gate sits ahead of the DDL: the `user_version` format marker
+ * (`DATABASE_FORMAT_VERSION`). Any database that already holds tables under a
+ * different version — or under no version, as pre-marker dev builds wrote —
+ * is refused before the schema is touched; only a table-free database is
+ * created and stamped.
  */
 const configure = Effect.fnUntraced(function* (
   sql: SqlClient.SqlClient,
   mode: 'persistent' | 'ephemeral',
+  path: string,
 ) {
   yield* sql.unsafe('PRAGMA foreign_keys = ON', []);
   yield* sql.unsafe('PRAGMA synchronous = NORMAL', []);
@@ -1224,6 +1243,38 @@ const configure = Effect.fnUntraced(function* (
     mode === 'persistent' ? 'wal' : 'memory',
   );
   yield* verifyPragma(sql, 'foreign_keys', 1);
+  // The format marker is checked before the DDL creates anything, so a
+  // database holding state is never mutated by an open that will refuse it.
+  // A database with no user tables is fresh regardless of its stamp — there
+  // is no state to protect — and is (re)stamped below. The `:memory:` open is
+  // always fresh, so the ephemeral path needs no exemption.
+  const stored = z
+    .int()
+    .parse(
+      (yield* sql.unsafe<Record<string, unknown>>('PRAGMA user_version', []))[0]
+        ?.user_version ?? 0,
+    );
+  const tables = z
+    .int()
+    .nonnegative()
+    .parse(
+      (yield* sql.unsafe<Record<string, unknown>>(
+        `SELECT count(*) AS tables FROM sqlite_master
+       WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`,
+        [],
+      ))[0]?.tables ?? 0,
+    );
+  const fresh = tables === 0;
+  if (!fresh && stored !== DATABASE_FORMAT_VERSION) {
+    return yield* Effect.fail(
+      new Error(
+        `Refusing to open ${path}: written by an incompatible TeXRA 1.0-dev ` +
+          `build (database format ${String(stored)}, this build expects ` +
+          `${String(DATABASE_FORMAT_VERSION)}). Pre-release state is not ` +
+          `migrated by design; delete this database and start fresh.`,
+      ),
+    );
+  }
   // The official driver prepares one statement at a time. This fixed schema
   // contains only DDL statements, with no semicolons inside SQL literals.
   for (const statement of SCHEMA.split(';')
@@ -1231,6 +1282,12 @@ const configure = Effect.fnUntraced(function* (
     .filter(Boolean)) {
     yield* sql.unsafe(statement, []);
   }
+  // PRAGMA takes no bound parameters; the version is this module's own int.
+  if (fresh)
+    yield* sql.unsafe(
+      `PRAGMA user_version = ${String(DATABASE_FORMAT_VERSION)}`,
+      [],
+    );
 });
 
 const verifyPragma = Effect.fnUntraced(function* (

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -68,7 +68,10 @@ import {
 import { closeSession, openSession } from '@agent/runtime/sessionGraph';
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import { inquiryRecordsLayer } from '@controllers/session/inquiryRecords';
-import { databaseLayer } from '@controllers/session/Database';
+import {
+  DATABASE_FORMAT_VERSION,
+  databaseLayer,
+} from '@controllers/session/Database';
 import { collectPendingDeletions } from '@controllers/session/deletionCleanup';
 import { sessionRequests } from '@controllers/session/SessionRequests';
 import {
@@ -942,6 +945,58 @@ describe('the C1 event table and the C6 publisher', () => {
     db.exec('PRAGMA foreign_keys = ON');
     return db;
   };
+
+  it.effect('stamps a fresh database with the format version', () => {
+    const storage = workspace();
+    return Effect.gen(function* () {
+      yield* Database;
+      const stamped = yield* Effect.sync(() => {
+        const raw = reader(storage);
+        try {
+          return raw.prepare('PRAGMA user_version').get()?.user_version;
+        } finally {
+          raw.close();
+        }
+      });
+      expect(stamped).toBe(DATABASE_FORMAT_VERSION);
+    }).pipe(Effect.provide(substrate(storage)));
+  });
+
+  it.effect('refuses a database from an incompatible dev build', () =>
+    Effect.gen(function* () {
+      // A pre-marker dev build left tables behind with no user_version stamp.
+      const unmarked = workspace();
+      yield* Effect.sync(() => {
+        const raw = reader(unmarked);
+        try {
+          raw.exec('CREATE TABLE event (id INTEGER)');
+        } finally {
+          raw.close();
+        }
+      });
+      // A stamped database whose version this build does not write.
+      const foreign = workspace();
+      yield* Effect.sync(() => {
+        const raw = reader(foreign);
+        try {
+          raw.exec('CREATE TABLE event (id INTEGER)');
+          raw.exec(`PRAGMA user_version = ${DATABASE_FORMAT_VERSION + 1}`);
+        } finally {
+          raw.close();
+        }
+      });
+      for (const storage of [unmarked, foreign]) {
+        const failure = yield* Effect.flip(
+          Database.pipe(Effect.provide(substrate(storage))),
+        );
+        expect(failure._tag).toBe('DatabaseOpenFailed');
+        expect(String(failure.cause)).toContain('incompatible');
+        expect(String(failure.cause)).toContain('texra.db');
+      }
+      // A fresh database beside them still opens and stamps itself.
+      yield* Database.pipe(Effect.provide(substrate(workspace())));
+    }),
+  );
 
   it.effect('rejects a remote mount before creating the database', () => {
     const storage = workspace();


### PR DESCRIPTION
## Summary

TeXRA 1.0 keeps no compatibility with state written by earlier 1.0-dev builds, but today such rows either fail a per-row `.parse()` (loud but confusing) or are silently stripped. This adds the one database format marker the issue asks for: `DATABASE_FORMAT_VERSION` (currently `1`) beside `SCHEMA` in `src/controllers/session/Database.ts`, stored in SQLite's `PRAGMA user_version`.

`configure` — which already runs at every open — now checks the marker before the DDL creates anything:

- **Fresh database** (no user tables): the schema is applied and `user_version` is stamped. A table-free database is fresh regardless of its stamp, since there is no state to protect.
- **Database with tables under any other version** — including the unmarked `0` that pre-marker dev builds wrote: the open fails with one `DatabaseOpenFailed` naming the path and stating the state was written by an incompatible 1.0-dev build, is not migrated by design, and the fix is to delete the database and start fresh. The refusal happens before the DDL, so a refused database is never mutated.
- **`:memory:` opens** are always fresh, so the ephemeral path is stamped and needs no exemption.

The marker is checked ahead of the DDL deliberately: an open that will refuse a database must not create or alter tables in it first.

Closes #12251.

## Issue acceptance gates

- One database-level format marker (`PRAGMA user_version`), written when a database is created, checked when it is opened. ✅
- A mismatch refuses the whole database with one clear message naming the path — never a per-row failure, never a silent strip. ✅
- No reader of old shapes (out of scope per the issue): no reader of any other version exists. ✅
- The constant's docstring records the bump rule: bump in the same PR as any persisted-shape change on main until 1.0 ships; after 1.0 it is the one-fold PRD's versioning hook. ✅

## Single source of truth

`DATABASE_FORMAT_VERSION` in `src/controllers/session/Database.ts` owns the format version; `configure` owns the check, and it already owns every open of the single store.

## Duplication and abstraction budget

No new abstraction: the check lives inside the existing `configure`, reusing the existing `DatabaseOpenFailed` surfacing path (`mapDatabaseFailure(openFailed)`), so hosts get the refusal through the same error channel as every other open failure. All production opens of `texra.db` (`sessionLayer`, `inquiryRecords`, `updateCheckRecords`, desktop project records, CLI input history) go through `databaseLayer`; nothing opens the file directly.

## Net elements (R6)

n/a — feature PR, not a refactor/simplify. (2 files changed, +114/-2; one new export, `DATABASE_FORMAT_VERSION`, consumed by the test in this PR.)

## Consumer counts (R8)

n/a — no emit path or export deleted or re-routed; `configure` is module-private with one caller.

## Host impact

Extension: session open on an incompatible dev-build database fails with `DatabaseOpenFailed` (clear message naming the path) instead of later per-row failures.

Desktop: same, via `databaseLayer('persistent')` in `desktopProjectRecords`.

CLI: input history already degrades to empty on any open failure by design ("history failure must not prevent typing"), so an incompatible global database costs history only; session opens surface the refusal normally.

## Scheduled refactoring

None — the marker is the post-1.0 versioning hook; bumping it rides along with each persisted-shape PR.

## Validation

- New tests in `sessionEvents.vitest.ts` (the C1/C6 substrate suite): a fresh database is stamped with `DATABASE_FORMAT_VERSION`; a database with tables and no stamp (pre-marker dev build) and one with a foreign stamp both fail the open with `DatabaseOpenFailed` whose message names `texra.db` and the incompatibility; a fresh open beside them still succeeds. Confirmed the refusal test fails on main without the implementation.
- `npm run format`, `npm run lint`, `npm run typecheck:workspace`, `npm run typecheck:test-kernel` — clean.
- `npm run test:changed` — 166 files, 2071 passed / 1 skipped.
- `npx vitest run src/test-kernel/controllers/session src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts` — 4 files, 43 passed (covers persistent and `:memory:` opens).
