### PR TITLE
refactor(settings): give the skills rows the config slot; keep the git rows worktree-shared

### DIFF
--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -917,10 +917,14 @@ const TOOL_PATH_PROTECTION_RUNTIME_REACHABILITY = {
 } satisfies CliRuntimeReachability;
 
 /**
- * The one documented slot divergence in the catalog, shared by the git
- * identity and skill availability rows: the extension and desktop store them
- * in worktree-shared WorkspaceState while the CLI reads them from
- * `.texra/config.json`, which is where an existing user's values already live.
+ * The one documented slot divergence in the catalog, carried by the git
+ * identity rows: the extension and desktop store them in WorkspaceState —
+ * where `WorktreeStateStore` additionally shares them across every worktree of
+ * a repository, so one clone has one agent commit identity — while the CLI
+ * reads them from `.texra/config.json`, which is where an existing user's
+ * values already live. Do not move these rows to `config`: `.texra/` is
+ * gitignored by default, so the project config file is per-checkout, not
+ * repository-level, and the move would silently drop the worktree sharing.
  */
 const WORKSPACE_STATE_CLI_CONFIG_SLOTS: SettingSlots = {
   vscode: 'workspaceState',
@@ -1547,7 +1551,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     title: 'Skills',
     description: 'Enable or disable individual skills in this workspace.',
     category: 'tools',
-    slots: WORKSPACE_STATE_CLI_CONFIG_SLOTS,
+    slots: sameSlot('config'),
     honoredBy: everyHost(
       'src/skills/runtimeSkills.ts',
       SKILL_AVAILABILITY_REACHABILITY,
@@ -1561,7 +1565,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     title: 'Skill sources',
     description: 'Enable or disable skill source groups in this workspace.',
     category: 'tools',
-    slots: WORKSPACE_STATE_CLI_CONFIG_SLOTS,
+    slots: sameSlot('config'),
     honoredBy: everyHost(
       'src/skills/runtimeSkills.ts',
       SKILL_AVAILABILITY_REACHABILITY,

--- a/src/test-kernel/skills/RuntimeSkills.vitest.ts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.ts
@@ -38,11 +38,11 @@ setupPlatform({ workspacePath: '/workspace' });
 
 afterEach(async () => {
   setRuntimeSkillSources([]);
-  await workspaceRoots().workspaceState.update(
+  await workspaceRoots().config.update(
     WorkspaceStateKey.DISABLED_SKILLS,
     undefined,
   );
-  await workspaceRoots().workspaceState.update(
+  await workspaceRoots().config.update(
     WorkspaceStateKey.DISABLED_SKILL_SOURCES,
     undefined,
   );
@@ -160,7 +160,7 @@ describe('runtime skills', () => {
         { scope: 'project', path: projectRoot },
         { scope: 'user', path: userRoot },
       ]);
-      await workspaceRoots().workspaceState.update(key, value);
+      await workspaceRoots().config.update(key, value);
 
       const result = await loadRuntimeSkillCatalog();
 

--- a/src/utils/config/platformSettings.ts
+++ b/src/utils/config/platformSettings.ts
@@ -17,10 +17,10 @@ function requireEntry(key: string) {
 
 /**
  * The host this process is, for the catalog rows whose storage slot differs
- * by host (the git identity and skill availability rows live in workspace
- * state on the extension and desktop and in `.texra/config.json` on the
- * CLI). One process is one host, so the composition root installs it once,
- * beside `initProcessWorkspaceRoots()`.
+ * by host (the git identity rows live in worktree-shared workspace state on
+ * the extension and desktop and in `.texra/config.json` on the CLI). One
+ * process is one host, so the composition root installs it once, beside
+ * `initProcessWorkspaceRoots()`.
  */
 let processSettingHost: SettingHost = 'vscode';
 


### PR DESCRIPTION
Authorised by the owner ruling of 2026-09-12 recorded in `.git/texra-coord/findings/owner-rulings-2026-09-11b.md` — **persisted-schemas-4, "Make the CLI git and skills rows consistent"**, together with its **"Direction note: CLI git and skills rows"**. **The owner narrowed that direction on 2026-09-12**, after the texra-ai review of the first revision of this PR surfaced the worktree finding below: only the two skills rows move; the four `texra.git.*` rows stay exactly as they are on `main`. Nothing on the ruling's KEEP list is touched (`preferShortModelNames`, `delegate_multi_agents`, External Inquiry, Google background Interactions, the VS Code Lean path, inline criticism, desktop shortcut customization, the desktop browser tab, pinned memories).

## Summary

**Two rows move; four rows deliberately do not.**

| Row | Before (vscode / desktop / cli) | After |
|---|---|---|
| `texra.skills.disabled` | `workspaceState` / `workspaceState` / `config` | **`config` / `config` / `config`** |
| `texra.skills.disabledSources` | `workspaceState` / `workspaceState` / `config` | **`config` / `config` / `config`** |
| `texra.git.markCommits` | `workspaceState` / `workspaceState` / `config` | unchanged |
| `texra.git.authorName` | `workspaceState` / `workspaceState` / `config` | unchanged |
| `texra.git.authorEmail` | `workspaceState` / `workspaceState` / `config` | unchanged |
| `texra.git.worktreeSupport` | `workspaceState` / `workspaceState` / `config` | unchanged |

The two skills rows swap `slots: WORKSPACE_STATE_CLI_CONFIG_SLOTS` for `slots: sameSlot('config')`, so all three hosts read and write them from the project `.texra/config.json` instead of the CLI reading config while the extension and desktop read a per-workspace state store. No row's key, schema, default, title, description, category, `configTarget`, `honoredBy` or `surfaces` changes — this is only about which slot holds the two skills rows.

## Why the git rows stay worktree-shared

The first revision of this PR moved all six rows and justified it with "the project config file is repository-level". **That justification was false, and the move silently deleted a live behaviour:**

- `WorktreeStateStore` (`src/platform/defaults/worktreeStateStore.ts`) names exactly those four git keys in `WORKTREE_SHARED_KEYS` and routes them through the *global* store under `worktree:<gitCommonRoot>:<key>`. The common root is resolved at `packages/extension/src/extension.ts:514` (`resolveGitCommonRoot`) and the store is installed at `:522`. The effect is that on the extension, every worktree of one repository shares one agent commit identity and one subagent-worktree toggle.
- `store: 'config'` resolves to `workspaceTexraConfigPath(workspaceRoot)` = `<openedFolder>/.texra/config.json`, and `.texra/` is **gitignored by default** (root `.gitignore:10`; `texra init --gitignore` writes the same entry). So the project config file is per-checkout, not repository-level, and the move would have replaced worktree-shared identity with per-worktree identity while reporting itself as a no-op refactor.

This also matches the standing precedent: the 2026-08-15 ruling on the `slots` migration says "prefer the shared store unless **a worktree-scoping need is documented on the row**", and for these four rows that need is documented, in the catalog, at the slot constant. This PR strengthens that comment instead of deleting it, so the next editor does not repeat the move.

The two skills rows were never in `WORKTREE_SHARED_KEYS`, so nothing worktree-shared exists for them to lose.

**Consequently the per-host slot machinery stays.** `SettingSlots`, `sameSlot()`, `WORKSPACE_STATE_CLI_CONFIG_SLOTS`, `settingSlot(entry, host)` and the `host` parameter threaded through `readSetting` / `writeSetting` / `resetSetting`, `buildSettingsSnapshotMessage`, `StateSettingUpdatePorts`, `SettingsProfileControllerDeps` and `readPlatformSetting` / `writePlatformSetting` all remain: the four git rows are still host-dependent, so the machinery still has a job. A smaller diff is the correct outcome here — the machinery is not forced out, it is left where it is still load-bearing.

## User-visible consequence

**Existing extension and desktop values for the two skills rows are not migrated, and the rows fall back to their defaults (both `[]`).** Their old values sat in a workspace-state store (VS Code's workspace `Memento` on the extension — *not* worktree-shared, these two keys were never in `WORKTREE_SHARED_KEYS` — and the desktop `state.json` on the desktop app), and after this change nothing reads them. Concretely, for a user whose project `.texra/config.json` does not already carry the keys — i.e. anyone who has only ever used the extension or desktop app, never the CLI — **any disabled skills and disabled skill sources re-enable.** The orphaned state-store entries are left in place rather than cleaned up.

This is authorised by the 1.0 no-compat rule (AGENTS.md "Compatibility and format retirement") — we are not writing a migration reader for intermediate-era data — but per the repo's "delete compat early, **loudly**" convention it is stated here rather than left to be discovered as a bug report, and it wants a changelog line at release.

**No worktree behaviour changes.** `WORKTREE_SHARED_KEYS` is untouched, `WorktreeStateStore` is untouched, and every worktree of a repository keeps sharing the same agent commit identity and subagent-worktree toggle exactly as on `main`. `git diff origin/main...HEAD -- src/platform/defaults/worktreeStateStore.ts` returns empty.

**Second consequence, intended and small:** on the extension, writing one of the two skills rows now goes through the same `requiresOpenWorkspace` guard every other workspace-target config row uses (`src/shared/settingsView/handlers/stateSettingWrite.ts:126-132`, wired at `packages/extension/src/settingsView/SettingsViewMessageHandler.ts:569-571`), so toggling a skill in an empty VS Code window reports "Open a workspace folder before changing …" instead of writing to a window-local state store the project could never see. The skills *master* toggle (`texra.skills.enabled`, `AGENT_SKILLS_CONFIG_KEY`) is already a config row and already behaves this way, so the Skills tab is now internally consistent rather than half-guarded. With no folder open there is no workspace root either way, so nothing that used to be readable becomes unreadable.

## Net elements (R6)

Files: **3 changed** (2 production, 1 test-kernel). No file added or deleted.

- `^[+-]export` symbols: **net 0** — no export added or removed.
- Type / class / interface / enum declarations: **net 0** — none added or removed.
- Module-private symbols: **net 0**. `WORKSPACE_STATE_CLI_CONFIG_SLOTS` survives with two of its six consumers moved off it (four git rows remain); `SettingSlots`, `sameSlot()` and `settingSlot()` are untouched.
- Behavioural elements: **2 catalog rows re-slotted**, from a 3-host divergent map to `sameSlot('config')`.

Net LOC from `git diff --stat origin/main...HEAD`: **3 files changed, 17 insertions(+), 13 deletions(-) → +4**, of which +8/−4 is the strengthened slot-constant comment that records why the git rows must not move. The code change itself is 2 lines.

## Consumer counts (R8)

Nothing is deleted, so there is no "consumers before → 0" table. What matters is that **every reader and writer of the two moved rows moves with them on all three hosts, and every reader and writer of the four git rows is byte-identical to `origin/main`.** Verified by reading each site, not by assuming:

`texra.skills.disabled` / `texra.skills.disabledSources` — **7 access sites, all catalog-routed, 0 direct store touches:**

| Site | R/W | Route |
|---|---|---|
| `src/skills/runtimeSkills.ts:76,78` (`readDisabledSkills`) | READ | `readPlatformSetting` → `readSetting(entry, stores, processSettingHost)` |
| `src/shared/settingsView/handlers/settingsSnapshot.ts:39-43` | READ | `readSetting(entry, stores, host)` over `settingsViewSnapshotEntries('skills')` — the one path to both the extension and desktop webviews |
| `packages/cli/src/chat/tui/forms/SkillsSettingsForm.tsx:45-54` | READ | `readSetting(requireSetting(KEY), stores, 'cli')` |
| `packages/cli/src/chat/tui/forms/SkillsSettingsForm.tsx:110-121` | WRITE | `applyStateSettingUpdate(key, next, { host: 'cli', stores })` |
| `packages/cli/src/chat/tui/forms/CliConfigForm.tsx:185-223` | R/W/RESET | generic over `CLI_STATE_SETTINGS`; both rows carry `surfaces.cliConfig` |
| `packages/extension/src/settingsView/SettingsViewMessageHandler.ts:565-576` | WRITE | `applyStateSettingUpdate(key, value, { host: 'vscode', … })`, fed by `SkillsTab.ts:90-98,120-128` posting `UPDATE_STATE_SETTING` |
| `packages/desktop/src/main/desktopSettingsIpc.ts:305-340` | WRITE | `applyStateSettingUpdate(key, value, { host: 'desktop', … })` |

Webview state (`packages/extension/src/settingsView/frontend/settingsState.ts:245-250`) is a catalog-keyed signal hydrated from the snapshot; it touches no store. So the row change moves all seven sites at once — there is no half-moved reader left pointing at workspace state.

`texra.git.*` — **11 access sites plus the storage-layer routing**, all unchanged: `src/utils/system/gitAuthorEnv.ts:17,20,21`, `src/utils/config/worktreeConfig.ts:13`, the same `settingsSnapshot` builder, `packages/cli/src/commands/config.ts:64-69`, `CliConfigForm.tsx:185-223`, `GitTab.ts:369-413`, `MultiAgentTab.ts:351-354`, `SettingsViewMessageHandler.ts:565-576`, `desktopSettingsIpc.ts:305-340`, and `WorktreeStateStore` at `worktreeStateStore.ts:22-25,46-62`.

Derived key sets, re-checked for the new scope — **all three produce byte-identical sets to `origin/main`:**

| Derivation | Filter | Effect of this PR |
|---|---|---|
| `CLI_CONFIG_SLOT_KEYS` (`stateSettings.ts:1675`) | `entry.slots.cli === 'config' && (honoredBy.cli \|\| writtenBy.cli)` | none — both skills rows already had `slots.cli === 'config'`, and `sameSlot('config')` keeps it |
| `KNOWN_TEXRA_KEYS` (`packages/cli/src/schemas/knownKeys.ts:23`) | `[...CLI_CONFIG_SLOT_KEYS, ...CLI_SETTING_PATHS]` | none — derived from the above, so `.texra/config.json` still recognises exactly the same keys and no entry starts warning as unknown |
| `CLI_STATE_SETTINGS` (`stateSettings.ts:1667`) | `surfaces.cliConfig === true` | none — `surfaces` is untouched |

`requiresOpenWorkspace` (`stateSettingWrite.ts:96-102`, gate at `:126-132`, sole caller `SettingsViewMessageHandler.ts:569-571`) is correct for the new scope: its gate is `slots[host] === 'config' && configTarget !== 'global'`, so it newly fires for the two skills rows on the extension (intended, see above) and continues not to fire for the four git rows, which stay `slots.vscode === 'workspaceState'`.

## Tests

Zero added (behaviour-preserving refactor). One existing suite is retargeted, because it seeded the store the rows no longer use: `src/test-kernel/skills/RuntimeSkills.vitest.ts` seeds and clears `workspaceRoots().config` instead of `workspaceRoots().workspaceState` for the two skills keys (3 lines). Its assertions are unchanged, so coverage of the moved rows is preserved rather than dropped.

Every slot assertion elsewhere keeps passing untouched, which is itself the check that the git rows did not move: `stateSettings.vitest.ts:433-440` ("routes extension writes to the canonical store" — `GIT_MARK_COMMITS` lands in `workspaceState`, not `config`), `:442-454` ("routes CLI writes to the CLI slot (config)"), `:498-505`, `:370-404` (the `KNOWN_TEXRA_KEYS` ↔ `slots.cli === 'config'` equivalence and the whole config-file half), and `DesktopSettingsIpc.vitest.ts:205-208,325-363` (desktop git writes still land in `workspaceState`). `AgentSkillsWorkspaceGuard.vitest.ts`, `ConfigForm.vitest.ts`, `StateSettingWrite.vitest.ts` and `DesktopSupabaseAuth.vitest.ts` are back to their `origin/main` contents.

## Gates

Rebased onto `origin/main` `e69f163487` before gating. All run with `FORCE_COLOR=0`; the full `npm run typecheck` and the whole vitest suite are left to CI, since both are OOM-killed on this machine.

- **vitest — exit 0.** `npx vitest run src/test-kernel/shared/stateSettings.vitest.ts src/test-kernel/shared/StateSettingWrite.vitest.ts src/test-kernel/cli/ConfigForm.vitest.ts src/test-kernel/skills/RuntimeSkills.vitest.ts src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts --testTimeout=120000` → **6 files / 86 tests passed**.
- **vitest architecture — exit 0.** `npx vitest run src/test-kernel/architecture --testTimeout=120000` → **13 files / 70 tests passed**.
- **effect ratchet — exit 0.** `node scripts/check-effect-migration-ratchet.mjs` → "Effect migration ratchet OK: no count grew, no baseline headroom." No file under `config/ratchets/` is in the diff.
- **dead-code ratchet — exit 0.** `bash $C/gate.sh npm run check:dead-code-ratchet` → "12 normal, 214 production; 214 combined vs 214 baselined … no new findings." `config/ratchets/knip-baseline.json` unchanged.
- **typecheck — exit 0** on both tsconfigs that cover the diff, run individually: `tsconfig.json` and `tsconfig.test-kernel.json`. No file under `packages/` is in the diff any more, so no per-package tsconfig is implicated.
- **prettier — exit 0**, "All matched files use Prettier code style!" over all 3 changed files. **eslint — exit 0** over all 3 changed files.
- `git ls-files -s | awk '$1=="120000"' | grep node_modules` — empty, no tracked symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
