### PR TITLE
fix(run): review follow-ups: claim before an ownerless stop, narrower inquiry compensation, status bar on the fold's interrupted reading

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -827,6 +827,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
 
   const disposeStatusListener = subscribeStatusBarSessionEvents({
     session: statusBarSession,
+    tracker: statusBarUsageTracker,
     onStatusChanged: () => {
       updateStatusBarTooltip();
       updateStatusBarText();

--- a/packages/extension/src/frontend/review/AgentReviewRunController.ts
+++ b/packages/extension/src/frontend/review/AgentReviewRunController.ts
@@ -6,6 +6,10 @@ import {
   type AgentRunHandle,
   type SessionHandle,
 } from '@agent/runtime';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+
+/** Log channel of the Agent Review surface this controller stops runs for. */
+const CHANNEL = 'AgentReview';
 
 /**
  * What one reviewer session is collecting findings against. Reported issues
@@ -86,10 +90,7 @@ export class AgentReviewRunController {
   }
 
   /** Attach the exact run handle and replay any earlier stop. */
-  bind(
-    run: AgentReviewRunToken,
-    handle: AgentRunHandle,
-  ): Effect.Effect<void, Error> {
+  bind(run: AgentReviewRunToken, handle: AgentRunHandle): Effect.Effect<void> {
     if (this.activeRun !== run) return Effect.void;
     run.handle = handle;
     return run.stopRequested ? this.stop(run) : Effect.void;
@@ -98,7 +99,7 @@ export class AgentReviewRunController {
   /** Request one idempotent stop of the active run. */
   requestStop(): {
     readonly accepted: boolean;
-    readonly settlement: Effect.Effect<void, Error>;
+    readonly settlement: Effect.Effect<void>;
   } {
     const run = this.activeRun;
     if (!run || run.stopRequested)
@@ -108,7 +109,7 @@ export class AgentReviewRunController {
   }
 
   /** Stop the active run and drop whatever it still produces. */
-  discard(): Effect.Effect<void, Error> {
+  discard(): Effect.Effect<void> {
     const run = this.activeRun;
     if (!run) return Effect.void;
     const stop = this.requestStop();
@@ -124,14 +125,31 @@ export class AgentReviewRunController {
     return true;
   }
 
-  /** Fails when the run's stop could not be written: the run is still in
-   *  flight, and the caller that asked for it hears so. */
-  private stop(run: AgentReviewRunToken): Effect.Effect<void, Error> {
+  /**
+   * Stop the run, and report a stop the run refused: the review is still in
+   * flight, which the user has to hear. Reported here, at the one place
+   * every stop path funnels through, so the command, the commit watcher and
+   * the launch binding each observe a settlement that cannot fail.
+   */
+  private stop(run: AgentReviewRunToken): Effect.Effect<void> {
     const handle = run.handle;
     if (!handle) return Effect.void;
     if (run.session.runs.getHandle(handle.runId) !== handle) return Effect.void;
-    return run.session.runs.stopAgentRun(handle.runId, {
-      detachActiveChildren: detachSubagentsOnStop(),
-    });
+    return run.session.runs
+      .stopAgentRun(handle.runId, {
+        detachActiveChildren: detachSubagentsOnStop(),
+      })
+      .pipe(
+        Effect.catch((error) =>
+          Effect.promise(() =>
+            showLoggedErrorMessage(
+              CHANNEL,
+              'The agent review run could not be stopped',
+              error,
+            ),
+          ),
+        ),
+        Effect.asVoid,
+      );
   }
 }

--- a/packages/extension/src/frontend/review/AgentReviewRunController.ts
+++ b/packages/extension/src/frontend/review/AgentReviewRunController.ts
@@ -86,7 +86,10 @@ export class AgentReviewRunController {
   }
 
   /** Attach the exact run handle and replay any earlier stop. */
-  bind(run: AgentReviewRunToken, handle: AgentRunHandle): Effect.Effect<void> {
+  bind(
+    run: AgentReviewRunToken,
+    handle: AgentRunHandle,
+  ): Effect.Effect<void, Error> {
     if (this.activeRun !== run) return Effect.void;
     run.handle = handle;
     return run.stopRequested ? this.stop(run) : Effect.void;
@@ -95,7 +98,7 @@ export class AgentReviewRunController {
   /** Request one idempotent stop of the active run. */
   requestStop(): {
     readonly accepted: boolean;
-    readonly settlement: Effect.Effect<void>;
+    readonly settlement: Effect.Effect<void, Error>;
   } {
     const run = this.activeRun;
     if (!run || run.stopRequested)
@@ -105,7 +108,7 @@ export class AgentReviewRunController {
   }
 
   /** Stop the active run and drop whatever it still produces. */
-  discard(): Effect.Effect<void> {
+  discard(): Effect.Effect<void, Error> {
     const run = this.activeRun;
     if (!run) return Effect.void;
     const stop = this.requestStop();
@@ -121,7 +124,9 @@ export class AgentReviewRunController {
     return true;
   }
 
-  private stop(run: AgentReviewRunToken): Effect.Effect<void> {
+  /** Fails when the run's stop could not be written: the run is still in
+   *  flight, and the caller that asked for it hears so. */
+  private stop(run: AgentReviewRunToken): Effect.Effect<void, Error> {
     const handle = run.handle;
     if (!handle) return Effect.void;
     if (run.session.runs.getHandle(handle.runId) !== handle) return Effect.void;

--- a/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
+++ b/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
@@ -4,16 +4,26 @@ import { SubscriptionRef } from 'effect';
 import type { SessionHandle } from '@agent/runtime';
 import { sumUsageStats, type TokenUsageStats } from '@shared/schemas';
 import { isActivePhase, isInFlightPhase } from '@shared/runs/runStatus';
+import type { RunView } from '@shared/session/sessionView';
+
+/** A run whose durable phase says in flight but whose owner is gone: the
+ *  fold's interrupted reading (5.2), which no durable row records — a crash
+ *  leaves RUNNING or WAITING behind. Nothing is spending on it, so it counts
+ *  towards neither the spinner nor the in-flight total. */
+function ownerLost(run: RunView): boolean {
+  return run.group === 'interrupted';
+}
 
 /**
  * Projects the accumulated spend of the runs currently in flight for the
  * extension status bar.
  *
  * Holds no state of its own: the session's fold is the one reader of which
- * runs are in flight (`RunView.status`) and carries each run's metered
- * total (`RunView.usage`). Both getters read that view live, so a run
- * leaving flight drops out of the total without any bookkeeping here, and
- * the summing rule has a single home (`sumUsageStats`).
+ * runs are in flight (`RunView.status` beside the interrupted reading of
+ * `RunView.group`) and carries each run's metered total (`RunView.usage`).
+ * Both getters read that view live, so a run leaving flight drops out of the
+ * total without any bookkeeping here, and the summing rule has a single home
+ * (`sumUsageStats`).
  */
 export class StatusBarUsageTracker {
   constructor(private readonly session: Pick<SessionHandle, 'view'>) {}
@@ -23,7 +33,7 @@ export class StatusBarUsageTracker {
     for (const run of SubscriptionRef.getUnsafe(
       this.session.view,
     ).runs.values()) {
-      if (isActivePhase(run.status)) count += 1;
+      if (isActivePhase(run.status) && !ownerLost(run)) count += 1;
     }
     return count;
   }
@@ -33,7 +43,8 @@ export class StatusBarUsageTracker {
     for (const run of SubscriptionRef.getUnsafe(
       this.session.view,
     ).runs.values()) {
-      if (isInFlightPhase(run.status)) usages.push(run.usage);
+      if (isInFlightPhase(run.status) && !ownerLost(run))
+        usages.push(run.usage);
     }
     return sumUsageStats(usages);
   }

--- a/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
+++ b/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
@@ -3,52 +3,52 @@ import { Effect, Fiber, Stream } from 'effect';
 // Local imports - runtime events
 import type { SessionHandle } from '@agent/runtime';
 import { effectRuntime } from '@platform/processRuntime';
-import { aggregateTarget } from '@shared/schemas';
-import { isInFlightPhase } from '@shared/runs/runStatus';
+import type { StatusBarUsageTracker } from './StatusBarUsageTracker';
 
 interface StatusBarSessionEventOptions {
-  session: Pick<SessionHandle, 'folded' | 'now' | 'runView'>;
+  session: Pick<SessionHandle, 'viewChanges'>;
+  /** What the two callbacks paint: the subscription refreshes the bar when
+   *  one of these projections moves, and nothing else. */
+  tracker: Pick<StatusBarUsageTracker, 'activeRunCount' | 'totalUsage'>;
   onStatusChanged: () => void;
   onUsageChanged: () => void;
 }
 
 /**
- * Refreshes the extension status bar when a run's phase or usage moves. The
- * facts themselves are not mirrored here: both callbacks read the session's
- * fold, so this reads the fold-gated tail (`SessionHandle.folded`, PRD 7.2)
- * and not the raw plane. A row reaches these readers only once the view holds
- * the state that row produced, so a terminal `run.end` never refreshes a
- * status bar that still projects the run as running.
+ * Refreshes the extension status bar when the projection it paints moves.
+ *
+ * The one input is the session's view as a level stream
+ * (`SessionHandle.viewChanges`, PRD 7.2): the fold's own state, so it carries
+ * both the durable rows and the local facts no row records — an owner proved
+ * dead reclassifies its runs as interrupted with nothing committed, and the
+ * fold-gated event tail would never wake this listener for it. Nothing is
+ * mirrored here: each view is read back through the tracker, and a view that
+ * leaves both projections where they were paints nothing.
  */
 export function subscribeStatusBarSessionEvents({
   session,
+  tracker,
   onStatusChanged,
   onUsageChanged,
 }: StatusBarSessionEventOptions): () => void {
+  let activeRuns = tracker.activeRunCount;
+  let usage = tracker.totalUsage;
   const fiber = effectRuntime().runFork(
-    Stream.runForEach(session.folded(session.now()), (event) =>
+    Stream.runForEach(session.viewChanges, () =>
       Effect.sync(() => {
-        // The rows the phase is folded from (one run model, section 3.3):
-        // an activation, a step (the park and the steps that leave it), and
-        // the terminal `run.end`.
-        if (
-          event.type === 'run.activate' ||
-          event.type === 'flow.step' ||
-          event.type === 'run.end'
-        ) {
+        const nextActiveRuns = tracker.activeRunCount;
+        if (nextActiveRuns !== activeRuns) {
+          activeRuns = nextActiveRuns;
           onStatusChanged();
         }
-        // The runtime publishes the in-flight status before usage for a
-        // round; usage for a run not in flight cannot change the projected
-        // total, so stale async events skip the refresh.
-        if (event.type === 'usage') {
-          const target = aggregateTarget(event.aggregateId);
-          if (
-            target.kind === 'run' &&
-            isInFlightPhase(session.runView(target.id)?.status)
-          ) {
-            onUsageChanged();
-          }
+        const nextUsage = tracker.totalUsage;
+        if (
+          nextUsage.cost !== usage.cost ||
+          nextUsage.inputTokens !== usage.inputTokens ||
+          nextUsage.outputTokens !== usage.outputTokens
+        ) {
+          usage = nextUsage;
+          onUsageChanged();
         }
       }),
     ),

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -279,6 +279,8 @@ export class SessionHandle {
       publish: (events) => this.publish(events),
       approvals,
       finalizeRun: (input) => finalizeRun(this, input),
+      acquireRunClaim: (runId) =>
+        this.acquireClaims(qualifyAggregateId('run', runId)),
       releaseRootRunLease: (runId) => this.releaseRunLease(runId),
     });
 

--- a/src/agent/runtime/runRegistry.ts
+++ b/src/agent/runtime/runRegistry.ts
@@ -5,9 +5,8 @@
  * notification, and subagent lineage tracking in a single module.
  */
 
-import { Cause, Effect, Exit } from 'effect';
+import { Effect } from 'effect';
 
-import { createChannelTrace } from '@agent/trace';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionApprovals } from '@agent/runtime/runApprovalQueue';
 import {
@@ -33,8 +32,6 @@ import {
   WaitingTermination,
   type WaitingTerminationContext,
 } from './waitingTermination';
-
-const logger = createChannelTrace('runRegistry');
 
 /**
  * Child policy shared by `kill()` and `stopAgentRun()`. The caller owns the
@@ -116,6 +113,16 @@ interface RunRegistryInit {
    */
   readonly releaseRootRunLease: WaitingTerminationContext['releaseRootRunLease'];
   readonly finalizeRun: WaitingTerminationContext['finalizeRun'];
+  /**
+   * Admit one run's claim (`SessionHandle.acquireClaims`) and hand back its
+   * release. A run aggregate takes an append from its claim holder alone, so
+   * a stop that reached no live handle takes the claim the same fenced way a
+   * decision over a dead owner does (`SessionRequests.decide`) before it
+   * writes the run's terminal row.
+   */
+  readonly acquireRunClaim: (
+    runId: RunId,
+  ) => Effect.Effect<Effect.Effect<void, Error>, Error>;
 }
 
 /**
@@ -137,6 +144,7 @@ export class RunRegistry {
   private readonly approvals: SessionApprovals;
   private readonly releaseRootRunLease: WaitingTerminationContext['releaseRootRunLease'];
   private readonly finalizeRun: WaitingTerminationContext['finalizeRun'];
+  private readonly acquireRunClaim: RunRegistryInit['acquireRunClaim'];
   private readonly listeners = new Map<
     string,
     Set<(handle: RunHandle | undefined) => void>
@@ -151,6 +159,7 @@ export class RunRegistry {
     this.approvals = options.approvals;
     this.releaseRootRunLease = options.releaseRootRunLease;
     this.finalizeRun = options.finalizeRun;
+    this.acquireRunClaim = options.acquireRunClaim;
     this.waitingTermination = new WaitingTermination({
       releaseRootRunLease: this.releaseRootRunLease,
       finalizeRun: this.finalizeRun,
@@ -587,11 +596,15 @@ export class RunRegistry {
    *
    * Hosts should call this instead of reconstructing stop behavior from
    * child-interrupts, root interrupts, and run-status writes.
+   *
+   * Fails when the run's terminal row could not be written: the run is still
+   * in flight, and a caller that reported the stop done would be lying about
+   * it.
    */
   stopAgentRun(
     runId: RunId,
     options: RunStopOptions = {},
-  ): Effect.Effect<void> {
+  ): Effect.Effect<void, Error> {
     const rootHandle = this.handles.get(runId);
     // Shared across the child sweep and the root cascade so each run in
     // the chain is interrupted exactly once.
@@ -616,10 +629,10 @@ export class RunRegistry {
     // already-untracked) run still needs the `run.end` row, which is the
     // run's terminal fact: without the finalize below the fold, history and
     // every other host would keep the stopped run in flight.
-    if (!stopped) {
-      settlements.push(this.finalizeOwnerlessStop(runId));
-    }
-    return Effect.all(settlements, { concurrency: 'unbounded', discard: true });
+    const all: Effect.Effect<void, Error>[] = stopped
+      ? settlements
+      : [...settlements, this.finalizeOwnerlessStop(runId)];
+    return Effect.all(all, { concurrency: 'unbounded', discard: true });
   }
 
   /**
@@ -759,31 +772,36 @@ export class RunRegistry {
    * ended with its own verdict, which is what the status machine's refusal to
    * leave a terminal phase used to express. The checkpoint is preserved: a
    * cancelled run is exactly the one a user resumes.
+   *
+   * The row is an append on the run aggregate, which takes one only from its
+   * claim holder: the write is fenced by the same acquire/release a decision
+   * over a dead owner takes, and the claim goes back so a later resume can
+   * still take the run. A refusal — a live foreign owner, a rolled-back
+   * transaction — fails the stop rather than being logged behind a caller
+   * that already reported it done.
    */
-  private finalizeOwnerlessStop(runId: RunId): Effect.Effect<void> {
-    return Effect.gen({ self: this }, function* () {
-      const finalization = yield* Effect.exit(
+  private finalizeOwnerlessStop(runId: RunId): Effect.Effect<void, Error> {
+    return Effect.acquireUseRelease(
+      this.acquireRunClaim(runId),
+      () =>
         this.finalizeRun({
           runId,
           outcome: RUN_OUTCOME.CANCELLED,
           keepExistingOutcome: true,
-        }),
-      );
-      if (Exit.isFailure(finalization)) {
-        logger.warn('Failed to finalize a stop with no live run handle', {
-          data: { runId, error: Cause.squash(finalization.cause) },
-        });
-        return;
-      }
-      if (!finalization.value.ok)
-        logger.warn('Failed to finalize a stop with no live run handle', {
-          data: {
-            runId,
-            outcomePersisted: finalization.value.outcomePersisted,
-            error: finalization.value.error,
-          },
-        });
-    });
+        }).pipe(
+          Effect.flatMap((finalization) =>
+            finalization.ok
+              ? Effect.void
+              : Effect.fail(
+                  new Error(
+                    `Failed to finalize a stop with no live run handle for run ${runId}`,
+                    { cause: finalization.error },
+                  ),
+                ),
+          ),
+        ),
+      (release) => release.pipe(Effect.orDie),
+    );
   }
 
   private notifyWaiters(runId: RunId): void {

--- a/src/agent/runtime/runRegistry.ts
+++ b/src/agent/runtime/runRegistry.ts
@@ -600,10 +600,34 @@ export class RunRegistry {
    * Fails when the run's terminal row could not be written: the run is still
    * in flight, and a caller that reported the stop done would be lying about
    * it.
+   *
+   * A stop of a run no handle here owns writes that row from outside the
+   * run, so the run's claim fences the whole gesture — the descendant sweep
+   * included. Taken first, a refusal leaves the descendants running instead
+   * of detaching or killing them and then reporting the stop unavailable. A
+   * locally owned run is already this process's to stop and takes the direct
+   * path.
    */
   stopAgentRun(
     runId: RunId,
     options: RunStopOptions = {},
+  ): Effect.Effect<void, Error> {
+    if (this.handles.has(runId)) return this.applyStop(runId, options);
+    return Effect.acquireUseRelease(
+      this.acquireRunClaim(runId),
+      () => this.applyStop(runId, options),
+      (release) => release.pipe(Effect.orDie),
+    );
+  }
+
+  /**
+   * Apply one stop: the descendant policy the caller declared, the root
+   * handle's own termination, and — when no live handle took it — the
+   * terminal row an ownerless stop must write itself.
+   */
+  private applyStop(
+    runId: RunId,
+    options: RunStopOptions,
   ): Effect.Effect<void, Error> {
     const rootHandle = this.handles.get(runId);
     // Shared across the child sweep and the root cascade so each run in
@@ -774,33 +798,28 @@ export class RunRegistry {
    * cancelled run is exactly the one a user resumes.
    *
    * The row is an append on the run aggregate, which takes one only from its
-   * claim holder: the write is fenced by the same acquire/release a decision
-   * over a dead owner takes, and the claim goes back so a later resume can
-   * still take the run. A refusal — a live foreign owner, a rolled-back
-   * transaction — fails the stop rather than being logged behind a caller
-   * that already reported it done.
+   * claim holder: {@link stopAgentRun} holds that claim around the whole
+   * ownerless stop, and a run this process still tracks is its own writer
+   * already. A refusal — a live foreign owner, a rolled-back transaction —
+   * fails the stop rather than being logged behind a caller that already
+   * reported it done.
    */
   private finalizeOwnerlessStop(runId: RunId): Effect.Effect<void, Error> {
-    return Effect.acquireUseRelease(
-      this.acquireRunClaim(runId),
-      () =>
-        this.finalizeRun({
-          runId,
-          outcome: RUN_OUTCOME.CANCELLED,
-          keepExistingOutcome: true,
-        }).pipe(
-          Effect.flatMap((finalization) =>
-            finalization.ok
-              ? Effect.void
-              : Effect.fail(
-                  new Error(
-                    `Failed to finalize a stop with no live run handle for run ${runId}`,
-                    { cause: finalization.error },
-                  ),
-                ),
-          ),
-        ),
-      (release) => release.pipe(Effect.orDie),
+    return this.finalizeRun({
+      runId,
+      outcome: RUN_OUTCOME.CANCELLED,
+      keepExistingOutcome: true,
+    }).pipe(
+      Effect.flatMap((finalization) =>
+        finalization.ok
+          ? Effect.void
+          : Effect.fail(
+              new Error(
+                `Failed to finalize a stop with no live run handle for run ${runId}`,
+                { cause: finalization.error },
+              ),
+            ),
+      ),
     );
   }
 

--- a/src/controllers/session/SessionRequests.ts
+++ b/src/controllers/session/SessionRequests.ts
@@ -51,6 +51,7 @@ import {
 import type { Outcome, RuntimeRequest } from '@shared/session/runtimeRequest';
 import { recordInquiryDecision } from '@tools/inquiry/inquiryActions';
 import { withPerKeyLane, type PerKeyLane } from '@utils/core/perKeyQueue';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const done: Outcome = { kind: 'done' };
 
@@ -318,7 +319,20 @@ function handle(
         session.runs.stopAgentRun(req.runId, {
           detachActiveChildren: req.detachActiveChildren ?? undefined,
         }),
-      ).pipe(Effect.as(done), Effect.uninterruptible);
+      ).pipe(
+        // The stop fails when the run's terminal row was refused (a live
+        // foreign owner, a rolled-back transaction): the run is still in
+        // flight, so the requester hears that rather than `done`.
+        Effect.mapError(
+          (error): RequestError =>
+            new Unavailable({
+              runId: req.runId,
+              reason: `The run could not be stopped: ${toErrorMessage(error)}`,
+            }),
+        ),
+        Effect.as(done),
+        Effect.uninterruptible,
+      );
     case 'run.delete':
       return deleteAdmittedRun(session, log, req.runId, admitted, 'single');
     case 'run.compact':

--- a/src/test-kernel/agent/runtime/RunRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunRegistry.vitest.ts
@@ -167,6 +167,7 @@ function createRegistry(
     approvals: createSessionApprovals({ setApprovalBypassState() {} }),
     releaseRootRunLease: () => Effect.void,
     finalizeRun: (input) => finalizeRun(defaultSession(), input),
+    acquireRunClaim: () => Effect.succeed(Effect.void),
     ...options,
   });
   return { events, phases, registry };

--- a/src/test-kernel/agent/storage/RunLease.vitest.ts
+++ b/src/test-kernel/agent/storage/RunLease.vitest.ts
@@ -517,6 +517,7 @@ describe('cross-process run leases', () => {
       releaseRootRunLease: () => Effect.void,
       finalizeRun: (input) =>
         Effect.succeed({ ok: true, outcome: input.outcome }),
+      acquireRunClaim: () => Effect.succeed(Effect.void),
     });
     const readToken = async (): Promise<string> => {
       const [record, ...rest] = await readLeaseRecords(runId);

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -342,9 +342,13 @@ function installOwnerSession(): {
       request: (req: RuntimeRequest) =>
         Effect.gen(function* (): Effect.fn.Return<Outcome> {
           if (req.kind === 'run.stop') {
-            yield* session.runs.stopAgentRun(req.runId, {
-              detachActiveChildren: req.detachActiveChildren ?? undefined,
-            });
+            yield* session.runs
+              .stopAgentRun(req.runId, {
+                detachActiveChildren: req.detachActiveChildren ?? undefined,
+              })
+              // The handler words a refused stop as a request error; this
+              // stub has no such vocabulary, so a refusal is a defect here.
+              .pipe(Effect.orDie);
           }
           return { kind: 'done' };
         }),

--- a/src/test-kernel/support/runHandleFixtures.ts
+++ b/src/test-kernel/support/runHandleFixtures.ts
@@ -42,5 +42,6 @@ export function testRunRegistry(): RunRegistry {
     releaseRootRunLease: () => Effect.void,
     finalizeRun: (input) =>
       Effect.succeed({ ok: true, outcome: input.outcome }),
+    acquireRunClaim: () => Effect.succeed(Effect.void),
   });
 }

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -16,7 +16,7 @@
  *   - `list` → enumerate threads by status / scope
  */
 
-import { Effect } from 'effect';
+import { Cause, Effect } from 'effect';
 import { z } from 'zod';
 import {
   currentSession,
@@ -337,11 +337,18 @@ export class ExternalInquiryTool extends defineTool({
                       }),
                     ),
               ),
-              Effect.catch((error) =>
+              // `catchCause`, not `catch`: the aggregate read is exposed as
+              // a defect-only effect (`sessionLayer` reads it through
+              // `Effect.orDie`), so a database failure here arrives as a
+              // defect and a typed catch would let it replace the commit
+              // failure this compensation runs under. Either way the thread
+              // stays open, which the warning says, and the original failure
+              // is what the tool reports.
+              Effect.catchCause((cause) =>
                 Effect.sync(() => {
                   logger.warn(
                     `Inquiry thread ${manifest.threadId} stays open after its request failed to open`,
-                    { data: error },
+                    { data: Cause.squash(cause) },
                   );
                 }),
               ),

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -315,23 +315,37 @@ export class ExternalInquiryTool extends defineTool({
           ),
           // The turn is committed in the global inquiry database before the
           // request that renders it, and the two stores cannot share a
-          // transaction. A publication that fails or is interrupted takes
-          // the turn back down with it: left open, no surface would list it
-          // and no later `ask` could re-dispatch on the thread.
+          // transaction. A publication that never landed takes the turn back
+          // down with it: left open, no surface would list it and no later
+          // `ask` could re-dispatch on the thread. `commit` appends before it
+          // waits for the fold to settle, so failing is not proof of a
+          // rolled-back append: the committed rows decide, and a turn whose
+          // request is durably open stays open with it.
           Effect.onError(() =>
-            records
-              .markDropped({ threadId: manifest.threadId, turnIndex })
-              .pipe(
-                Effect.catch((error) =>
-                  Effect.sync(() => {
-                    logger.warn(
-                      `Inquiry thread ${manifest.threadId} stays open after its request failed to open`,
-                      { data: error },
-                    );
-                  }),
-                ),
-                Effect.asVoid,
+            session.readAggregate(qualifyAggregateId('run', runId)).pipe(
+              Effect.flatMap((rows) =>
+                rows.some(
+                  (row) =>
+                    row.type === 'request.opened' &&
+                    row.requestId === requestId,
+                )
+                  ? Effect.void
+                  : Effect.asVoid(
+                      records.markDropped({
+                        threadId: manifest.threadId,
+                        turnIndex,
+                      }),
+                    ),
               ),
+              Effect.catch((error) =>
+                Effect.sync(() => {
+                  logger.warn(
+                    `Inquiry thread ${manifest.threadId} stays open after its request failed to open`,
+                    { data: error },
+                  );
+                }),
+              ),
+            ),
           ),
         );
 


### PR DESCRIPTION
Follow-ups to the last Codex round on #12329, which merged before they could land on that branch.

- **Ownerless stop takes the claim.** `finalizeOwnerlessStop` runs inside the same fenced acquire/release a decision over a dead owner uses, and a refused `run.end` fails the stop (surfaced as unavailable) instead of being logged behind a `done`.
- **Inquiry compensation only when the request did not land.** `SessionHandle.commit` appends before it waits for fold settlement, so the tool's cleanup now reads the committed rows and drops the opened turn only when no `request.opened` for it exists.
- **Status bar reads the fold's interrupted classification** for the active count and the in-flight usage, and subscribes to the view's level stream so a liveness reclassification that commits no row still repaints. One subscription, no timer.

Declined from the same round, by rule: a compatibility reader for pre-1.0 trace exports without `steps` (no legacy-format readers in 1.0).

Typecheck, test:changed, test:pure, and both ratchets green; no ratchet row moved; no new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)