### PR TITLE
refactor(session): share the run-selection rule between Surface and the CLI TUI

### DIFF
--- a/.agents/docs/proposed/simplification/2026-09-09-session-systems-survey.md
+++ b/.agents/docs/proposed/simplification/2026-09-09-session-systems-survey.md
@@ -124,6 +124,13 @@ substrate. Not #11867, whose SQLite cutover has landed, and not #11869.
 
 ## 3. The TUI never adopted `Surface`
 
+**The narrow proposal below has landed** (`resolveSelected` split into
+`resolveSelectedId` plus the `keepWhenViewEmpty` arm; `cliState.ts`'s
+`selectedRunId` now calls it instead of reimplementing the rule). The rest of
+this section — `Surface.expanded` vs. `expandedStreams`, `Surface.launch` vs.
+`sessionMeta`, `Surface.phase` vs. `WORKFLOW_POPUP_VIEW`, and the full
+`Surface` adoption in #11866 — is unchanged and still open.
+
 PRD §10.1 says in writing that the TUI "Gains a `Surface`." It did not.
 `rg -c "shared/session/surface" packages/cli/src` returns zero: the TUI imports
 no part of the shared record, not `applySurfaceAction`, not `pruneSurface`, not

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -14,6 +14,7 @@ import {
   type RunId,
 } from '@shared/schemas';
 import type { RunView } from '@shared/session/sessionView';
+import { resolveSelectedId } from '@shared/session/surface';
 import { RUN_GROUP_LABELS } from '@shared/runs/runStatusDisplay';
 import type { WorkflowRowGroup } from '@shared/runs/workflowRunModel';
 import { sessionView } from './sessionView';
@@ -91,21 +92,20 @@ function defaultSessionMeta(): SessionMeta {
 export const activeRunId = signal<RunId | undefined>(undefined);
 
 /**
- * The run the transcript and status bar show: the Surface's selection
- * resolved against the view (PRD 9). The selected run while the view
- * holds it; the first top-level run once it has left; the selection
- * itself while the view holds no run at all (the pre-run local
- * conversation is a Surface-only id). A computed rather than an effect that
- * clears a stale selection, and a signal rather than a per-render derivation
- * so every component reads one answer.
+ * The run the transcript and status bar show: `resolveSelectedId` (PRD 9,
+ * shared with the extension and desktop `Surface`), with `keepWhenViewEmpty`
+ * for the pre-run local conversation (a Surface-only id the view has never
+ * heard of). `undefined`/`null` are reconciled here, the one call site,
+ * since the TUI spells "no selection" as `undefined` rather than `Surface`'s
+ * `null`. A computed rather than an effect that clears a stale selection,
+ * and a signal rather than a per-render derivation so every component reads
+ * one answer.
  */
 export const selectedRunId: Signal.Computed<RunId | undefined> = computed(
-  () => {
-    const selected = activeRunId.get();
-    const view = sessionView().get();
-    if (selected === undefined || view.runs.has(selected)) return selected;
-    return view.runs.size === 0 ? selected : view.order.at(0);
-  },
+  () =>
+    resolveSelectedId(sessionView().get(), activeRunId.get() ?? null, {
+      keepWhenViewEmpty: true,
+    }) ?? undefined,
 );
 
 /**

--- a/src/shared/session/surface.ts
+++ b/src/shared/session/surface.ts
@@ -310,19 +310,36 @@ export function reconcileLaunch(surface: Surface, host: HostSnapshot): Surface {
 }
 
 /**
- * What a surface shows: `selected` if the view still has that stream, else
- * the first top-level stream, else `null`. The fallback applies only to a
- * non-null id that has disappeared; an explicit `null` is the New-task
- * state and resolves to itself.
+ * The PRD 9 selection rule: `selected` if the view still has that run,
+ * else the first top-level run, else `null`. The fallback applies only to
+ * a non-null id that has disappeared; an explicit `null` resolves to
+ * itself.
+ *
+ * `keepWhenViewEmpty` covers the CLI's pre-run local conversation (a
+ * Surface-only id that predates any run in the view): when set, a `selected`
+ * the view has never heard of is kept as-is rather than falling back, but
+ * only while the view holds no runs at all — once any run exists, a
+ * `selected` absent from it still falls back to the first one. Extension
+ * and desktop never carry such an id (their `selected` is only ever set to
+ * a run the view already knows) and leave this at the default.
  */
+export function resolveSelectedId(
+  view: SessionView,
+  selected: RunId | null,
+  options: { readonly keepWhenViewEmpty?: boolean } = {},
+): RunId | null {
+  if (selected === null) return null;
+  if (view.runs.has(selected)) return selected;
+  if (options.keepWhenViewEmpty && view.runs.size === 0) return selected;
+  return view.order.at(0) ?? null;
+}
+
+/** What a surface shows: {@link resolveSelectedId} applied to `surface.selected`. */
 export function resolveSelected(
   view: SessionView,
   surface: Surface,
 ): RunId | null {
-  const { selected } = surface;
-  if (selected === null) return null;
-  if (view.runs.has(selected)) return selected;
-  return view.order.at(0) ?? null;
+  return resolveSelectedId(view, surface.selected);
 }
 
 /**


### PR DESCRIPTION
## Summary

A codebase audit for confusing/overlapping responsibilities found that `resolveSelected` (`src/shared/session/surface.ts`) and the CLI TUI's `selectedRunId` computed (`packages/cli/src/chat/tui/state/cliState.ts`) independently implemented the identical PRD-9 rule for resolving a selected run against the current `SessionView` — "the selection if the view still has it, else the first top-level run, else keep the (possibly stale) selection." The TUI never imported anything from the shared `Surface` module (`rg -c "shared/session/surface" packages/cli/src` returned 0), despite [the governing PRD](.agents/docs/implemented/architecture/2026-09-03-prd-one-fold-three-renderers.md) §10.1 stating in writing that the TUI "gains a `Surface`." The two implementations had already drifted once (a `Stream*` → `Run*` rename applied to one and not the other) and would drift again on the next edge-case change to either.

This was already scoped, independently, as the narrow item in `.agents/docs/proposed/simplification/2026-09-09-session-systems-survey.md` §3 ("give `resolveSelected` the extra arm the CLI needs... and have `selectedStreamId` call it") but had not been implemented — the CLI still reimplemented the rule inline. This PR lands exactly that narrow fix.

## Issue acceptance gates

No tracking issue; found via an audit of the codebase for overlapping responsibilities. Gate: the CLI's selection-resolution rule is deleted and replaced with a call to the shared function, with no behavior change on any host.

## Single source of truth

`resolveSelectedId` (`src/shared/session/surface.ts`) now owns the "resolve a selected run id against a `SessionView`" rule for all three hosts. `resolveSelected(view, surface)` (extension/desktop) and the CLI's `selectedRunId` computed both call it.

## Duplication and abstraction budget

Removed: the CLI's independent reimplementation of the PRD-9 selection rule (`cliState.ts`'s old 4-line inline branch). Added: one `options.keepWhenViewEmpty` parameter on the extracted function, which is the CLI's one genuine behavioral divergence (keeping a stale pre-run local-conversation id when the view holds no runs at all) — not a new abstraction, the same rule made to cover both cases it was already asked to cover. `resolveSelected` stays as a thin, unchanged-signature wrapper so all seven existing extension/desktop call sites are untouched.

## Net elements (R6)

Files: 2 code files changed (+ 1 doc annotation), no files added/removed. Diffstat: 3 files changed, 44 insertions(+), 20 deletions(-). Exported symbols (`^[+-]export` over the diff): +2 / -1 → net +1 (`resolveSelectedId` is a new export; `resolveSelected` is deleted and re-added with the same name and signature, so it is net 0). No new classes/interfaces/enums.

## Consumer counts (R8)

Not deleting or re-routing an emit path or export. `resolveSelected`'s signature and behavior are unchanged, so all 7 existing extension/desktop call sites (`progressWebview.ts`, `ProgressApp.ts`, `sessionSurfaces.ts` ×3, `RunTabs.ts`, `taskShell.ts`) needed no changes — verified by `npm run typecheck:workspace` passing clean. The CLI's `selectedRunId` (5 consuming files per the prior survey) keeps its existing public type (`Signal.Computed<RunId | undefined>`) and behavior.

## Host impact

Extension: no behavior change (verified by typecheck + `npm run test:changed`).

Desktop: no behavior change (verified by typecheck + `npm run test:changed`).

CLI: no behavior change — `selectedRunId` now delegates to the shared rule instead of reimplementing it; the pre-run local-conversation fallback (view empty → keep selection) is preserved via `keepWhenViewEmpty`.

## Scheduled refactoring

None from this PR. The broader `Surface` convergence work that §3 of the survey doc explicitly deferred (`Surface.expanded` vs. `expandedStreams`, `Surface.launch` vs. `sessionMeta`, `Surface.phase` vs. `WORKFLOW_POPUP_VIEW`) remains open under #11866, unchanged by this PR. The doc is annotated to record that its narrow proposal landed here.

## Validation

- `npm run typecheck:cli` — clean
- `npm run typecheck:workspace` — clean (covers `src/shared/session/surface.ts` and all extension/desktop call sites)
- `npx eslint` on both changed files — clean
- `npm run test:changed` — 42 test files, 608 passed / 1 skipped
- `npm run test:pure` — 199 test files, 2335 passed / 1 skipped (includes the architecture ratchets)
- `npm run check:dead-code-ratchet` — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EqPaYMkmto6ykSEX5ew9X

---
_Generated by [Claude Code](https://claude.ai/code/session_012EqPaYMkmto6ykSEX5ew9X)_