### PR TITLE
simplify(cli): drop the chatDefaults history tier (1.0 clean slate)

### DIFF
--- a/config/ratchets/host-agent-mock-baseline.json
+++ b/config/ratchets/host-agent-mock-baseline.json
@@ -2,11 +2,6 @@
   "semantics": "Distinct (file, form, specifier) mock() and doMock() call sites (on vi or on a createModuleMocks() recorder) in host-side (CLI + desktop) test-kernel suites and the shared support modules they import (src/test-kernel/cli/**, src/test-kernel/desktop/**, src/test-kernel/support/**) that mock an internal @agent/* module specifier. Each site pins @agent's current internal module layout from outside src/agent, per issue #7684 QA-2 / #9731. The ratchet fails on any live tuple absent from this baseline (new edge) and on any baseline tuple with no live site (stale headroom); regenerating to remove stale entries is welcome and should shrink this file.",
   "sites": [
     {
-      "file": "src/test-kernel/cli/ChatDefaults.vitest.ts",
-      "form": "mock",
-      "specifier": "@agent/storage"
-    },
-    {
       "file": "src/test-kernel/cli/chatSessionController.vitest.ts",
       "form": "mock",
       "specifier": "@agent/runtime/executeAgent"

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -198,18 +198,15 @@ export async function runChat(
   await effectRuntime().runPromise(loadAgents());
   const visibleToolUseAgents = getVisibleAgents(AgentCategory.ToolUse);
   const defaults = await effectRuntime().runPromise(
-    resolveChatDefaults(
-      {
-        cwd: context.cwd,
-        agentOverride: explicitAgent ?? setupAgentOverride,
-        modelOverride: initialResume?.config.model ?? init.modelOverride,
-        envAgent: context.envAgent,
-        envModel: context.envModel,
-        visibleToolUseAgents,
-        quiet: context.quietLogs,
-      },
-      runtimeSession,
-    ),
+    resolveChatDefaults({
+      cwd: context.cwd,
+      agentOverride: explicitAgent ?? setupAgentOverride,
+      modelOverride: initialResume?.config.model ?? init.modelOverride,
+      envAgent: context.envAgent,
+      envModel: context.envModel,
+      visibleToolUseAgents,
+      quiet: context.quietLogs,
+    }),
   );
   const agentUsageError = chatToolUseAgentUsageError(defaults.agent);
   if (agentUsageError) {

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -1,6 +1,5 @@
 import { Effect } from 'effect';
 import { defineCommand } from 'citty';
-import type { SessionHandle } from '@agent/runtime';
 
 import { getVisibleAgents, refresh } from '@agent/index';
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -16,7 +15,6 @@ import { AgentCategory, byCategory } from '@shared/schemas';
 import { RESEARCHER_ACCESS_AUTH } from '@shared/copy/accountAuth';
 import { getFirstRunDone } from '@shared/state/onboardingState';
 import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
-import { initializeCliTranscriptSession } from '../runtime/transcriptSession';
 
 import {
   firstRunSetupAgentOverride,
@@ -87,20 +85,16 @@ const log = createLog('orchestrate');
 const canLaunchWithDefaultModel = Effect.fn(function* (
   context: CliContext,
   models: readonly CliModelAccess[],
-  session: SessionHandle,
   stores: ModelOptionStores,
 ): Effect.fn.Return<boolean, Error> {
   if (models.length === 0) return true;
 
-  const defaults = yield* resolveChatDefaults(
-    {
-      cwd: context.cwd,
-      envAgent: context.envAgent,
-      envModel: context.envModel,
-      quiet: context.quietLogs,
-    },
-    session,
-  );
+  const defaults = yield* resolveChatDefaults({
+    cwd: context.cwd,
+    envAgent: context.envAgent,
+    envModel: context.envModel,
+    quiet: context.quietLogs,
+  });
   return yield* Effect.tryPromise({
     try: () =>
       selectCliRunnableModel(defaults.model, {
@@ -149,9 +143,6 @@ async function runOrchestration(context: CliContext): Promise<number> {
     ...context,
     quietLogs: true,
   });
-  // Every model-availability read below goes through the stores this entry
-  // point already wired, rather than looking a host up again.
-  const session = await initializeCliTranscriptSession(services);
   // First-run gate: a credential-less interactive user picks sign-in or a key
   // here instead of landing on a launcher full of "login required" models. On
   // success the models read below re-reads the freshly-set credentials
@@ -232,7 +223,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       loadCliApiStatus(services.secrets, authProfile),
     ]);
     const allowDefaultModelLaunch = await effectRuntime().runPromise(
-      canLaunchWithDefaultModel(context, models, session, services),
+      canLaunchWithDefaultModel(context, models, services),
     );
     const { runOrchestrationTui } =
       await import('../orchestration/runOrchestrationTui');

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -153,10 +153,10 @@ interface ResolveChatDefaultsInit {
 }
 
 /**
- * Three-tier lookup per `.agents/docs/archived/feature/2026-05-14-cli-tui-ink/2026-05-14-10-architecture.md#entrypoint-default`:
- * workspace `.texra/config.json` → user `<global-storage>/config.json` →
- * built-in. Per-field independence: a workspace that only sets `agent` still
- * falls through to the user config for `model`.
+ * Three-tier lookup: workspace `.texra/config.json` → user
+ * `<global-storage>/config.json` → built-in. Per-field independence: a
+ * workspace that only sets `agent` still falls through to the user config for
+ * `model`.
  */
 export const resolveChatDefaults = Effect.fn(function* (
   init: ResolveChatDefaultsInit,

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -1,19 +1,12 @@
 import { Effect } from 'effect';
-import type { SessionHandle } from '@agent/runtime';
-import {
-  isUserVisibleRun,
-  listRuns,
-  type RunListingEntry,
-} from '@agent/storage';
 import { isFileNotFoundError } from '@common/errors';
 import {
   decideRunModel,
   type RunModelDecisionReason,
 } from '@model/runModelDecision';
 import { TEXRA_CONFIG_FILE_NAME } from '@platform/defaults/nodeStorage';
-import { AgentCategory } from '@shared/schemas';
 import { isImplicitDefaultEligible } from '@shared/constants/agents';
-import { isObject, toNewestFirstByTimestamp } from '@utils/core';
+import { isObject } from '@utils/core';
 import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 import {
@@ -22,7 +15,6 @@ import {
   loadWorkspaceCliConfig,
   parseCliConfigValues,
   resolveConfiguredAgent,
-  resolveKnownCliModelId,
   type CliConfigValues,
 } from './cliConfig';
 import { pickDefaultToolUseAgent } from './defaultAgents';
@@ -52,7 +44,6 @@ type ChatDefaultValueSource = Extract<
   | 'environment'
   | 'workspace-config'
   | 'user-config'
-  | 'history'
   | 'builtin-default'
 >;
 
@@ -147,28 +138,6 @@ const loadUserDefaults = Effect.fn(function* (
   return defaultsFromConfigValues(values);
 });
 
-const loadHistoryDefaults = Effect.fn(function* (
-  session: SessionHandle,
-): Effect.fn.Return<PartialDefaults> {
-  // An unreadable history listing means no history defaults.
-  const entries: RunListingEntry[] = yield* listRuns(session).pipe(
-    Effect.catch(() => Effect.succeed([])),
-  );
-  const candidates = toNewestFirstByTimestamp(
-    entries.filter(isUserVisibleRun).filter(
-      (entry) =>
-        entry.record.agentCategory === AgentCategory.ToolUse &&
-        // A multi-agent team run's root is an orchestrator agent, not a
-        // sensible default for a plain single-agent chat session.
-        !entry.record.cli?.multiAgentPresetId,
-    ),
-    (item) => item.timestamp,
-  );
-  const mostRecent = candidates[0];
-  if (!mostRecent) return {};
-  return { model: resolveKnownCliModelId(mostRecent.record.model) };
-});
-
 interface ResolveChatDefaultsInit {
   readonly cwd: string;
   readonly agentOverride?: string;
@@ -184,15 +153,13 @@ interface ResolveChatDefaultsInit {
 }
 
 /**
- * Four-tier lookup per `.agents/docs/archived/feature/2026-05-14-cli-tui-ink/2026-05-14-10-architecture.md#entrypoint-default`:
+ * Three-tier lookup per `.agents/docs/archived/feature/2026-05-14-cli-tui-ink/2026-05-14-10-architecture.md#entrypoint-default`:
  * workspace `.texra/config.json` → user `<global-storage>/config.json` →
- * last single-agent toolUse run's model → built-in. Per-field
- * independence: a workspace that only sets `agent` still falls through to
- * user/history for `model`, but history never changes the single-chat agent.
+ * built-in. Per-field independence: a workspace that only sets `agent` still
+ * falls through to the user config for `model`.
  */
 export const resolveChatDefaults = Effect.fn(function* (
   init: ResolveChatDefaultsInit,
-  session: SessionHandle,
 ): Effect.fn.Return<ChatDefaults, Error> {
   const overrideAgent = init.agentOverride?.trim();
   const overrideModel = init.modelOverride?.trim();
@@ -204,24 +171,21 @@ export const resolveChatDefaults = Effect.fn(function* (
 
   let workspace: PartialDefaults = {};
   let user: PartialDefaults = {};
-  let history: PartialDefaults = {};
 
   if (!skipDefaultTierIo) {
     // Tiers are independent I/O — fan out in parallel.
     // Workspace defaults use the same .texra/config.json reader as the CLI
     // context so startup does not depend on platform initialization.
-    [workspace, user, history] = yield* Effect.all(
+    [workspace, user] = yield* Effect.all(
       [
         loadWorkspaceCliConfig(init.cwd).pipe(
           Effect.map((loaded) => defaultsFromConfigValues(loaded.values)),
         ),
         loadUserDefaults(init.quiet ?? false),
-        loadHistoryDefaults(session),
       ],
       { concurrency: 'unbounded' },
     );
-    // History never changes the chat agent, so only the two config tiers can
-    // supply one; the order below is the per-field fallthrough.
+    // The order below is the per-field fallthrough.
     for (const defaults of [workspace, user]) {
       if (!agent && defaults.agent) agent = defaults.agent;
     }
@@ -232,7 +196,6 @@ export const resolveChatDefaults = Effect.fn(function* (
     { model: envModel, reason: 'environment' },
     { model: workspace.model, reason: 'workspace-config' },
     { model: user.model, reason: 'user-config' },
-    { model: history.model, reason: 'history' },
     { model: CLI_BUILTIN_DEFAULT_MODEL, reason: 'builtin-default' },
   ]);
 

--- a/src/test-kernel/cli/ChatDefaults.vitest.ts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.ts
@@ -238,7 +238,7 @@ describe('CLI chat defaults', () => {
     expect(mockedLoadWorkspaceCliConfig).toHaveBeenCalledOnce();
   });
 
-  it('skips user I/O when environment resolves agent and model', async () => {
+  it('skips workspace and user I/O when environment resolves agent and model', async () => {
     await expectChatDefaults(
       { cwd: NO_WORKSPACE, envAgent: 'assistant', envModel: 'sonnet46T' },
       {
@@ -247,6 +247,7 @@ describe('CLI chat defaults', () => {
         modelSource: 'environment',
       },
     );
+    expect(mockedLoadWorkspaceCliConfig).not.toHaveBeenCalled();
     expect(mockedReadJson).not.toHaveBeenCalled();
   });
 

--- a/src/test-kernel/cli/ChatDefaults.vitest.ts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.ts
@@ -5,9 +5,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { Effect } from 'effect';
-import type { SessionHandle } from '@agent/runtime';
-import type { RunListingEntry } from '@agent/storage';
-import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
   __resetUserConfigWarningDedupeForTests,
   resolveChatDefaults as nativeResolveChatDefaults,
@@ -17,10 +14,7 @@ import {
   loadWorkspaceCliConfig,
 } from '@cli/runtime/cliConfig';
 import * as logSinks from '@cli/runtime/logSinks';
-import type { RunId } from '@shared/schemas';
-import { AgentCategory } from '@shared/schemas';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
-import { ensureError } from '@utils/errors/errorMessage';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
 /** A cwd with no `.texra` directory, so the workspace tier finds nothing. */
@@ -46,21 +40,9 @@ function enoentError(): NodeJS.ErrnoException {
   return error;
 }
 
-const mocks = vi.hoisted(() => ({
-  listRuns: vi.fn(async (): Promise<RunListingEntry[]> => []),
-}));
 const resolveChatDefaults = (
   options: Parameters<typeof nativeResolveChatDefaults>[0],
-) => Effect.runPromise(nativeResolveChatDefaults(options, {} as SessionHandle));
-
-vi.mock('@agent/storage', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@agent/storage')>()),
-  listRuns: () =>
-    Effect.tryPromise({
-      try: () => mocks.listRuns(),
-      catch: ensureError,
-    }),
-}));
+) => Effect.runPromise(nativeResolveChatDefaults(options));
 
 // Spied, not stubbed: the workspace tiers below still read real `.texra`
 // config files, while the fast-path tests assert the loader is never reached.
@@ -73,28 +55,7 @@ vi.mock('@cli/runtime/cliConfig', async (importOriginal) => {
   };
 });
 
-const mockedListRuns = mocks.listRuns;
 const mockedLoadWorkspaceCliConfig = vi.mocked(loadWorkspaceCliConfig);
-
-function historyEntry(
-  agent: string,
-  overrides: Record<string, unknown> = {},
-  timestamp = '2026-05-21T08:00:00.000Z',
-) {
-  return {
-    kind: 'run',
-    id: 'abc123' as RunId,
-    timestamp,
-    identity: { kind: 'agent', agent },
-    checkpointPresent: false,
-    record: AgentConfigSchema.parse({
-      agent,
-      model: 'sonnet46T',
-      agentCategory: AgentCategory.ToolUse,
-      ...overrides,
-    }),
-  } satisfies RunListingEntry;
-}
 
 vi.mock('@utils/files/storageFS', () => ({
   GlobalStorageFS: {
@@ -108,8 +69,6 @@ const mockedReadJson = vi.mocked(GlobalStorageFS.readJson);
 
 beforeEach(() => {
   mockedLoadWorkspaceCliConfig.mockClear();
-  mockedListRuns.mockReset();
-  mockedListRuns.mockResolvedValue([]);
   mockedReadJson.mockReset();
   // A missing user config (the common case) mirrors a real ENOENT rejection.
   mockedReadJson.mockRejectedValue(enoentError());
@@ -192,100 +151,6 @@ describe('CLI chat defaults', () => {
     );
   });
 
-  it('inherits only the model from recent single-agent tool-use history', async () => {
-    mockedListRuns.mockResolvedValueOnce([historyEntry('research')]);
-
-    await expectChatDefaults(
-      { cwd: NO_WORKSPACE },
-      {
-        // History contributes the model only; the agent stays on the built-in
-        // default rather than the history row's agent.
-        agent: 'assistant',
-        model: 'sonnet46T',
-        modelSource: 'history',
-      },
-    );
-  });
-
-  it('ignores a history model that the CLI cannot run', async () => {
-    mockedListRuns.mockResolvedValueOnce([
-      historyEntry('research', { model: 'Copilot GPT-4o' }),
-    ]);
-
-    await expectChatDefaults(
-      { cwd: NO_WORKSPACE },
-      {
-        agent: 'assistant',
-        model: 'deepseekproT',
-        modelSource: 'builtin-default',
-      },
-    );
-  });
-
-  it('does not inherit the model from a multi-agent team run', async () => {
-    // A `texra multi-agent run physicist` is stored as a tool-use run
-    // whose root is the team orchestrator. It must not affect plain
-    // `texra chat` defaults — fall back to the built-ins instead.
-    mockedListRuns.mockResolvedValueOnce([
-      historyEntry('leanOrchestrator', {
-        cli: { multiAgentPresetId: 'lean-project' },
-      }),
-    ]);
-
-    await expectChatDefaults(
-      { cwd: NO_WORKSPACE },
-      {
-        agent: 'assistant',
-        model: 'deepseekproT',
-      },
-    );
-  });
-
-  // A stale `bash` row used to win the agent tier and crash on first submit
-  // with "Could not find agent: bash" — see #4397. History is now model-only,
-  // so the single-chat agent stays on the built-in `assistant` default; the
-  // same holds for `simplifier`, which is never a default chat agent.
-  it.each(['bash', 'simplifier'])(
-    'does not inherit %s as the default single-chat agent',
-    async (agent) => {
-      mockedListRuns.mockResolvedValueOnce([
-        historyEntry(agent, {}, '2026-05-21T08:02:00.000Z'),
-        historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),
-      ]);
-
-      await expectChatDefaults(
-        { cwd: NO_WORKSPACE },
-        {
-          agent: 'assistant',
-          model: 'sonnet46T',
-          modelSource: 'history',
-        },
-      );
-    },
-  );
-
-  it('skips a team run to reach an earlier single-agent model', async () => {
-    mockedListRuns.mockResolvedValueOnce([
-      historyEntry(
-        'orchestrator',
-        {
-          cli: { multiAgentPresetId: 'physicist' },
-        },
-        '2026-05-21T08:02:00.000Z',
-      ),
-      historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),
-    ]);
-
-    await expectChatDefaults(
-      { cwd: NO_WORKSPACE },
-      {
-        agent: 'assistant',
-        model: 'sonnet46T',
-        modelSource: 'history',
-      },
-    );
-  });
-
   it('ignores simplifier from configured chat default tiers', async () => {
     const workspace = await workspaceWithConfig({
       'texra.chat': { agent: 'simplifier', model: 'sonnet46T' },
@@ -336,7 +201,7 @@ describe('CLI chat defaults', () => {
     );
   });
 
-  it('skips workspace, user, and history I/O when explicit overrides resolve agent and model', async () => {
+  it('skips workspace and user I/O when explicit overrides resolve agent and model', async () => {
     const workspace = await workspaceWithConfig({
       'texra.chat': { agent: 'assistant', model: 'sonnet46T' },
     });
@@ -355,7 +220,6 @@ describe('CLI chat defaults', () => {
     );
     expect(mockedLoadWorkspaceCliConfig).not.toHaveBeenCalled();
     expect(mockedReadJson).not.toHaveBeenCalled();
-    expect(mockedListRuns).not.toHaveBeenCalled();
   });
 
   it('keeps default-tier loading when only the model is directly resolved', async () => {
@@ -374,7 +238,7 @@ describe('CLI chat defaults', () => {
     expect(mockedLoadWorkspaceCliConfig).toHaveBeenCalledOnce();
   });
 
-  it('skips user and history I/O when environment resolves agent and model', async () => {
+  it('skips user I/O when environment resolves agent and model', async () => {
     await expectChatDefaults(
       { cwd: NO_WORKSPACE, envAgent: 'assistant', envModel: 'sonnet46T' },
       {
@@ -384,21 +248,22 @@ describe('CLI chat defaults', () => {
       },
     );
     expect(mockedReadJson).not.toHaveBeenCalled();
-    expect(mockedListRuns).not.toHaveBeenCalled();
   });
 
-  it('still loads history when only the agent is directly resolved', async () => {
-    mockedListRuns.mockResolvedValueOnce([historyEntry('research')]);
+  it('still loads the model tiers when only the agent is directly resolved', async () => {
+    const workspace = await workspaceWithConfig({
+      'texra.chat': { model: 'sonnet46T' },
+    });
 
     await expectChatDefaults(
-      { cwd: NO_WORKSPACE, agentOverride: 'simplifier' },
+      { cwd: workspace, agentOverride: 'simplifier' },
       {
         agent: 'simplifier',
         model: 'sonnet46T',
-        modelSource: 'history',
+        modelSource: 'workspace-config',
       },
     );
-    expect(mockedListRuns).toHaveBeenCalledOnce();
+    expect(mockedLoadWorkspaceCliConfig).toHaveBeenCalledOnce();
   });
 
   it('uses prefixed command-specific workspace defaults', async () => {


### PR DESCRIPTION
Authorised by the owner ruling **"Drop the chatDefaults history tier" (cli-runtime-4)** in `.git/texra-coord/findings/owner-rulings-2026-09-11b.md` — IMPLEMENT list, second batch, line 53: *"Drop the chatDefaults history tier (cli-runtime-4). Owner: the CLI lane."* It is taken under the AGENTS.md "TeXRA 1.0 direction" premise: no persisted-data compatibility, build the 1.0 design directly, no adapters or shims. No KEEP-list item from that ruling appears in this diff.

## Drop the chatDefaults history tier (cli-runtime-4)

`resolveChatDefaults` resolved the chat model from four tiers: workspace `.texra/config.json` → user `<global-storage>/config.json` → **the last single-agent tool-use run's model** → the built-in default. The third tier listed every stored run on every launch (and on every pass of `orchestrate`'s launcher loop) just to read one model id off the newest row, and it was the only reason the module touched the run store at all.

It is gone. The chat model now falls from config straight to `CLI_BUILTIN_DEFAULT_MODEL` instead of being sticky to the last run. The workspace and user tiers keep their precedence order and their `workspace-config` / `user-config` reason strings unchanged, as does the per-field independence rule (a workspace that only sets `agent` still falls through to the user config for `model`).

Deleted in `packages/cli/src/runtime/chatDefaults.ts`:

- the `'history'` member of the `ChatDefaultValueSource` union;
- `loadHistoryDefaults` — the `listRuns` read, the `Effect.catch(() => [])` over it, the `isUserVisibleRun` / `AgentCategory.ToolUse` / `!cli?.multiAgentPresetId` filtering and the newest-first pick;
- the third `Effect.all` arm and the `history` local;
- the `{ model: history.model, reason: 'history' }` precedence entry.

**The transcript/history-store dependency is dropped too.** With the tier gone nothing in the module needs a `SessionHandle`, so `resolveChatDefaults`' second parameter is deleted along with the `@agent/runtime` and `@agent/storage` imports, and with them the now-unused `AgentCategory`, `toNewestFirstByTimestamp` and `resolveKnownCliModelId` imports. Both call sites follow: `runChatTui.tsx` just drops the argument (it uses `runtimeSession` for a dozen other things), and in `orchestrate.ts` `canLaunchWithDefaultModel` loses its `session` parameter — which leaves that command's eager `const session = await initializeCliTranscriptSession(services)` with no consumer, so it goes as well.

### Two consequences worth stating outright

**1. The "persistent transcripts are required" throw moves to the first real reader — accepted deliberately.** Dropping orchestrate's eager `initializeCliTranscriptSession` does not lose the guard: every downstream branch opens the same session from the same `services`, so session ownership and its indexed cleanup are unchanged — the launcher loop via `listCliHistoryEntries` → `runtime/history.ts:162`, `setupAgentOverride` → `runChat` at `runChatTui.tsx:171`, and resume via `runResumeCommand`. All three are still ahead of anything that needs a transcript. There is exactly one behavioral difference: on `onboarding.declined` (`orchestrate.ts:155`) the command now returns `CliExitCode.Success` without ever checking transcripts, where it previously threw. **That is a conscious accept, not a side effect** — a user who declines onboarding should exit cleanly rather than eat a persistence error about a session they never asked to start.

**2. There is now no in-app writer for the chat *model*.** With the history tier gone, `texra chat` always starts on `CLI_BUILTIN_DEFAULT_MODEL` unless the user hand-edits `.texra/config.json` or `<global-storage>/config.json`. `setWorkspaceCliChatAgent` (`packages/cli/src/runtime/cliConfig.ts:456`) is the only chat-config writer in the CLI and it covers the **agent** only — both `/config` (`commands/config.ts:166,171`) and `AgentRosterForm.tsx:278` call it, and a grep for a model-writing sibling returns nothing. So nothing in the CLI persists a model choice any more. This is the intended shape of the ruling (the sticky-last-run behavior was the thing being removed), but it is the whole of the user-visible change and the owner should see it stated: if a persisted model preference is wanted back, it belongs in the config writer, not in a read of the run store.

Comments and docs describing the old shape are updated: the "Four-tier lookup … last single-agent toolUse run's model → built-in" doc block is now three-tier wording, and the "History never changes the chat agent, so only the two config tiers can supply one" comment above the agent fallthrough loop is rewritten. The doc comment's citation of `.agents/docs/archived/feature/2026-05-14-cli-tui-ink/2026-05-14-10-architecture.md#entrypoint-default` is **removed rather than kept**: that archived section still enumerates four tiers (including "3. Last-used"), so the code would otherwise cite a doc it contradicts. The archived note is a historical record — already stale on other points (it still says `agent: chat`, `model: deepseekT`) — and belongs to the docs slice, so it is left untouched. No published or live doc described the history tier (`docs/guide/texra-cli.md` and `ConfigPrecedenceStack.vue` never mentioned it).

**The `'history'` run-model reason itself stays** in `RunModelDecisionReason` / `RUN_MODEL_PRECEDENCE`. The original finding claimed chatDefaults was its sole producer; that is wrong. `chatSessionController.ts` still produces it via `adoptRunConfig(config, 'history')` when a resumed run's config is adopted (two call sites plus the parameter type), and `cliState.modelSource` carries it. `src/model/runModelDecision.ts` is untouched.

Tests: six history-only cases and the `historyEntry` helper are deleted, along with the `listRuns` hoisted mock and the `vi.mock('@agent/storage')` it needed. Two surviving cases are renamed with their `listRuns` assertions dropped (`skips workspace and user I/O when explicit overrides resolve agent and model`, `skips workspace and user I/O when environment resolves agent and model` — the latter also gains the one `mockedLoadWorkspaceCliConfig` assertion its title had always implied but never checked), and `still loads history when only the agent is directly resolved` is adapted to `still loads the model tiers when only the agent is directly resolved` (workspace-config model under an `agentOverride`) so the `skipDefaultTierIo` half-resolution behavior stays pinned. The `it.each(['bash','simplifier'])` #4397 regression case is deleted on purpose: a stale run row can no longer reach the agent tier at all, so that state is unrepresentable rather than merely untested — and the config-tier analogue of the guard (`usableConfiguredAgent` / `isImplicitDefaultEligible`) is still pinned by the surviving `ignores simplifier from configured chat default tiers` case. Zero new test files.

`config/ratchets/host-agent-mock-baseline.json` shrinks by the one entry that the deleted mock made stale (`src/test-kernel/cli/ChatDefaults.vitest.ts` / `mock` / `@agent/storage`); that ratchet has no `--update` path and its own failure message asks for the stale row to be removed by hand. A shrink, never a widen. `knip-baseline.json`, `effect-migration-baseline.json` and `host-agent-import-baseline.json` need no change.

## Net elements (R6)

**Files changed: 5** (3 production CLI, 1 test suite, 1 ratchet baseline)

| file | + | − |
|---|---|---|
| `config/ratchets/host-agent-mock-baseline.json` | 0 | 5 |
| `packages/cli/src/chat/tui/runChatTui.tsx` | 9 | 12 |
| `packages/cli/src/commands/orchestrate.ts` | 7 | 16 |
| `packages/cli/src/runtime/chatDefaults.ts` | 7 | 44 |
| `src/test-kernel/cli/ChatDefaults.vitest.ts` | 11 | 145 |

**`^[+-]export` symbols: 0 added, 0 removed.** (`git diff origin/main -U0 | grep -E '^[+-]export'` is empty — `loadHistoryDefaults` was module-private, and `resolveChatDefaults` / `__resetUserConfigWarningDedupeForTests` both survive.)

**class / interface / enum declarations: 0 added, 0 removed.** `ChatDefaults`, `PartialDefaults` and `ResolveChatDefaultsInit` are unchanged; the `ChatDefaultValueSource` type alias loses one union member.

**Function/helper declarations removed: 2** — `loadHistoryDefaults` (production, module-private) and `historyEntry` (test helper). **Parameters removed: 3** — `resolveChatDefaults(…, session)`, `canLaunchWithDefaultModel(…, session, …)`, and the `session` local in `runOrchestration`. **Mock sites removed: 2** — `vi.mock('@agent/storage')` and the `mocks.listRuns` recorder. **Test cases removed: 7** (6 history-only + the `it.each` #4397 pair counted once). **Assertions added: 1.**

**Net LOC (`git diff --numstat origin/main`): 5 files changed, 34 insertions(+), 222 deletions(-) → −188.**

## Consumer counts (R8)

No public symbol, CLI command, flag, subcommand or setting is deleted by this PR — the only surface change is one dropped function parameter.

| symbol / surface | before | after | notes |
|---|---|---|---|
| `resolveChatDefaults` (2nd param `session` dropped) | 2 production callers + 2 test suites | same 4, all updated | `packages/cli/src/commands/orchestrate.ts`, `packages/cli/src/chat/tui/runChatTui.tsx`; `src/test-kernel/cli/ChatDefaults.vitest.ts` (direct wrapper), `src/test-kernel/cli/RunChatSignalOwnership.vitest.ts` (spread-args mock, needed no edit) |
| `loadHistoryDefaults` | 1 caller (module-private) | deleted | no export, no re-export shim left |
| `'history'` as a `RunModelDecisionReason` | 4 producers | 3 producers | kept: `chatSessionController.ts:348` (param type), `:704`, `:863` (`adoptRunConfig(config, 'history')`). `src/model/runModelDecision.ts` untouched |
| `initializeCliTranscriptSession` | 11 call sites / 8 files | 10 call sites / 7 files | dropped only orchestrate's eager call; `resumeRun`, `workflow`, `commands/history` (×2), `executeCli`, `runtime/history` (×3), `runChatTui` unchanged |
| `setWorkspaceCliChatAgent` | 2 production callers | 2, unchanged | `commands/config.ts` (×2), `AgentRosterForm.tsx`. Agent-only — see consequence 2 above |
| `listRuns` | 8 files | 8 files | still live |
| `isUserVisibleRun` | 7 files | 7 files | still live |
| `toNewestFirstByTimestamp` | 5 files | 5 files | still live |
| `resolveKnownCliModelId` | 5 files | 5 files | still live (`enabledModels`, `modelAccess` ×2, `runModel`, its definition in `cliConfig`) |
| `__resetUserConfigWarningDedupeForTests` | 1 test consumer | unchanged | still knip-baselined, still needed by the surviving user-config warning tests |

No shared history helper lost its last consumer, so nothing was deleted outside `packages/cli` and no spillover into another partition slice was required.

## Gates

Rebased onto `origin/main` at **479b2a334c** (`fix(extension): paint the status bar on the first view emission (#12347)`) — a clean rebase with no conflicts, so no ratchet baseline needed regenerating. Main advanced twice mid-session (concurrent sessions share this `.git`); every gate below was re-run in full on that final base. Run with `FORCE_COLOR=0` from the isolated worktree. Full `npm run typecheck` and the whole vitest suite were deliberately skipped: they get OOM-killed on this machine.

- **`npx vitest run src/test-kernel/architecture src/test-kernel/cli/ChatDefaults.vitest.ts --testTimeout=120000`** → **exit 0**, 14 files / 90 tests passed (10.5s), `hostAgentMockRatchet`, `dependencyDirection`, `subsystemEdgeRatchet` and `pure-tier-kernel-suites` included.
- **`npx vitest run src/test-kernel/cli/{RunChatSignalOwnership,OnboardingGate,CliInitPlatform,ResumeCommand,Completion,SetupCommand}.vitest.ts --testTimeout=120000 --hookTimeout=120000`** → **exit 0**, 6 files / 49 tests passed. With ChatDefaults' 20 that is the full 7-file / 69-test consumer set, green.
- **`node scripts/check-effect-migration-ratchet.mjs`** → **exit 0**. `Effect migration ratchet OK: no count grew, no baseline headroom.` Every row exactly at baseline with zero headroom (incl. `Effect.run*` 9 files / 24 sites, `catch:effect-importer` 6 files / 8 sites). No baseline update.
- **`npm run check:dead-code-ratchet`** (through the coord gate semaphore) → **exit 0**, `GATE_EXIT=0`. `knip dead-code findings: 12 normal, 217 production; 217 combined (unused=12, productionDead=205) vs 217 baselined` / `Dead-code ratchet OK: no new findings.`
- **`npx tsc -p packages/cli/tsconfig.json --noEmit`** → **exit 0**. **`npx tsc -p tsconfig.test-kernel.json --noEmit`** → **exit 0**.
- **`npx eslint`** over the four changed source files → **exit 0**, no output. **`npx prettier --check`** over those four plus the ratchet baseline → **exit 0**, `All matched files use Prettier code style!`
- `git ls-files -s | awk '$1=="120000"' | grep node_modules` → no output (no committed symlink). `pnpm-lock.yaml` untouched; neither main commit changed the dependency set, so no reinstall was needed.

**Flake note for CI:** one early combined 4-suite CLI run reported 7 `Test timed out` failures at 285s wall under machine pressure. All four suites then passed individually (20 + 2 + 10 + 15 = exactly the 47 tests of that run), and the full 7-suite set passed together in 32.8s once load dropped. Load-induced, not a real failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Re-gated before push
Rebased onto origin/main `445102f2cb` (HEAD `ec12847408`,  5 files changed, 34 insertions(+), 222 deletions(-)). The gate results above were captured in the worktree; after the rebase the Effect migration ratchet and `prettier --check` over the changed files were re-run and pass. The full typecheck and whole vitest suite are left to CI: local runs get OOM-killed on this machine. **Opened as a draft; marked ready once CI is green.**
Open PRs touching the same files: #12342 
