### PR TITLE
docs,test: record the removed CLI surfaces and re-cover pathSeparatorVariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,39 @@ All notable changes to this project will be documented in this file.
 - TeXRA 1.0 starts with new session history. Earlier conversations and saved
   runs remain on disk but are not imported or available to resume. Project
   documents and research files are unchanged.
+- **One streaming toggle instead of one per provider** — the per-provider
+  Streaming switches in the Models tab are gone. The global **Enable
+  streaming** setting now governs every provider.
+- **The OpenAI "Use the Responses API" setting is gone** — requests to OpenAI
+  always use the Responses API, and the classic Chat Completions fallback is
+  removed. OpenAI models routed through OpenRouter are unaffected.
 
 ### Bug Fixes
 
 - Generated agent definitions, session titles and helper answers no longer inherit document text-replacement rules.
+
+### Extension (VS Code)
+
+#### Breaking Changes
+
+- **"Clean All LLM Output Files (Workspace-wide)" is removed** — it is gone
+  from the command palette, the Progress toolbar and the getting-started
+  walkthrough. Clean in the Progress toolbar now clears the selected run's
+  output folder, and "Clean All Build Files (Workspace-wide)" is unchanged.
 
 ### CLI and Agent SDK
 
 #### Breaking Changes
 
 - Node.js 22.16.0 or later in 22.x, or Node.js 24 or later is required.
+- **`texra history show --export html` no longer takes `--assets-dir`** — the
+  shared-assets export mode, which staged the trace viewer into a directory and
+  wrote only the trace JSON to stdout, is gone. The default single-file HTML
+  export is unchanged.
+- **`texra chat` no longer starts on the last run's model** — the chat model
+  comes from your workspace or user config, and otherwise from the CLI's
+  built-in default. Set a model in config if you relied on the previous run's
+  choice carrying over.
 
 ## [0.40.10] - 2026-09-06
 

--- a/src/test-kernel/desktop/DesktopLogRedaction.vitest.ts
+++ b/src/test-kernel/desktop/DesktopLogRedaction.vitest.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { pathSeparatorVariants } from '@desktop/main/desktopPathVariants';
 import { PROVIDER_KEY_REDACTION_RULES, redactSecrets } from '@logger/redaction';
 import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
 
@@ -49,5 +50,27 @@ describe('desktop log redaction', () => {
     expect(Object.keys(PROVIDER_KEY_REDACTION_RULES).toSorted()).toEqual(
       [...API_KEY_PROVIDER_IDS].toSorted(),
     );
+  });
+});
+
+// The redactor feeds every prefix it scrubs through pathSeparatorVariants, so
+// a path whose variants are wrong silently stops being redacted from the
+// desktop log file.
+describe('pathSeparatorVariants', () => {
+  it('spells a path both ways, trimming and deduplicating', () => {
+    expect(pathSeparatorVariants('  /Users/alice/paper  ')).toEqual([
+      '/Users/alice/paper',
+      '\\Users\\alice\\paper',
+    ]);
+    expect(pathSeparatorVariants('C:\\Users\\alice/paper')).toEqual([
+      'C:\\Users\\alice/paper',
+      'C:/Users/alice/paper',
+      'C:\\Users\\alice\\paper',
+    ]);
+  });
+
+  it('drops blank input and keeps the POSIX root single-spelled', () => {
+    expect(pathSeparatorVariants('   ')).toEqual([]);
+    expect(pathSeparatorVariants('/')).toEqual(['/']);
   });
 });


### PR DESCRIPTION
Two substantive reviewer findings that the 1.0 clean-slate cuts deferred, rather than batched away.

## Item 1 — CHANGELOG entries for user-facing removals that merged without notice

Reviewers flagged that #12353 and #12354 landed with no user-facing record, because the sweep's convention was to collect changelog entries later. Collected now, in the `Unreleased` section, using the file's existing `### <surface>` / `#### Breaking Changes` structure and its `**lead-in** — prose` bullet style.

- **#12353** — `texra history show --export html` no longer takes `--assets-dir`; the default single-file HTML export is unchanged.
- **#12354** — `texra chat` no longer starts on the last run's model; the model now comes from workspace/user config, else the CLI's built-in default.

Checking the sibling 1.0 cuts merged the same day found three more clearly user-visible removals with no entry, added with the same care:

- **#12295** — the per-provider Streaming switches in the Models tab are gone; the global **Enable streaming** setting governs every provider.
- **#12326** — the OpenAI "Use the Responses API" setting is gone; OpenAI-direct requests always use Responses.
- **#12293** — "Clean All LLM Output Files (Workspace-wide)" is removed from the palette, the Progress toolbar and the walkthrough.

Deliberately left out, with reasons:

- **#12283** — build/release plumbing only (manifest snapshot, dead update feed, one trace-viewer build, bundler residue). No user-visible behaviour changes; the "automatic updates" promise it removed was already only a doc sentence about machinery #7682 had ruled out.
- **#12355** — the Sentry integration turned on only when `TEXRA_SENTRY_DSN` was set, had no UI and no DSN was ever provisioned. Nothing a user could observe.
- **#12357** — the `inline` `AgentSource` had no production producer and was never exported from the SDK surface. Not reachable by any user.
- **#12293's flat-filename half** — latexdiff/clean/pack no longer parse the pre-1.0 `<base>_<chunk>_r<N>_<model>.tex` grammar. That scan is only reachable from an old run, and old runs are already covered by the existing Unreleased note that 1.0 does not import or resume earlier runs. A second bullet would restate it.

No existing `Unreleased` bullet duplicated any of the five; the section previously held only the session-history break, one bug fix, and the Node version floor.

## Item 2 — restore direct coverage for `pathSeparatorVariants`

#12355 deleted `DesktopCrashReporting.vitest.ts`, which was the only direct test of `pathSeparatorVariants` (`packages/desktop/src/main/desktopPathVariants.ts`). The helper is still live: `desktopAppLog.ts` flat-maps every redaction prefix through it, so a wrong variant silently stops redacting the desktop log file. `DesktopLogRedaction.vitest.ts` covered `redactSecrets` only.

One `describe` with two cases now sits at the end of that suite, pinning the helper's real contract as written: trim the input, emit the raw/forward/back spellings, deduplicate (so a pure-POSIX path yields two entries and a mixed-separator path three), return `[]` for blank input, and leave the POSIX root `/` single-spelled.

This is a deliberate, review-motivated exception to the repo's zero-new-tests-per-PR default, kept to the minimum.

## Net elements (R6)

| Element | Before | After | Δ |
| --- | --- | --- | --- |
| CHANGELOG `Unreleased` bullets | 3 | 8 | +5 |
| CHANGELOG `Unreleased` sections | 3 | 4 | +1 (`### Extension (VS Code)`) |
| `describe` blocks in `DesktopLogRedaction.vitest.ts` | 1 | 2 | +1 |
| `it` cases in `DesktopLogRedaction.vitest.ts` | 4 | 6 | +2 |
| Production modules changed | 0 | 0 | 0 |
| Exports added/removed | 0 | 0 | 0 |

A documentation-and-coverage PR, so the net is additive by construction; no production code, no new exports, no new helpers, no new files.

## Consumer counts (R8)

- `pathSeparatorVariants` — 1 production consumer (`packages/desktop/src/main/desktopAppLog.ts:217`, inside `redactPathPrefixes`), now 1 direct test consumer again. It was 0 direct test consumers between #12355 and this PR.
- `redactSecrets` — unchanged; the existing cases in the same suite are untouched.
- No new symbol is introduced, so no consumer needs to be found for one.

## Gates

Run with `FORCE_COLOR=0` in a dedicated worktree off `origin/main` with a real `pnpm install`. The full `npm run typecheck` and the whole Vitest suite were skipped on purpose — they get OOM-killed on this machine — in favour of the scoped equivalents below.

| Gate | Exit |
| --- | --- |
| `npx vitest run src/test-kernel/desktop/DesktopLogRedaction.vitest.ts src/test-kernel/architecture --testTimeout=120000` | 0 — 14 files, 76 tests passed |
| `node scripts/check-effect-migration-ratchet.mjs` | 0 — "no count grew, no baseline headroom" |
| `npm run check:dead-code-ratchet` (via the coordination gate) | 0 — 214 combined vs 214 baselined, "no new findings" |
| `npx tsc -p packages/desktop/tsconfig.json --noEmit` | 0 |
| `npx tsc -p tsconfig.test-kernel.json --noEmit` | 0 |
| `npx eslint src/test-kernel/desktop/DesktopLogRedaction.vitest.ts` | 0 |
| `npx prettier --check CHANGELOG.md src/test-kernel/desktop/DesktopLogRedaction.vitest.ts` | 0 — "All matched files use Prettier code style!" |

`git ls-files -s | awk '$1=="120000"' | grep node_modules` prints nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
