### PR TITLE
docs: record two consolidation attempts reverted after security/CI review

### DIFF
--- a/.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md
+++ b/.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md
@@ -101,7 +101,9 @@ this one function.
   resolves instead of being rejected.
 - `supabase/functions/github-app-token-exchange/index.ts`: the local
   `bearerToken` function is deleted; the file imports `bearerToken` from
-  `./auth.ts` alongside its existing imports from that module.
+  `../_shared/auth.ts` (the module that actually exports it — see
+  "Correction" below) alongside its existing imports from the local
+  `./auth.ts`.
 
 Verified: `npm run typecheck` (all seven workspace/package checks) passes
 clean; `npx eslint` on both touched files reports zero errors (the Supabase
@@ -111,6 +113,25 @@ change); `npx prettier --check` passes on both files; `npx vitest run
 memory` (26 tests, 6 files) passes; `npm run test:pure` (2335 tests) passes;
 `npm run check:dead-code-ratchet` reports no new findings; the full `npm
 test` (6295 tests, 591 files) passes.
+
+**Correction (PR #12319 review):** the first pushed commit (`c356c80`)
+imported `bearerToken` from `./auth.ts` — the wrong module. This
+`github-app-token-exchange/` directory has its own local `auth.ts` (GitHub
+OIDC-claim helpers only: `verifyGitHubActionsToken`, `parseRepositoryClaim`,
+`validateWorkflowIdentity`), separate from the shared
+`supabase/functions/_shared/auth.ts` that actually exports `bearerToken`.
+None of the checks listed above catch this: Supabase edge functions are
+Deno projects outside the pnpm workspace's `tsc`/ESLint scope, validated
+instead by CI's dedicated `deno check` step, which this session could not
+run locally (no `deno` binary available, and the sandboxed network policy
+blocked fetching one). Both Codex and the repo's own `texra-ai` PR review
+caught the dangling import independently; fixed in commit `df663c1` by
+importing `bearerToken` from `../_shared/auth.ts` instead, matching the
+three other edge functions (`auth-device`, `get-agent-config`,
+`log-usage`) that already import it that way. Lesson for this series: a
+proposed consolidation in a directory with a same-named local module
+(`auth.ts` here) needs the import path double-checked against a same-stack
+type checker, not just visual similarity to the target export.
 
 ## 4. What was checked and ruled out
 

--- a/.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md
+++ b/.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md
@@ -1,0 +1,199 @@
+# Survey: code consolidation and native-method opportunities (2026-09-12)
+
+Status: implemented
+Archived: 2026-09-12
+
+> **Status:** Written 2026-09-12 against branch HEAD `03b7e4a` (`refactor(memory):
+one Effect leaf per memory file operation; delete the duplicated tryPromise
+wrappers`, #12317). Scheduled routine re-ran the standing question — "find
+> duplicate/similar logic to consolidate, and hand-rolled code that a native
+> method or the standard library already covers" — six days after
+> `2026-09-06-consolidation-and-native-methods-survey.md`. **Verdict: two
+> small, isolated candidates clear the bar and are fixed in this pass; both
+> outside the churning "1.0 clean slate" run-model surface.**
+> `src/tools/memory/memoryUtils.ts`'s `displayToStoragePath` hand-rolled
+> absolute-path containment instead of calling the shared symlink-aware
+> `relativeToRoot` helper, and
+> `supabase/functions/github-app-token-exchange/index.ts` reimplemented the
+> `bearerToken` helper already exported by `supabase/functions/_shared/auth.ts`.
+
+## 0. Window covered
+
+`701824c..HEAD` (36 commits touching `src/` or `packages/*/src/`) was this
+pass's window — `701824c` is the most recent commit before this run whose
+subject starts `consolidate:` (`consolidate: shared wa-details toggle guard,
+native toSorted over spread+sort`, #12244), the same marker the prior entries
+in this series use to find their own grounding point. The window is
+dominated by the "1.0 clean slate" push and the new run-ledger/run-loop
+architecture (`feat(run): the run ledger foundation`, #12287;
+`feat(run): two Effect loops on the ledger and the llm Model; delete the
+PocketFlow engine`, #12314; a dozen more `refactor(run):`/`simplify:` PRs
+landing in the same span) — active, fast-moving surface that this pass
+deliberately avoided proposing changes into, per this series' standing rule
+to prefer isolated wins over touching code mid-refactor.
+
+Note: the runner's git history is shallow (50 commits), so `701824c` was the
+oldest `consolidate:`-prefixed commit reachable at all; the exact grounding
+commit the 2026-09-06 entry used (`03d2cfd`) is outside the fetched range.
+This pass's window is therefore a superset of the untouched gap, not an
+exact diff against the prior entry — see "Method" below for how that gap was
+covered.
+
+## 1. Method
+
+Given the shallow history, this pass could not do a pure `git diff
+<prior-grounding-commit>..HEAD` sweep for new tells the way the 2026-08-29
+through 2026-09-06 entries did. Instead it ran four parallel domain surveys
+(the same tells this series has always checked — duplicate/near-duplicate
+logic, hand-rolled code a Node builtin or an existing dependency already
+covers, and re-derived facts) across the whole repo, cross-checked each
+candidate's file against `701824c..HEAD` to see whether it fell inside the
+actively-churning run-model surface, and rejected anything that did:
+
+- **`src/agent/`, `src/tools/`** (agent runtime, model handlers, tool
+  implementations).
+- **The three webview frontend trees** (`webview/`, `progressView/`,
+  `settingsView/` under `packages/extension/src/`).
+- **`src/platform/`, `src/hosts/`, `src/common/storage/`**, and per-host
+  platform implementations.
+- **`scripts/`, `docs/scripts/`, `packages/extension/resources/`,
+  `prompts/`, `supabase/functions/`, `src/utils/`.**
+
+## 2. What was found
+
+**`memoryUtils.ts` hand-rolled path containment instead of the shared
+symlink-aware helper.** `src/tools/memory/memoryUtils.ts`'s
+`displayToStoragePath` built `path.resolve` + `path.relative` +
+`isPathWithin` by hand to validate a memory path stays under
+`MEMORY_STORAGE_DIR`. `src/platform/defaults/nodeWorkspace.ts`'s
+`relativeToRoot` already does the same containment check _and_ additionally
+falls back to a symlink-canonicalized comparison
+(`canonicalizeWorkspacePath`) when the lexical check fails — the exact
+helper `src/tools/pathResolution.ts:131-135` calls out in a comment as "the
+shared symlink-aware absolute-path containment helper" and
+`src/utils/files/workspaceFS.ts:44` already uses. Grepping every
+`isPathWithin` call site (`deletionCleanup.ts`, `workspaceStorage.ts`,
+`externalRoots.ts`, `nodeWorkspace.ts` itself, and `memoryUtils.ts`) showed
+`memoryUtils.ts` was the only remaining caller building the containment
+sequence by hand rather than through `relativeToRoot`. This was a real
+behavioral gap, not just style: a memory storage root reached through a
+symlink would fail `memoryUtils.ts`'s check while succeeding through
+`pathResolution.ts`'s.
+
+**Duplicate `bearerToken` helper in a Supabase edge function.**
+`supabase/functions/_shared/auth.ts:11-14` exports `bearerToken(req)`.
+`supabase/functions/github-app-token-exchange/index.ts:50-53` defined an
+identical local copy, in a file that already imports three other helpers
+from that same `./auth.ts` module (`parseRepositoryClaim`,
+`validateWorkflowIdentity`, `verifyGitHubActionsToken`) — so the shared
+module was already a normal dependency for this file, just not used for
+this one function.
+
+## 3. Fix
+
+- `src/tools/memory/memoryUtils.ts`: `displayToStoragePath` now calls
+  `relativeToRoot(MEMORY_STORAGE_DIR, resolved)` and checks
+  `relative === undefined` instead of resolving a second `base` path and
+  calling `isPathWithin` directly; the `isPathWithin` import is gone (no
+  other use in the file) and `relativeToRoot` is imported from
+  `@platform/defaults/nodeWorkspace`. Error message and return value are
+  unchanged for every non-symlink case; a symlinked storage root now
+  resolves instead of being rejected.
+- `supabase/functions/github-app-token-exchange/index.ts`: the local
+  `bearerToken` function is deleted; the file imports `bearerToken` from
+  `./auth.ts` alongside its existing imports from that module.
+
+Verified: `npm run typecheck` (all seven workspace/package checks) passes
+clean; `npx eslint` on both touched files reports zero errors (the Supabase
+function is outside the ESLint project's configured scope, so it only
+carries the expected "no matching configuration" notice, unrelated to this
+change); `npx prettier --check` passes on both files; `npx vitest run
+memory` (26 tests, 6 files) passes; `npm run test:pure` (2335 tests) passes;
+`npm run check:dead-code-ratchet` reports no new findings; the full `npm
+test` (6295 tests, 591 files) passes.
+
+## 4. What was checked and ruled out
+
+- **Platform/hosts/storage** (`src/platform/`, `src/hosts/`,
+  `src/common/storage/`, per-host platform implementations): already
+  thoroughly consolidated — shared secrets (`secretsGet`), shared
+  composition helpers (`createNodePlatform`, `createNodeWorkspaceRoots`,
+  `openTexraConfigStores`), `node:crypto`-backed ID hashing, no
+  migration/compatibility readers for internal formats, no `.catch()`
+  masking corrupted persisted state. One trivial, low-confidence,
+  not-worth-a-standalone-change item noted (`packages/desktop/src/main/platform/paths.ts`'s
+  `isExistingDirectory` could use `statSync(..., { throwIfNoEntry: false
+})` instead of a try/catch — purely stylistic, same behavior) and left
+  unfixed.
+- **Agent runtime and tools** (`src/agent/`, `src/tools/`): equally
+  consolidated — `auxiliaryRetry`/`pRetry`, `matchMappedSdkError`,
+  `ToolCallAccumulator`/`ChannelStreamAggregator`, `KeyedMutex`,
+  `pathResolution.ts`'s containment helper, and `agentCliShared.ts` are all
+  genuine shared bases with no duplicate reimplementations found (zero
+  duplicate exported function names across the whole domain). No hand-rolled
+  promise chains, manual retry loops, or manual debounce/throttle found; the
+  two rate-limiting implementations that exist are deliberately different
+  algorithms with a comment explaining the choice, not duplicates. Google's
+  media-classification fork (`mediaClassification.ts:14-19`) is a
+  documented, conscious tradeoff (needs a `video` category the shared
+  classifier doesn't have), not unowned debt — left as a note, not fixed.
+- **Webviews** (the three frontend trees): a hand-rolled `Set` + notify
+  listener pattern recurs at five call sites
+  (`progressView/frontend/sessionSurfaces.ts`,
+  `src/controllers/session/hostDraftRequests.ts`,
+  `src/agent/runtime/SessionHandle.ts`,
+  `src/agent/followUp/ToolUseFollowUpQueueManager.ts`,
+  `packages/desktop/src/main/desktopProjects.ts`) instead of the existing,
+  browser-safe `createListenerSet` (`src/utils/core/listenerSet.ts`, today
+  only adopted by `TraceEmitter`). Not fixed in this pass: three of the five
+  sites (`SessionHandle.ts`, `ToolUseFollowUpQueueManager.ts`,
+  `hostDraftRequests.ts`) sit inside or adjacent to the run-ledger/session
+  surface this window's dominant "1.0 clean slate" work is actively
+  rewriting (see §0), so touching them now risks colliding with in-flight
+  restructuring rather than being a clean, isolated win. Worth a follow-up
+  pass once that work settles. `installWebviewTransport`'s request/response
+  correlation map (`progressView/frontend/sessionTransport.ts`) has only one
+  consumer today — noted as a "name it before a second caller forces a worse
+  copy" candidate, not an active duplicate. `BaseWebviewApp` not being
+  shared by `ProgressApp` is intentional architecture per the
+  one-fold-three-renderers PRD, not overlooked duplication. All other
+  classic tells (manual dedup, manual debounce/throttle,
+  `JSON.parse(JSON.stringify(`, hand-rolled deep-equal, clipboard handling,
+  `EventTarget` reimplementation) were absent or already routed through
+  shared helpers, matching this series' 2026-09-02 through 2026-09-06
+  findings.
+- **Scripts, resources, prompts, Supabase, utils**: a real duplicated LaTeX
+  `\criticize` color-coding macro across seven `prompts/agents/remote/workflow/*.yaml`
+  files has drifted into a genuine severity-mapping bug (`criticize.yaml`
+  and `enhance.yaml` gate the lowest severity on `\ifnum#2=0`, which never
+  fires given the documented 1–5 severity scale, while `elevate.yaml` has
+  the correct `\ifnum#2=1`), and a 15-line style-guide `itemize` block is
+  duplicated verbatim across `correct.yaml`, `polish.yaml`, and
+  `generic.yaml`. Both are real findings but are prompt-content fixes with
+  no include/anchor mechanism available (`agentLoad.ts` parses each YAML as
+  a standalone document) and land in the same prompt-authoring surface this
+  window's `refactor: inline the polish prompt and delete
+initializeBundledPrompts` (#12297) just touched — deferred to a
+  dedicated pass rather than folded into this consolidation sweep. A
+  hand-rolled flag parser in `scripts/check-effect-migration-ratchet.mjs`
+  (vs. the `node:util.parseArgs` already used by
+  `scripts/sync-remote-agents.mjs` in the same directory) and a ~4-line
+  duplicated "current branch, treat HEAD as absent" check between
+  `src/utils/git/worktreeInfo.ts` and `src/utils/git/repositoryOverview.ts`
+  were both judged too thin to extract on their own (single-ternary logic,
+  not the kind of real duplicated logic this series' bar requires) and were
+  not fixed.
+
+## 5. Verdict
+
+Six days after the 2026-09-06 entry, and against a window dominated by the
+large in-flight run-ledger/run-loop rewrite, the standing sweep found two
+genuine, isolated, low-risk consolidation candidates outside that churning
+surface — both fixed and verified in this pass (typecheck, lint, format,
+targeted tests, the full suite, and the dead-code ratchet all clean). Three
+further candidates (the webview listener-set duplication, the prompt YAML
+macro/style-block duplication) are real but were deliberately left for a
+follow-up pass because they sit inside actively-changing surfaces this
+window is still rewriting; two more (the flag-parser inconsistency, the
+git-branch-detection duplicate) were judged too thin to be worth a
+standalone change.

--- a/.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md
+++ b/.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md
@@ -8,20 +8,38 @@ one Effect leaf per memory file operation; delete the duplicated tryPromise
 wrappers`, #12317). Scheduled routine re-ran the standing question — "find
 > duplicate/similar logic to consolidate, and hand-rolled code that a native
 > method or the standard library already covers" — six days after
-> `2026-09-06-consolidation-and-native-methods-survey.md`. **Verdict: one
-> small, isolated candidate clears the bar and is fixed in this pass, outside
-> the churning "1.0 clean slate" run-model surface; a second candidate was
-> reverted after review because deduping it costs more than it saves.**
-> `src/tools/memory/memoryUtils.ts`'s `displayToStoragePath` hand-rolled
-> absolute-path containment instead of calling the shared symlink-aware
-> `relativeToRoot` helper — fixed. A `bearerToken` helper duplicated in
-> `supabase/functions/github-app-token-exchange/index.ts` looked like a
-> straightforward dedup against `supabase/functions/_shared/auth.ts`'s
-> export, but that shared module also pulls in `@supabase/supabase-js` at
-> module scope for its (unrelated, unused-here) `authenticateJwt` export —
-> importing `bearerToken` from it would have added a full Supabase-client
-> dependency to an OIDC-only, Supabase-free endpoint. Reverted to the local
-> three-line copy; see "Correction" below.
+> `2026-09-06-consolidation-and-native-methods-survey.md`. **Verdict: two
+> candidates were proposed; both were reverted after PR review (#12319) found
+> a real cost neither the original survey nor local validation caught. No
+> code shipped from this pass.**
+>
+> - `src/tools/memory/memoryUtils.ts`'s `displayToStoragePath` hand-rolled
+>   absolute-path containment instead of calling the shared symlink-aware
+>   `relativeToRoot` helper. Looked like a clean behavior-preserving
+>   consolidation (plus a symlink-support improvement) and passed every local
+>   check (typecheck, lint, format, the full test suite). A security-focused
+>   PR reviewer then pointed out that `relativeToRoot`'s realpath fallback
+>   (`canonicalizeWorkspacePath`) calls synchronous `realpathSync` on a path
+>   the original code never touched the filesystem for — and the memory
+>   tool's path argument is model-controlled with no absolute-path
+>   pre-filter, so a crafted `/memories/\\server\share\x` on a Windows host
+>   could force a blocking SMB lookup (a known UNC-path attack class:
+>   NTLM-hash leakage / DoS). Reverted to the original implementation.
+> - `supabase/functions/github-app-token-exchange/index.ts` reimplemented
+>   `bearerToken`, already exported by `supabase/functions/_shared/auth.ts`.
+>   The first attempt imported from the wrong same-named local `auth.ts`
+>   (a broken import, caught by CI and two review bots); the corrected import
+>   then failed CI's `deno check` because the shared module transitively
+>   requires `@supabase/supabase-js`, which this deliberately
+>   Supabase-free, GitHub-OIDC-only function doesn't declare. Reverted to the
+>   original local three-line copy, now with a comment recording why it
+>   isn't deduped.
+>
+> Full narrative in §2–3 below. This entry is archived as a completed pass
+> even though nothing shipped: the record of what was tried, why it looked
+> safe, and why it wasn't is the useful output, and both reversions are
+> pinned so a future pass doesn't repeat them without re-deriving the same
+> two lessons.
 
 ## 0. Window covered
 
@@ -65,92 +83,129 @@ actively-churning run-model surface, and rejected anything that did:
 - **`scripts/`, `docs/scripts/`, `packages/extension/resources/`,
   `prompts/`, `supabase/functions/`, `src/utils/`.**
 
-## 2. What was found
+## 2. What was found, tried, and reverted
 
-**`memoryUtils.ts` hand-rolled path containment instead of the shared
-symlink-aware helper.** `src/tools/memory/memoryUtils.ts`'s
-`displayToStoragePath` built `path.resolve` + `path.relative` +
-`isPathWithin` by hand to validate a memory path stays under
-`MEMORY_STORAGE_DIR`. `src/platform/defaults/nodeWorkspace.ts`'s
-`relativeToRoot` already does the same containment check _and_ additionally
-falls back to a symlink-canonicalized comparison
-(`canonicalizeWorkspacePath`) when the lexical check fails — the exact
-helper `src/tools/pathResolution.ts:131-135` calls out in a comment as "the
-shared symlink-aware absolute-path containment helper" and
-`src/utils/files/workspaceFS.ts:44` already uses. Grepping every
-`isPathWithin` call site (`deletionCleanup.ts`, `workspaceStorage.ts`,
-`externalRoots.ts`, `nodeWorkspace.ts` itself, and `memoryUtils.ts`) showed
-`memoryUtils.ts` was the only remaining caller building the containment
-sequence by hand rather than through `relativeToRoot`. This was a real
-behavioral gap, not just style: a memory storage root reached through a
-symlink would fail `memoryUtils.ts`'s check while succeeding through
-`pathResolution.ts`'s.
+### 2a. `memoryUtils.ts` — hand-rolled path containment vs. the shared helper
 
-**Duplicate `bearerToken` helper in a Supabase edge function — proposed,
-then reverted (see "Correction" below).**
+`src/tools/memory/memoryUtils.ts`'s `displayToStoragePath` built
+`path.resolve` + `path.relative` + `isPathWithin` by hand to validate a
+memory path stays under `MEMORY_STORAGE_DIR`.
+`src/platform/defaults/nodeWorkspace.ts`'s `relativeToRoot` already does the
+same containment check _and_ additionally falls back to a
+symlink-canonicalized comparison (`canonicalizeWorkspacePath`) when the
+lexical check fails — the exact helper `src/tools/pathResolution.ts:131-135`
+calls out in a comment as "the shared symlink-aware absolute-path
+containment helper" and `src/utils/files/workspaceFS.ts:44` already uses.
+Grepping every `isPathWithin` call site showed `memoryUtils.ts` was the only
+remaining caller building the containment sequence by hand.
+
+**Tried:** routed `displayToStoragePath` through `relativeToRoot`, removing
+the local `isPathWithin` sequence. Passed `npm run typecheck` (all seven
+workspace/package checks), `npx eslint`, `npx prettier --check`, `npx
+vitest run memory` (26/26), `npm run test:pure` (2335/2335), `npm run
+check:dead-code-ratchet`, and the full `npm test` (6295/6295) — every check
+this session could run locally.
+
+**Reverted after review:** none of those checks exercise the
+security-relevant difference. The old code's lexical `isPathWithin` never
+touches the filesystem for a path outside the root; `relativeToRoot`'s
+fallback calls `realpathSync` on the path before rejecting it. A PR
+reviewer pointed out that `MemoryTool.run`'s `locate` closure
+(`src/tools/memory/MemoryTool.ts:215-222`) passes the model's raw tool-call
+argument straight into `displayToStoragePath` with no absolute-path
+pre-filter — only a `/memories`-prefix string check
+(`memoryUtils.ts:22-25`), which a value like
+`/memories/\\attacker-host\share\x` still satisfies. `path.resolve` treats
+an absolute (or, on Windows, UNC-rooted) suffix as replacing the base
+entirely, per Node's documented last-absolute-argument-wins behavior, so
+`resolved` becomes the raw attacker string regardless of `MEMORY_STORAGE_DIR`.
+The old code's `isPathWithin(base, resolved)` then just returns false
+(string comparison, no I/O) and throws. The new code's `relativeToRoot`
+falls through to `canonicalizeWorkspacePath`, which calls `realpathSync` on
+that same attacker string before it can return `undefined` — on Windows,
+`realpathSync` on a UNC path is a synchronous, blocking SMB connection
+attempt to a host the model chose, a known attack class (NTLM-hash
+relay/leak via forced authentication, or event-loop-blocking DoS if the
+host doesn't respond). This is a real regression: the old function never
+performed I/O on a rejected path, and the new one does.
+
+This is not a defect in `relativeToRoot` itself — `pathResolution.ts`'s own
+existing use of it (`pathResolution.ts:135`) has the same shape for
+arbitrary absolute tool paths, so the underlying question of whether that
+call site needs a pre-filter is a separate, repo-wide concern outside a
+routine consolidation sweep's scope to decide unilaterally. For
+`memoryUtils.ts` specifically, the safe choice was to revert: the original
+implementation is restored verbatim (confirmed via `git diff origin/main`
+showing zero diff on this file), and the "let's dedupe this" attempt is
+recorded here so it isn't retried without addressing the pre-filter
+question first.
+
+### 2b. Duplicate `bearerToken` helper in a Supabase edge function
+
 `supabase/functions/_shared/auth.ts:11-14` exports `bearerToken(req)`.
 `supabase/functions/github-app-token-exchange/index.ts:50-53` defined an
-identical local copy. At first glance this looked like a normal dependency
-already in use: the file imports three other helpers
-(`parseRepositoryClaim`, `validateWorkflowIdentity`,
-`verifyGitHubActionsToken`) from a module named `./auth.ts` — but that
-import is from this directory's own **local** `auth.ts` (GitHub
-OIDC-claim helpers only), a different file from the **shared**
-`supabase/functions/_shared/auth.ts` that exports `bearerToken`. The two
-same-named modules were conflated in the first pass.
+identical local copy. This looked like a normal dependency already in use:
+the file imports three other helpers (`parseRepositoryClaim`,
+`validateWorkflowIdentity`, `verifyGitHubActionsToken`) from a module named
+`./auth.ts` — but that import is from this directory's own **local**
+`auth.ts` (GitHub OIDC-claim helpers only), a different file from the
+**shared** `supabase/functions/_shared/auth.ts` that exports `bearerToken`.
+The two same-named modules were conflated in the first pass.
 
-## 3. Fix
+**Tried (attempt 1, commit `c356c80`):** imported `bearerToken` from the
+wrong module (`./auth.ts`, the local one, which doesn't export it) — a
+straight-up broken import. Local validation (`npm run typecheck`, `npx
+eslint`, `npx prettier`) could not catch this: Supabase edge functions are
+Deno projects outside the pnpm workspace's `tsc`/ESLint scope, checked
+instead by CI's dedicated `deno check` step, which this session has no
+local `deno` binary to run (and the sandboxed network policy blocked
+fetching one). Caught independently by both Codex and the repo's own
+`texra-ai` PR review within minutes of the PR opening.
 
-- `src/tools/memory/memoryUtils.ts`: `displayToStoragePath` now calls
-  `relativeToRoot(MEMORY_STORAGE_DIR, resolved)` and checks
-  `relative === undefined` instead of resolving a second `base` path and
-  calling `isPathWithin` directly; the `isPathWithin` import is gone (no
-  other use in the file) and `relativeToRoot` is imported from
-  `@platform/defaults/nodeWorkspace`. Error message and return value are
-  unchanged for every non-symlink case; a symlinked storage root now
-  resolves instead of being rejected.
-- `supabase/functions/github-app-token-exchange/index.ts`: unchanged from
-  before this pass — the local `bearerToken` stays. See "Correction".
+**Tried (attempt 2, commit `df663c1`):** pointed the import at the real
+owner, `../_shared/auth.ts`, matching the three other edge functions
+(`auth-device`, `get-agent-config`, `log-usage`) that already import
+`bearerToken` that way.
 
-Verified (for the `memoryUtils.ts` fix that shipped): `npm run typecheck`
-(all seven workspace/package checks) passes clean; `npx eslint` reports
-zero errors; `npx prettier --check` passes; `npx vitest run memory` (26
-tests, 6 files) passes; `npm run test:pure` (2335 tests) passes; `npm run
-check:dead-code-ratchet` reports no new findings; the full `npm test`
-(6295 tests, 591 files) passes.
+**Reverted after CI (`static checks (linux)`, `deno check`):**
+`_shared/auth.ts` imports `@supabase/supabase-js` at module scope for its
+`authenticateJwt` export, so importing anything from that module — even
+just `bearerToken` — pulls the Supabase client SDK into `deno check`'s
+dependency resolution. `github-app-token-exchange/deno.json` only declares
+`@octokit/auth-app` and `jose`; it never needed a Supabase client because
+this endpoint verifies GitHub's OIDC tokens, not Supabase JWTs. Declaring
+`@supabase/supabase-js` would have made `deno check` pass, but it means
+giving a deliberately Supabase-free, minimal-dependency endpoint a
+transitive dependency on a full Supabase client SDK just to reuse a
+three-line header parse — a worse trade than the duplication it removes.
+Reverted to the local `bearerToken` copy (confirmed unchanged behavior),
+now with a comment recording why it isn't deduped against the shared one.
 
-**Correction (PR #12319 review):** the first pushed commit (`c356c80`)
-imported `bearerToken` from `./auth.ts` — the local module, which doesn't
-export it — a straight-up broken import, caught independently by both
-Codex and the repo's own `texra-ai` PR review. The obvious fix looked like
-pointing the import at the real owner, `../_shared/auth.ts`, and commit
-`df663c1` did that. But CI's `static checks` job then failed `deno check`
-for a different reason: `_shared/auth.ts` imports `@supabase/supabase-js`
-at module scope for its `authenticateJwt` export, so importing anything
-from that module — even just `bearerToken` — pulls the Supabase client SDK
-into `deno check`'s dependency resolution, and this function's
-`deno.json` never declared it (unlike `auth-device`, `get-agent-config`,
-and `log-usage`, which already need `@supabase/supabase-js` for their own
-`authenticateJwt` calls and declare it accordingly). Adding that
-declaration would have "worked", but it means giving a Supabase-free,
-GitHub-OIDC-only endpoint a transitive dependency on a full Supabase
-client just to reuse a three-line header parse — a worse trade than the
-duplication it removes for a function that is deliberately minimal
-(`deno.json` only lists `@octokit/auth-app` and `jose` today). Reverted
-instead: the local `bearerToken` copy stays, now with a comment recording
-why it isn't deduped against the shared one. Net result for this
-candidate: no code change, caught before merge.
+### Lessons for this series
 
-Lessons for this series: (1) a same-named local module in the target
-directory (`auth.ts` here, colliding with `_shared/auth.ts`) needs the
-import path checked against a same-stack compiler, not visual similarity
-to the export name; (2) "the export already exists in a module we import
-from" is not sufficient evidence for a safe dedup when the target module
-has other exports with their own dependencies — check what else the
-target module pulls in at module scope before proposing the merge,
-especially for a deliberately dependency-light edge function.
+1. A same-named local module in the target directory (`auth.ts` colliding
+   with `_shared/auth.ts`) needs the import path checked against a
+   same-stack compiler, not visual similarity to the export name.
+2. "The export already exists in a module we could import from" is not
+   sufficient evidence for a safe dedup when the target module has other
+   exports with their own dependencies (`authenticateJwt`'s
+   `@supabase/supabase-js` import) or other code paths with different
+   trust assumptions (`relativeToRoot`'s realpath fallback, safe for a
+   validated workspace root, live for a model-controlled tool argument with
+   no absolute-path pre-filter). Passing typecheck/lint/test is necessary
+   but not sufficient for a security-relevant path or dependency-boundary
+   change — those need a reviewer (or a repo-specific security checklist)
+   looking at what changed about _when I/O or a new dependency gets
+   pulled in_, not just whether the output is the same on the happy path.
+3. For a scheduled, unattended routine specifically: when a PR reviewer
+   raises a plausible security concern on a change this pass cannot fully
+   resolve within its own scope (here, whether `pathResolution.ts`'s
+   existing absolute-path handling needs a UNC/absolute pre-filter is a
+   separate, repo-wide question), the correct move is to revert and record
+   it, not to argue the risk down to keep a "nice-to-have" consolidation
+   that fixes no active bug.
 
-## 4. What was checked and ruled out
+## 3. What was checked and ruled out
 
 - **Platform/hosts/storage** (`src/platform/`, `src/hosts/`,
   `src/common/storage/`, per-host platform implementations): already
@@ -159,10 +214,10 @@ especially for a deliberately dependency-light edge function.
   `openTexraConfigStores`), `node:crypto`-backed ID hashing, no
   migration/compatibility readers for internal formats, no `.catch()`
   masking corrupted persisted state. One trivial, low-confidence,
-  not-worth-a-standalone-change item noted (`packages/desktop/src/main/platform/paths.ts`'s
-  `isExistingDirectory` could use `statSync(..., { throwIfNoEntry: false
-})` instead of a try/catch — purely stylistic, same behavior) and left
-  unfixed.
+  not-worth-a-standalone-change item noted
+  (`packages/desktop/src/main/platform/paths.ts`'s `isExistingDirectory`
+  could use `statSync(..., { throwIfNoEntry: false })` instead of a
+  try/catch — purely stylistic, same behavior) and left unfixed.
 - **Agent runtime and tools** (`src/agent/`, `src/tools/`): equally
   consolidated — `auxiliaryRetry`/`pRetry`, `matchMappedSdkError`,
   `ToolCallAccumulator`/`ChannelStreamAggregator`, `KeyedMutex`,
@@ -201,44 +256,44 @@ especially for a deliberately dependency-light edge function.
   shared helpers, matching this series' 2026-09-02 through 2026-09-06
   findings.
 - **Scripts, resources, prompts, Supabase, utils**: a real duplicated LaTeX
-  `\criticize` color-coding macro across seven `prompts/agents/remote/workflow/*.yaml`
-  files has drifted into a genuine severity-mapping bug (`criticize.yaml`
-  and `enhance.yaml` gate the lowest severity on `\ifnum#2=0`, which never
-  fires given the documented 1–5 severity scale, while `elevate.yaml` has
-  the correct `\ifnum#2=1`), and a 15-line style-guide `itemize` block is
-  duplicated verbatim across `correct.yaml`, `polish.yaml`, and
-  `generic.yaml`. Both are real findings but are prompt-content fixes with
-  no include/anchor mechanism available (`agentLoad.ts` parses each YAML as
-  a standalone document) and land in the same prompt-authoring surface this
-  window's `refactor: inline the polish prompt and delete
-initializeBundledPrompts` (#12297) just touched — deferred to a
-  dedicated pass rather than folded into this consolidation sweep. A
-  hand-rolled flag parser in `scripts/check-effect-migration-ratchet.mjs`
-  (vs. the `node:util.parseArgs` already used by
-  `scripts/sync-remote-agents.mjs` in the same directory) and a ~4-line
-  duplicated "current branch, treat HEAD as absent" check between
-  `src/utils/git/worktreeInfo.ts` and `src/utils/git/repositoryOverview.ts`
-  were both judged too thin to extract on their own (single-ternary logic,
-  not the kind of real duplicated logic this series' bar requires) and were
-  not fixed.
+  `\criticize` color-coding macro across seven
+  `prompts/agents/remote/workflow/*.yaml` files has drifted into a genuine
+  severity-mapping bug (`criticize.yaml` and `enhance.yaml` gate the lowest
+  severity on `\ifnum#2=0`, which never fires given the documented 1–5
+  severity scale, while `elevate.yaml` has the correct `\ifnum#2=1`), and a
+  15-line style-guide `itemize` block is duplicated verbatim across
+  `correct.yaml`, `polish.yaml`, and `generic.yaml`. Both are real findings
+  but are prompt-content fixes with no include/anchor mechanism available
+  (`agentLoad.ts` parses each YAML as a standalone document) and land in
+  the same prompt-authoring surface this window's `refactor: inline the
+polish prompt and delete initializeBundledPrompts` (#12297) just touched
+  — deferred to a dedicated pass rather than folded into this consolidation
+  sweep. A hand-rolled flag parser in
+  `scripts/check-effect-migration-ratchet.mjs` (vs. the `node:util.parseArgs`
+  already used by `scripts/sync-remote-agents.mjs` in the same directory)
+  and a ~4-line duplicated "current branch, treat HEAD as absent" check
+  between `src/utils/git/worktreeInfo.ts` and
+  `src/utils/git/repositoryOverview.ts` were both judged too thin to
+  extract on their own (single-ternary logic, not the kind of real
+  duplicated logic this series' bar requires) and were not fixed.
 
-## 5. Verdict
+## 4. Verdict
 
 Six days after the 2026-09-06 entry, and against a window dominated by the
 large in-flight run-ledger/run-loop rewrite, the standing sweep found two
-candidates outside that churning surface. One — `memoryUtils.ts`'s path
-containment — was genuine, isolated, and low-risk, and is fixed and
-verified in this pass (typecheck, lint, format, targeted tests, the full
-suite, and the dead-code ratchet all clean). The other — the Supabase
-`bearerToken` dedup — looked equally safe but, once PR review forced a
-same-stack `deno check` against the actual dependency graph, turned out to
-trade a three-line duplication for a real cost (an unwanted transitive
-`@supabase/supabase-js` dependency on a deliberately Supabase-free
-function); it was reverted rather than shipped, which is the correct
-outcome for a consolidation series that only wants net wins. Three further
-candidates (the webview listener-set duplication, the prompt YAML
-macro/style-block duplication) are real but were deliberately left for a
-follow-up pass because they sit inside actively-changing surfaces this
-window is still rewriting; two more (the flag-parser inconsistency, the
-git-branch-detection duplicate) were judged too thin to be worth a
-standalone change.
+candidates outside that churning surface — and both were wrong to ship, for
+two different reasons neither the survey nor this session's local
+validation could catch: a security-relevant behavior change
+(`memoryUtils.ts` newly performing realpath I/O, including a synchronous
+network call on Windows, on a model-controlled path that used to be
+rejected lexically with no I/O) and a dependency-boundary cost (pulling a
+Supabase client SDK into a Supabase-free edge function). Both were reverted
+to their original implementations in PR #12319, which ships no code change
+— only this record and, on the Supabase side, an explanatory comment. That
+is the correct outcome for a consolidation series whose bar is "net win
+after review," not "passed local checks." Three further candidates (the
+webview listener-set duplication, the prompt YAML macro/style-block
+duplication) are real but were deliberately left for a follow-up pass
+because they sit inside actively-changing surfaces this window is still
+rewriting; two more (the flag-parser inconsistency, the git-branch-detection
+duplicate) were judged too thin to be worth a standalone change.

--- a/.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md
+++ b/.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md
@@ -8,14 +8,20 @@ one Effect leaf per memory file operation; delete the duplicated tryPromise
 wrappers`, #12317). Scheduled routine re-ran the standing question — "find
 > duplicate/similar logic to consolidate, and hand-rolled code that a native
 > method or the standard library already covers" — six days after
-> `2026-09-06-consolidation-and-native-methods-survey.md`. **Verdict: two
-> small, isolated candidates clear the bar and are fixed in this pass; both
-> outside the churning "1.0 clean slate" run-model surface.**
+> `2026-09-06-consolidation-and-native-methods-survey.md`. **Verdict: one
+> small, isolated candidate clears the bar and is fixed in this pass, outside
+> the churning "1.0 clean slate" run-model surface; a second candidate was
+> reverted after review because deduping it costs more than it saves.**
 > `src/tools/memory/memoryUtils.ts`'s `displayToStoragePath` hand-rolled
 > absolute-path containment instead of calling the shared symlink-aware
-> `relativeToRoot` helper, and
-> `supabase/functions/github-app-token-exchange/index.ts` reimplemented the
-> `bearerToken` helper already exported by `supabase/functions/_shared/auth.ts`.
+> `relativeToRoot` helper — fixed. A `bearerToken` helper duplicated in
+> `supabase/functions/github-app-token-exchange/index.ts` looked like a
+> straightforward dedup against `supabase/functions/_shared/auth.ts`'s
+> export, but that shared module also pulls in `@supabase/supabase-js` at
+> module scope for its (unrelated, unused-here) `authenticateJwt` export —
+> importing `bearerToken` from it would have added a full Supabase-client
+> dependency to an OIDC-only, Supabase-free endpoint. Reverted to the local
+> three-line copy; see "Correction" below.
 
 ## 0. Window covered
 
@@ -80,14 +86,18 @@ behavioral gap, not just style: a memory storage root reached through a
 symlink would fail `memoryUtils.ts`'s check while succeeding through
 `pathResolution.ts`'s.
 
-**Duplicate `bearerToken` helper in a Supabase edge function.**
+**Duplicate `bearerToken` helper in a Supabase edge function — proposed,
+then reverted (see "Correction" below).**
 `supabase/functions/_shared/auth.ts:11-14` exports `bearerToken(req)`.
 `supabase/functions/github-app-token-exchange/index.ts:50-53` defined an
-identical local copy, in a file that already imports three other helpers
-from that same `./auth.ts` module (`parseRepositoryClaim`,
-`validateWorkflowIdentity`, `verifyGitHubActionsToken`) — so the shared
-module was already a normal dependency for this file, just not used for
-this one function.
+identical local copy. At first glance this looked like a normal dependency
+already in use: the file imports three other helpers
+(`parseRepositoryClaim`, `validateWorkflowIdentity`,
+`verifyGitHubActionsToken`) from a module named `./auth.ts` — but that
+import is from this directory's own **local** `auth.ts` (GitHub
+OIDC-claim helpers only), a different file from the **shared**
+`supabase/functions/_shared/auth.ts` that exports `bearerToken`. The two
+same-named modules were conflated in the first pass.
 
 ## 3. Fix
 
@@ -99,39 +109,46 @@ this one function.
   `@platform/defaults/nodeWorkspace`. Error message and return value are
   unchanged for every non-symlink case; a symlinked storage root now
   resolves instead of being rejected.
-- `supabase/functions/github-app-token-exchange/index.ts`: the local
-  `bearerToken` function is deleted; the file imports `bearerToken` from
-  `../_shared/auth.ts` (the module that actually exports it — see
-  "Correction" below) alongside its existing imports from the local
-  `./auth.ts`.
+- `supabase/functions/github-app-token-exchange/index.ts`: unchanged from
+  before this pass — the local `bearerToken` stays. See "Correction".
 
-Verified: `npm run typecheck` (all seven workspace/package checks) passes
-clean; `npx eslint` on both touched files reports zero errors (the Supabase
-function is outside the ESLint project's configured scope, so it only
-carries the expected "no matching configuration" notice, unrelated to this
-change); `npx prettier --check` passes on both files; `npx vitest run
-memory` (26 tests, 6 files) passes; `npm run test:pure` (2335 tests) passes;
-`npm run check:dead-code-ratchet` reports no new findings; the full `npm
-test` (6295 tests, 591 files) passes.
+Verified (for the `memoryUtils.ts` fix that shipped): `npm run typecheck`
+(all seven workspace/package checks) passes clean; `npx eslint` reports
+zero errors; `npx prettier --check` passes; `npx vitest run memory` (26
+tests, 6 files) passes; `npm run test:pure` (2335 tests) passes; `npm run
+check:dead-code-ratchet` reports no new findings; the full `npm test`
+(6295 tests, 591 files) passes.
 
 **Correction (PR #12319 review):** the first pushed commit (`c356c80`)
-imported `bearerToken` from `./auth.ts` — the wrong module. This
-`github-app-token-exchange/` directory has its own local `auth.ts` (GitHub
-OIDC-claim helpers only: `verifyGitHubActionsToken`, `parseRepositoryClaim`,
-`validateWorkflowIdentity`), separate from the shared
-`supabase/functions/_shared/auth.ts` that actually exports `bearerToken`.
-None of the checks listed above catch this: Supabase edge functions are
-Deno projects outside the pnpm workspace's `tsc`/ESLint scope, validated
-instead by CI's dedicated `deno check` step, which this session could not
-run locally (no `deno` binary available, and the sandboxed network policy
-blocked fetching one). Both Codex and the repo's own `texra-ai` PR review
-caught the dangling import independently; fixed in commit `df663c1` by
-importing `bearerToken` from `../_shared/auth.ts` instead, matching the
-three other edge functions (`auth-device`, `get-agent-config`,
-`log-usage`) that already import it that way. Lesson for this series: a
-proposed consolidation in a directory with a same-named local module
-(`auth.ts` here) needs the import path double-checked against a same-stack
-type checker, not just visual similarity to the target export.
+imported `bearerToken` from `./auth.ts` — the local module, which doesn't
+export it — a straight-up broken import, caught independently by both
+Codex and the repo's own `texra-ai` PR review. The obvious fix looked like
+pointing the import at the real owner, `../_shared/auth.ts`, and commit
+`df663c1` did that. But CI's `static checks` job then failed `deno check`
+for a different reason: `_shared/auth.ts` imports `@supabase/supabase-js`
+at module scope for its `authenticateJwt` export, so importing anything
+from that module — even just `bearerToken` — pulls the Supabase client SDK
+into `deno check`'s dependency resolution, and this function's
+`deno.json` never declared it (unlike `auth-device`, `get-agent-config`,
+and `log-usage`, which already need `@supabase/supabase-js` for their own
+`authenticateJwt` calls and declare it accordingly). Adding that
+declaration would have "worked", but it means giving a Supabase-free,
+GitHub-OIDC-only endpoint a transitive dependency on a full Supabase
+client just to reuse a three-line header parse — a worse trade than the
+duplication it removes for a function that is deliberately minimal
+(`deno.json` only lists `@octokit/auth-app` and `jose` today). Reverted
+instead: the local `bearerToken` copy stays, now with a comment recording
+why it isn't deduped against the shared one. Net result for this
+candidate: no code change, caught before merge.
+
+Lessons for this series: (1) a same-named local module in the target
+directory (`auth.ts` here, colliding with `_shared/auth.ts`) needs the
+import path checked against a same-stack compiler, not visual similarity
+to the export name; (2) "the export already exists in a module we import
+from" is not sufficient evidence for a safe dedup when the target module
+has other exports with their own dependencies — check what else the
+target module pulls in at module scope before proposing the merge,
+especially for a deliberately dependency-light edge function.
 
 ## 4. What was checked and ruled out
 
@@ -209,10 +226,17 @@ initializeBundledPrompts` (#12297) just touched — deferred to a
 
 Six days after the 2026-09-06 entry, and against a window dominated by the
 large in-flight run-ledger/run-loop rewrite, the standing sweep found two
-genuine, isolated, low-risk consolidation candidates outside that churning
-surface — both fixed and verified in this pass (typecheck, lint, format,
-targeted tests, the full suite, and the dead-code ratchet all clean). Three
-further candidates (the webview listener-set duplication, the prompt YAML
+candidates outside that churning surface. One — `memoryUtils.ts`'s path
+containment — was genuine, isolated, and low-risk, and is fixed and
+verified in this pass (typecheck, lint, format, targeted tests, the full
+suite, and the dead-code ratchet all clean). The other — the Supabase
+`bearerToken` dedup — looked equally safe but, once PR review forced a
+same-stack `deno check` against the actual dependency graph, turned out to
+trade a three-line duplication for a real cost (an unwanted transitive
+`@supabase/supabase-js` dependency on a deliberately Supabase-free
+function); it was reverted rather than shipped, which is the correct
+outcome for a consolidation series that only wants net wins. Three further
+candidates (the webview listener-set duplication, the prompt YAML
 macro/style-block duplication) are real but were deliberately left for a
 follow-up pass because they sit inside actively-changing surfaces this
 window is still rewriting; two more (the flag-parser inconsistency, the

--- a/src/tools/memory/memoryUtils.ts
+++ b/src/tools/memory/memoryUtils.ts
@@ -1,8 +1,8 @@
 import * as path from 'node:path';
 
-import { relativeToRoot } from '@platform/defaults/nodeWorkspace';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { normalizeFilePath } from '@utils/core';
+import { isPathWithin } from '@utils/core/pathCore';
 
 import { MEMORY_DISPLAY_ROOT } from './constants';
 
@@ -32,11 +32,9 @@ export function displayToStoragePath(displayPath: string): string {
       ? ''
       : displayPath.slice(`${MEMORY_DISPLAY_ROOT}/`.length);
   const resolved = path.resolve(MEMORY_STORAGE_DIR, suffix);
-  // `relativeToRoot` is the shared symlink-aware containment helper (see
-  // `src/tools/pathResolution.ts`): a lexical pass, then a realpath
-  // comparison, so a storage dir reached through a symlink still resolves.
-  const relative = relativeToRoot(MEMORY_STORAGE_DIR, resolved);
-  if (relative === undefined) {
+  const base = path.resolve(MEMORY_STORAGE_DIR);
+  const relative = path.relative(base, resolved);
+  if (!isPathWithin(base, resolved)) {
     throw new Error(`Invalid memory path: ${displayPath}`);
   }
   // Memory paths use a forward-slash display convention regardless of host

--- a/src/tools/memory/memoryUtils.ts
+++ b/src/tools/memory/memoryUtils.ts
@@ -1,8 +1,8 @@
 import * as path from 'node:path';
 
+import { relativeToRoot } from '@platform/defaults/nodeWorkspace';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { normalizeFilePath } from '@utils/core';
-import { isPathWithin } from '@utils/core/pathCore';
 
 import { MEMORY_DISPLAY_ROOT } from './constants';
 
@@ -32,9 +32,11 @@ export function displayToStoragePath(displayPath: string): string {
       ? ''
       : displayPath.slice(`${MEMORY_DISPLAY_ROOT}/`.length);
   const resolved = path.resolve(MEMORY_STORAGE_DIR, suffix);
-  const base = path.resolve(MEMORY_STORAGE_DIR);
-  const relative = path.relative(base, resolved);
-  if (!isPathWithin(base, resolved)) {
+  // `relativeToRoot` is the shared symlink-aware containment helper (see
+  // `src/tools/pathResolution.ts`): a lexical pass, then a realpath
+  // comparison, so a storage dir reached through a symlink still resolves.
+  const relative = relativeToRoot(MEMORY_STORAGE_DIR, resolved);
+  if (relative === undefined) {
     throw new Error(`Invalid memory path: ${displayPath}`);
   }
   // Memory paths use a forward-slash display convention regardless of host

--- a/supabase/functions/github-app-token-exchange/index.ts
+++ b/supabase/functions/github-app-token-exchange/index.ts
@@ -5,7 +5,6 @@
  * Deploy with `--no-verify-jwt`: this endpoint verifies GitHub's OIDC token,
  * not a Supabase user JWT.
  */
-import { bearerToken } from '../_shared/auth.ts';
 import { handleCors } from '../_shared/cors.ts';
 import { errorResponse, jsonResponse } from '../_shared/responses.ts';
 import {
@@ -46,6 +45,17 @@ function productionDependencies(): ExchangeDependencies {
     appId: Deno.env.get('GITHUB_APP_ID'),
     privateKey: Deno.env.get('GITHUB_APP_PRIVATE_KEY'),
   };
+}
+
+/**
+ * Deliberately not imported from `../_shared/auth.ts`: that module's
+ * `authenticateJwt` pulls in `@supabase/supabase-js` at module scope, and
+ * this Supabase-free OIDC-only endpoint shouldn't gain that dependency just
+ * to reuse a three-line header parse.
+ */
+function bearerToken(req: Request): string | null {
+  const header = req.headers.get('Authorization');
+  return header?.startsWith('Bearer ') ? header.slice(7) : null;
 }
 
 export async function handleExchangeRequest(

--- a/supabase/functions/github-app-token-exchange/index.ts
+++ b/supabase/functions/github-app-token-exchange/index.ts
@@ -5,10 +5,10 @@
  * Deploy with `--no-verify-jwt`: this endpoint verifies GitHub's OIDC token,
  * not a Supabase user JWT.
  */
+import { bearerToken } from '../_shared/auth.ts';
 import { handleCors } from '../_shared/cors.ts';
 import { errorResponse, jsonResponse } from '../_shared/responses.ts';
 import {
-  bearerToken,
   parseRepositoryClaim,
   validateWorkflowIdentity,
   verifyGitHubActionsToken,

--- a/supabase/functions/github-app-token-exchange/index.ts
+++ b/supabase/functions/github-app-token-exchange/index.ts
@@ -8,6 +8,7 @@
 import { handleCors } from '../_shared/cors.ts';
 import { errorResponse, jsonResponse } from '../_shared/responses.ts';
 import {
+  bearerToken,
   parseRepositoryClaim,
   validateWorkflowIdentity,
   verifyGitHubActionsToken,
@@ -45,11 +46,6 @@ function productionDependencies(): ExchangeDependencies {
     appId: Deno.env.get('GITHUB_APP_ID'),
     privateKey: Deno.env.get('GITHUB_APP_PRIVATE_KEY'),
   };
-}
-
-function bearerToken(req: Request): string | null {
-  const header = req.headers.get('Authorization');
-  return header?.startsWith('Bearer ') ? header.slice(7) : null;
 }
 
 export async function handleExchangeRequest(


### PR DESCRIPTION
## Summary

Scheduled consolidation sweep (find duplicate/similar logic to consolidate, and hand-rolled code a native method or the standard library already covers). Two candidates were tried; **both were reverted** after PR review caught real costs that local validation (typecheck/lint/format/full test suite) could not catch. This PR now ships no production behavior change — only a one-line explanatory comment and the dated survey doc recording what was tried and why. Full narrative: [`.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md`](../blob/claude/optimistic-cori-wh2f9s/.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md).

- **`src/tools/memory/memoryUtils.ts`** — proposed routing `displayToStoragePath`'s path-containment check through the shared `relativeToRoot` helper (`src/platform/defaults/nodeWorkspace.ts`). Passed every local check, but a reviewer pointed out that `relativeToRoot`'s realpath fallback (`canonicalizeWorkspacePath`) calls synchronous `realpathSync` on a path the original code never touched the filesystem for. `MemoryTool.run`'s `locate` closure passes the model's raw tool-call path straight into `displayToStoragePath` with only a `/memories`-prefix string check, no absolute-path pre-filter — so a crafted `/memories/\\server\share\x` on a Windows host could force a blocking SMB lookup (NTLM-relay/leak or event-loop DoS, a known UNC-path attack class). **Reverted to the original implementation** (confirmed zero diff vs. `main` on this file).
- **`supabase/functions/github-app-token-exchange/index.ts`** — proposed importing the shared `bearerToken` (`supabase/functions/_shared/auth.ts`) instead of the local duplicate. First attempt imported from the wrong same-named local `auth.ts` (caught immediately by CI and two review bots). The corrected import then failed CI's `deno check`: the shared module transitively requires `@supabase/supabase-js`, which this deliberately Supabase-free, GitHub-OIDC-only function's `deno.json` doesn't declare — adding it would work but gives a minimal-dependency endpoint a full Supabase client SDK dependency just to reuse a 3-line header parse. **Reverted to the original local copy**, now with a one-line comment recording why it isn't deduped.

## Issue acceptance gates

No tracked issue — this is a routine consolidation sweep. Acceptance gate met: neither candidate ships with an unresolved cost; both revert cleanly to pre-PR behavior.

## Single source of truth

N/A — no consolidation shipped. Both attempts are reverted; see the survey doc for the reasoning trail in case a future pass reconsiders either one (e.g. after `pathResolution.ts`'s own absolute-path handling gets a UNC/absolute pre-filter, or after `_shared/auth.ts` is split to isolate `bearerToken` from `authenticateJwt`'s Supabase dependency).

## Duplication and abstraction budget

Net zero: both duplications identified in the survey are still present, deliberately, with comments (one pre-existing, one newly added) recording why deduping them costs more than it saves today.

## Net elements (R6)

- Files: 2 changed from `main` — `.agents/docs/archived/simplification/2026-09-12-consolidation-and-native-methods-survey.md` (new, docs only) and `supabase/functions/github-app-token-exchange/index.ts` (+10/-1, a restored local function plus an explanatory comment; behavior identical to `main`). `src/tools/memory/memoryUtils.ts` has **zero diff** against `main` (confirmed via `git diff origin/main -- src/tools/memory/memoryUtils.ts`).
- Exported symbols: none added or removed.
- Classes/interfaces/enums: none.
- Net LoC in production code: 0 behavioral lines changed (`github-app-token-exchange/index.ts`'s diff is a restored function plus a comment). This PR does not carry a `refactor`/`simplify`/`consolidate`/`dedupe` production change, despite the title's `docs:` framing reflecting that.

## Consumer counts (R8)

N/A — no export was added, removed, or re-routed. `relativeToRoot` and `bearerToken`'s consumer counts are unchanged from `main`.

## Host impact

Extension: none — no production code changed.

Desktop: none — no production code changed.

CLI: none — no production code changed.

## Scheduled refactoring

None from this PR. The survey doc records three further candidates deliberately deferred (a webview `Set`+notify listener duplication partly inside the actively-churning run-ledger/session-model rewrite, and a duplicated/drifted `\criticize` LaTeX macro plus style-guide block across `prompts/agents/remote/workflow/*.yaml`), and two lessons for the next pass in this series about verifying import targets against a same-stack compiler and checking a target module's other dependencies/trust assumptions before proposing a dedup.

## Validation

- `npm run typecheck`, `npx eslint`, `npx prettier --check`, `npx vitest run memory` (26/26), `npm run test:pure` (2335/2335), `npm run check:dead-code-ratchet`, full `npm test` (6295/6295) — all clean on the (ultimately reverted) `memoryUtils.ts` attempt; irrelevant now since the file matches `main`.
- `git diff origin/main -- src/tools/memory/memoryUtils.ts` — empty, confirming the full revert.
- CI on the current head: pending — will confirm `static checks (linux)` (`deno check`) passes now that `github-app-token-exchange` no longer imports the shared `_shared/auth.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfBRJKfHTLbRfPFBpwR1Jo