### PR TITLE
fix(extension): paint the status bar on the first view emission

### DIFF
--- a/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
+++ b/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
@@ -31,8 +31,12 @@ export function subscribeStatusBarSessionEvents({
   onStatusChanged,
   onUsageChanged,
 }: StatusBarSessionEventOptions): () => void {
-  let activeRuns = tracker.activeRunCount;
-  let usage = tracker.totalUsage;
+  // Unseeded on purpose: `viewChanges` replays the current view on subscribe,
+  // and that first emission must paint both projections (a run already
+  // RUNNING when the bar subscribes would otherwise read Idle until the count
+  // next changes).
+  let activeRuns: number | undefined;
+  let usage: StatusBarUsageTracker['totalUsage'] | undefined;
   const fiber = effectRuntime().runFork(
     Stream.runForEach(session.viewChanges, () =>
       Effect.sync(() => {
@@ -43,6 +47,7 @@ export function subscribeStatusBarSessionEvents({
         }
         const nextUsage = tracker.totalUsage;
         if (
+          usage === undefined ||
           nextUsage.cost !== usage.cost ||
           nextUsage.inputTokens !== usage.inputTokens ||
           nextUsage.outputTokens !== usage.outputTokens


### PR DESCRIPTION
Follow-up to the last texra-review thread on #12344. `SessionHandle.viewChanges` replays the current view on subscribe, and the status bar seeded its change sentinels from that same view, so the first emission compared equal and neither callback fired: a run already running when the bar subscribed read Idle until the active count next changed. The sentinels now start unset, so the replayed first emission paints both the status text and the usage tooltip.

One file, +9/-2. Typecheck, test:changed, lint and prettier green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)