### PR TITLE
simplify(session): delete the producerless transcript.entry durable arm

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -770,12 +770,6 @@
       "name": "resolveCommonRootFromGitdir"
     },
     {
-      "file": "packages/trace-viewer/src/traceDataSchema.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "TraceDataSchema"
-    },
-    {
       "file": "src/agent/index/agentRegistry.ts",
       "category": "production-dead",
       "kind": "exports",
@@ -1152,6 +1146,12 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "STATE_SETTINGS"
+    },
+    {
+      "file": "src/shared/schemas/streamLogEntry.ts",
+      "category": "production-dead",
+      "kind": "exports",
+      "name": "StreamLogEntrySchema"
     },
     {
       "file": "src/shared/schemas/subscriptionUsage.ts",

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -77,10 +77,7 @@ import {
   isInFlightPhase,
   isTerminalOutcomePhase,
 } from '@shared/runs/runStatus';
-import {
-  StreamLog,
-  type StreamLogAppendInput,
-} from '@shared/session/traceEntries';
+import type { StreamLogAppendInput } from '@shared/session/traceEntries';
 import {
   buildScenario,
   foldAll,
@@ -647,7 +644,6 @@ HARNESS_DISPOSERS.push(
 HARNESS_DISPOSERS.push(announceForegroundApprovals());
 
 const harnessRuns = new Set<RunId>();
-const harnessLogs = new Map<RunId, StreamLog>();
 
 /** Mint a run: its `run.start` existence fact (PRD 6, item 2), then the
  *  `run.config` launch fact a real run publishes next, which names the model
@@ -769,22 +765,26 @@ function removeRun(runId: RunId): void {
   harnessRuns.delete(runId);
 }
 
-/** Publish complete fixture rows on the event plane. */
+/**
+ * Publish complete fixture rows on the event plane. Every fixture builder
+ * below emits a `LOG` entry, so each maps onto one `log` trace row; the
+ * transcript fold mints the row's id and timestamp from the published fact.
+ */
 function seedRows(
   runId: RunId,
   entries: readonly StreamLogAppendInput[],
 ): void {
   seedRun(runId);
-  let log = harnessLogs.get(runId);
-  if (!log) {
-    log = new StreamLog();
-    harnessLogs.set(runId, log);
-  }
   publish(
     ...entries.map((entry) => ({
-      type: 'transcript.entry' as const,
+      type: 'log' as const,
       aggregateId: qualifyAggregateId('run', runId),
-      entry: log.appendSettled(entry),
+      level: entry.level,
+      message: entry.text ?? '',
+      messageType: entry.messageType,
+      data: entry.data,
+      stageId: entry.groupId,
+      verbose: entry.verbose,
     })),
   );
 }

--- a/packages/desktop/design-harness/scenes/desktop.ts
+++ b/packages/desktop/design-harness/scenes/desktop.ts
@@ -13,11 +13,7 @@ import {
   type RailProject,
 } from '@desktop/renderer/taskShell.js';
 import type { WorkbenchTab } from '@desktop/shared/desktopTaskShell.js';
-import {
-  MESSAGE_TYPES,
-  STREAM_LOG_ENTRY_TYPES,
-  type RunId,
-} from '@shared/schemas';
+import { MESSAGE_TYPES, type RunId } from '@shared/schemas';
 import type { ProjectDisplay } from '@shared/session/hostSnapshot';
 import {
   emptySessionView,
@@ -64,20 +60,19 @@ function withConversation(): SessionView {
   const scenario = buildScenario();
   const { log } = scenario;
   const before = log.events.length;
-  const LOG = STREAM_LOG_ENTRY_TYPES.LOG;
   // The chat lands three minutes ago, after the child started (BOARD_NOW).
   const CHAT = BOARD_NOW - 3 * 60_000;
-  log.entry(CHILD, CHAT, {
-    id: 'chat-user',
-    type: LOG,
+  log.emit(CHILD, CHAT, {
+    type: 'log',
+    level: 'info',
     messageType: MESSAGE_TYPES.USER_MESSAGE,
-    text: 'what should we do next',
+    message: 'what should we do next',
   });
-  log.entry(CHILD, CHAT + 10, {
-    id: 'chat-bash',
-    type: LOG,
+  log.emit(CHILD, CHAT + 10, {
+    type: 'log',
+    level: 'info',
     messageType: MESSAGE_TYPES.TOOL_USE,
-    text: 'bash',
+    message: 'bash',
     data: {
       toolName: 'bash',
       input: { command: 'git status && echo "--- LOG ---" && git log -n 5' },
@@ -85,11 +80,11 @@ function withConversation(): SessionView {
       status: 'completed',
     },
   });
-  log.entry(CHILD, CHAT + 20, {
-    id: 'chat-glob',
-    type: LOG,
+  log.emit(CHILD, CHAT + 20, {
+    type: 'log',
+    level: 'info',
     messageType: MESSAGE_TYPES.TOOL_USE,
-    text: 'glob',
+    message: 'glob',
     data: {
       toolName: 'glob',
       input: { pattern: '*' },
@@ -97,11 +92,11 @@ function withConversation(): SessionView {
       status: 'completed',
     },
   });
-  log.entry(CHILD, CHAT + 30, {
-    id: 'chat-reply',
-    type: LOG,
+  log.emit(CHILD, CHAT + 30, {
+    type: 'log',
+    level: 'info',
     messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-    text:
+    message:
       'Two candidates for the next step. Section 2 still cites the retracted ' +
       'Palomar registry, and the soundness proof in Appendix B has an ' +
       "unproven lemma the reviewer flagged. I'd start with the citation fix " +

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -65,7 +65,6 @@ const hostSnapshot = {
 function sessionLog() {
   const events = [];
   const seqs = new Map();
-  const entrySeqs = new Map();
   let commit = 0;
   const emit = (logicalId, at, body) => {
     const aggregateId = JSON.stringify(['run', logicalId]);
@@ -75,12 +74,7 @@ function sessionLog() {
     events.push({ aggregateId, seq, commit, ownerId: OWNER, at, ...body });
   };
   const entry = (runId, at, fields) => {
-    const seqNo = (entrySeqs.get(runId) ?? 0) + 1;
-    entrySeqs.set(runId, seqNo);
-    emit(runId, at, {
-      type: 'transcript.entry',
-      entry: { seqNo, level: 'info', timestamp: at, type: 'log', ...fields },
-    });
+    emit(runId, at, { type: 'log', level: 'info', ...fields });
   };
   return { events, emit, entry };
 }
@@ -137,14 +131,12 @@ function conversationEvents({ approval = false } = {}) {
     description: 'Check citation coverage and suggest BibTeX entries.',
   });
   log.entry(RUN, NOW, {
-    id: 'msg-1',
     messageType: 'userMessage',
-    text: 'hello world',
+    message: 'hello world',
   });
   log.entry(RUN, NOW + 1000, {
-    id: 'msg-2',
     messageType: 'modelResponse',
-    text: 'I will inspect the manuscript and report missing citations.',
+    message: 'I will inspect the manuscript and report missing citations.',
   });
   log.emit(RUN, NOW + 1500, {
     type: 'conversation.progress',
@@ -177,9 +169,9 @@ function conversationEvents({ approval = false } = {}) {
       thread: null,
     });
     log.entry(RUN, NOW + 3000, {
-      id: 'msg-3',
       messageType: 'modelResponse',
-      text: 'I found a one-line correction and need approval before editing main.tex.',
+      message:
+        'I found a one-line correction and need approval before editing main.tex.',
     });
   }
   return log.events;

--- a/scripts/webview-electron-harness.mjs
+++ b/scripts/webview-electron-harness.mjs
@@ -103,7 +103,7 @@ export function renderSessionHarnessBridge({
     function harnessFrame(subscribe) {
       const named = new Set(subscribe.aggregates.map((aggregate) => aggregate.id));
       const events = harnessSession.events.flatMap((event) => {
-        if (event.type !== 'transcript.entry') {
+        if (event.type !== 'log') {
           return [{ _tag: 'event', read: 'listing', event }];
         }
         return named.has(event.aggregateId)

--- a/src/controllers/session/SessionFramer.ts
+++ b/src/controllers/session/SessionFramer.ts
@@ -21,9 +21,8 @@
  *
  * Display redaction (contract C3): every framer to a renderer process
  * applies display redaction and truncation. The rows this plane carries
- * today are listing facts, approval payloads scrubbed at publish
- * (`redactedForFact`), and `transcript.entry` rows the transcript recorder
- * scrubbed at record time; the byte-exact flow rows of the run
+ * today are listing facts and approval payloads scrubbed at publish
+ * (`redactedForFact`); the byte-exact flow rows of the run
  * aggregate arrive with the persistence cutover, and that cutover lands the
  * redaction map here, in `cutFrame`, as the obligation it makes
  * load-bearing. Nothing is framed that is not already display-safe.

--- a/src/shared/schemas/sessionEvent.ts
+++ b/src/shared/schemas/sessionEvent.ts
@@ -57,7 +57,6 @@ import {
   ToolResultPayloadSchema,
 } from './runLedgerEvent';
 import { UserFollowUpSupportSchema, WorktreeInfoSchema } from './run';
-import { StreamLogEntrySchema } from './streamLogEntry';
 import {
   ApprovalBypassesSchema,
   ConversationProgressSchema,
@@ -382,14 +381,6 @@ const DisplaySessionEventDraftSchema = z.discriminatedUnion('type', [
    * carries its coordinates; its five siblings below are ledger-private.
    */
   durable('flow.step', { payload: FlowStepPayloadSchema }),
-  /**
-   * One transcript row, in the recorder's persisted row format: the only
-   * transcript-tier arm before the cutover. The trace's flow rows replace it
-   * when the event table lands (`2026-09-04-agent-runtime-on-effect.md`,
-   * section 2.1). Subject to the residency rule: folded for subscribed
-   * aggregates only (PRD 5.2).
-   */
-  durable('transcript.entry', { entry: StreamLogEntrySchema }),
   ...Object.values(TranscriptEventSchemas).map((schema) =>
     schema.extend({
       /** Stamped at publication (`SessionHandle.publish`), so a draft does
@@ -604,7 +595,6 @@ export function listingTypeOf(
   event: Pick<SessionEvent, 'type'>,
 ): string | null {
   switch (event.type) {
-    case 'transcript.entry':
     case 'log':
     case 'stage.start':
     case 'stage.end':

--- a/src/shared/session/runStateFold.ts
+++ b/src/shared/session/runStateFold.ts
@@ -228,7 +228,6 @@ const IGNORED_ROW_TYPES: Readonly<
   inquiryThreadUpdated: true,
   updateQueuedFollowUps: true,
   'approval.policy': true,
-  'transcript.entry': true,
   log: true,
   'stage.start': true,
   'stage.end': true,

--- a/src/shared/session/sessionFold.ts
+++ b/src/shared/session/sessionFold.ts
@@ -141,10 +141,6 @@ import { StreamLog } from './traceEntries';
 import type { SessionView, RunView, TranscriptView } from './sessionView';
 
 type RunStartEvent = Extract<DisplaySessionEvent, { type: 'run.start' }>;
-type TranscriptEntryEvent = Extract<
-  DisplaySessionEvent,
-  { type: 'transcript.entry' }
->;
 
 /** Workflow-script run ids whose run model a batch derives at its end. */
 type DeferredRunModels = Set<RunId> | null;
@@ -826,16 +822,6 @@ function childProgressChanged(prev: RunView, next: RunView): boolean {
   );
 }
 
-/** Whether a transcript entry is one the run model reads: a group boundary
- *  (phases), a workflow card, or a plan marker. */
-function entryAffectsRunModel(entry: StreamLogEntry): boolean {
-  return (
-    entry.type !== STREAM_LOG_ENTRY_TYPES.LOG ||
-    entry.messageType === MESSAGE_TYPES.WORKFLOW_TASK ||
-    workflowMarkerOf(entry) !== undefined
-  );
-}
-
 /**
  * The run model's residency (PRD 5.2, section 4 of the build note): the
  * newest dashboard rows up to the cap, and the phase groups those rows still
@@ -1355,10 +1341,7 @@ function wrongArm(run: RunView, event: DisplaySessionEvent): never {
 
 /** The event's own arm applied to its run (topology, session slices, and
  *  the transcript tier are handled by the caller). */
-function applyOwnArm(
-  run: RunView,
-  event: Exclude<DisplaySessionEvent, TranscriptEntryEvent>,
-): RunView {
+function applyOwnArm(run: RunView, event: DisplaySessionEvent): RunView {
   switch (event.type) {
     case 'log':
     case 'stage.start':
@@ -1645,9 +1628,6 @@ function foldDurable(
   deferred: DeferredRunModels,
   read: 'listing' | 'aggregate' | 'all',
 ): boolean {
-  if (event.type === 'transcript.entry') {
-    return foldTranscriptRow(view, event, deferred);
-  }
   const traceChanged =
     read !== 'listing' &&
     (isTranscriptEvent(event) ||
@@ -1775,35 +1755,6 @@ function foldTraceEvent(
       deferred,
     ),
   );
-  return true;
-}
-
-/**
- * The transcript tier (5.2, "Residency"): a row folds only for an aggregate
- * in the subscription set and only above the seq the view has retained for
- * it, which it then advances. A dropped row never touches `folded`.
- */
-function foldTranscriptRow(
-  view: SessionView,
-  event: TranscriptEntryEvent,
-  deferred: DeferredRunModels,
-): boolean {
-  const retained = view.folded.get(event.aggregateId);
-  if (retained === undefined || event.seq <= retained) return false;
-  const runId = runIdOf(event.aggregateId);
-  const run = runId === null ? undefined : view.runs.get(runId);
-  if (!run) return false;
-  writableMap(view, 'folded').set(event.aggregateId, event.seq);
-  const withEntry: RunView = {
-    ...run,
-    lastTimestamp: event.at,
-    transcript: applyEntry(view, run, event.entry),
-  };
-  const next = withTranscriptFacts(withEntry);
-  setRun(view, next);
-  if (entryAffectsRunModel(event.entry)) {
-    setRun(view, runModelAt(view, next, deferred));
-  }
   return true;
 }
 

--- a/src/shared/session/traceEntries.ts
+++ b/src/shared/session/traceEntries.ts
@@ -104,24 +104,6 @@ export class StreamLog {
     return resolved;
   }
 
-  /** Fold a canonical recorded entry without allocating new entry coordinates. */
-  record(entry: StreamLogEntry): void {
-    const index = this.indexById.get(entry.id);
-    if (index === undefined) {
-      this.indexById.set(entry.id, this.entries.length);
-      this.entries.push(entry);
-      this.pendingAppendedIds.push(entry.id);
-    } else {
-      this.entries[index] = entry;
-      this.pendingDirtiedIds.add(entry.id);
-    }
-    this.settlementSeqCounter = Math.max(
-      this.settlementSeqCounter,
-      entry.settlementSeqNo ?? 0,
-      this.entries.length,
-    );
-  }
-
   append(entry: StreamLogAppendInput): StreamLogEntry {
     return this.appendWithSettlement(entry, false);
   }

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -1460,17 +1460,12 @@ describe('the C1 event table and the C6 publisher', () => {
         const failure = yield* Effect.flip(
           db.appendAll([
             {
-              type: 'transcript.entry',
+              type: 'log',
               aggregateId: runStart.aggregateId,
-              entry: {
-                seqNo: 1,
-                id: 'non-json',
-                type: 'log',
-                level: 'info',
-                timestamp: 1,
-                messageType: 'internal',
-                data: 1n,
-              },
+              level: 'info',
+              message: 'non-json',
+              messageType: 'internal',
+              data: 1n,
             },
           ]),
         );

--- a/src/test-kernel/controllers/session/sessionFramer.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionFramer.vitest.ts
@@ -89,18 +89,10 @@ const running: SessionEventDraft = {
  *  `rowId` paints into once its entry folds. */
 function streamingRow(runId: RunId, rowId: string): SessionEventDraft {
   return {
-    type: 'transcript.entry',
+    type: 'stream.start',
     aggregateId: qualifyAggregateId('run', runId),
-    entry: {
-      seqNo: 1,
-      id: rowId,
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      level: 'info',
-      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-      timestamp: 0,
-      text: '',
-      data: { status: 'running' },
-    },
+    id: rowId,
+    kind: MESSAGE_TYPES.MODEL_RESPONSE,
   };
 }
 
@@ -569,7 +561,18 @@ describe('session framer', () => {
       }).pipe(
         Effect.provide(
           Layer.merge(
-            runtimeGraph([runStart, waiting, streamingRow(RUN, 'row-1')]),
+            // The row opens while the loop is still between steps: a parked
+            // loop closes the transcript boundary, and a closed boundary
+            // opens no streaming row for the live text to paint into.
+            runtimeGraph([
+              runStart,
+              {
+                type: 'run.description',
+                aggregateId: qualifyAggregateId('run', RUN),
+                description: 'framing',
+              },
+              streamingRow(RUN, 'row-1'),
+            ]),
             WebviewSessions.layerNoDeps,
           ),
         ),

--- a/src/test-kernel/shared/session/fanOutScenario.ts
+++ b/src/test-kernel/shared/session/fanOutScenario.ts
@@ -11,8 +11,6 @@ import {
   AgentConfigFieldsSchema,
   emptyRunEndOutput,
   MESSAGE_TYPES,
-  RUN_PHASE,
-  STREAM_LOG_ENTRY_TYPES,
   RunIdSchema,
   ToolConfigSchema,
   type ApprovalPolicySnapshot,
@@ -20,7 +18,6 @@ import {
   type LocalRuntimeState,
   type RunIdentity,
   type DisplaySessionEvent,
-  type StreamLogEntry,
   type RunId,
   type RunParent,
   type WorkflowCallProgress,
@@ -47,7 +44,7 @@ const sec = (n: number): number => n * 1000;
 /** The fan-out's beats: the root started 12m ago, the child 4m ago, the
  *  grandchild finished 1m ago, the process leads the order at 30s ago; the
  *  tail that closes the run lands in the last 20s. */
-const T = {
+export const T = {
   root: BOARD_NOW - min(12),
   child: BOARD_NOW - min(4),
   childProgress: BOARD_NOW - min(3),
@@ -79,13 +76,6 @@ export const ROOT_POLICY: ApprovalPolicySnapshot = {
   bypasses: { bash: false, toolEdit: true, superYolo: false },
 };
 
-/** `Omit` over each member of a union, so a fixture keeps its arm. */
-type EntryFixture = StreamLogEntry extends infer E
-  ? E extends unknown
-    ? Omit<E, 'seqNo' | 'timestamp' | 'level'>
-    : never
-  : never;
-
 /** A durable arm without its envelope: what a publisher builds before the
  *  aggregate, seq, commit, owner, and clock are stamped on. */
 type DisplaySessionEventBody = DisplaySessionEvent extends infer E
@@ -99,7 +89,6 @@ type DisplaySessionEventBody = DisplaySessionEvent extends infer E
 export class Log {
   readonly events: DisplaySessionEvent[] = [];
   private readonly seq = new Map<string, number>();
-  private readonly entrySeq = new Map<RunId, number>();
   /** Each run's creation commit: what the database stamps on a child's
    *  `run.start.parent` (one run model, section 3.2). */
   private readonly startCommit = new Map<RunId, number>();
@@ -170,19 +159,6 @@ export class Log {
       },
     };
   }
-
-  entry(runId: RunId, at: number, entry: EntryFixture): StreamLogEntry {
-    const seqNo = (this.entrySeq.get(runId) ?? 0) + 1;
-    this.entrySeq.set(runId, seqNo);
-    const full: StreamLogEntry = {
-      ...entry,
-      seqNo,
-      timestamp: at,
-      level: 'info',
-    };
-    this.emit(runId, at, { type: 'transcript.entry', entry: full });
-    return full;
-  }
 }
 
 function call(
@@ -230,7 +206,6 @@ export function foldAll(
  */
 export function buildScenario({ proposal = false } = {}) {
   const log = new Log();
-  const rootEntries: StreamLogEntry[] = [];
 
   log.emit(ROOT, T.root, {
     type: 'run.start',
@@ -264,21 +239,6 @@ export function buildScenario({ proposal = false } = {}) {
     phases: [{ title: 'Map' }],
     tasks: [{ id: 'inspect', label: 'inspect', phase: 'Map' }],
   });
-  rootEntries.push(
-    log.entry(ROOT, T.root + 1, {
-      id: 'phase-Map',
-      type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
-      text: 'Map',
-      messageType: MESSAGE_TYPES.DEFAULT,
-      data: {
-        status: RUN_PHASE.RUNNING,
-        kind: 'phase',
-        index: 0,
-        total: 1,
-        attemptId: 'attempt-1',
-      },
-    }),
-  );
   log.emit(ROOT, T.root + 1, {
     type: 'stage.start',
     id: 'phase-Map',
@@ -287,15 +247,12 @@ export function buildScenario({ proposal = false } = {}) {
     index: 0,
     total: 1,
   });
-  rootEntries.push(
-    log.entry(ROOT, T.root + 2, {
-      id: 'call-1',
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      messageType: MESSAGE_TYPES.WORKFLOW_TASK,
-      groupId: 'phase-Map',
-      data: call('queued'),
-    }),
-  );
+  log.emit(ROOT, T.root + 2, {
+    type: 'workflow.call',
+    logId: 'call-1',
+    stageId: 'phase-Map',
+    call: call('queued'),
+  });
 
   // The child agent run: its run.start carries the whole parent edge.
   log.emit(CHILD, T.child, {
@@ -319,15 +276,12 @@ export function buildScenario({ proposal = false } = {}) {
     category: AgentCategory.ToolUse,
     isRemote: false,
   });
-  rootEntries.push(
-    log.entry(ROOT, T.child + 1, {
-      id: 'call-1',
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      messageType: MESSAGE_TYPES.WORKFLOW_TASK,
-      groupId: 'phase-Map',
-      data: call('running', CHILD),
-    }),
-  );
+  log.emit(ROOT, T.child + 1, {
+    type: 'workflow.call',
+    logId: 'call-1',
+    stageId: 'phase-Map',
+    call: call('running', CHILD),
+  });
   // The loop's position: an agent run reads as initializing until its first
   // step, so a mid-flight fixture carries one (one run model, 3.3).
   log.emit(CHILD, T.childProgress, {
@@ -359,12 +313,11 @@ export function buildScenario({ proposal = false } = {}) {
     toolName: 'delegate_agent',
     input: { agent: 'lint', instruction: 'lint appendix B' },
   };
-  const dispatched = log.entry(CHILD, T.grandchild - 1, {
-    id: 'dispatch-lint',
-    type: STREAM_LOG_ENTRY_TYPES.LOG,
-    messageType: MESSAGE_TYPES.TOOL_USE,
-    text: 'delegate_agent',
-    data: { ...dispatchData, status: 'in_progress' },
+  log.emit(CHILD, T.grandchild - 1, {
+    type: 'tool.start',
+    logId: 'dispatch-lint',
+    toolName: dispatchData.toolName,
+    input: dispatchData.input,
   });
   log.emit(GRANDCHILD, T.grandchild, {
     type: 'run.start',
@@ -392,25 +345,14 @@ export function buildScenario({ proposal = false } = {}) {
     outcome: 'completed',
     output: emptyRunEndOutput(AgentCategory.ToolUse),
   });
-  // The tool's result lands the way the recorder's `update` lands it: the
-  // patch merged over the stored entry, so the row keeps its id, seqNo, and
+  // The tool's result lands the way the recorder settles it: the outcome
+  // merged over the stored row, so the row keeps its id, seqNo, and
   // timestamp under a later commit.
   log.emit(CHILD, T.grandchildDone + 1, {
-    type: 'transcript.entry',
-    entry: {
-      id: 'dispatch-lint',
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      messageType: MESSAGE_TYPES.TOOL_USE,
-      text: 'delegate_agent',
-      seqNo: dispatched.seqNo,
-      timestamp: dispatched.timestamp,
-      level: dispatched.level,
-      data: {
-        ...dispatchData,
-        output: 'Appendix B: no findings.',
-        status: 'completed',
-      },
-    },
+    type: 'tool.end',
+    logId: 'dispatch-lint',
+    status: 'completed',
+    result: { ...dispatchData, output: 'Appendix B: no findings.' },
   });
 
   // A top-level process run, newer than the root: leads the order.
@@ -438,11 +380,11 @@ export function buildScenario({ proposal = false } = {}) {
     ' ✓ src/test-kernel/latex/Compile.vitest.ts (12 tests) 340ms\n',
     ' ✓ src/test-kernel/shared/session/sessionFold.vitest.ts (31 tests) 1.2s\n',
   ].entries()) {
-    log.entry(PROCESS, T.process + sec(1 + offset), {
-      id: `out-${offset}`,
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
+    log.emit(PROCESS, T.process + sec(1 + offset), {
+      type: 'log',
+      level: 'info',
       messageType: MESSAGE_TYPES.DEFAULT,
-      text,
+      message: text,
     });
   }
 
@@ -501,24 +443,17 @@ export function buildScenario({ proposal = false } = {}) {
     outcome: 'completed',
     output: emptyRunEndOutput(AgentCategory.ToolUse),
   });
-  rootEntries.push(
-    log.entry(ROOT, T.childDone + 1, {
-      id: 'call-1',
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      messageType: MESSAGE_TYPES.WORKFLOW_TASK,
-      groupId: 'phase-Map',
-      data: call('completed', CHILD),
-    }),
-  );
-  rootEntries.push(
-    log.entry(ROOT, T.childDone + 2, {
-      id: 'phase-Map',
-      type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
-      text: 'Map',
-      messageType: MESSAGE_TYPES.DEFAULT,
-      data: { kind: 'phase', status: 'completed', endTime: T.childDone + 2 },
-    }),
-  );
+  log.emit(ROOT, T.childDone + 1, {
+    type: 'workflow.call',
+    logId: 'call-1',
+    stageId: 'phase-Map',
+    call: call('completed', CHILD),
+  });
+  log.emit(ROOT, T.childDone + 2, {
+    type: 'stage.end',
+    id: 'phase-Map',
+    status: 'completed',
+  });
   log.emit(ROOT, T.rootDone, {
     type: 'run.end',
     outcome: 'completed',
@@ -528,7 +463,6 @@ export function buildScenario({ proposal = false } = {}) {
   const events = log.events.map(tail);
   return {
     log,
-    rootEntries,
     /** The replay a subscriber of every transcript folds. */
     events: [
       subscribe(ROOT, CHILD, GRANDCHILD, PROCESS),
@@ -907,68 +841,45 @@ function boardView({
     usage: { inputTokens: 210_000, outputTokens: 41_000, cost: 1.84 },
   });
   const phases = ['Scout', 'Review', 'Verify', 'Report'];
-  log.entry(ROOT, startedAt + 1, {
-    id: 'plan',
-    type: STREAM_LOG_ENTRY_TYPES.LOG,
-    messageType: MESSAGE_TYPES.INTERNAL,
-    text: '',
-    data: {
-      kind: 'workflowPlan',
-      attemptId: 'attempt-1',
-      phases: phases.map((title) => ({ title })),
-      tasks: [
-        ...calls.map((entry) => ({
-          id: entry.id,
-          label: entry.id,
-          phase: entry.phase,
-        })),
-        { id: 'review:release', label: 'review:release', phase: 'Review' },
-        { id: 'verify', label: 'verify', phase: 'Verify' },
-        { id: 'report', label: 'report', phase: 'Report' },
-      ],
-    },
+  log.emit(ROOT, startedAt + 1, {
+    type: 'workflow.plan',
+    attemptId: 'attempt-1',
+    phases: phases.map((title) => ({ title })),
+    tasks: [
+      ...calls.map((entry) => ({
+        id: entry.id,
+        label: entry.id,
+        phase: entry.phase,
+      })),
+      { id: 'review:release', label: 'review:release', phase: 'Review' },
+      { id: 'verify', label: 'verify', phase: 'Verify' },
+      { id: 'report', label: 'report', phase: 'Report' },
+    ],
   });
 
   const openPhase = (title: string, at: number): void => {
-    const index = phases.indexOf(title);
-    log.entry(ROOT, at, {
-      id: `phase-${title}`,
-      type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
-      text: title,
-      messageType: MESSAGE_TYPES.DEFAULT,
-      data: {
-        status: RUN_PHASE.RUNNING,
-        kind: 'phase',
-        index,
-        total: phases.length,
-        attemptId: 'attempt-1',
-      },
-    });
     log.emit(ROOT, at, {
       type: 'stage.start',
       id: `phase-${title}`,
       label: title,
       kind: 'phase',
-      index,
+      index: phases.indexOf(title),
       total: phases.length,
     });
   };
   const closePhase = (title: string, at: number): void => {
-    log.entry(ROOT, at, {
+    log.emit(ROOT, at, {
+      type: 'stage.end',
       id: `phase-${title}`,
-      type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
-      text: title,
-      messageType: MESSAGE_TYPES.DEFAULT,
-      data: { kind: 'phase', status: 'completed', endTime: at },
+      status: 'completed',
     });
   };
   const card = (entry: BoardCall, at: number): void => {
-    log.entry(ROOT, at, {
-      id: `call-${entry.id}`,
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      messageType: MESSAGE_TYPES.WORKFLOW_TASK,
-      groupId: `phase-${entry.phase}`,
-      data: boardProgress(entry),
+    log.emit(ROOT, at, {
+      type: 'workflow.call',
+      logId: `call-${entry.id}`,
+      stageId: `phase-${entry.phase}`,
+      call: boardProgress(entry),
     });
   };
 
@@ -1009,11 +920,11 @@ function boardView({
         payload: { family: 'toolUse', step: 'turn.begin', turn: 1 },
       });
       if (kid.latest) {
-        log.entry(kid.id, kid.startedAt + 1, {
-          id: `${entry.id}-instruction`,
-          type: STREAM_LOG_ENTRY_TYPES.LOG,
+        log.emit(kid.id, kid.startedAt + 1, {
+          type: 'log',
+          level: 'info',
           messageType: MESSAGE_TYPES.USER_MESSAGE,
-          text: kid.latest,
+          message: kid.latest,
         });
       }
       if (kid.toolCalls !== undefined) {
@@ -1095,12 +1006,10 @@ function boardView({
       }
     }
     const outcome = failed ? 'failed' : 'completed';
-    log.entry(ROOT, closedAt + 1, {
+    log.emit(ROOT, closedAt + 1, {
+      type: 'stage.end',
       id: 'phase-Review',
-      type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
-      text: 'Review',
-      messageType: MESSAGE_TYPES.DEFAULT,
-      data: { kind: 'phase', status: outcome, endTime: closedAt + 1 },
+      status: outcome,
     });
     log.emit(ROOT, closedAt + 2, {
       type: 'run.end',

--- a/src/test-kernel/shared/session/sessionFold.vitest.ts
+++ b/src/test-kernel/shared/session/sessionFold.vitest.ts
@@ -17,7 +17,6 @@ import {
   listingTypeOf,
   MESSAGE_TYPES,
   isTranscriptEvent,
-  STREAM_LOG_ENTRY_TYPES,
   RUN_PHASE,
   RunIdSchema,
   runIdentityDisplayName,
@@ -27,12 +26,9 @@ import {
   type OutputFileInfo,
   type SessionEvent,
   type SessionEventDraft,
-  type StreamLogEntry,
   type RunId,
-  type TaskGroup,
 } from '@shared/schemas';
 
-import { projectTranscriptRow, type TranscriptRow } from '@shared/transcript';
 import { foldRunState } from '@shared/session/runStateFold';
 import { fold } from '@shared/session/sessionFold';
 import { redactTraceDraft } from '@shared/session/traceRedaction';
@@ -43,7 +39,6 @@ import {
 } from '@shared/session/sessionView';
 import { compareByNewestCreationTime } from '@shared/runs/runOrdering';
 
-import { upsertTaskGroupFromStreamLog } from '@shared/runs/taskGroupProjection';
 import {
   workflowRunModel,
   type ChildRunProgress,
@@ -61,6 +56,7 @@ import {
   ROOT,
   ROOT_IDENTITY,
   ROOT_POLICY,
+  T,
   buildScenario,
   foldAll,
   local,
@@ -82,29 +78,6 @@ function roundMapsOf(view: SessionView, id: RunId) {
     throw new Error(`run ${id} is not a tool-use run`);
   const { outputs, missingOutputs, compileFailures } = run;
   return { outputs, missingOutputs, compileFailures };
-}
-
-/** Full replay through the production reducer (the resync path). */
-function taskGroupsOf(entries: readonly StreamLogEntry[]): TaskGroup[] {
-  const taskGroups: TaskGroup[] = [];
-  const index = new Map<string, number>();
-  for (const entry of entries) {
-    upsertTaskGroupFromStreamLog(taskGroups, index, entry);
-  }
-  return taskGroups;
-}
-
-/** Sequential projection keyed by id, the way a host upserts rows. */
-function rowsOf(entries: readonly StreamLogEntry[]): TranscriptRow[] {
-  const byId = new Map<string, TranscriptRow>();
-  for (const entry of entries) {
-    const row = projectTranscriptRow(entry, {
-      previousRow: byId.get(entry.id),
-      projectLifecycleToTaskGroups: true,
-    });
-    if (row) byId.set(entry.id, row);
-  }
-  return [...byId.values()];
 }
 
 const alive = local({ self: [OWNER] });
@@ -269,10 +242,60 @@ describe('sessionFold', () => {
     const root = runView(view, ROOT);
     const child = runView(view, CHILD);
 
-    expect(root.transcript.taskGroups).toStrictEqual(
-      taskGroupsOf(scenario.rootEntries),
-    );
-    expect(root.transcript.rows).toStrictEqual(rowsOf(scenario.rootEntries));
+    // The phase the stage pair opened and closed, and the one call card the
+    // workflow rows carry: what the shared group and row reducers make of
+    // the root's trace.
+    expect(root.transcript.taskGroups).toStrictEqual([
+      {
+        id: 'phase-Map',
+        name: 'Map',
+        startTime: T.root + 1,
+        status: 'completed',
+        kind: 'phase',
+        index: 0,
+        attemptId: 'attempt-1',
+        total: 1,
+        endTime: T.childDone + 2,
+      },
+    ]);
+    expect(root.transcript.rows).toStrictEqual([
+      {
+        id: 'phase-Map',
+        seqNo: 2,
+        timestamp: T.root + 1,
+        level: 'info',
+        settlementSeqNo: 2,
+        verbose: false,
+        messageType: MESSAGE_TYPES.DEFAULT,
+        kind: 'phase',
+        heading: 'Map (1/1)',
+        phaseLabel: 'Map',
+        phaseIndex: 0,
+        phaseTotal: 1,
+      },
+      {
+        id: 'call-1',
+        seqNo: 3,
+        timestamp: T.root + 2,
+        level: 'info',
+        settlementSeqNo: 3,
+        verbose: false,
+        groupId: 'phase-Map',
+        messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+        kind: 'workflowTask',
+        call: {
+          id: 'inspect',
+          label: 'inspect',
+          phase: 'Map',
+          attemptId: 'attempt-1',
+          childRunId: CHILD,
+          status: 'completed',
+        },
+        line: 'Finished: inspect',
+        statusLabel: 'Finished',
+        metadataParts: [],
+      },
+    ]);
     // The transcript tier retained the rows: the aggregate's newest seq.
     expect(view.folded.get(qualifyAggregateId('run', ROOT))).toBe(
       Math.max(
@@ -280,8 +303,7 @@ describe('sessionFold', () => {
           .filter(
             (e) =>
               e.aggregateId === qualifyAggregateId('run', ROOT) &&
-              (e.type === 'transcript.entry' ||
-                e.type === 'run.activate' ||
+              (e.type === 'run.activate' ||
                 e.type === 'run.end' ||
                 isTranscriptEvent(e)),
           )
@@ -487,20 +509,16 @@ describe('sessionFold', () => {
       to: number,
       text: string,
     ): FoldInput => ({ _tag: 'chunk', runId: CHILD, rowId, from, to, text });
-    const response = (
-      id: string,
-      text: string,
-      status: 'running' | 'completed',
-    ): FoldInput => {
-      log.entry(CHILD, 1501, {
-        id,
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-        text,
-        data: { status },
-      });
-      return tail(log.events.at(-1)!);
-    };
+    const opens = (id: string): FoldInput =>
+      tail(
+        log.emit(CHILD, 1501, {
+          type: 'stream.start',
+          id,
+          kind: MESSAGE_TYPES.MODEL_RESPONSE,
+        }),
+      );
+    const closes = (id: string, finalText: string): FoldInput =>
+      tail(log.emit(CHILD, 1501, { type: 'stream.end', id, finalText }));
     const started = log.events.map(tail);
     // A chunk can reach the fold before its row; a redelivered chunk and a
     // chunk below the text held are no-ops.
@@ -508,7 +526,7 @@ describe('sessionFold', () => {
       subscribe(CHILD),
       ...started,
       chunk('response-2', 0, 3, 'Ear'),
-      response('response-1', '', 'running'),
+      opens('response-1'),
       chunk('response-1', 0, 3, 'Hel'),
       chunk('response-1', 3, 5, 'lo'),
       chunk('response-1', 0, 3, 'Hel'),
@@ -522,15 +540,14 @@ describe('sessionFold', () => {
     expect(child.transcript.settledRows).toBe(0);
     expect(child.latestLine).toBeNull();
     // The row that arrives after its chunks projects with them.
-    const view = fold(streaming, response('response-2', '', 'running'));
+    const view = fold(streaming, opens('response-2'));
     const second = runView(view, CHILD).transcript.rows[1];
     expect(second.kind === 'assistant' && second.text.full).toBe('Ear');
-    // An entry that folds carrying buffered text seeds the held text, so the
-    // bridge's re-delivery of that text from offset zero is a no-op and a
-    // later chunk extends it.
+    // A row's held text is the chunks' own: the first seeds it from offset
+    // zero and a later chunk extends it.
     const buffered = foldAll(
       [
-        response('response-3', 'Buf', 'running'),
+        opens('response-3'),
         chunk('response-3', 0, 3, 'Buf'),
         chunk('response-3', 3, 6, 'fer'),
       ],
@@ -543,7 +560,7 @@ describe('sessionFold', () => {
     // cannot reopen it; a replacement chunk truncates at `from`.
     const settled = foldAll(
       [
-        response('response-1', 'Hello world', 'completed'),
+        closes('response-1', 'Hello world'),
         chunk('response-1', 5, 7, '!!'),
         chunk('response-2', 0, 4, 'Late'),
       ],
@@ -583,7 +600,7 @@ describe('sessionFold', () => {
     const rootEntry = scenario.log.events.find(
       (e) =>
         e.aggregateId === qualifyAggregateId('run', ROOT) &&
-        e.type === 'transcript.entry',
+        e.type === 'workflow.call',
     )!;
     // An aggregate read replaying an older activation, start, or row after
     // the tail folded the current one changes nothing, and the cursor stays.
@@ -910,25 +927,39 @@ describe('sessionFold', () => {
     const childBefore = runView(before, CHILD);
     const rowsBefore = childBefore.transcript.rows;
     const rowCount = rowsBefore.length;
+    const childSeq = before.folded.get(qualifyAggregateId('run', CHILD))!;
+    // The settled child takes a follow-up turn: its activation reopens the
+    // transcript boundary the terminal outcome closed, then one streaming
+    // row opens and its chunks extend it.
     const after = fold(before, [
       tail({
         aggregateId: qualifyAggregateId('run', CHILD),
-        seq: before.folded.get(qualifyAggregateId('run', CHILD))! + 1,
+        seq: childSeq + 1,
+        commit: 199,
+        ownerId: OWNER,
+        at: 3900,
+        type: 'run.activate',
+        category: AgentCategory.ToolUse,
+        isRemote: false,
+      }),
+      tail({
+        aggregateId: qualifyAggregateId('run', CHILD),
+        seq: childSeq + 2,
         commit: 200,
         ownerId: OWNER,
         at: 4000,
-        type: 'transcript.entry',
-        entry: {
-          id: 'late',
-          type: STREAM_LOG_ENTRY_TYPES.LOG,
-          messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-          text: 'Late',
-          data: { status: 'running' },
-          seqNo: 999,
-          timestamp: 4000,
-          level: 'info',
-        },
+        type: 'stream.start',
+        id: 'late',
+        kind: MESSAGE_TYPES.MODEL_RESPONSE,
       }),
+      {
+        _tag: 'chunk',
+        runId: CHILD,
+        rowId: 'late',
+        from: 0,
+        to: 4,
+        text: 'Late',
+      },
       {
         _tag: 'chunk',
         runId: CHILD,
@@ -962,21 +993,14 @@ describe('sessionFold', () => {
       after,
       tail({
         aggregateId: qualifyAggregateId('run', CHILD),
-        seq: before.folded.get(qualifyAggregateId('run', CHILD))! + 2,
+        seq: childSeq + 3,
         commit: 201,
         ownerId: OWNER,
         at: 4100,
-        type: 'transcript.entry',
-        entry: {
-          id: 'settled',
-          type: STREAM_LOG_ENTRY_TYPES.LOG,
-          messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-          text: 'Done',
-          data: { status: 'completed' },
-          seqNo: 1000,
-          timestamp: 4100,
-          level: 'info',
-        },
+        type: 'log',
+        level: 'info',
+        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+        message: 'Done',
       }),
     );
     const childLogged = runView(logged, CHILD);

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -20,7 +20,6 @@ import {
   aggregateId,
   LOG_LEVELS,
   MESSAGE_TYPES,
-  STREAM_LOG_ENTRY_TYPES,
   type ExecResult,
   RunIdSchema,
   type RunId,
@@ -373,36 +372,24 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     Effect.gen(function* () {
       const runId = yield* registerProcessRun('legacy command');
       const session = defaultSession();
-      let seqNo = 0;
       const append = (
-        id: string,
         text: string,
         level:
           typeof LOG_LEVELS.INFO | typeof LOG_LEVELS.WARN = LOG_LEVELS.INFO,
       ): void => {
         session.publish([
           {
-            type: 'transcript.entry',
+            type: 'log',
             aggregateId: aggregateId('run', runId),
-            entry: {
-              seqNo: ++seqNo,
-              id,
-              type: STREAM_LOG_ENTRY_TYPES.LOG,
-              level,
-              messageType: MESSAGE_TYPES.DEFAULT,
-              timestamp: Date.now(),
-              text,
-            },
+            level,
+            messageType: MESSAGE_TYPES.DEFAULT,
+            message: text,
           },
         ]);
       };
-      append('legacy-one', 'legacy one');
-      append('legacy-two', 'legacy two');
-      append(
-        'legacy-warning',
-        'legacy warning\r\n\rlegacy tail\r',
-        LOG_LEVELS.WARN,
-      );
+      append('legacy one');
+      append('legacy two');
+      append('legacy warning\r\n\rlegacy tail\r', LOG_LEVELS.WARN);
 
       const result = yield* readOutput(runId);
       const output = result.output ?? '';

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -59,7 +59,6 @@ import {
   FlowSnapshotPayloadSchema,
 } from '@shared/schemas';
 import type { RunId, TodoItem } from '@shared/schemas';
-import { StreamLog } from '@shared/session/traceEntries';
 import type { StreamLogAppendInput } from '@shared/session/traceEntries';
 import {
   createTempDirPlatform,
@@ -157,20 +156,21 @@ function logRow(
   };
 }
 
-/** Seed recorded transcript entries through the canonical historical-entry event. */
+/** Seed recorded transcript rows through the durable log fact. */
 async function appendRows(
   runId: RunId,
   rows: readonly LogRow[],
 ): Promise<void> {
   if (!taskSession.transcripts.has(runId))
     publishTestRunStart(taskSession, runId);
-  const entries = new StreamLog();
-  for (const row of rows) entries.appendSettled(row);
   taskSession.publish(
-    entries.toJSON().map((entry) => ({
-      type: 'transcript.entry',
+    rows.map((row) => ({
+      type: 'log' as const,
       aggregateId: aggregateId('run', runId),
-      entry,
+      level: row.level,
+      message: row.text ?? '',
+      messageType: row.messageType,
+      data: row.data,
     })),
   );
   await taskSession.settlePublications();

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -44,8 +44,7 @@ function applyEvent(
   fold: ReturnType<typeof createTranscriptFold>,
   event: SessionEvent,
 ): void {
-  if (event.type === 'transcript.entry') log.record(event.entry);
-  else if (event.type === 'run.activate') fold.status(RUN_PHASE.RUNNING);
+  if (event.type === 'run.activate') fold.status(RUN_PHASE.RUNNING);
   else if (event.type === 'flow.step') {
     if (event.payload.step === 'waiting') fold.status(RUN_PHASE.WAITING);
     else if (event.payload.step !== 'halted') fold.status(RUN_PHASE.RUNNING);


### PR DESCRIPTION
**Stacked on #12359** — review that one first. This PR's base is `simplify/v1-2c-trace-export`, because #12359 deletes the last production producer of the `transcript.entry` event. Once it merges I'll retarget this to `main`.

## What this deletes

With zero producers left, the arm and everything downstream of it goes:

- the `transcript.entry` durable event and its listing case, plus the schema import that only served it;
- `TranscriptEntryEvent`, `foldTranscriptRow`, `entryAffectsRunModel` and the fold's dispatch branch — `applyOwnArm` widens back to the plain display event;
- the exhaustive ignored-row key for it in the run-state fold;
- `StreamLog.record` and the store branch that called it.

## Producer count, re-verified independently

Zero in production. Beyond grepping the literal, the check looked for indirect construction (an `entry:` near any publish/emit/draft, a `TRANSCRIPT_ENTRY` constant, any `'transcript.'` prefix build) across all four hosts, `scripts/` and `.mjs` files. Everything left was a reader, a test seed or a harness.

Two counts in the survey were **undercounts**, both found by re-deriving rather than trusting it:
- the fixture helper has 14 call sites across two scenario builders, and one more test site goes through a helper that a literal grep misses;
- there are **4** harness producers, not 3 — the desktop design-harness scene only surfaced through the desktop tooling typecheck.

## Fixtures: re-seeded, and stronger

24 seed sites move to the trace vocabulary. Three changes are worth reading closely, and each ends up more production-faithful, not weaker:

- The fan-out scenario was **dual-writing** a phase: a hand-written group row *and* a real stage. With the arm gone the stage is the sole writer, so the phase keeps its index, total and attempt id through the close — the hand-written literal dropped them.
- A projection-based expectation (`rowsOf` / `taskGroupsOf`) is replaced by explicit literal expectations for the root's task group and rows. Re-projecting the fixture proves less than stating the answer.
- Two seeds needed the transcript boundary reopened, because the fold refuses to open a streaming row on a closed boundary. They now publish the activation a real follow-up turn would, which is what a late streaming row means in production.

## The CLI harness

`seedRows` publishes one `log` fact per fixture row instead of one durable entry; all six fixture builders are untouched, and the fold rebuilds an identical row (level, message type, data and stage all pass through). **Row identity changes**: the id is now the fold's key rather than the fixture's own string, and the timestamp is the publish clock. The TUI validator matches on row text and scenario names, never on a row id, so nothing there references it.

This is the minimal change needed for the scripts typecheck to pass. `validate:tui` was deliberately **not** run here — this machine has been at load 88 with a dozen sibling test runs — and the CLI slice owner has agreed to verify it on a quiet machine and rewrite `seedRows` if any scenario expectation shifts.

## Net elements (R6)

16 files, +247 / −422, **net −175 LOC**, plus the baseline commit.

Declarations removed: the durable arm and its listing case, `TranscriptEntryEvent`, `foldTranscriptRow`, `entryAffectsRunModel`, the ignored-row key, `StreamLog.record`, and in tests `EntryFixture`, the entry helper and its sequence counter, `rootEntries`, `rowsOf`, `taskGroupsOf`, the harness log map and sequence map. One export added (`T`, the scenario's beat timestamps) replacing `rootEntries`, so the fixture's export count is unchanged. Six now-unused imports dropped.

## Dead-code baseline

Deleting the arm removed `StreamLogEntrySchema`'s last production consumer; it survives for its own inferred type and five suites that parse fixtures with it. That is the routine test-only-export case which 205 of the 217 baselined findings already cover, so it is baselined here, in the same PR, as the script's own message directs (it has no update path). The same commit drops the entry #12359 resolved, so the baseline count stays at 217.

The considered alternative — un-exporting the schema and converting five suites off `parse()` — was rejected: it weakens fixture validation to satisfy a lint.

## Verification

- `CI=true npm run typecheck`: clean, including the CLI scripts project and all five desktop projects. Its first run is what caught the missed desktop harness producer.
- `vitest run --changed <base>`: 431 files, 4,537 passed, 1 skipped. No timeouts, no isolation re-runs needed. Two suites that got import-only edits afterwards were re-run individually.
- `eslint` (batched) and `prettier`: clean.
- `check:dead-code-ratchet`: green with the baseline change above.
- `check:effect-migration-ratchet`: every count exactly at baseline.
- `git diff --check`: clean.

## Follow-ups noted, not acted on

- A streaming-entry branch in the fold looks unreachable now — the durable arm was the only thing that folded a running streaming row that already carried text. Proving it needs a survey of every dirtied-entry path, so it stays.
- With no production parse boundary left, the schema is now purely a type source plus five fixtures; whether those suites should build entries another way is worth a look, and would let the export die instead of being baselined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)