### PR TITLE
refactor(memory): one Effect leaf per memory file operation; delete the duplicated tryPromise wrappers

### DIFF
--- a/src/controllers/settingsView/SettingsMemoryController.ts
+++ b/src/controllers/settingsView/SettingsMemoryController.ts
@@ -6,12 +6,11 @@ import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { MemoryPreview, MemoryViewItem } from '@shared/schemas';
 import { MAX_PINNED_MEMORIES } from '@tools/memory/constants';
 import {
+  deleteMemoryPath,
   loadMemoryItems,
   loadMemoryPreview,
-  MemoryFileUnwritable,
   setMemoryPinned,
 } from '@tools/memory/memoryFileSystem';
-import { StorageFS } from '@utils/files/storageFS';
 
 interface SettingsMemoryControllerDeps {
   prompt: Pick<PromptHost, 'confirm' | 'warning'>;
@@ -82,10 +81,7 @@ export class SettingsMemoryController {
       if (!confirmed) return null;
 
       const storagePath = resolveMemoryStoragePath(input.storagePath);
-      yield* Effect.tryPromise({
-        try: () => StorageFS.delete(storagePath, { recursive: true }),
-        catch: (cause) => new MemoryFileUnwritable({ storagePath, cause }),
-      });
+      yield* deleteMemoryPath(storagePath);
       return yield* this.getMemoryDataMessage();
     },
   );

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -17,11 +17,14 @@ import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { replaceLiteralMatches } from '@tools/fileEditFlow';
 import {
-  MemoryEntryUnreadable,
+  deleteMemoryPath,
   MemoryFileUnwritable,
   memoryPathExists,
+  readMemoryFile,
   setMemoryPinned,
+  statMemoryEntry,
   walkMemoryDirectory,
+  writeMemoryFile,
 } from '@tools/memory/memoryFileSystem';
 import { executed } from '@tools/core/result';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -54,21 +57,10 @@ import {
 } from './constants';
 import { displayToStoragePath, toDisplayPath } from './memoryUtils';
 import {
-  parseFrontmatter,
-  buildFile,
   createMeta,
   formatAttribution,
   type MemoryFileMeta,
 } from './memoryMeta';
-
-/** Stat one memory path; the two callers share the one wrap of `StorageFS`. */
-const statMemoryStorage = Effect.fn('MemoryTool.statMemoryStorage')(
-  (storagePath: string) =>
-    Effect.tryPromise({
-      try: () => StorageFS.stat(storagePath),
-      catch: (cause) => new MemoryEntryUnreadable({ storagePath, cause }),
-    }),
-);
 
 /** Create a memory directory and its parents. */
 const ensureMemoryDir = Effect.fn('MemoryTool.ensureMemoryDir')(
@@ -272,21 +264,8 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     }
   });
 
-  /** Read a memory file, stripping frontmatter. Returns user-visible content and optional metadata. */
-  private readonly readMemoryFile = Effect.fn('MemoryTool.readMemoryFile')(
-    (resolvedPath: string) =>
-      Effect.map(
-        Effect.tryPromise({
-          try: () => StorageFS.read(resolvedPath),
-          catch: (cause) =>
-            new MemoryEntryUnreadable({ storagePath: resolvedPath, cause }),
-        }),
-        (raw) => parseFrontmatter(raw),
-      ),
-  );
-
   /** Write a memory file with fresh attribution frontmatter, preserving pinned status from existing file. */
-  private readonly writeMemoryFile = Effect.fn('MemoryTool.writeMemoryFile')(
+  private readonly writeAttributed = Effect.fn('MemoryTool.writeAttributed')(
     (
       resolvedPath: string,
       content: string,
@@ -301,13 +280,11 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
           runId === undefined
             ? undefined
             : getRunContextSession(ctx)?.runs.getHandle(runId)?.agentName;
-        const meta = createMeta(agentName, runId, existingMeta);
-        return Effect.tryPromise({
-          try: () =>
-            StorageFS.writeAtomic(resolvedPath, buildFile(content, meta)),
-          catch: (cause) =>
-            new MemoryFileUnwritable({ storagePath: resolvedPath, cause }),
-        });
+        return writeMemoryFile(
+          resolvedPath,
+          content,
+          createMeta(agentName, runId, existingMeta),
+        );
       }),
   );
 
@@ -333,7 +310,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     'MemoryTool.requireEditableFile',
   )(function* (resolvedPath: string, inputPath: string) {
     const errorMsg = `The path ${inputPath} does not exist or is a directory.`;
-    const stats = yield* statMemoryStorage(resolvedPath).pipe(
+    const stats = yield* statMemoryEntry(resolvedPath).pipe(
       Effect.catchTag('MemoryEntryUnreadable', () =>
         Effect.fail(new ToolError(errorMsg)),
       ),
@@ -369,7 +346,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       );
     }
 
-    const stats = yield* statMemoryStorage(resolvedPath);
+    const stats = yield* statMemoryEntry(resolvedPath);
     if (isDirectory(stats.type)) {
       const allEntries = yield* this.buildDirectoryListing(resolvedPath, stats);
       recordToolFileRead(inputPath);
@@ -387,7 +364,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       );
     }
 
-    const { meta, content } = yield* this.readMemoryFile(resolvedPath);
+    const { meta, content } = yield* readMemoryFile(resolvedPath);
     recordToolFileRead(inputPath);
     const lines = splitContentLines(content);
     if (lines.length > MAX_VIEW_LINES) {
@@ -430,7 +407,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
 
     yield* ensureMemoryDir(MEMORY_STORAGE_DIR);
     yield* ensureMemoryDir(path.dirname(resolvedPath));
-    yield* this.writeMemoryFile(resolvedPath, fileText);
+    yield* this.writeAttributed(resolvedPath, fileText);
     recordToolFileRead(inputPath);
 
     return executed(
@@ -459,7 +436,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     const readGate = this.requireViewBeforeModify(inputPath);
     if (readGate) return readGate;
 
-    const { content, meta } = yield* this.readMemoryFile(resolvedPath);
+    const { content, meta } = yield* readMemoryFile(resolvedPath);
     const replacement = replaceLiteralMatches({
       content,
       search: oldStr,
@@ -472,7 +449,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     });
 
     const updated = replacement.content;
-    yield* this.writeMemoryFile(resolvedPath, updated, meta);
+    yield* this.writeAttributed(resolvedPath, updated, meta);
     recordToolFileRead(inputPath);
 
     const updatedLines = updated.split('\n');
@@ -496,7 +473,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     const readGate = this.requireViewBeforeModify(inputPath);
     if (readGate) return readGate;
 
-    const { content, meta } = yield* this.readMemoryFile(resolvedPath);
+    const { content, meta } = yield* readMemoryFile(resolvedPath);
     const lines = content.split('\n');
     const totalLines = lines.length;
     if (insertLine < 0 || insertLine > totalLines) {
@@ -514,7 +491,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       ...lines.slice(insertLine),
     ];
 
-    yield* this.writeMemoryFile(resolvedPath, updatedLines.join('\n'), meta);
+    yield* this.writeAttributed(resolvedPath, updatedLines.join('\n'), meta);
     recordToolFileRead(inputPath);
 
     return executed(
@@ -538,11 +515,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     const readGate = this.requireViewBeforeModify(inputPath, 'deleting');
     if (readGate) return readGate;
 
-    yield* Effect.tryPromise({
-      try: () => StorageFS.delete(resolvedPath, { recursive: true }),
-      catch: (cause) =>
-        new MemoryFileUnwritable({ storagePath: resolvedPath, cause }),
-    });
+    yield* deleteMemoryPath(resolvedPath);
     return executed(
       `Successfully deleted ${inputPath}`,
       `Deleted: ${inputPath}`,

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -121,7 +121,8 @@ export const memoryPathExists = Effect.fn('memoryFileSystem.memoryPathExists')(
     }),
 );
 
-const statEntry = Effect.fn('memoryFileSystem.statEntry')(
+/** Stat one memory path. The one `StorageFS.stat` wrap the tree shares. */
+export const statMemoryEntry = Effect.fn('memoryFileSystem.statMemoryEntry')(
   (storagePath: string) =>
     Effect.tryPromise({
       try: () => StorageFS.stat(storagePath),
@@ -129,10 +130,40 @@ const statEntry = Effect.fn('memoryFileSystem.statEntry')(
     }),
 );
 
+/** Read one memory file whole and split its frontmatter from its content. */
+export const readMemoryFile = Effect.fn('memoryFileSystem.readMemoryFile')(
+  (storagePath: string) =>
+    Effect.map(
+      Effect.tryPromise({
+        try: () => StorageFS.read(storagePath),
+        catch: (cause) => new MemoryEntryUnreadable({ storagePath, cause }),
+      }),
+      (raw) => parseFrontmatter(raw),
+    ),
+);
+
+/** Write one memory file atomically, frontmatter first. */
+export const writeMemoryFile = Effect.fn('memoryFileSystem.writeMemoryFile')(
+  (storagePath: string, content: string, meta: MemoryFileMeta | null) =>
+    Effect.tryPromise({
+      try: () => StorageFS.writeAtomic(storagePath, buildFile(content, meta)),
+      catch: (cause) => new MemoryFileUnwritable({ storagePath, cause }),
+    }),
+);
+
+/** Delete one memory path and everything under it. */
+export const deleteMemoryPath = Effect.fn('memoryFileSystem.deleteMemoryPath')(
+  (storagePath: string) =>
+    Effect.tryPromise({
+      try: () => StorageFS.delete(storagePath, { recursive: true }),
+      catch: (cause) => new MemoryFileUnwritable({ storagePath, cause }),
+    }),
+);
+
 /** Read at most `maxBytes` from the head of a memory file. */
 const readStoragePrefix = Effect.fn('memoryFileSystem.readStoragePrefix')(
   function* (storagePath: string, maxBytes: number, stats?: { size: number }) {
-    const fileStats = stats ?? (yield* statEntry(storagePath));
+    const fileStats = stats ?? (yield* statMemoryEntry(storagePath));
     if (fileStats.size === 0) {
       return { text: '', truncated: false };
     }
@@ -214,7 +245,7 @@ const describeEntry = Effect.fn('memoryFileSystem.describeEntry')(function* (
   relativePath: string,
   type: number,
 ) {
-  const stats = yield* statEntry(storagePath);
+  const stats = yield* statMemoryEntry(storagePath);
   const entry = {
     relativePath,
     storagePath,
@@ -378,11 +409,7 @@ type SetMemoryPinnedResult =
  */
 export const setMemoryPinned = Effect.fn('memoryFileSystem.setMemoryPinned')(
   function* (storagePath: string, pinned: boolean) {
-    const raw = yield* Effect.tryPromise({
-      try: () => StorageFS.read(storagePath),
-      catch: (cause) => new MemoryEntryUnreadable({ storagePath, cause }),
-    });
-    const { meta, content } = parseFrontmatter(raw);
+    const { meta, content } = yield* readMemoryFile(storagePath);
 
     const alreadyInState = pinned ? !!meta?.pinned : !meta?.pinned;
     if (alreadyInState) {
@@ -398,12 +425,7 @@ export const setMemoryPinned = Effect.fn('memoryFileSystem.setMemoryPinned')(
       pinnedCount = priorPinned + 1;
     }
 
-    const updatedMeta = setPinnedMeta(meta, pinned);
-    yield* Effect.tryPromise({
-      try: () =>
-        StorageFS.writeAtomic(storagePath, buildFile(content, updatedMeta)),
-      catch: (cause) => new MemoryFileUnwritable({ storagePath, cause }),
-    });
+    yield* writeMemoryFile(storagePath, content, setPinnedMeta(meta, pinned));
     return { status: 'changed', pinnedCount } satisfies SetMemoryPinnedResult;
   },
 );


### PR DESCRIPTION
Four `Effect.tryPromise` wrappers in `MemoryTool.ts` and `SettingsMemoryController.ts` duplicated, callee and tagged error for tagged error, the Effect-returning leaves `memoryFileSystem.ts` already had. They now call the shared leaf (`statMemoryEntry`, `readMemoryFile`, `writeMemoryFile`, `deleteMemoryPath`); `setMemoryPinned` stops re-inlining the read and write it shares. Error channels are unchanged (`MemoryEntryUnreadable` / `MemoryFileUnwritable` with the same storage path); nothing widened.

Measured against the rooted-filesystem reconnaissance: the other 45 leaf wrappers over the filesystem ports are not removable without the port conversion that lane owns, so they stay; this is the orthogonal redundancy (the same wrapper authored twice), net minus 9 lines. Typecheck, the pure tier, the touched suites, lint, and all ratchets green; no ratchet row moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)