### PR TITLE
refactor(run): declare the fresh RunState and the not-resumable message once

### DIFF
--- a/src/agent/runtime/loop/reflection.ts
+++ b/src/agent/runtime/loop/reflection.ts
@@ -78,6 +78,7 @@ import { deriveRunOutcome } from '@shared/runs/runStatus';
 import {
   AgentCategory,
   AgentRunStateSnapshotSchema,
+  EMPTY_RUN_USAGE_TOTALS,
   fileLocationDisplayPath,
   MESSAGE_TYPES,
   OUTPUT_END_TAG,
@@ -94,7 +95,7 @@ import {
   type RunUsageTotals,
 } from '@shared/schemas';
 import { RunLedger, RunLedgerRefused } from '@shared/session/runLedger';
-import type { RunState } from '@shared/session/runStateFold';
+import { freshRunState, type RunState } from '@shared/session/runStateFold';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
@@ -109,6 +110,7 @@ import { ModelInvoker, turnText } from '../ModelInvoker';
 import {
   appendRow,
   haltedStepRow,
+  NOT_RESUMABLE_MESSAGE,
   reflectionFlowState,
   reflectionSnapshotRow,
   runtimeSnapshotRow,
@@ -124,8 +126,6 @@ const K_SLICE = 200;
 const CONTINUE_LIMIT = 10;
 const INPUT_TOKEN_LIMIT = 1500000;
 const OUTPUT_TOKEN_LIMIT_FACTOR = 2.5;
-const NOT_RESUMABLE_MESSAGE =
-  'This run was recorded before the run ledger and is not resumable under this release, and a request it left pending (an approval, a retry, a question) is not resumable either. Start a new run instead.';
 
 export interface ReflectionStart {
   /** The caller launched this as a resume; the ledger decides what it is. */
@@ -329,29 +329,10 @@ export const runReflection = Effect.fn('reflection.run')(function* (
   };
 
   const fresh = (bound: BoundModel): RunState => ({
-    commit: 0,
-    snapshotCommit: null,
-    rowsBeforeSnapshot: 0,
+    ...freshRunState(0),
     family: 'reflection',
-    step: null,
-    outcome: null,
-    phase: null,
-    round: 0,
-    turn: 0,
-    continuationIndex: 0,
     modelId: bound.modelId,
     modelCompatibilityKey: bound.compatibilityKey,
-    lastError: null,
-    pendingRetry: null,
-    messages: [],
-    continuation: null,
-    openAttempt: null,
-    lastTurn: null,
-    pendingResponse: null,
-    pendingIntents: {},
-    requests: {},
-    usage: AgentRunStateSnapshotSchema.parse({}).usageAccumulator.totals,
-    flow: null,
   });
 
   // -------------------------------------------------------------- opening
@@ -1268,9 +1249,7 @@ export const runReflection = Effect.fn('reflection.run')(function* (
   ): ReflectionResult => ({
     outcome,
     roundOutputs: roundsToPersisted(outputState),
-    usage:
-      at?.usage ??
-      AgentRunStateSnapshotSchema.parse({}).usageAccumulator.totals,
+    usage: at?.usage ?? EMPTY_RUN_USAGE_TOTALS,
     ...(lastError !== undefined && outcome === RUN_OUTCOME.FAILED
       ? { error: lastError }
       : {}),

--- a/src/agent/runtime/loop/rows.ts
+++ b/src/agent/runtime/loop/rows.ts
@@ -23,6 +23,11 @@ import type { z } from 'zod';
 
 export type Message = z.infer<typeof MessageSchema>;
 
+/** Why a run the ledger holds no rows for cannot be continued. Both run
+ *  programs refuse a resume with it. */
+export const NOT_RESUMABLE_MESSAGE =
+  'This run was recorded before the run ledger and is not resumable under this release, and a request it left pending (an approval, a retry, a question) is not resumable either. Start a new run instead.';
+
 type ToolUseSnapshot = Extract<FlowSnapshotPayload, { family: 'toolUse' }>;
 type ReflectionSnapshot = Extract<
   FlowSnapshotPayload,

--- a/src/agent/runtime/loop/toolUse.ts
+++ b/src/agent/runtime/loop/toolUse.ts
@@ -36,6 +36,7 @@ import type { ProcessServices } from '@platform/processRuntime';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
 import {
   AgentRunStateSnapshotSchema,
+  EMPTY_RUN_USAGE_TOTALS,
   RUN_OUTCOME,
   RUN_PHASE,
   type JsonValue,
@@ -45,7 +46,7 @@ import {
   type RunUsageTotals,
 } from '@shared/schemas';
 import { RunLedger, RunLedgerRefused } from '@shared/session/runLedger';
-import type { RunState } from '@shared/session/runStateFold';
+import { freshRunState, type RunState } from '@shared/session/runStateFold';
 import { GoalStore, setGoalSessionAutoApproval } from '@tools/goal';
 import { ensureError } from '@utils/errors/errorMessage';
 
@@ -55,10 +56,11 @@ import { bindModel, type BoundModel } from '../run/modelBinding';
 import { mediaInputParts, type InputPart } from '../run/mediaInput';
 import { toolDefinitionsFor } from '../run/tools';
 import { FollowUps, type ConsumedFollowUps } from '../FollowUps';
-import { ModelInvoker, turnText } from '../ModelInvoker';
+import { ModelInvoker } from '../ModelInvoker';
 import {
   appendRow,
   haltedStepRow,
+  NOT_RESUMABLE_MESSAGE,
   rowAggregate,
   snapshotRow,
   stepRow,
@@ -77,8 +79,6 @@ const MODEL_SWITCH_DIFFERENT_FORMAT_REASON =
 const BLANK_TOOL_RESULT_CONTINUATION =
   'The previous assistant turn after a tool result was blank. Continue now with the final answer or next required action.';
 const FINAL_TOOL_INSTRUCTION = 'Submit the final structured output now.';
-const NOT_RESUMABLE_MESSAGE =
-  'This run was recorded before the run ledger and is not resumable under this release, and a request it left pending (an approval, a retry, a question) is not resumable either. Start a new run instead.';
 
 /** The live control surface a host reaches through the run handle. */
 export interface ToolUseFlowContext {
@@ -393,29 +393,10 @@ export const runToolUse = Effect.fn('toolUse.run')(function* (
 
   /** The state a fresh run's opening snapshot is authored against. */
   const fresh = (bound: BoundModel): RunState => ({
-    commit: 0,
-    snapshotCommit: null,
-    rowsBeforeSnapshot: 0,
+    ...freshRunState(0),
     family: 'toolUse',
-    step: null,
-    outcome: null,
-    phase: null,
-    round: 0,
-    turn: 0,
-    continuationIndex: 0,
     modelId: bound.modelId,
     modelCompatibilityKey: bound.compatibilityKey,
-    lastError: null,
-    pendingRetry: null,
-    messages: [],
-    continuation: null,
-    openAttempt: null,
-    lastTurn: null,
-    pendingResponse: null,
-    pendingIntents: {},
-    requests: {},
-    usage: AgentRunStateSnapshotSchema.parse({}).usageAccumulator.totals,
-    flow: null,
   });
 
   const restore = (state: RunState): void => {
@@ -882,9 +863,7 @@ export const runToolUse = Effect.fn('toolUse.run')(function* (
     outcome,
     response,
     files: workspace.interactions.toSnapshot().edits.map((e) => e.path),
-    usage:
-      at?.usage ??
-      AgentRunStateSnapshotSchema.parse({}).usageAccumulator.totals,
+    usage: at?.usage ?? EMPTY_RUN_USAGE_TOTALS,
     structured: run.structured.value,
     ...(lastError !== undefined && outcome === RUN_OUTCOME.FAILED
       ? { error: lastError }

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -121,3 +121,8 @@ export const RunUsageTotalsSchema = z.object({
 });
 
 export type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
+
+/** A run's usage before its first turn: every counter at its zero. */
+export const EMPTY_RUN_USAGE_TOTALS: RunUsageTotals = Object.freeze(
+  RunUsageTotalsSchema.parse({}),
+);

--- a/src/shared/session/runStateFold.ts
+++ b/src/shared/session/runStateFold.ts
@@ -26,6 +26,7 @@ import {
   type TurnResult,
 } from '@llm/turn';
 import {
+  EMPTY_RUN_USAGE_TOTALS,
   FlowSnapshotPayloadSchema,
   RunUsageTotalsSchema,
   requestParksItsCaller,
@@ -272,7 +273,9 @@ function byId<T>(entries: Iterable<readonly [string, T]>): Record<string, T> {
   return record;
 }
 
-const fresh = (commit: CommitOrdinal): RunState => ({
+/** The state a run starts from: every field at its zero, no family bound
+ *  yet. Both run programs open from this and stamp their own family. */
+export const freshRunState = (commit: CommitOrdinal): RunState => ({
   commit,
   snapshotCommit: null,
   rowsBeforeSnapshot: 0,
@@ -294,7 +297,7 @@ const fresh = (commit: CommitOrdinal): RunState => ({
   pendingResponse: null,
   pendingIntents: byId([]),
   requests: byId([]),
-  usage: RunUsageTotalsSchema.parse({}),
+  usage: EMPTY_RUN_USAGE_TOTALS,
   flow: null,
 });
 
@@ -497,7 +500,7 @@ function foldRow(current: RunState | null, row: SessionEvent): Fold | null {
   switch (row.type) {
     case 'flow.step': {
       const p = row.payload;
-      const state = current ?? fresh(commit);
+      const state = current ?? freshRunState(commit);
       if (state.family !== null && state.family !== p.family) {
         return refuse('out-of-order', 'a step of another family', commit);
       }
@@ -529,7 +532,7 @@ function foldRow(current: RunState | null, row: SessionEvent): Fold | null {
     }
     case 'flow.snapshot': {
       const p = row.payload;
-      const state = current ?? fresh(commit);
+      const state = current ?? freshRunState(commit);
       if (state.family !== null && state.family !== p.family) {
         return refuse('stale-snapshot', 'a snapshot of another family', commit);
       }
@@ -644,7 +647,7 @@ function foldRow(current: RunState | null, row: SessionEvent): Fold | null {
     case 'model.message': {
       const p = row.payload;
       if (p.kind === 'append' && p.sourceResponse === null) {
-        const state = current ?? fresh(commit);
+        const state = current ?? freshRunState(commit);
         return Result.succeed({
           ...state,
           commit,


### PR DESCRIPTION
## Summary

The fresh `RunState` literal was declared three times (privately in the fold and in each loop's `fresh()`), `NOT_RESUMABLE_MESSAGE` twice, and the empty usage totals were re-derived by parsing an empty object at four sites. One declaration each: `freshRunState` exported from the fold, the message in `loop/rows.ts`, and a frozen `EMPTY_RUN_USAGE_TOTALS` in the usage schema. Each loop's `fresh()` is now the shared state plus its three family overrides. The dead `turnText` import in the tool-use loop is dropped.

## Issue acceptance gates

Cheap slice of the two-loop skeleton measurement recorded in the session ledger (the full fold measured at -48 and was not worth a lane). Gate: one owner per shared literal, halt/finalize/interrupt/pricing untouched. Met.

## Single source of truth

`freshRunState` in `src/shared/session/runStateFold.ts`; `NOT_RESUMABLE_MESSAGE` in `src/agent/runtime/loop/rows.ts`; `EMPTY_RUN_USAGE_TOTALS` in `src/shared/schemas/usage.ts`.

## Duplication and abstraction budget

Removed two copies of a 24-field literal, one duplicate constant, and four runtime Zod parses of `{}`. No new abstraction; one private function became an export with two new callers.

## Net elements (R6)

5 files, +29/-58 (net -29). Exports +2 (`freshRunState`, `EMPTY_RUN_USAGE_TOTALS`) with three and five consumers; constants deleted 1, literals deleted 2.

## Consumer counts (R8)

n/a: no emit path or subscribe surface changes.

## Host impact

Extension: none. Desktop: none. CLI: none. Behaviour-preserving; the only observable difference is that a fresh loop state's `pendingIntents`/`requests` are null-prototype records as in the fold, read only through `Object.entries`.

## Scheduled refactoring

None.

## Validation

Typecheck, test:pure, the agent runtime / follow-up / session suites (426 tests) plus the whole `src/test-kernel/agent` tree (960 tests), the dead-code ratchet, the effect-migration ratchet, eslint and prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)