### PR TITLE
fix(agents): packaged agent definitions stay read-only when read in place

### DIFF
--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -181,6 +181,17 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
       getCustomAgentDirectory: directory.getCustomAgentDirectory,
       getSourceDirectory: directory.getSourceDirectory,
       openDocument: directory.openPath,
+      // The desktop has no editor of its own and hands the path to the OS,
+      // so a packaged definition is shown through a temporary copy that the
+      // external editor may save without touching the installed bundle.
+      openReadOnlyDocument: async (filePath) => {
+        const target = path.join(
+          await createTexraTempDir('texra-agent-yaml-'),
+          path.basename(filePath),
+        );
+        await AbsoluteFS.copy(filePath, target, { overwrite: true });
+        await directory.openPath(target);
+      },
       revealFile: directory.revealPath,
       confirmAction: (message, confirmLabel) =>
         prompts.confirm({

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -25,6 +25,7 @@ import type {
 import {
   AGENT_SOURCE,
   agentKey as agentKeyFromSourceName,
+  isPackagedAgentSource,
 } from '@shared/schemas';
 import {
   renderLabeledActionButton,
@@ -291,8 +292,7 @@ export class AgentSelectionPanel extends LitElement {
 
   /** Detail-pane actions in render order, each with the condition that shows it. */
   private renderDetailActions(agent: AgentSelectionItem): TemplateResult[] {
-    // Only the two built-in sources lack a decorator row, hence no badge.
-    const builtIn = sourceMeta(agent.source).badge === undefined;
+    const builtIn = isPackagedAgentSource(agent.source);
     const isCustom = agent.source === AGENT_SOURCE.CUSTOM;
     const actions: ReadonlyArray<{
       readonly when: boolean;
@@ -302,8 +302,15 @@ export class AgentSelectionPanel extends LitElement {
         when: agent.hasPath,
         button: {
           icon: 'file-lines',
-          text: 'Open YAML',
-          label: 'Open agent YAML definition',
+          // A packaged definition ships inside the app and cannot be edited
+          // in place; Customize is the action that produces an editable copy.
+          text: builtIn ? 'View YAML' : 'Open YAML',
+          label: builtIn
+            ? 'View agent YAML definition'
+            : 'Open agent YAML definition',
+          title: builtIn
+            ? 'View the built-in definition (read-only). Use Customize to edit it.'
+            : 'Open this agent YAML definition for editing',
           className: 'agent-action-btn',
           kind: 'ghost',
           onClick: () =>

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -87,6 +87,15 @@ export class AgentHandlers {
         const doc = await vscode.workspace.openTextDocument(filePath);
         await vscode.window.showTextDocument(doc, { preview: false });
       },
+      // An untitled buffer holds the text, so Ctrl+S prompts for a new
+      // location instead of writing back into the packaged resources.
+      openReadOnlyDocument: async (filePath) => {
+        const doc = await vscode.workspace.openTextDocument({
+          content: await AbsoluteFS.read(filePath),
+          language: 'yaml',
+        });
+        await vscode.window.showTextDocument(doc, { preview: false });
+      },
       revealFile: async (filePath) => {
         await vscode.commands.executeCommand(
           'revealFileInOS',

--- a/src/controllers/settingsView/backend/SettingsAgentActions.ts
+++ b/src/controllers/settingsView/backend/SettingsAgentActions.ts
@@ -6,7 +6,11 @@ import type { SettingsAgentDirectoryController } from '@controllers/settingsView
 import type { MessageHost } from '@hosts/uiHosts';
 // Local imports - shared
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import type { AgentSource, SettingsMessageFor } from '@shared/schemas';
+import {
+  isPackagedAgentSource,
+  type AgentSource,
+  type SettingsMessageFor,
+} from '@shared/schemas';
 // Local imports - utilities
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { isStrictlyWithin } from '@utils/core/pathCore';
@@ -46,6 +50,11 @@ interface SettingsAgentActionsOptions {
     source: AgentSource,
   ) => Promise<string | undefined>;
   readonly openDocument: (filePath: string) => Promise<void>;
+  /**
+   * Show a file the user must not edit in place. Hosts present it however
+   * they can without handing back a buffer that saves over the original.
+   */
+  readonly openReadOnlyDocument: (filePath: string) => Promise<void>;
   readonly revealFile: (filePath: string) => Promise<void>;
   readonly confirmAction: (
     message: string,
@@ -101,7 +110,13 @@ export function createSettingsAgentActions(
           );
           return;
         }
-        await options.openDocument(result.path);
+        // A packaged definition lives inside the installed host bundle, so
+        // opening the file itself would let a save mutate the built-in agent
+        // every later scan and launch reads — and silently bypass the
+        // adjacent Customize action that makes the editable copy.
+        await (isPackagedAgentSource(message.agentSource)
+          ? options.openReadOnlyDocument(result.path)
+          : options.openDocument(result.path));
       }),
 
     revealAgentFile: (message) =>

--- a/src/shared/schemas/agent.ts
+++ b/src/shared/schemas/agent.ts
@@ -50,6 +50,19 @@ export const AgentSourceSchema = z.enum(AGENT_SOURCE);
 
 export type AgentSource = z.infer<typeof AgentSourceSchema>;
 
+/**
+ * True for the two sources whose definitions ship inside the host bundle.
+ * Their directories are registered `writable: false`, so every surface that
+ * offers to open one must present it read-only and point edits at the
+ * custom copy instead.
+ */
+export function isPackagedAgentSource(source: AgentSource): boolean {
+  return (
+    source === AGENT_SOURCE.BUILT_IN_WORKFLOW ||
+    source === AGENT_SOURCE.BUILT_IN_TOOL_USE
+  );
+}
+
 const AGENT_NAME_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9_-]*$/u;
 
 export const AgentNameSchema = z

--- a/src/shared/schemas/agent.ts
+++ b/src/shared/schemas/agent.ts
@@ -51,10 +51,10 @@ export const AgentSourceSchema = z.enum(AGENT_SOURCE);
 export type AgentSource = z.infer<typeof AgentSourceSchema>;
 
 /**
- * True for the two sources whose definitions ship inside the host bundle.
- * Their directories are registered `writable: false`, so every surface that
- * offers to open one must present it read-only and point edits at the
- * custom copy instead.
+ * True for the two sources whose definitions ship inside the host bundle and
+ * are read in place. Every surface that offers to open one presents it
+ * read-only and points edits at the custom copy; the extension additionally
+ * registers those directories `writable: false` for its file tools.
  */
 export function isPackagedAgentSource(source: AgentSource): boolean {
   return (

--- a/src/test-kernel/tools/PathResolution.vitest.ts
+++ b/src/test-kernel/tools/PathResolution.vitest.ts
@@ -7,8 +7,10 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { installPlatform } from '@test/support/setupPlatform';
 import {
   assertNoParentTraversal,
+  assertWritable,
   resolveWorkspaceRelativePath,
 } from '@tools/pathResolution';
+import { registerExternalRoot } from '@utils/files/externalRoots';
 
 describe('assertNoParentTraversal', () => {
   it.each(['../x', 'a/../../x'])('rejects %s', (targetPath) => {
@@ -54,5 +56,33 @@ describe('resolveWorkspaceRelativePath path protection', () => {
       absolute: outsidePath,
       fsPath: outsidePath,
     });
+  });
+
+  // Last in the file on purpose: the registry has no unregister, so the
+  // registration lives until the module registry is torn down with the file.
+  it('keeps a read-only external root that sits inside the workspace non-writable', async () => {
+    await installPlatform({ workspacePath });
+    const packagedAgents = path.join(
+      workspacePath,
+      'packages',
+      'extension',
+      'resources',
+      'agents',
+    );
+    registerExternalRoot(packagedAgents, {
+      kind: 'builtInToolUse',
+      writable: false,
+      label: 'Packaged agents',
+    });
+
+    const targetPath = 'packages/extension/resources/agents/proof.yaml';
+    const resolved = resolveWorkspaceRelativePath(targetPath);
+
+    expect(resolved.external?.writable).toBe(false);
+    expect(() => assertWritable(resolved, targetPath)).toThrowError(
+      new ToolError(
+        `Cannot write ${targetPath}: Packaged agents is read-only.`,
+      ),
+    );
   });
 });

--- a/src/tools/pathResolution.ts
+++ b/src/tools/pathResolution.ts
@@ -187,7 +187,11 @@ export function resolveWorkspaceRelativePath(
   }
 
   const relative = resolved.relativePath || '.';
-  return { relative, absolute: resolved.absolutePath, fsPath: relative };
+  return annotateExternalPermission({
+    relative,
+    absolute: resolved.absolutePath,
+    fsPath: relative,
+  });
 }
 
 /** Permission metadata carried for a path inside a registered external root. */
@@ -202,13 +206,18 @@ function externalInfo(
 }
 
 /**
- * Attach external-root permission metadata when a resolution (from the
- * working_directory branch) happens to land inside a registered root.
+ * Attach external-root permission metadata when a resolution that stayed
+ * inside its containing root (the `working_directory` branch or the
+ * workspace branch) happens to land inside a registered root.
  *
- * Without this, a subagent launched with `working_directory` set to a
- * read-only external root (e.g. the built-in agents dir) could bypass
- * `assertWritable` by addressing files with paths relative to `root` —
- * the in-root branches return without touching the allowlist otherwise.
+ * Containment inside a root does not imply writability: a registered
+ * read-only root may itself sit inside the workspace or the working
+ * directory — the packaged agent definitions do exactly that when the
+ * extension is run from its own source checkout, where `resourcesPath`
+ * is `${workspaceFolder}/packages/extension/resources`. Without this the
+ * in-root branches return without touching the allowlist, and
+ * `assertWritable` would let `write_file`/`edit_file` overwrite files the
+ * host registered `writable: false`.
  *
  * Preserves `relative`/`absolute`/`fsPath` as the caller already built
  * them so display and I/O remain unchanged; only `external` is added.

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -139,6 +139,10 @@ export function findExternalRoot(
   absolutePath: string,
 ): MatchedExternalRoot | null {
   if (!path.isAbsolute(absolutePath)) return null;
+  // Nothing registered means nothing can match. Checked before
+  // canonicalisation so hosts that register no roots do not pay a realpath
+  // syscall on every path a tool resolves.
+  if (roots.size === 0) return null;
 
   let resolved: string;
   try {


### PR DESCRIPTION
Follow-up to the two Codex findings on #12365, which reads packaged agent defaults in place.

- **Read-only roots inside the workspace.** The workspace branch of `resolveWorkspaceRelativePath` was the one in-root return that skipped `annotateExternalPermission`, so a registered read-only root contained by the workspace (extension development puts `resources` under `packages/extension`) lost its `writable: false` metadata and `write_file`/`edit_file` could overwrite bundled YAML. It now runs through the same step. `findExternalRoot` short-circuits on an empty registry, so the added lookup costs nothing on hosts that register no roots.
- **"Open YAML" on a packaged agent** goes through a new `openReadOnlyDocument` port instead of `openDocument`: an untitled buffer in VS Code (Save prompts for a location), a temp copy on the desktop, the same mechanisms both hosts already use to show a remote agent's prompt. The shared Agents-tab button reads "View YAML" for packaged agents with a tooltip pointing at Customize; `isPackagedAgentSource` replaces the badge heuristic that decided `builtIn`.

7 files, +81/-13. Typecheck, lint, test:pure, test:changed, both ratchets green; no baseline touched; no new tests (no suite pins external-root writability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)