### PR TITLE
fix: cancel Overleaf clone subprocesses with their Effect

### DIFF
--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -104,15 +104,19 @@ function buildOverleafClonePorts(
 
     runClone: (remoteUrl, cloneInto) =>
       Effect.tryPromise({
-        try: async () => {
+        try: async (signal) => {
           await mkdir(cloneInto, { recursive: true });
           canonicalWorkspacePath = await realpath(cloneInto);
+          // execa starts its child before observing an already-aborted
+          // cancelSignal, so do not enter it after the fiber is interrupted.
+          signal.throwIfAborted();
           await execa('git', ['clone', remoteUrl, '.'], {
             cwd: canonicalWorkspacePath,
             // extendEnv: false is required — makeMachineGitEnv omits the
             // helper-invoking keys, and execa's default merge re-adds them.
             env: makeMachineGitEnv(),
             extendEnv: false,
+            cancelSignal: signal,
           });
         },
         catch: ensureError,

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -229,14 +229,17 @@ function buildOverleafClonePorts(
 
     runClone: (remoteUrl, workspacePath) =>
       Effect.tryPromise({
-        try: () =>
+        try: (signal) =>
           vscode.window.withProgress(
             {
               location: vscode.ProgressLocation.Notification,
               title: `Cloning ${remote.isOverleaf ? 'Overleaf' : 'ShareLaTeX'}…`,
             },
-            () =>
-              execa('git', ['clone', remoteUrl, '.'], {
+            () => {
+              // execa starts its child before observing an already-aborted
+              // cancelSignal, so do not enter it after the fiber is interrupted.
+              signal.throwIfAborted();
+              return execa('git', ['clone', remoteUrl, '.'], {
                 cwd: workspacePath,
                 // Same extended PATH as the executeCommandSync preflight
                 // above, so the probe can't pass while the clone misses git
@@ -245,7 +248,9 @@ function buildOverleafClonePorts(
                 // execa's default merge re-adds them.
                 env: makeMachineGitEnv(),
                 extendEnv: false,
-              }),
+                cancelSignal: signal,
+              });
+            },
           ),
         catch: ensureError,
       }).pipe(Effect.asVoid),

--- a/src/test-kernel/cli/OverleafCloneCommand.vitest.ts
+++ b/src/test-kernel/cli/OverleafCloneCommand.vitest.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Local imports
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { canonicalizeWorkspacePath } from '@platform/defaults/nodeWorkspace';
+import { effectRuntime } from '@platform/processRuntime';
 import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { makeMachineGitEnv } from '@utils/system/gitEnv';
@@ -126,6 +127,7 @@ describe('CLI Overleaf clone command', () => {
         cwd: workspacePath,
         env: makeMachineGitEnv(),
         extendEnv: false,
+        cancelSignal: expect.any(AbortSignal),
       },
     );
     expect(JSON.parse(stdout)).toEqual({
@@ -162,12 +164,59 @@ describe('CLI Overleaf clone command', () => {
         cwd: destination,
         env: makeMachineGitEnv(),
         extendEnv: false,
+        cancelSignal: expect.any(AbortSignal),
       },
     );
     expect(JSON.parse(stdout)).toMatchObject({
       cloned: true,
       destination: destination,
     });
+  });
+
+  it('cancels the Git process when the host interrupts cloning', async () => {
+    const controller = new AbortController();
+    const runtime = effectRuntime();
+    const runPromise = runtime.runPromise.bind(runtime);
+    const runSpy = vi
+      .spyOn(runtime, 'runPromise')
+      .mockImplementation((program, options) =>
+        runPromise(program, { ...options, signal: controller.signal }),
+      );
+    let cancelled = false;
+    mocks.execa.mockImplementation(
+      (_file, _args, options: { cancelSignal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options.cancelSignal?.addEventListener(
+            'abort',
+            () => {
+              cancelled = true;
+              reject(options.cancelSignal?.reason);
+            },
+            { once: true },
+          );
+          queueMicrotask(() => controller.abort());
+        }),
+    );
+
+    try {
+      await expect(
+        runCli([
+          'clone',
+          PROJECT_ID,
+          '--cwd',
+          workspacePath,
+          '--output-format',
+          'json',
+          '--no-input',
+        ]),
+      ).rejects.toBeInstanceOf(Error);
+
+      expect(mocks.execa).toHaveBeenCalledOnce();
+      expect(cancelled).toBe(true);
+      expect(stdout).not.toContain('"cloned":true');
+    } finally {
+      runSpy.mockRestore();
+    }
   });
 
   it('does not create a positional destination when the token is missing', async () => {


### PR DESCRIPTION
## Summary

Interrupting an Overleaf or ShareLaTeX clone now forwards the Effect fiber's cancellation signal to Git in both the CLI and VS Code. Each callback also refuses to spawn Git if it was interrupted while preparing the destination or waiting for the progress callback.

## Issue acceptance gates

Addresses the clone portion of #12193 and the independent cancellation batch recorded in #12025. The TikZ and automatic-PDF compilation portions of #12193 remain open and owned by the active compiler migration.

The existing Git environment isolation and credential-redaction assertions continue to pass. One added regression drives the public CLI command through a host interruption and verifies that the external Git adapter receives an abort event. Removing cancellation forwarding makes that regression fail.

## Single source of truth

The existing Effect fiber owns cancellation. Execa receives its signal at the foreign-process boundary; no additional production AbortController or cancellation registry is added.

## Duplication and abstraction budget

No new helper, service, adapter, or API. Two existing host callbacks forward the signal to the supported Execa `cancelSignal` option.

## Net elements (R6)

Three files changed, 63 lines added and 5 removed (net +58, including the regression). No added/deleted files, exported symbols, classes, interfaces, or enums.

## Consumer counts (R8)

Two host implementations of the existing `runClone` port change. No exported contract or call-site signature changes; no emit/subscriber path is removed.

## Host impact

- Extension: interrupted clone work cancels Git; a delayed progress callback cannot start an already-cancelled clone.
- CLI: interrupted clone work cancels Git; cancellation during destination preparation prevents the subsequent spawn.
- Desktop: no changed entry point.

## Scheduled refactoring

The remaining migration batches and their ownership gates are recorded in #12025. This PR has no changed-file overlap with the 21 open PRs checked, including the complete 256-file scope of #12329 at `0d3ef941ce7b67d3ddb0220c4f031dd3deb518ff`. Shared ratchet files and the active compiler/runtime worktree are untouched.

## Validation

- `npm run format`, `git diff --check`
- `npm run typecheck` (all seven projects)
- `npm run compile:fast`
- `npm run lint`
- Focused CLI clone suite: 11 passed
- Regression with the forwarding line temporarily removed: fails at the missing-abort assertion; original file restored before final checks
- `npm run test:changed -- origin/main`: 152 passed, 1 skipped, 9 suites
- `npm run test:pure`: 2,156 passed, 178 suites
- `node scripts/check-effect-migration-ratchet.mjs`: passes, no baseline changes
- `npm test`: 5,740 passed, 1 skipped, 545 suites
- Git merge simulation with #12329 head `0d3ef941ce7b67d3ddb0220c4f031dd3deb518ff`: clean. Behavioral checks above ran on this PR branch, not on the simulated combined tree.
