### PR TITLE
fix(progress): pass the edited file to texra.merge so the Tools sheet Merge works

### DIFF
--- a/packages/extension/src/progressView/extensionHostRequests.ts
+++ b/packages/extension/src/progressView/extensionHostRequests.ts
@@ -348,7 +348,7 @@ export function createExtensionHostRequests(
         await workflowFileActions.acceptFile(editedFile, baseFile);
         return;
       case 'merge':
-        await runCommand('texra.merge', baseFile, undefined, editedFile);
+        await runCommand('texra.merge', baseFile, editedFile);
         return;
       case 'latexdiff':
         await runCommand('texra.latexdiff', undefined, baseFile, editedFile);


### PR DESCRIPTION
## The bug

In the VS Code Tools sheet, choosing a base file and an edited file and pressing **Merge** always failed with "Both base file and edited file must be specified for merge operation". Merge was unusable from that surface.

## Cause

`packages/extension/src/progressView/extensionHostRequests.ts:351` called the command with three arguments:

```ts
await runCommand('texra.merge', baseFile, undefined, editedFile);
```

`handleMerge` (`packages/extension/src/commands/agent/mergeCommands.ts:17-20`) takes `(baseFile, editedFile)`. So `editedFile` was `undefined`, the handler's own guard fired, and it showed the docs message instead of launching the merge agent.

`runCommand` forwards varargs to `vscode.commands.executeCommand`, which is untyped, so nothing caught the arity mismatch at build time.

## Fix

One line: pass `(baseFile, editedFile)`.

Two neighbours are deliberately left alone:
- `:217`, the run-toolbar merge, already passes two arguments and works.
- `:354`, `texra.latexdiff`, keeps its leading `undefined`: `handleLatexdiff(inputFile, baseFile, editedFile)` really is three-argument, and `resolveDiffBase(inputFile, baseFile)` falls back to the base file.

The whole class of bug goes away with the queued follow-up that replaces these 28 in-process `runCommand` calls with typed direct calls; this is the one-line fix for the live defect.

## Verification

- `CI=true npm run typecheck`: clean.
- `npx vitest run --changed origin/main`: 4 files, 25 tests passed.
- `eslint` and `prettier --check` on the changed file: clean.

No new test: the untyped `executeCommand` boundary is exactly the seam a unit test would have to mock, so a test here would pin the mock rather than the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)