### PR TITLE
refactor(workflow): one workflow status vocabulary

### DIFF
--- a/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
@@ -24,7 +24,6 @@ import {
 } from '@cli/tui/ui/glyphs';
 import {
   RUN_PHASE,
-  WORKFLOW_TASK_STATUS_LABEL,
   fileLocationDisplayPath,
   outputDiffCounts,
   outputDisplayName,
@@ -104,15 +103,16 @@ function taskGroupLine(
   return {
     key: `group:${group.id}`,
     // A task group's status is a RunPhase, so it is worded with the stream
-    // vocabulary — the same one the progress view's group icon announces.
-    // WORKFLOW_TASK_STATUS_LABEL words a workflow *call* ('Finished',
-    // 'Saved result'), which is a different thing that happens to share four
-    // key names with this one.
+    // vocabulary — the same one the progress view's group icon announces,
+    // never the workflow-call vocabulary that happens to share key names.
     text: `${appearance.marker} ${safeTerminalText(label)} ${formatRunStatusLabel(status)}${duration}`,
     tone: appearance.tone,
     role: 'lifecycle',
   };
 }
+
+/** A workflow-agent round the run has not reached yet. */
+const ROUND_PLANNED_LABEL = 'Planned';
 
 function lifecyclePriority(
   status: TaskGroupStatus | undefined,
@@ -191,7 +191,7 @@ function workflowRunDetailGroups(
       );
     } else {
       const label = planned
-        ? `${formatRoundStageLabel({ index: round, total: plannedTotal })} ${WORKFLOW_TASK_STATUS_LABEL.planned}`
+        ? `${formatRoundStageLabel({ index: round, total: plannedTotal })} ${ROUND_PLANNED_LABEL}`
         : `${formatRoundStageLabel({ index: round })} results`;
       lines.push({
         key: `round:${round}`,

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -162,7 +162,6 @@ export const COMPACTION_ACTIVITY_STATUS_STYLE = {
  *  `WORKFLOW_CALL_STATUS_GLYPH`, read directly wherever a row is painted. */
 export const WORKFLOW_TASK_STATUS_COLOR = {
   declared: COLOR_BORDER,
-  planned: undefined,
   queued: undefined,
   running: COLOR_HINT,
   completed: COLOR_SUCCESS,

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -16,7 +16,6 @@ import { effectRuntime } from '@platform/processRuntime';
 import {
   AgentCategory,
   RUN_PHASE,
-  WORKFLOW_TASK_STATUS_LABEL,
   type RunId,
   type RunPhase,
 } from '@shared/schemas';
@@ -441,10 +440,10 @@ function workflowPlainLines(run: RunView): ReadonlyMap<string, string> {
     isTerminalOutcomePhase(run.status) &&
     run.identity?.kind === 'multiAgentWorkflow'
   ) {
-    lines.set(
-      'outcome',
-      `${WORKFLOW_TASK_STATUS_LABEL[run.status]}: ${run.identity.workflowName}`,
-    );
+    // `run.status` is a run phase, so the word comes from the fold's own
+    // run-status label, never from the workflow-*call* status table the two
+    // vocabularies happen to share four key names with.
+    lines.set('outcome', `${run.statusLabel}: ${run.identity.workflowName}`);
   }
   return lines;
 }

--- a/packages/extension/src/progressView/frontend/components/WorkflowRunBoard.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowRunBoard.styles.ts
@@ -237,7 +237,6 @@ export const workflowRunBoardStyles = css`
     color: var(--wa-color-danger-on-quiet);
   }
 
-  .row.status-planned .row-icon,
   .row.status-queued .row-icon,
   .row.status-declared .row-icon,
   .row.status-skipped .row-icon,

--- a/packages/extension/src/progressView/frontend/components/WorkflowRunBoard.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowRunBoard.ts
@@ -101,7 +101,6 @@ function workflowCallStatusIcon(
   switch (status) {
     case 'declared':
       return 'circle';
-    case 'planned':
     case 'queued':
       return 'circle-dot';
     case 'running':

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -15,14 +15,15 @@ import {
 } from 'effect';
 import type {
   RunId,
+  RunOutcome,
   WorkflowCallIdentity,
   WorkflowControlAction,
   WorkflowRunSnapshot,
 } from '@shared/schemas';
 import {
+  RUN_OUTCOME,
   WORKFLOW_CALL_KIND,
   WORKFLOW_CALL_STATUS,
-  WORKFLOW_RUN_LIFECYCLE,
   WorkflowScriptFilesSchema,
 } from '@shared/schemas';
 import { isNonEmptyString, onAbort } from '@utils/core';
@@ -424,17 +425,13 @@ export function runWorkflowScript<R = never>(
 
               const interrupted =
                 Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause);
-              let terminalLifecycle: 'completed' | 'failed' | 'cancelled' =
-                WORKFLOW_RUN_LIFECYCLE.FAILED;
+              let terminalOutcome: RunOutcome = RUN_OUTCOME.FAILED;
               if (firstFatalFault !== undefined) {
-                terminalLifecycle = WORKFLOW_RUN_LIFECYCLE.FAILED;
+                terminalOutcome = RUN_OUTCOME.FAILED;
               } else if (Exit.isSuccess(exit)) {
-                terminalLifecycle = WORKFLOW_RUN_LIFECYCLE.COMPLETED;
-              } else if (
-                firstFatalFault === undefined &&
-                (interrupted || options.signal?.aborted)
-              ) {
-                terminalLifecycle = WORKFLOW_RUN_LIFECYCLE.CANCELLED;
+                terminalOutcome = RUN_OUTCOME.COMPLETED;
+              } else if (interrupted || options.signal?.aborted) {
+                terminalOutcome = RUN_OUTCOME.CANCELLED;
               }
               const terminalError =
                 firstFatalFault ??
@@ -442,7 +439,7 @@ export function runWorkflowScript<R = never>(
                   ? Cause.squash(exit.cause)
                   : scriptFailure);
               workflowRunState.finish(
-                terminalLifecycle,
+                terminalOutcome,
                 terminalError === undefined
                   ? undefined
                   : toErrorMessage(terminalError),

--- a/src/agent/workflowScript/workflowRunState.ts
+++ b/src/agent/workflowScript/workflowRunState.ts
@@ -1,7 +1,8 @@
 import {
+  RUN_OUTCOME,
   TERMINAL_WORKFLOW_CALL_STATUSES,
   WORKFLOW_CALL_STATUS,
-  WORKFLOW_RUN_LIFECYCLE,
+  type RunOutcome,
   type WorkflowCallIdentity,
   type WorkflowCallKind,
   type WorkflowRunCall,
@@ -55,12 +56,10 @@ export class WorkflowRunState {
       options.initialSnapshot?.calls ?? [],
     );
     const fresh: WorkflowRunSnapshot = {
-      lifecycle: WORKFLOW_RUN_LIFECYCLE.WAITING,
       stages: options.phases.map((phase, index) => ({
         id: stageIdFor(index),
         title: phase.title,
         order: index,
-        lifecycle: WORKFLOW_RUN_LIFECYCLE.WAITING,
       })),
       calls: options.tasks.map((task) => {
         const timestamp = now();
@@ -113,7 +112,6 @@ export class WorkflowRunState {
         id: stageIdFor(nextIndex),
         title,
         order: nextIndex,
-        lifecycle: WORKFLOW_RUN_LIFECYCLE.WAITING,
       });
     }
     const currentStageIndex = this.currentPhaseIndex;
@@ -124,24 +122,9 @@ export class WorkflowRunState {
     }
     if (nextIndex === currentStageIndex) return;
 
-    const transitionAt = now();
-    const prior = this.#snapshot.stages[currentStageIndex];
-    if (prior) this.#settleStage(prior.id, transitionAt);
-    for (const stage of this.#snapshot.stages) {
-      if (
-        stage.order < nextIndex &&
-        stage.lifecycle === WORKFLOW_RUN_LIFECYCLE.WAITING
-      ) {
-        stage.lifecycle = WORKFLOW_RUN_LIFECYCLE.SKIPPED;
-        stage.completedAt = transitionAt;
-      }
-    }
     const active = this.#snapshot.stages[nextIndex];
-    active.lifecycle = WORKFLOW_RUN_LIFECYCLE.ACTIVE;
-    active.startedAt ??= transitionAt;
-    active.completedAt = undefined;
+    active.startedAt ??= now();
     this.#snapshot.currentStageId = active.id;
-    this.#snapshot.lifecycle = WORKFLOW_RUN_LIFECYCLE.ACTIVE;
     this.#emit();
   }
 
@@ -193,7 +176,7 @@ export class WorkflowRunState {
       id: definition.id,
       ...canonical,
       attempts: [],
-      status: WORKFLOW_CALL_STATUS.PLANNED,
+      status: WORKFLOW_CALL_STATUS.QUEUED,
       timestamps: { createdAt: timestamp, updatedAt: timestamp },
     };
     let prior: WorkflowRunCall | undefined;
@@ -216,7 +199,7 @@ export class WorkflowRunState {
       call,
       canonical,
       (isReusableStatus(call.status) || recoverySource?.journalProven) && {
-        status: WORKFLOW_CALL_STATUS.PLANNED,
+        status: WORKFLOW_CALL_STATUS.QUEUED,
         timestamps: { createdAt: call.timestamps.createdAt },
       },
     );
@@ -241,13 +224,6 @@ export class WorkflowRunState {
     if (this.#sealed) return;
     Object.assign(call, patch);
     call.timestamps.updatedAt = now();
-    if (
-      patch.status === WORKFLOW_CALL_STATUS.QUEUED ||
-      patch.status === WORKFLOW_CALL_STATUS.RUNNING
-    ) {
-      this.#snapshot.lifecycle = WORKFLOW_RUN_LIFECYCLE.ACTIVE;
-    }
-    this.#refreshExitedStage(call.stageId);
     this.#emit();
   }
 
@@ -315,7 +291,6 @@ export class WorkflowRunState {
     call.status = WORKFLOW_CALL_STATUS.RUNNING;
     call.timestamps.startedAt ??= startedAt;
     call.timestamps.updatedAt = startedAt;
-    this.#snapshot.lifecycle = WORKFLOW_RUN_LIFECYCLE.ACTIVE;
     this.#emit();
   }
 
@@ -358,20 +333,13 @@ export class WorkflowRunState {
     return true;
   }
 
-  finish(
-    lifecycle: 'completed' | 'failed' | 'cancelled',
-    error?: string,
-  ): void {
+  finish(outcome: RunOutcome, error?: string): void {
     if (this.#sealed) return;
     const completedAt = now();
-    // Capture before clearing so orchestration failures can terminalize the
-    // stage the script was inside even when no call encodes that failure.
-    const activeStageId = this.#snapshot.currentStageId;
-    this.#snapshot.lifecycle = lifecycle;
+    this.#snapshot.outcome = outcome;
     this.#snapshot.currentStageId = undefined;
     this.#snapshot.timestamps.completedAt = completedAt;
     if (error) this.#snapshot.error = error;
-    const sweepSettledStageIds = new Set<string>();
     for (const [index, call] of this.#snapshot.calls.entries()) {
       const attempts = call.attempts.map((attempt, attemptIndex) =>
         attemptIndex === call.attempts.length - 1 &&
@@ -384,11 +352,7 @@ export class WorkflowRunState {
         updatedAt: completedAt,
         completedAt,
       };
-      if (
-        call.status === WORKFLOW_CALL_STATUS.DECLARED ||
-        call.status === WORKFLOW_CALL_STATUS.PLANNED
-      ) {
-        if (call.stageId) sweepSettledStageIds.add(call.stageId);
+      if (call.status === WORKFLOW_CALL_STATUS.DECLARED) {
         this.#snapshot.calls[index] = {
           ...call,
           attempts,
@@ -400,9 +364,8 @@ export class WorkflowRunState {
         call.status === WORKFLOW_CALL_STATUS.QUEUED ||
         call.status === WORKFLOW_CALL_STATUS.RUNNING
       ) {
-        if (call.stageId) sweepSettledStageIds.add(call.stageId);
         this.#snapshot.calls[index] =
-          lifecycle === WORKFLOW_RUN_LIFECYCLE.CANCELLED
+          outcome === RUN_OUTCOME.CANCELLED
             ? {
                 ...call,
                 attempts,
@@ -420,83 +383,8 @@ export class WorkflowRunState {
               };
       }
     }
-    for (const stage of this.#snapshot.stages) {
-      if (stage.lifecycle === WORKFLOW_RUN_LIFECYCLE.WAITING) {
-        stage.lifecycle = WORKFLOW_RUN_LIFECYCLE.SKIPPED;
-        stage.completedAt = completedAt;
-      } else {
-        // Re-derive the lifecycle after the call sweep above. A stage whose
-        // call the sweep just terminalized ends now; genuinely settled stages
-        // keep their own end instant rather than taking the run's terminal one.
-        this.#settleStage(
-          stage.id,
-          sweepSettledStageIds.has(stage.id)
-            ? completedAt
-            : (stage.completedAt ?? completedAt),
-        );
-      }
-    }
-    // Call-derived settlement alone can mark the active stage completed or
-    // skipped when the script threw/cancelled after phase() with no live
-    // failed call (e.g. a JS reduction error). Force the active stage to the
-    // workflow terminal lifecycle so /executions/{id} shows where orchestration
-    // failed.
-    if (
-      activeStageId !== undefined &&
-      (lifecycle === WORKFLOW_RUN_LIFECYCLE.FAILED ||
-        lifecycle === WORKFLOW_RUN_LIFECYCLE.CANCELLED)
-    ) {
-      const activeStage = this.#snapshot.stages.find(
-        (stage) => stage.id === activeStageId,
-      );
-      if (activeStage) {
-        // Guarded above to lifecycle === FAILED | CANCELLED, so the lifecycle
-        // is its own mapping.
-        activeStage.lifecycle = lifecycle;
-        activeStage.completedAt = completedAt;
-      }
-    }
     this.#emit();
     this.#sealed = true;
-  }
-
-  #refreshExitedStage(stageId: string | undefined): void {
-    if (!stageId || stageId === this.#snapshot.currentStageId) return;
-    const calls = this.#snapshot.calls.filter(
-      (call) => call.stageId === stageId,
-    );
-    if (
-      calls.every((call) => TERMINAL_WORKFLOW_CALL_STATUSES.has(call.status))
-    ) {
-      this.#settleStage(stageId, now());
-    }
-  }
-
-  #settleStage(stageId: string, completedAt: string): void {
-    const stage = this.#snapshot.stages.find(
-      (candidate) => candidate.id === stageId,
-    );
-    if (!stage) return;
-    const calls = this.#snapshot.calls.filter(
-      (call) => call.stageId === stageId,
-    );
-    if (
-      calls.length === 0 ||
-      calls.every((call) => call.status === WORKFLOW_CALL_STATUS.SKIPPED)
-    ) {
-      stage.lifecycle = WORKFLOW_RUN_LIFECYCLE.SKIPPED;
-    } else if (
-      calls.some((call) => call.status === WORKFLOW_CALL_STATUS.FAILED)
-    ) {
-      stage.lifecycle = WORKFLOW_RUN_LIFECYCLE.FAILED;
-    } else if (
-      calls.some((call) => call.status === WORKFLOW_CALL_STATUS.CANCELLED)
-    ) {
-      stage.lifecycle = WORKFLOW_RUN_LIFECYCLE.CANCELLED;
-    } else {
-      stage.lifecycle = WORKFLOW_RUN_LIFECYCLE.COMPLETED;
-    }
-    stage.completedAt = completedAt;
   }
 
   #emit(): void {
@@ -562,7 +450,7 @@ function recoverCall(
   }
   if (
     fresh.status !== WORKFLOW_CALL_STATUS.DECLARED &&
-    fresh.status !== WORKFLOW_CALL_STATUS.PLANNED
+    fresh.status !== WORKFLOW_CALL_STATUS.QUEUED
   ) {
     throw new Error(`Fresh workflow call ${fresh.id} is not a plan stub.`);
   }

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -158,7 +158,6 @@ export function formatWorkflowCallLine(call: WorkflowCallProgress): string {
  */
 export const WORKFLOW_CALL_STATUS_GLYPH = {
   declared: '□',
-  planned: '□',
   queued: '□',
   running: '☐',
   completed: '☑',

--- a/src/shared/runs/workflowRunModel.ts
+++ b/src/shared/runs/workflowRunModel.ts
@@ -626,11 +626,6 @@ function isAttentionStatus(
   return status === 'failed' || status === 'running';
 }
 
-const QUEUED_STATUSES: ReadonlySet<WorkflowCallProgress['status']> = new Set([
-  'planned',
-  'queued',
-]);
-
 function taskRowOf(row: WorkflowTaskRow): WorkflowPhaseRow {
   return { kind: 'task', key: `task:${row.id}`, row };
 }
@@ -694,7 +689,7 @@ export function workflowPhaseRows(
   for (const row of phase.tasks) {
     const status = row.call.status;
     if (isAttentionStatus(status)) attention.push(row);
-    else if (QUEUED_STATUSES.has(status)) queued.push(row);
+    else if (status === 'queued') queued.push(row);
     else done.push(row);
   }
   const rank = (row: WorkflowTaskRow): number =>

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -113,10 +113,6 @@ export const WorkflowCallProgressSchema = z.discriminatedUnion('status', [
   WorkflowCallProgressBaseSchema.extend({
     status: z.literal(WORKFLOW_CALL_STATUS.DECLARED),
   }),
-  /** Issued by the script; not yet queued for a concurrency slot. */
-  WorkflowCallProgressBaseSchema.extend({
-    status: z.literal(WORKFLOW_CALL_STATUS.PLANNED),
-  }),
   /** Issued and waiting for one of the run's concurrency slots. */
   WorkflowCallProgressBaseSchema.extend({
     status: z.literal(WORKFLOW_CALL_STATUS.QUEUED),
@@ -199,7 +195,6 @@ export function interruptedWorkflowCall(
 
 export const WORKFLOW_TASK_STATUS_LABEL = {
   declared: 'Declared',
-  planned: 'Planned',
   queued: 'Queued',
   running: 'Running',
   completed: 'Finished',

--- a/src/shared/schemas/workflowRunSnapshot.ts
+++ b/src/shared/schemas/workflowRunSnapshot.ts
@@ -226,10 +226,17 @@ export function stageTitleFor(
  * How one stage is doing, derived from the calls it owns rather than stored
  * beside them, so a stage state can never disagree with its calls.
  *
- * A stage is `started` once the script has entered it or any of its calls has
- * been issued — before that there is nothing to show. It settles once it is
- * no longer current and every call it owns is terminal, and its `outcome` is
- * then the worst of those calls: failed beats cancelled beats completed.
+ * A stage is `started` once the script has entered it or one of its calls has
+ * actually been issued. A call the terminal sweep skipped was never issued, so
+ * a stage the run never reached stays unstarted and carries no outcome at all
+ * rather than reading completed for work that never ran.
+ *
+ * A started stage settles once it is no longer current and every call it owns
+ * is terminal, and its `outcome` is then the worst of those calls: failed
+ * beats cancelled beats completed. A reached stage whose every call the sweep
+ * skipped settled on the run's own end, so the run's outcome is its outcome;
+ * one that issued no call at all had nothing the run could cut short and
+ * simply completed.
  */
 export interface WorkflowStageState {
   readonly current: boolean;
@@ -239,15 +246,20 @@ export interface WorkflowStageState {
 }
 
 export function deriveWorkflowStageState(
-  snapshot: Pick<WorkflowRunSnapshot, 'calls' | 'currentStageId'>,
+  snapshot: Pick<WorkflowRunSnapshot, 'calls' | 'currentStageId' | 'outcome'>,
   stage: Pick<WorkflowRunSnapshot['stages'][number], 'id' | 'startedAt'>,
 ): WorkflowStageState {
   const current = stage.id === snapshot.currentStageId;
   const calls = snapshot.calls.filter((call) => call.stageId === stage.id);
-  const started =
-    current ||
-    stage.startedAt !== undefined ||
-    calls.some((call) => call.status !== WORKFLOW_CALL_STATUS.DECLARED);
+  // A plan label is not an invocation, and neither is one the terminal sweep
+  // skipped: the run ended before issuing it. Every other call was issued.
+  const issued = calls.filter(
+    (call) =>
+      call.status !== WORKFLOW_CALL_STATUS.DECLARED &&
+      (call.status !== WORKFLOW_CALL_STATUS.SKIPPED ||
+        call.settledBySweep !== true),
+  );
+  const started = current || stage.startedAt !== undefined || issued.length > 0;
   const settled =
     !current &&
     started &&
@@ -256,12 +268,17 @@ export function deriveWorkflowStageState(
     return { current, started, outcome: undefined, completedAt: undefined };
   }
   // Worst wins: one failed call fails the stage, one cancelled call cancels
-  // it, and a stage whose calls all skipped simply completed.
-  let outcome: RunOutcome = RUN_OUTCOME.COMPLETED;
-  if (calls.some((call) => call.status === WORKFLOW_CALL_STATUS.CANCELLED)) {
+  // it. A reached stage the sweep settled outright has no call of its own to
+  // read, so the run's end is the stage's end; a stage that issued nothing at
+  // all completed.
+  let outcome: RunOutcome =
+    calls.length > 0 && issued.length === 0
+      ? (snapshot.outcome ?? RUN_OUTCOME.COMPLETED)
+      : RUN_OUTCOME.COMPLETED;
+  if (issued.some((call) => call.status === WORKFLOW_CALL_STATUS.CANCELLED)) {
     outcome = RUN_OUTCOME.CANCELLED;
   }
-  if (calls.some((call) => call.status === WORKFLOW_CALL_STATUS.FAILED)) {
+  if (issued.some((call) => call.status === WORKFLOW_CALL_STATUS.FAILED)) {
     outcome = RUN_OUTCOME.FAILED;
   }
   return {

--- a/src/shared/schemas/workflowRunSnapshot.ts
+++ b/src/shared/schemas/workflowRunSnapshot.ts
@@ -1,17 +1,7 @@
 import { z } from 'zod';
 
 import { RunIdSchema } from './identifiers';
-
-export const WORKFLOW_RUN_LIFECYCLE = {
-  WAITING: 'waiting',
-  ACTIVE: 'active',
-  COMPLETED: 'completed',
-  FAILED: 'failed',
-  SKIPPED: 'skipped',
-  CANCELLED: 'cancelled',
-} as const;
-const WorkflowRunLifecycleSchema = z.enum(WORKFLOW_RUN_LIFECYCLE);
-type WorkflowRunLifecycle = z.infer<typeof WorkflowRunLifecycleSchema>;
+import { RUN_OUTCOME, RunOutcomeSchema, type RunOutcome } from './run';
 
 /**
  * The one status vocabulary of a workflow-script call, shared by the
@@ -21,7 +11,6 @@ type WorkflowRunLifecycle = z.infer<typeof WorkflowRunLifecycleSchema>;
  */
 export const WORKFLOW_CALL_STATUS = {
   DECLARED: 'declared',
-  PLANNED: 'planned',
   QUEUED: 'queued',
   RUNNING: 'running',
   COMPLETED: 'completed',
@@ -43,7 +32,8 @@ export type WorkflowCallStatus = z.infer<typeof WorkflowCallStatusSchema>;
  * host UI that offers it — so a control a host can name is always a control
  * the engine implements.
  */
-export type WorkflowControlAction = 'skip' | 'retry';
+export const WorkflowControlActionSchema = z.enum(['skip', 'retry']);
+export type WorkflowControlAction = z.infer<typeof WorkflowControlActionSchema>;
 
 const WorkflowRunLiveTimestampsSchema = z.strictObject({
   createdAt: z.iso.datetime(),
@@ -55,13 +45,17 @@ const WorkflowRunTerminalTimestampsSchema =
   WorkflowRunLiveTimestampsSchema.extend({
     completedAt: z.iso.datetime(),
   });
+/**
+ * A stage is a `phase()` title and the instant the script entered it. It
+ * carries no state of its own: how a stage is doing is derived from its own
+ * calls at read time by `deriveWorkflowStageState`, so a stored stage state
+ * can never disagree with the calls it summarizes.
+ */
 const WorkflowRunStageSchema = z.strictObject({
   id: z.string().min(1),
   title: z.string().min(1),
   order: z.int().nonnegative(),
-  lifecycle: WorkflowRunLifecycleSchema,
   startedAt: z.iso.datetime().optional(),
-  completedAt: z.iso.datetime().optional(),
 });
 const WorkflowRunAttemptSchema = z.strictObject({
   number: z.int().positive(),
@@ -142,10 +136,6 @@ const WorkflowRunCallSchema = z
       timestamps: WorkflowRunLiveTimestampsSchema,
     }),
     WorkflowRunIssuedCallSchema.extend({
-      status: z.literal(WORKFLOW_CALL_STATUS.PLANNED),
-      timestamps: WorkflowRunLiveTimestampsSchema,
-    }),
-    WorkflowRunIssuedCallSchema.extend({
       status: z.literal(WORKFLOW_CALL_STATUS.QUEUED),
       timestamps: WorkflowRunLiveTimestampsSchema,
     }),
@@ -203,14 +193,12 @@ export type WorkflowRunCall = z.infer<typeof WorkflowRunCallSchema>;
 
 type WorkflowRunCounts = Record<WorkflowCallStatus, number> & {
   readonly total: number;
-  readonly waiting: number;
 };
 
 /**
  * The one owner of "how many calls are in each state". Derived from the calls
  * themselves at the read boundary rather than stored beside them, so a tally
- * can never disagree with the array it summarizes. `waiting` is the composite
- * every consumer asks for: every call not yet queued, declared plus planned.
+ * can never disagree with the array it summarizes.
  */
 export function deriveWorkflowCounts(
   calls: readonly Pick<WorkflowRunCall, 'status'>[],
@@ -219,11 +207,7 @@ export function deriveWorkflowCounts(
     Object.values(WORKFLOW_CALL_STATUS).map((status) => [status, 0]),
   ) as Record<WorkflowCallStatus, number>;
   for (const call of calls) byStatus[call.status] += 1;
-  return {
-    total: calls.length,
-    waiting: byStatus.declared + byStatus.planned,
-    ...byStatus,
-  };
+  return { total: calls.length, ...byStatus };
 }
 
 /**
@@ -238,6 +222,63 @@ export function stageTitleFor(
   return snapshot.stages.find((stage) => stage.id === call.stageId)?.title;
 }
 
+/**
+ * How one stage is doing, derived from the calls it owns rather than stored
+ * beside them, so a stage state can never disagree with its calls.
+ *
+ * A stage is `started` once the script has entered it or any of its calls has
+ * been issued — before that there is nothing to show. It settles once it is
+ * no longer current and every call it owns is terminal, and its `outcome` is
+ * then the worst of those calls: failed beats cancelled beats completed.
+ */
+export interface WorkflowStageState {
+  readonly current: boolean;
+  readonly started: boolean;
+  readonly outcome: RunOutcome | undefined;
+  readonly completedAt: string | undefined;
+}
+
+export function deriveWorkflowStageState(
+  snapshot: Pick<WorkflowRunSnapshot, 'calls' | 'currentStageId'>,
+  stage: Pick<WorkflowRunSnapshot['stages'][number], 'id' | 'startedAt'>,
+): WorkflowStageState {
+  const current = stage.id === snapshot.currentStageId;
+  const calls = snapshot.calls.filter((call) => call.stageId === stage.id);
+  const started =
+    current ||
+    stage.startedAt !== undefined ||
+    calls.some((call) => call.status !== WORKFLOW_CALL_STATUS.DECLARED);
+  const settled =
+    !current &&
+    started &&
+    calls.every((call) => TERMINAL_WORKFLOW_CALL_STATUSES.has(call.status));
+  if (!settled) {
+    return { current, started, outcome: undefined, completedAt: undefined };
+  }
+  // Worst wins: one failed call fails the stage, one cancelled call cancels
+  // it, and a stage whose calls all skipped simply completed.
+  let outcome: RunOutcome = RUN_OUTCOME.COMPLETED;
+  if (calls.some((call) => call.status === WORKFLOW_CALL_STATUS.CANCELLED)) {
+    outcome = RUN_OUTCOME.CANCELLED;
+  }
+  if (calls.some((call) => call.status === WORKFLOW_CALL_STATUS.FAILED)) {
+    outcome = RUN_OUTCOME.FAILED;
+  }
+  return {
+    current,
+    started,
+    outcome,
+    completedAt: calls.reduce<string | undefined>(
+      (latest, call) =>
+        call.timestamps.completedAt !== undefined &&
+        (latest === undefined || call.timestamps.completedAt > latest)
+          ? call.timestamps.completedAt
+          : latest,
+      undefined,
+    ),
+  };
+}
+
 export const TERMINAL_WORKFLOW_CALL_STATUSES: ReadonlySet<WorkflowCallStatus> =
   new Set([
     WORKFLOW_CALL_STATUS.COMPLETED,
@@ -246,16 +287,10 @@ export const TERMINAL_WORKFLOW_CALL_STATUSES: ReadonlySet<WorkflowCallStatus> =
     WORKFLOW_CALL_STATUS.SKIPPED,
     WORKFLOW_CALL_STATUS.CACHED,
   ]);
-const TERMINAL_LIFECYCLES = new Set<WorkflowRunLifecycle>([
-  WORKFLOW_RUN_LIFECYCLE.COMPLETED,
-  WORKFLOW_RUN_LIFECYCLE.FAILED,
-  WORKFLOW_RUN_LIFECYCLE.SKIPPED,
-  WORKFLOW_RUN_LIFECYCLE.CANCELLED,
-]);
-
 export const WorkflowRunSnapshotSchema = z
   .strictObject({
-    lifecycle: WorkflowRunLifecycleSchema,
+    /** The run's own outcome, present exactly once the run has finished. */
+    outcome: RunOutcomeSchema.optional(),
     currentStageId: z.string().min(1).optional(),
     stages: z.array(WorkflowRunStageSchema),
     calls: z.array(WorkflowRunCallSchema),
@@ -269,16 +304,6 @@ export const WorkflowRunSnapshotSchema = z
   .superRefine((snapshot, context) => {
     const stageIds = new Set<string>();
     const stageOrders = new Set<number>();
-    const activeStages = snapshot.stages.filter(
-      (stage) => stage.lifecycle === WORKFLOW_RUN_LIFECYCLE.ACTIVE,
-    );
-    if (activeStages.length > 1) {
-      context.addIssue({
-        code: 'custom',
-        path: ['stages'],
-        message: 'A workflow snapshot can have at most one active stage.',
-      });
-    }
     for (const [index, stage] of snapshot.stages.entries()) {
       if (stageIds.has(stage.id))
         context.addIssue({
@@ -292,25 +317,17 @@ export const WorkflowRunSnapshotSchema = z
           path: ['stages', index, 'order'],
           message: `Duplicate workflow stage order ${stage.order}.`,
         });
-      if (
-        stage.lifecycle !== WORKFLOW_RUN_LIFECYCLE.WAITING &&
-        stage.lifecycle !== WORKFLOW_RUN_LIFECYCLE.ACTIVE &&
-        stage.completedAt === undefined
-      ) {
-        context.addIssue({
-          code: 'custom',
-          path: ['stages', index, 'completedAt'],
-          message: 'A terminal workflow stage requires completedAt.',
-        });
-      }
       stageIds.add(stage.id);
       stageOrders.add(stage.order);
     }
-    if (snapshot.currentStageId !== activeStages[0]?.id) {
+    if (
+      snapshot.currentStageId !== undefined &&
+      !stageIds.has(snapshot.currentStageId)
+    ) {
       context.addIssue({
         code: 'custom',
         path: ['currentStageId'],
-        message: 'currentStageId must identify the one active workflow stage.',
+        message: 'currentStageId must identify one of the workflow stages.',
       });
     }
 
@@ -331,7 +348,13 @@ export const WorkflowRunSnapshotSchema = z
         });
       }
     }
-    if (TERMINAL_LIFECYCLES.has(snapshot.lifecycle)) {
+    if (snapshot.outcome !== undefined) {
+      if (snapshot.currentStageId !== undefined)
+        context.addIssue({
+          code: 'custom',
+          path: ['currentStageId'],
+          message: 'A finished workflow snapshot has no current stage.',
+        });
       if (snapshot.timestamps.completedAt === undefined)
         context.addIssue({
           code: 'custom',

--- a/src/shared/session/runtimeRequest.ts
+++ b/src/shared/session/runtimeRequest.ts
@@ -15,7 +15,11 @@
 import { z } from 'zod';
 
 import { APPROVAL_BYPASS_KINDS } from '@shared/approvalBypassKind';
-import { RequestDecisionSchema, RunIdSchema } from '@shared/schemas';
+import {
+  RequestDecisionSchema,
+  RunIdSchema,
+  WorkflowControlActionSchema,
+} from '@shared/schemas';
 
 const runScoped = { runId: RunIdSchema };
 
@@ -68,7 +72,7 @@ export const RuntimeRequestSchema = z.discriminatedUnion('kind', [
     kind: z.literal('workflow.control'),
     ...runScoped,
     childRunId: RunIdSchema,
-    action: z.enum(['skip', 'retry']),
+    action: WorkflowControlActionSchema,
   }),
 ]);
 export type RuntimeRequest = z.infer<typeof RuntimeRequestSchema>;

--- a/src/test-kernel/agent/WorkflowRunObservability.vitest.ts
+++ b/src/test-kernel/agent/WorkflowRunObservability.vitest.ts
@@ -77,11 +77,16 @@ return 'done'`,
         expect(declaredReviewStages.filter(Boolean)).toEqual([]);
         // Drain-time cloning: every delivered snapshot is its own isolated copy.
         expect(new Set(snapshots).size).toBe(snapshots.length);
+        // Draft ran and completed; Review was never entered, so it stays
+        // unstarted with no outcome — its swept plan label is not work done.
         expect(
-          result.snapshot.stages.map(
-            (stage) => deriveWorkflowStageState(result.snapshot, stage).outcome,
+          result.snapshot.stages.map((stage) =>
+            deriveWorkflowStageState(result.snapshot, stage),
           ),
-        ).toEqual(['completed', 'completed']);
+        ).toMatchObject([
+          { started: true, outcome: 'completed' },
+          { started: false, outcome: undefined },
+        ]);
         expect(result.snapshot.calls.map((call) => call.status)).toEqual([
           'completed',
           'skipped',

--- a/src/test-kernel/agent/WorkflowRunObservability.vitest.ts
+++ b/src/test-kernel/agent/WorkflowRunObservability.vitest.ts
@@ -8,6 +8,7 @@ import { WORKFLOW_SKIPPED_RESULT } from '@agent/workflowScript/types';
 import {
   WorkflowRunSnapshotSchema,
   deriveWorkflowCounts,
+  deriveWorkflowStageState,
   type RunId,
   type WorkflowRunSnapshot,
 } from '@shared/schemas';
@@ -25,6 +26,11 @@ const META = `export const meta = {
 
 function finalSnapshot(snapshots: readonly WorkflowRunSnapshot[]) {
   return snapshots.at(-1)!;
+}
+
+/** The derived state of one stage by position, for assertions. */
+function stageState(snapshot: WorkflowRunSnapshot, index: number) {
+  return deriveWorkflowStageState(snapshot, snapshot.stages[index]!);
 }
 
 function recordingSnapshots(): {
@@ -56,28 +62,26 @@ return 'done'`,
         });
 
         // Stage gating: the later-phase call is declared in some snapshot, and
-        // wherever it is declared its own stage is still unreached (waiting, or
-        // skipped by the settle sweep), never a stage the run has entered.
+        // wherever it is declared its own stage is still unreached — never a
+        // stage the run has entered, so nothing shows it yet.
         const declaredReviewStages = snapshots.flatMap((snapshot) => {
           const review = snapshot.calls.find((call) => call.id === 'review');
           if (review?.status !== 'declared') return [];
           const stage = snapshot.stages.find(
             (entry) => entry.id === review.stageId,
           );
-          return [stage?.lifecycle ?? 'unstaged'];
+          if (!stage) return [];
+          return [deriveWorkflowStageState(snapshot, stage).started];
         });
         expect(declaredReviewStages.length).toBeGreaterThan(0);
-        expect(
-          declaredReviewStages.filter(
-            (lifecycle) => lifecycle !== 'waiting' && lifecycle !== 'skipped',
-          ),
-        ).toEqual([]);
+        expect(declaredReviewStages.filter(Boolean)).toEqual([]);
         // Drain-time cloning: every delivered snapshot is its own isolated copy.
         expect(new Set(snapshots).size).toBe(snapshots.length);
-        expect(result.snapshot.stages.map((stage) => stage.lifecycle)).toEqual([
-          'completed',
-          'skipped',
-        ]);
+        expect(
+          result.snapshot.stages.map(
+            (stage) => deriveWorkflowStageState(result.snapshot, stage).outcome,
+          ),
+        ).toEqual(['completed', 'completed']);
         expect(result.snapshot.calls.map((call) => call.status)).toEqual([
           'completed',
           'skipped',
@@ -104,7 +108,7 @@ return null`,
           }),
         );
         expect(error.message).toMatch(/monotonically/);
-        expect(finalSnapshot(failedSnapshots).lifecycle).toBe('failed');
+        expect(finalSnapshot(failedSnapshots).outcome).toBe('failed');
       }),
   );
 
@@ -315,7 +319,7 @@ return [failed, passed]`,
               : Effect.succeed('passed'),
         });
         expect(failed.result).toEqual([null, 'passed']);
-        expect(failed.snapshot.lifecycle).toBe('completed');
+        expect(failed.snapshot.outcome).toBe('completed');
         expect(deriveWorkflowCounts(failed.snapshot.calls)).toMatchObject({
           failed: 1,
           completed: 1,
@@ -381,11 +385,14 @@ return [await draft, review]`,
             const review = snapshot.calls.find(
               (call) => call.id === 'review-call',
             );
+            // Draft is behind the run but still draining: derived from its
+            // own calls it stays live, where the stored lifecycle used to
+            // read completed while its call was still running.
             return (
               snapshot.currentStageId === 'stage-2' &&
               draft?.status === 'running' &&
               review?.status === 'running' &&
-              snapshot.stages[0]?.lifecycle === 'completed'
+              stageState(snapshot, 0).outcome === undefined
             );
           }),
         ).toBe(true);
@@ -409,20 +416,22 @@ return [failed, passed]`,
           onSnapshot: failureOnSnapshot,
         });
         expect(continued.result).toEqual([null, 'passed']);
-        expect(continued.snapshot.stages[0]?.lifecycle).toBe('failed');
+        expect(stageState(continued.snapshot, 0).outcome).toBe('failed');
         expect(
-          failureSnapshots.some(
-            (snapshot) =>
+          failureSnapshots.some((snapshot) => {
+            const stage = stageState(snapshot, 0);
+            return (
               snapshot.calls[0]?.status === 'failed' &&
-              snapshot.stages[0]?.lifecycle === 'active' &&
-              snapshot.stages[0]?.completedAt === undefined,
-          ),
+              stage.current &&
+              stage.outcome === undefined
+            );
+          }),
         ).toBe(true);
       }),
   );
 
   it.effect(
-    'marks the active stage failed when orchestration throws with no failed call',
+    'fails the run when orchestration throws after a successful call',
     () =>
       Effect.gen(function* () {
         const { snapshots, onSnapshot } = recordingSnapshots();
@@ -442,40 +451,39 @@ throw new Error('reduce failed after success')`,
         );
         expect(error.message).toMatch(/reduce failed after success/);
 
-        // Script throw after a successful call must not leave Merge as completed
-        // just because call-derived settlement saw only completed work.
+        // The orchestration failure is the run's, not the call's: Merge's own
+        // work completed, and the run's outcome is what records the throw.
         const terminal = finalSnapshot(snapshots);
-        expect(terminal.lifecycle).toBe('failed');
-        expect(terminal.stages[0]?.lifecycle).toBe('failed');
+        expect(terminal.outcome).toBe('failed');
         expect(terminal.calls[0]?.status).toBe('completed');
+        expect(stageState(terminal, 0).outcome).toBe('completed');
       }),
   );
 
-  it.effect(
-    'marks a call-less active stage failed on orchestration throw',
-    () =>
-      Effect.gen(function* () {
-        const { snapshots, onSnapshot } = recordingSnapshots();
-        const error = yield* Effect.flip(
-          runWorkflowScript({
-            script: `export const meta = {
+  it.effect('fails the run when a call-less stage throws', () =>
+    Effect.gen(function* () {
+      const { snapshots, onSnapshot } = recordingSnapshots();
+      const error = yield* Effect.flip(
+        runWorkflowScript({
+          script: `export const meta = {
   name: 'empty-stage-fail',
   description: 'phase with no agent() then throw',
   phases: ['Merge'],
 }
 phase('Merge')
 throw new Error('reduce only')`,
-            runAgent: () => Effect.fail(new Error('must not run')),
-            onSnapshot,
-          }),
-        );
-        expect(error.message).toMatch(/reduce only/);
+          runAgent: () => Effect.fail(new Error('must not run')),
+          onSnapshot,
+        }),
+      );
+      expect(error.message).toMatch(/reduce only/);
 
-        const terminal = finalSnapshot(snapshots);
-        expect(terminal.lifecycle).toBe('failed');
-        // Without the active-stage override, call-less stages settle as skipped.
-        expect(terminal.stages[0]?.lifecycle).toBe('failed');
-      }),
+      const terminal = finalSnapshot(snapshots);
+      expect(terminal.outcome).toBe('failed');
+      // A stage owns no state of its own: with no call to fail, Merge shows
+      // nothing and the run's outcome carries the throw.
+      expect(stageState(terminal, 0).outcome).toBe('completed');
+    }),
   );
 
   it.effect(
@@ -508,7 +516,7 @@ return await agent('cancel secret', { label: 'Cancelled task' })`,
         expect(cancellation).toMatchObject({ name: 'AbortError' });
 
         const terminal = finalSnapshot(snapshots);
-        expect(terminal.lifecycle).toBe('cancelled');
+        expect(terminal.outcome).toBe('cancelled');
         expect(terminal.error).toBe('cancelled');
         expect(terminal.calls[0]?.error).toBeUndefined();
         expect(

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -1655,11 +1655,12 @@ return 'delivered'`,
           script: `export const meta = {
   name: 'sweep-stage',
   description: 'distinguishes settled work from terminal-sweep work',
-  phases: ['Settled', 'A', 'B'],
+  phases: ['Settled', 'A', 'B', 'C'],
   tasks: [
     { id: 'settled', label: 'Settled normally', phase: 'Settled' },
     { id: 'live', label: 'Ignores cancellation', phase: 'A' },
     { id: 'unreached', label: 'Never issued', phase: 'B' },
+    { id: 'bypassed', label: 'Never reached', phase: 'C' },
   ],
 }
 phase('Settled')
@@ -1674,29 +1675,44 @@ return 'done'`,
               : Effect.never,
         });
 
+        expect(run.snapshot.outcome).toBe('completed');
         expect(run.snapshot.calls).toMatchObject([
           { id: 'settled', status: 'completed' },
           { id: 'live', status: 'failed', settledBySweep: true },
           { id: 'unreached', status: 'skipped', settledBySweep: true },
+          { id: 'bypassed', status: 'skipped', settledBySweep: true },
         ]);
         expect(run.snapshot.calls[0]).not.toHaveProperty(
           'settledBySweep',
           true,
         );
-        const [settledStage, sweptStage, plannedStage] =
+        const [settledStage, sweptStage, enteredStage, bypassedStage] =
           run.snapshot.stages.map((stage) =>
             deriveWorkflowStageState(run.snapshot, stage),
           );
         const terminalAt = run.snapshot.timestamps.completedAt;
         expect(settledStage).toMatchObject({ outcome: 'completed' });
         expect(settledStage?.completedAt).toBeDefined();
+        // A stage whose own call the sweep failed reads failed, at the run's
+        // terminal instant rather than an end of its own.
         expect(sweptStage).toMatchObject({
           outcome: 'failed',
           completedAt: terminalAt,
         });
-        expect(plannedStage).toMatchObject({
+        // B was entered and issued nothing before the run ended, so the run's
+        // own outcome is its outcome.
+        expect(enteredStage).toMatchObject({
+          started: true,
           outcome: 'completed',
           completedAt: terminalAt,
+        });
+        // C was never entered: a swept plan label is not work it did, so it
+        // has no end and no outcome at all rather than reading completed.
+        expect(bypassedStage).toEqual({
+          current: false,
+          started: false,
+          outcome: undefined,
+          completedAt: undefined,
         });
       }),
   );

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -13,7 +13,11 @@ import type {
 import { runWorkflowScript } from '@agent/workflowScript/runWorkflowScript';
 import { WORKFLOW_SKIPPED_RESULT } from '@agent/workflowScript/types';
 import { runScriptInSandbox } from '@agent/workflowScript/sandbox';
-import { deriveWorkflowCounts, type RunId } from '@shared/schemas';
+import {
+  deriveWorkflowCounts,
+  deriveWorkflowStageState,
+  type RunId,
+} from '@shared/schemas';
 import { ensureError } from '@utils/errors/errorMessage';
 
 const META = `export const meta = {
@@ -1192,7 +1196,7 @@ return await agent('Inspect src', { id: 'inspect' })`,
         // A cached call that fails validation settles as failed with the real
         // cause; the terminal pass must not reclassify it as never-reached.
         const terminal = snapshots.at(-1);
-        expect(terminal?.lifecycle).toBe('failed');
+        expect(terminal?.outcome).toBe('failed');
         expect(terminal?.calls).toMatchObject([
           {
             id: 'call-0',
@@ -1272,8 +1276,11 @@ return null`,
         });
         expect(invocations[0].options.phase).toBe('Work');
         expect(run.snapshot.stages).toMatchObject([
-          { id: 'stage-1', title: 'Work', order: 0, lifecycle: 'completed' },
+          { id: 'stage-1', title: 'Work', order: 0 },
         ]);
+        expect(
+          deriveWorkflowStageState(run.snapshot, run.snapshot.stages[0]!),
+        ).toMatchObject({ outcome: 'completed' });
         expect(run.snapshot.calls).toMatchObject([
           {
             id: 'call-0',
@@ -1641,7 +1648,7 @@ return 'delivered'`,
   );
 
   it.live(
-    'restamps sweep-settled stages without restamping settled stages',
+    'derives a stage end from its calls, not from the run terminal instant',
     () =>
       Effect.gen(function* () {
         const run = yield* runWorkflowScript({
@@ -1676,16 +1683,19 @@ return 'done'`,
           'settledBySweep',
           true,
         );
-        const [settledStage, sweptStage, plannedStage] = run.snapshot.stages;
+        const [settledStage, sweptStage, plannedStage] =
+          run.snapshot.stages.map((stage) =>
+            deriveWorkflowStageState(run.snapshot, stage),
+          );
         const terminalAt = run.snapshot.timestamps.completedAt;
-        expect(settledStage).toMatchObject({ lifecycle: 'completed' });
+        expect(settledStage).toMatchObject({ outcome: 'completed' });
         expect(settledStage?.completedAt).toBeDefined();
         expect(sweptStage).toMatchObject({
-          lifecycle: 'failed',
+          outcome: 'failed',
           completedAt: terminalAt,
         });
         expect(plannedStage).toMatchObject({
-          lifecycle: 'skipped',
+          outcome: 'completed',
           completedAt: terminalAt,
         });
       }),
@@ -2577,7 +2587,7 @@ return 'done'`,
 
       expect(snapshots.length).toBeGreaterThan(0);
       expect(result.snapshot).toMatchObject({
-        lifecycle: 'completed',
+        outcome: 'completed',
         currentStageId: undefined,
         calls: [
           {

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -72,7 +72,7 @@ type ScriptRunOptions = Parameters<
   typeof projectWorkflowScriptProgress<never>
 >[1];
 
-const LIFECYCLE_STATUSES = ['planned', 'running', 'completed'] as const;
+const LIFECYCLE_STATUSES = ['queued', 'running', 'completed'] as const;
 
 /**
  * Project a run onto `trace` and run it against this file's session, the way
@@ -225,7 +225,7 @@ return await agent('Inspect', { id: 'inspect' })`,
             stageId: parent.id,
           }),
         );
-        const planned = workflowCallEvent(events, 'Inspect source', 'planned');
+        const queued = workflowCallEvent(events, 'Inspect source', 'queued');
         const running = workflowCallEvent(events, 'Inspect source', 'running');
         const completed = workflowCallEvent(
           events,
@@ -233,23 +233,23 @@ return await agent('Inspect', { id: 'inspect' })`,
           'completed',
         );
         // One stable, phase-derived stage across the whole lifecycle: the card is
-        // classified into its phase group when it is planned and never moves.
-        expect(planned).toMatchObject({
+        // classified into its phase group when it is queued and never moves.
+        expect(queued).toMatchObject({
           type: 'workflow.call',
           stageId: phaseId,
           call: { attemptId: expect.any(String) },
         });
         expect(running).toMatchObject({
           type: 'workflow.call',
-          logId: planned?.logId,
+          logId: queued?.logId,
           stageId: phaseId,
-          call: { attemptId: planned?.call.attemptId },
+          call: { attemptId: queued?.call.attemptId },
         });
         expect(completed).toMatchObject({
           type: 'workflow.call',
-          logId: planned?.logId,
+          logId: queued?.logId,
           stageId: phaseId,
-          call: { attemptId: planned?.call.attemptId },
+          call: { attemptId: queued?.call.attemptId },
         });
         expect(events).toContainEqual(
           expect.objectContaining({
@@ -693,7 +693,7 @@ return await agent('Retry review', { id: 'retry-review' })`;
 
           const reviewId = stageId(retry.events, 'Review');
           expect(
-            workflowCallEvent(retry.events, 'Retry review', 'planned'),
+            workflowCallEvent(retry.events, 'Retry review', 'queued'),
           ).toMatchObject({ stageId: reviewId, call: { phase: 'Review' } });
           expect(
             workflowCallEvent(retry.events, 'Retry review', 'completed'),
@@ -806,12 +806,12 @@ return await agent('Review the argument', { id: 'review-task' })`;
             total: 1,
           }),
         ]);
-        const planned = workflowCallEvent(events, 'Review argument', 'planned');
+        const queued = workflowCallEvent(events, 'Review argument', 'queued');
         for (const status of LIFECYCLE_STATUSES) {
           expect(
             workflowCallEvent(events, 'Review argument', status),
           ).toMatchObject({
-            logId: planned?.logId,
+            logId: queued?.logId,
             call: {
               id: 'review-task',
               label: 'Review argument',

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -1217,18 +1217,16 @@ throw new Error('script failed')`,
         ),
       ).toMatchObject({ message: expect.stringContaining('script failed') });
 
-      // The engine settled 'One' cleanly before the script threw inside 'Two';
-      // only the phase the failure happened in reads failed.
-      expect(events).toContainEqual({
-        type: 'stage.end',
-        id: stageId(events, 'One'),
-        status: RUN_OUTCOME.COMPLETED,
-      });
-      expect(events).toContainEqual({
-        type: 'stage.end',
-        id: stageId(events, 'Two'),
-        status: RUN_OUTCOME.FAILED,
-      });
+      // Every opened phase closes on the state its own calls derive — the
+      // one `/executions/{id}` reads. Neither phase owns a failed call, so
+      // neither reads failed and the throw stays the run's own fact.
+      for (const title of ['One', 'Two']) {
+        expect(events).toContainEqual({
+          type: 'stage.end',
+          id: stageId(events, title),
+          status: RUN_OUTCOME.COMPLETED,
+        });
+      }
     }),
   );
 });

--- a/src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts
@@ -14,7 +14,6 @@ function snapshot(status: 'declared' | 'running') {
   const timestamp = '2026-08-15T20:00:00.000Z';
   const active = status === 'running';
   return WorkflowRunSnapshotSchema.parse({
-    lifecycle: active ? 'active' : 'waiting',
     stages: [],
     calls: [
       {

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -187,7 +187,7 @@ function markToolUseAgent(...runIds: RunId[]): void {
 /** A workflow-task row as the projector builds one, for the suites that seed
  *  a dashboard directly instead of replaying a stream log. */
 function taskRow(id: string, call: WorkflowCallProgress): WorkflowTaskRow {
-  const statusLabel = call.status === 'running' ? 'Running' : 'Planned';
+  const statusLabel = call.status === 'running' ? 'Running' : 'Queued';
   return {
     kind: 'workflowTask',
     id,

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -155,7 +155,7 @@ function phaseRow(
 function workflowTaskRow(
   id: string,
   call: WorkflowCallProgress,
-  line = 'Planned: Task',
+  line = 'Queued: Task',
 ): TranscriptRow {
   return {
     kind: 'workflowTask',
@@ -214,7 +214,7 @@ describe('CLI conversation transcript', () => {
     const workflowTask = workflowTaskRow('w1', {
       id: 'w1',
       label: 'Task',
-      status: 'planned',
+      status: 'queued',
     });
     const workflowPhase = phaseRow('p2', 'After workflow task');
 

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -352,7 +352,7 @@ describe('workflow run model', () => {
         { id: 'ok1', phase: 'Derive', status: 'completed' },
         { id: 'r1', phase: 'Derive', status: 'running' },
         { id: 'bad', phase: 'Derive', status: 'failed' },
-        { id: 'q2', phase: 'Derive', status: 'planned' },
+        { id: 'q2', phase: 'Derive', status: 'queued' },
         { id: 'r2', phase: 'Derive', status: 'running' },
         { id: 'ok2', phase: 'Derive', status: 'cached' },
       ],

--- a/src/test-kernel/shared/session/fanOutScenario.ts
+++ b/src/test-kernel/shared/session/fanOutScenario.ts
@@ -186,7 +186,7 @@ export class Log {
 }
 
 function call(
-  status: 'planned' | 'running' | 'completed',
+  status: 'queued' | 'running' | 'completed',
   childRunId?: RunId,
 ): WorkflowCallProgress {
   return {
@@ -293,7 +293,7 @@ export function buildScenario({ proposal = false } = {}) {
       type: STREAM_LOG_ENTRY_TYPES.LOG,
       messageType: MESSAGE_TYPES.WORKFLOW_TASK,
       groupId: 'phase-Map',
-      data: call('planned'),
+      data: call('queued'),
     }),
   );
 
@@ -785,8 +785,8 @@ const BOARD_CALLS: readonly BoardCall[] = [
     costUsd: 0.09,
   },
   { id: 'review:legal', phase: 'Review', status: 'cached' },
-  { id: 'review:relay', phase: 'Review', status: 'planned' },
-  { id: 'review:auth', phase: 'Review', status: 'planned' },
+  { id: 'review:relay', phase: 'Review', status: 'queued' },
+  { id: 'review:auth', phase: 'Review', status: 'queued' },
 ];
 
 function boardProgress(entry: BoardCall): WorkflowCallProgress {
@@ -818,7 +818,6 @@ function boardProgress(entry: BoardCall): WorkflowCallProgress {
       return { ...base, status: 'skipped', reason: 'user', ...terminal };
     case 'cached':
     case 'declared':
-    case 'planned':
     case 'queued':
     case 'running':
       return { ...base, status: entry.status };
@@ -1091,7 +1090,7 @@ function boardView({
           },
           closedAt,
         );
-      } else if (entry.status === 'planned') {
+      } else if (entry.status === 'queued') {
         card({ ...entry, status: 'cancelled' }, closedAt);
       }
     }

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -609,14 +609,12 @@ describe('ExecutionsTool /executions/{id}/output', () => {
           (_, index) => `${'f'.repeat(600)}-${index}-file-tail.tex`,
         );
         yield* writeWorkflowRunSnapshot(defaultSession(), runId, {
-          lifecycle: 'active',
           currentStageId: longStageId,
           stages: [
             {
               id: longStageId,
               title: longTitle,
               order: 0,
-              lifecycle: 'active',
               startedAt: timestamp,
             },
           ],
@@ -709,7 +707,7 @@ describe('ExecutionsTool /executions/{id}/output', () => {
         const runId = yield* registerWorkflowRun('cancelled-summary');
         const timestamp = new Date().toISOString();
         yield* writeWorkflowRunSnapshot(defaultSession(), runId, {
-          lifecycle: 'cancelled',
+          outcome: 'cancelled',
           stages: [],
           calls: [
             {
@@ -781,22 +779,18 @@ describe('ExecutionsTool /executions/{id}/output', () => {
         });
         const failedAt = new Date(base).toISOString();
         yield* writeWorkflowRunSnapshot(defaultSession(), runId, {
-          lifecycle: 'active',
           currentStageId: 'stage-2',
           stages: [
             {
               id: 'stage-1',
               title: 'Earlier stage',
               order: 0,
-              lifecycle: 'failed',
               startedAt: failedAt,
-              completedAt: failedAt,
             },
             {
               id: 'stage-2',
               title: 'Current stage',
               order: 1,
-              lifecycle: 'active',
               startedAt: failedAt,
             },
           ],
@@ -871,22 +865,18 @@ describe('ExecutionsTool /executions/{id}/output', () => {
           },
         }));
         yield* writeWorkflowRunSnapshot(defaultSession(), runId, {
-          lifecycle: 'active',
           currentStageId: 'stage-2',
           stages: [
             {
               id: 'stage-1',
               title: 'Earlier stage',
               order: 0,
-              lifecycle: 'completed',
               startedAt: timestamp,
-              completedAt: timestamp,
             },
             {
               id: 'stage-2',
               title: 'Current stage',
               order: 1,
-              lifecycle: 'active',
               startedAt: timestamp,
             },
           ],

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -235,7 +235,7 @@ describe('attachTestTranscriptFold workflow task state', () => {
       call: {
         id: 'planned',
         label: 'Audit later',
-        status: 'planned',
+        status: 'queued',
       },
     });
 
@@ -395,7 +395,7 @@ describe('attachTestTranscriptFold workflow task state', () => {
         id: 'audit-core',
         label: 'Audit core',
         phase: 'Audit',
-        status: 'planned',
+        status: 'queued',
       },
     });
     trace.emit({

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -412,10 +412,10 @@ export function projectWorkflowScriptProgress<R>(
         });
       }
       for (const stage of snapshot.stages) {
-        // A declared phase the run has not entered and whose calls are all
-        // still plan labels is nothing to show: no header, no `Phase:` line.
-        // A phase the run bypassed opens once the settle sweep terminalizes
-        // the cards it owns, so their not-reached rows land under it.
+        // A phase the run never entered is nothing to announce: no header
+        // line, no `Phase:` line. One that owns declared cards still opens
+        // when the sweep terminalizes them — `emitCall` groups a card under
+        // its own phase — so their not-reached rows never land elsewhere.
         const state = deriveWorkflowStageState(snapshot, stage);
         if (!state.started) continue;
         const known = phases.has(stage.title);
@@ -501,9 +501,8 @@ export function projectWorkflowScriptProgress<R>(
       // duration) while later phases still run, and a failure in phase 3
       // cannot retroactively mark phases 1-2. The failed card that flips a
       // phase is already emitted above. Once the run itself has ended,
-      // `settle` closes whatever is still open with the run's own outcome:
-      // a stage the script threw inside owns no failed call to derive one
-      // from, and the throw is the run's fact, not the stage's.
+      // `settle` closes whatever is still open, reading the same derived
+      // stage state so the trace and `/executions/{id}` never disagree.
       if (snapshot.outcome !== undefined) return;
       for (const stage of snapshot.stages) {
         const phase = phases.get(stage.title);
@@ -552,8 +551,22 @@ export function projectWorkflowScriptProgress<R>(
       emitCall(call);
       recordTerminalActivity(call);
     }
-    for (const phase of phases.values()) {
-      phase.handle.end(phase.failed ? RUN_OUTCOME.FAILED : runOutcome);
+    for (const [title, phase] of phases) {
+      // One authority for how a phase ended: the same derived stage state
+      // `/executions/{id}` reads. A stage the script threw inside owns no
+      // failed call, so it reads as its own calls left it and the throw stays
+      // the run's fact. The run's outcome closes only what the snapshot has
+      // no stage state for: a phase opened for its not-reached rows alone,
+      // and — when a writer failure left the last snapshot stale — a phase
+      // whose calls this projection had to settle as unfinished itself.
+      const stage = lastSnapshot?.stages.find((entry) => entry.title === title);
+      const derived =
+        lastSnapshot && stage
+          ? deriveWorkflowStageState(lastSnapshot, stage).outcome
+          : undefined;
+      phase.handle.end(
+        phase.failed ? RUN_OUTCOME.FAILED : (derived ?? runOutcome),
+      );
     }
   };
   return {

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -10,13 +10,12 @@ import type {
   WorkflowScriptEvent,
 } from '@agent/workflowScript/types';
 import {
+  deriveWorkflowStageState,
   isTerminalWorkflowCallProgress,
   isTerminalWorkflowCallStatus,
   RUN_OUTCOME,
   stageTitleFor,
-  TERMINAL_WORKFLOW_CALL_STATUSES,
   WORKFLOW_CALL_STATUS,
-  WORKFLOW_RUN_LIFECYCLE,
   RunEndSchema,
   type RunOutcome,
   type WorkflowCallProgress,
@@ -335,7 +334,6 @@ export function projectWorkflowScriptProgress<R>(
               ...terminalMetadata(call),
             };
       case WORKFLOW_CALL_STATUS.DECLARED:
-      case WORKFLOW_CALL_STATUS.PLANNED:
       case WORKFLOW_CALL_STATUS.QUEUED:
       case WORKFLOW_CALL_STATUS.RUNNING:
       case WORKFLOW_CALL_STATUS.CACHED:
@@ -414,18 +412,12 @@ export function projectWorkflowScriptProgress<R>(
         });
       }
       for (const stage of snapshot.stages) {
-        if (stage.lifecycle === 'waiting') continue;
-        // A declared phase the run bypassed (`phase()` jumped past it, or the
-        // script ended first) and that owns no card is nothing to show: no
-        // header, no `Phase:` line. One that owns declared cards still opens
-        // so their not-reached rows land under it.
-        if (
-          stage.lifecycle === 'skipped' &&
-          stage.startedAt === undefined &&
-          !snapshot.calls.some((call) => call.stageId === stage.id)
-        ) {
-          continue;
-        }
+        // A declared phase the run has not entered and whose calls are all
+        // still plan labels is nothing to show: no header, no `Phase:` line.
+        // A phase the run bypassed opens once the settle sweep terminalizes
+        // the cards it owns, so their not-reached rows land under it.
+        const state = deriveWorkflowStageState(snapshot, stage);
+        if (!state.started) continue;
         const known = phases.has(stage.title);
         const phase = phaseFor(
           stage.title,
@@ -433,8 +425,8 @@ export function projectWorkflowScriptProgress<R>(
           stage.order < declaredStageTotal ? declaredStageTotal : undefined,
         );
         if (!known) onActivity?.(`Phase: ${stage.title}`);
-        if (stage.lifecycle === 'failed') phase.failed = true;
-        if (stage.lifecycle === 'active') currentPhase = stage.title;
+        if (state.outcome === RUN_OUTCOME.FAILED) phase.failed = true;
+        if (state.current) currentPhase = stage.title;
       }
       for (const call of snapshot.calls) {
         const last = projectedCalls.get(call.id);
@@ -504,37 +496,20 @@ export function projectWorkflowScriptProgress<R>(
           recordTerminalActivity(card as WorkflowCallTerminalProgress);
         }
       }
-      // Close a phase's stage when the engine has settled it, so a finished
-      // phase reads finished (icon, duration) while later phases still run,
-      // and a failure in phase 3 cannot retroactively mark phases 1-2. The
-      // schema has no "exited but draining" lifecycle — `#settleStage` stamps
-      // completed from call statuses while calls may still run — so close
-      // only once every call of the stage is terminal; the failed card that
-      // flips a phase is then already emitted above. `end` is idempotent, so
-      // the finally sweep stays the backstop for stages the engine never
-      // settled.
+      // Close a phase's stage once the run has left it and every call it
+      // owns is terminal, so a finished phase reads finished (icon,
+      // duration) while later phases still run, and a failure in phase 3
+      // cannot retroactively mark phases 1-2. The failed card that flips a
+      // phase is already emitted above. Once the run itself has ended,
+      // `settle` closes whatever is still open with the run's own outcome:
+      // a stage the script threw inside owns no failed call to derive one
+      // from, and the throw is the run's fact, not the stage's.
+      if (snapshot.outcome !== undefined) return;
       for (const stage of snapshot.stages) {
         const phase = phases.get(stage.title);
-        if (
-          !phase ||
-          stage.lifecycle === 'waiting' ||
-          stage.lifecycle === 'active'
-        ) {
-          continue;
-        }
-        const drained = snapshot.calls.every(
-          (call) =>
-            call.stageId !== stage.id ||
-            TERMINAL_WORKFLOW_CALL_STATUSES.has(call.status),
-        );
-        if (!drained) continue;
-        let outcome: RunOutcome = RUN_OUTCOME.COMPLETED;
-        if (phase.failed || stage.lifecycle === 'failed') {
-          outcome = RUN_OUTCOME.FAILED;
-        } else if (stage.lifecycle === 'cancelled') {
-          outcome = RUN_OUTCOME.CANCELLED;
-        }
-        phase.handle.end(outcome);
+        const outcome = deriveWorkflowStageState(snapshot, stage).outcome;
+        if (!phase || outcome === undefined) continue;
+        phase.handle.end(phase.failed ? RUN_OUTCOME.FAILED : outcome);
       }
     });
     if (Result.isFailure(projected)) {
@@ -548,7 +523,7 @@ export function projectWorkflowScriptProgress<R>(
 
   const settle = (completed: boolean): void => {
     if (completed) runOutcome = RUN_OUTCOME.COMPLETED;
-    if (lastSnapshot?.lifecycle === WORKFLOW_RUN_LIFECYCLE.CANCELLED) {
+    if (lastSnapshot?.outcome === RUN_OUTCOME.CANCELLED) {
       runOutcome = RUN_OUTCOME.CANCELLED;
     }
     // The engine's `finish()` publishes its terminal snapshot synchronously
@@ -558,11 +533,7 @@ export function projectWorkflowScriptProgress<R>(
     // live as unfinished. A writer failure leaves `lastSnapshot` stale and
     // non-terminal; re-folding stale state could move a card backwards, so
     // only a terminal snapshot is re-folded.
-    if (
-      lastSnapshot !== undefined &&
-      lastSnapshot.lifecycle !== WORKFLOW_RUN_LIFECYCLE.WAITING &&
-      lastSnapshot.lifecycle !== WORKFLOW_RUN_LIFECYCLE.ACTIVE
-    ) {
+    if (lastSnapshot?.outcome !== undefined) {
       fold(lastSnapshot);
     }
     closed = true;

--- a/src/tools/executions/workflowSummaryView.ts
+++ b/src/tools/executions/workflowSummaryView.ts
@@ -11,6 +11,8 @@
 // Local imports
 import {
   deriveWorkflowCounts,
+  deriveWorkflowStageState,
+  RUN_OUTCOME,
   stageTitleFor,
   TERMINAL_WORKFLOW_CALL_STATUSES,
   type WorkflowRunSnapshot,
@@ -27,15 +29,19 @@ function compactWorkflowText(value: string | undefined): string | undefined {
 }
 
 function workflowPhaseView(
+  snapshot: WorkflowRunSnapshot,
   stage: WorkflowRunSnapshot['stages'][number],
 ): unknown {
+  const state = deriveWorkflowStageState(snapshot, stage);
   return {
     id: compactWorkflowText(stage.id),
     title: compactWorkflowText(stage.title),
     order: stage.order,
-    lifecycle: stage.lifecycle,
+    // Live while the run is still inside the phase or its calls are still
+    // running; the triad once every call it owns has settled.
+    outcome: state.outcome,
     startedAt: stage.startedAt,
-    completedAt: stage.completedAt,
+    completedAt: state.completedAt,
   };
 }
 
@@ -93,7 +99,8 @@ export function workflowRunView(snapshot: WorkflowRunSnapshot): unknown {
     stage: WorkflowRunSnapshot['stages'][number],
   ): number => {
     if (stage.id === snapshot.currentStageId) return 0;
-    if (stage.lifecycle === 'failed' || stage.lifecycle === 'cancelled') {
+    const { outcome } = deriveWorkflowStageState(snapshot, stage);
+    if (outcome === RUN_OUTCOME.FAILED || outcome === RUN_OUTCOME.CANCELLED) {
       return 1;
     }
     return 2;
@@ -104,7 +111,7 @@ export function workflowRunView(snapshot: WorkflowRunSnapshot): unknown {
         phasePriority(left) - phasePriority(right) || right.order - left.order,
     )
     .slice(0, WORKFLOW_SUMMARY_MAX_ENTRIES)
-    .map(workflowPhaseView);
+    .map((stage) => workflowPhaseView(snapshot, stage));
   const calls = byPriority
     .slice(0, WORKFLOW_SUMMARY_MAX_ENTRIES)
     .map((call) => {
@@ -142,7 +149,7 @@ export function workflowRunView(snapshot: WorkflowRunSnapshot): unknown {
   );
   return {
     aggregate: {
-      lifecycle: snapshot.lifecycle,
+      outcome: snapshot.outcome,
       error: compactWorkflowText(snapshot.error),
       counts: deriveWorkflowCounts(snapshot.calls),
       timestamps: snapshot.timestamps,
@@ -153,7 +160,9 @@ export function workflowRunView(snapshot: WorkflowRunSnapshot): unknown {
         maxFilesPerKind: WORKFLOW_SUMMARY_MAX_FILES_PER_KIND,
       },
     },
-    currentPhase: currentPhase ? workflowPhaseView(currentPhase) : null,
+    currentPhase: currentPhase
+      ? workflowPhaseView(snapshot, currentPhase)
+      : null,
     phases,
     calls,
     ...(snapshot.stages.length > phases.length && {

--- a/src/tools/executions/workflowSummaryView.ts
+++ b/src/tools/executions/workflowSummaryView.ts
@@ -37,8 +37,10 @@ function workflowPhaseView(
     id: compactWorkflowText(stage.id),
     title: compactWorkflowText(stage.title),
     order: stage.order,
-    // Live while the run is still inside the phase or its calls are still
-    // running; the triad once every call it owns has settled.
+    // The triad once every call the phase owns has settled. Absent while the
+    // run is still inside the phase or its calls are still running, and
+    // absent alongside `startedAt` for a phase the run never reached, which
+    // therefore reads as the not-started phase it is rather than as done.
     outcome: state.outcome,
     startedAt: stage.startedAt,
     completedAt: state.completedAt,


### PR DESCRIPTION
## Summary

Retires the second workflow status vocabulary now that the engine runs on Effect and the ledger (#12329, #12337).

- **`WORKFLOW_RUN_LIFECYCLE` is gone** (6 states, with its schema, type, terminal set, `snapshot.lifecycle` and `stage.lifecycle`). The run carries a `RunOutcome` once finished. Stage state (`current`, `started`, `outcome`, `completedAt`) is derived by one function, `deriveWorkflowStageState`, from the stage's calls, the script's own `phase()` cursor and the run's outcome; the progress fold, the trace close and the summary view are its readers. `WorkflowRunState` loses `settleStage`, `refreshExitedStage` and the stage sweeps in `finish` and `enterStage`.
- **`WORKFLOW_CALL_STATUS` loses `planned`** (a call is created `queued`); `deriveWorkflowCounts` loses the duplicate `waiting` key. Renderer tables in the CLI panes, the extension board and the shared copy are edited in the same commit; they are `satisfies Record<status, ...>`, so a missed member fails typecheck.
- **`WorkflowControlAction` is one Zod enum**; the type and the `workflow.control` request arm derive from it.
- **Live bug fixed:** the headless progress line indexed the call-status label table with a run status (type-checked only because four key names coincide); it now reads the fold's own run status label.

Three readings change, all toward the calls: a stage the run has left while one of its calls still runs reads live (the stored lifecycle said completed); a stage the script threw inside with no failed call of its own no longer reads failed (the run's outcome carries the throw, and the trace close uses the same derived state as the summary); a stage the run never reached derives no outcome at all (previously `skipped`), while an entered stage whose calls were all swept takes the run's own outcome.

## Issue acceptance gates

No tracking issue; this is PR-B of the workflowScript manifest recorded in the session ledger (engine onto Effect landed as #12337). Gate: one status vocabulary for workflow runs, derived stage state with one owner, no persisted lifecycle field. All met. Not done: a manual pass over the CLI workflow popup and the webview board with a live two-phase script.

## Single source of truth

`deriveWorkflowStageState` in `src/shared/schemas/workflowRunSnapshot.ts` owns stage state; `RunOutcome` owns the run's end; `WorkflowControlActionSchema` owns the control vocabulary; `RUN_STATUS_LABELS` (via the fold's `statusLabel`) owns the run status word the headless renderer prints.

## Duplication and abstraction budget

Removed: a second run lifecycle vocabulary parallel to `RUN_PHASE`/`RUN_OUTCOME`, the stored stage lifecycle beside the calls that determine it, a duplicate `waiting` count key, a second spelling of `WorkflowControlAction`, and the trace's own terminal-close rule beside the summary's. Added: one derivation function (three readers). No pass-through layers.

## Net elements (R6)

24 files, +316/-382 (net -66 LoC, measured against the merge-base). Exports +4/-2: added `deriveWorkflowStageState`, `WorkflowStageState`, `WorkflowControlActionSchema` (and the derived `WorkflowControlAction` type re-declared from it); deleted `WORKFLOW_RUN_LIFECYCLE` and the hand-written `WorkflowControlAction` type. Module-private: deleted `WorkflowRunLifecycle`, `WorkflowRunLifecycleSchema`, `TERMINAL_LIFECYCLES`, `QUEUED_STATUSES`; added `ROUND_PLANNED_LABEL`. One enum member deleted (`planned`).

## Consumer counts (R8)

n/a: no emit path or subscribe surface is re-routed. `WORKFLOW_RUN_LIFECYCLE` had 4 importing files, all edited here.

## Host impact

Extension: `WorkflowRunBoard` and its styles lose the `planned` arm; the board reads the same derived stage state through the progress fold.

Desktop: reads the same webview board; no desktop-specific change.

CLI: `transcriptEntryLayout`, `WorkflowRunDetails` and `runProgressRenderer` lose the `planned` arm; the headless progress line prints the fold's run status word (`Completed:`/`Error:`/`Stopped:` instead of `Finished:`/`Failed:`).

## Scheduled refactoring

None. Persisted `run.workflow` rows and `workflowTask` transcript entries carrying the old fields are invalid under 1.0; there is no reader for them.

## Validation

Typecheck (all projects), lint, test:pure, test:changed, the full suite (5,589 tests on a quiet machine), the dead-code ratchet, the effect-migration ratchet, and `compile:fast`. Not run: the manual CLI/webview pass with a live script (noted above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)