### PR TITLE
test(harness): the fake host runs on a real temp root with the production filesystem; memfs deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "globals": "^17.12.0",
     "jsdom": "^30.0.1",
     "knip": "^6.34.0",
-    "memfs": "^4.71.0",
     "prettier": "^3.9.6",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8.70.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,9 +355,6 @@ importers:
       knip:
         specifier: ^6.34.0
         version: 6.34.0
-      memfs:
-        specifier: ^4.71.0
-        version: 4.71.0
       prettier:
         specifier: ^3.9.6
         version: 3.9.6
@@ -1550,126 +1547,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@jsonjoy.com/base64@1.1.2':
-    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/base64@17.67.0':
-    resolution: {integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/buffers@1.2.1':
-    resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/buffers@17.67.0':
-    resolution: {integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/codegen@1.0.0':
-    resolution: {integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/codegen@17.67.0':
-    resolution: {integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-core@4.71.0':
-    resolution: {integrity: sha512-9DFR/j+bm+tig1abs1CWS1/r0IVjNUdTp/+q6R/PXayXpO1rgbUh7tkanGYP40I0zdxbOreN3tmzBpVHgfMKzg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-fsa@4.71.0':
-    resolution: {integrity: sha512-dRw5ojxzep3lntVGVBLzQUMYj1hXLH+DAz9sK0vKU+594x/zA2nYPOiitlyhYtOJ2nv1FXNq7c55rgwANknIWw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node-builtins@4.71.0':
-    resolution: {integrity: sha512-BSzl+QFSxZF58BxGjV1wqCJ+qSn3b2IZnb+z3hDQq6goqOO5RuxF8gRihjsFx17AfpEpa7XjYcP8XpQtDU8RrQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node-to-fsa@4.71.0':
-    resolution: {integrity: sha512-OlXBZKIeDx5bIGcQmn0w+nVkLheCiuQSepKiBAiWSWimSdn8Q6Yc9ih2y8zStcJk31fieqnov9V+o8XTWn/5Rw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node-utils@4.71.0':
-    resolution: {integrity: sha512-YtzCL3jbKYx6LHxqS9ymJ9Ob7SO9cucI+kpNO3LijGNFEjFbvNsTlHkvFgocAMAjUk96TpQTCsYkzFQi1CdlAA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node@4.71.0':
-    resolution: {integrity: sha512-yt5Ak0otPdHPIlmMvF16aLG2qSZL52EYJ7HOkYpBcIPWw+kmT1FtTSj4oiV2OUkJbG8pLzA+RhMgrlRl85QuBw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-print@4.71.0':
-    resolution: {integrity: sha512-OhfDSdvyO8uGV0U11OP+mOeVCPgjuP1HqCGR/TdBQLxHoDEWJAK3KOP5fPXo57H7i3G0x0Vmv8xPRHDle4XGzA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-snapshot@4.71.0':
-    resolution: {integrity: sha512-md+Wov365xa9A3nfW9YQTHLcweHHAee/e/0UoVRbldEHxboPJknuO3sEkNVVECO0dTqKra/ERaQylAMRrGWd0Q==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pack@1.21.0':
-    resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pack@17.67.0':
-    resolution: {integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pointer@1.0.2':
-    resolution: {integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pointer@17.67.0':
-    resolution: {integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/util@1.9.0':
-    resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/util@17.67.0':
-    resolution: {integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
 
   '@keyv/bigmap@1.3.1':
     resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
@@ -4014,12 +3891,6 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob-to-regex.js@1.2.0:
-    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -4162,10 +4033,6 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
-
-  hyperdyperid@1.2.0:
-    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
-    engines: {node: '>=10.18'}
 
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
@@ -4678,9 +4545,6 @@ packages:
   media-typer@1.1.1:
     resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
     engines: {node: '>= 0.8'}
-
-  memfs@4.71.0:
-    resolution: {integrity: sha512-Zwrk7TpTXBkic7taZL+2QeppbauG0QOufRsT1zuXDYLW8jCajH0W1VSZ17+I7ODqiNbH9J1Vf1QJCqFlCfurDg==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -5739,12 +5603,6 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  thingies@2.6.1:
-    resolution: {integrity: sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==}
-    engines: {node: '>=10.18'}
-    peerDependencies:
-      tslib: ^2
-
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
@@ -5793,12 +5651,6 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
-
-  tree-dump@1.1.0:
-    resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -7110,134 +6962,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.6.0
-
-  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/base64@17.67.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/buffers@1.2.1(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/buffers@17.67.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/codegen@1.0.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/codegen@17.67.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-core@4.71.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-node-builtins': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.71.0(tslib@2.8.1)
-      thingies: 2.6.1(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-fsa@4.71.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-core': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.71.0(tslib@2.8.1)
-      thingies: 2.6.1(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node-builtins@4.71.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node-to-fsa@4.71.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-fsa': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.71.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node-utils@4.71.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-node-builtins': 4.71.0(tslib@2.8.1)
-      glob-to-regex.js: 1.2.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node@4.71.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-core': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-print': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-snapshot': 4.71.0(tslib@2.8.1)
-      glob-to-regex.js: 1.2.0(tslib@2.8.1)
-      thingies: 2.6.1(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-print@4.71.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-node-utils': 4.71.0(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-snapshot@4.71.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/json-pack': 17.67.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
-      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
-      '@jsonjoy.com/json-pointer': 1.0.2(tslib@2.8.1)
-      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
-      hyperdyperid: 1.2.0
-      thingies: 2.6.1(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pack@17.67.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/base64': 17.67.0(tslib@2.8.1)
-      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
-      '@jsonjoy.com/json-pointer': 17.67.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
-      hyperdyperid: 1.2.0
-      thingies: 2.6.1(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pointer@1.0.2(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pointer@17.67.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/util@17.67.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
-      tslib: 2.8.1
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
@@ -9606,10 +9330,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob-to-regex.js@1.2.0(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
-
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.6
@@ -9789,8 +9509,6 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
-
-  hyperdyperid@1.2.0: {}
 
   iceberg-js@0.8.1: {}
 
@@ -10271,23 +9989,6 @@ snapshots:
   mdurl@2.1.0: {}
 
   media-typer@1.1.1: {}
-
-  memfs@4.71.0:
-    dependencies:
-      '@jsonjoy.com/fs-core': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-fsa': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-to-fsa': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-print': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-snapshot': 4.71.0(tslib@2.8.1)
-      '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
-      glob-to-regex.js: 1.2.0(tslib@2.8.1)
-      thingies: 2.6.1(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
 
   merge-descriptors@2.0.0: {}
 
@@ -11398,10 +11099,6 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  thingies@2.6.1(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
-
   time-span@5.1.0:
     dependencies:
       convert-hrtime: 5.0.0
@@ -11444,10 +11141,6 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-
-  tree-dump@1.1.0(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
 
   tree-kill@1.2.2: {}
 

--- a/src/platform/defaults/fsEntryTypeBits.ts
+++ b/src/platform/defaults/fsEntryTypeBits.ts
@@ -1,32 +1,22 @@
 /**
- * Shared fs-entry-type bitmask resolution for FileSystemProvider.stat/readDirectory
- * implementations, parameterized on a minimal duck-typed stat-capable fs handle so
- * both node:fs and memfs's IFs (used by the test-kernel fake platform) can share it.
+ * Shared fs-entry-type bitmask resolution for the FileSystemProvider
+ * `stat` / `readDirectory` implementations.
  */
+import * as fs from 'node:fs';
+
 import { FileType } from '../interfaces';
 
-export type FileTypeProbe = {
+type FileTypeProbe = {
   isSymbolicLink(): boolean;
   isFile(): boolean;
   isDirectory(): boolean;
-};
-
-type StatCapableFs = {
-  promises: {
-    stat(
-      target: string,
-    ): Promise<Pick<FileTypeProbe, 'isFile' | 'isDirectory'>>;
-  };
 };
 
 /**
  * Resolve the target type of a symlink, producing combined bitmasks
  * (e.g. SymbolicLink | File = 65) matching vscode.FileType behavior.
  */
-async function resolveSymlinkType(
-  fs: StatCapableFs,
-  target: string,
-): Promise<number> {
+async function resolveSymlinkType(target: string): Promise<number> {
   let targetType: number = FileType.Unknown;
   try {
     const stats = await fs.promises.stat(target);
@@ -47,11 +37,10 @@ async function resolveSymlinkType(
  * entry's own path; for readDirectory, join the parent dir with the entry name.
  */
 export async function fileTypeFor(
-  fs: StatCapableFs,
   entry: FileTypeProbe,
   target: string,
 ): Promise<number> {
-  if (entry.isSymbolicLink()) return resolveSymlinkType(fs, target);
+  if (entry.isSymbolicLink()) return resolveSymlinkType(target);
   if (entry.isFile()) return FileType.File;
   if (entry.isDirectory()) return FileType.Directory;
   return FileType.Unknown;

--- a/src/platform/defaults/nodeFilesystem.ts
+++ b/src/platform/defaults/nodeFilesystem.ts
@@ -14,7 +14,7 @@ import { fileTypeFor } from './fsEntryTypeBits';
 export const nodeFilesystem: FileSystemProvider = {
   async stat(target: string): Promise<FileStat> {
     const lstats = await fs.promises.lstat(target);
-    const type = await fileTypeFor(fs, lstats, target);
+    const type = await fileTypeFor(lstats, target);
     // For symlinks, use stat (follows link) for size/timestamps to match
     // vscode.workspace.fs.stat behavior, falling back to lstat metadata for a
     // dangling symlink. For non-symlinks, lstat === stat.
@@ -104,11 +104,7 @@ export const nodeFilesystem: FileSystemProvider = {
     const entries = await fs.promises.readdir(target, { withFileTypes: true });
     return Promise.all(
       entries.map(async (entry) => {
-        const type = await fileTypeFor(
-          fs,
-          entry,
-          path.join(target, entry.name),
-        );
+        const type = await fileTypeFor(entry, path.join(target, entry.name));
         return [entry.name, type] as [string, number];
       }),
     );

--- a/src/test-kernel/agent/ReflectionLoop.vitest.ts
+++ b/src/test-kernel/agent/ReflectionLoop.vitest.ts
@@ -66,6 +66,7 @@ import {
   installPlatform,
   setupPlatform,
 } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import { generateRunId, isObject } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { createRunStorageLocation } from '@utils/files/fileLocation';
@@ -224,8 +225,8 @@ vi.mock('@agent/prompt/PromptBuilder', () => ({
 }));
 
 setupPlatform({
-  storagePath: '/storage',
-  workspacePath: '/workspace',
+  storagePath: fakePath('storage'),
+  workspacePath: fakePath('workspace'),
   workspaceState: {
     [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: true,
   },
@@ -662,8 +663,8 @@ describe('the reflection round loop', () => {
     Effect.gen(function* () {
       yield* Effect.promise(() =>
         installPlatform({
-          storagePath: '/storage',
-          workspacePath: '/workspace',
+          storagePath: fakePath('storage'),
+          workspacePath: fakePath('workspace'),
           workspaceState: {
             [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: false,
           },

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -16,6 +16,7 @@ import {
 import type { CompileLatex2PdfResult } from '@latex/texTools';
 import type { RunId, FileLocation } from '@shared/schemas';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { fakePath } from '@test/support/FakePlatform';
 
 // Local file imports
 import {
@@ -31,7 +32,7 @@ interface FakeCompileOptions {
 
 // The compiled PDF the fake engine reports; no test seeds it, so artifact
 // publication is a no-op — the path only has to be a plausible absolute one.
-const COMPILED_PDF = '/build/main.pdf';
+const COMPILED_PDF = fakePath('build/main.pdf');
 
 const mocks = vi.hoisted(() => ({
   compileLatex2Pdf: vi.fn(

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -15,8 +15,8 @@ import {
 } from '@agent/implementations/flows/reflection/output/outputState';
 import type { CompileLatex2PdfResult } from '@latex/texTools';
 import type { RunId, FileLocation } from '@shared/schemas';
-import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { fakePath } from '@test/support/FakePlatform';
+import { AbsoluteFS } from '@utils/files/absoluteFS';
 
 // Local file imports
 import {

--- a/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
+++ b/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
@@ -17,6 +17,7 @@ import {
 } from '@agent/implementations/flows/reflection/output/outputState';
 import type { RunId, FileLocation } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import { spiedTrace } from '@test/support/spiedTrace';
 import {
   createExternalLocation,
@@ -136,7 +137,7 @@ describe('workflow LaTeX compile input directories', () => {
     );
   });
 
-  it.each(['', '/external/source/main.tex'])(
+  it.each(['', fakePath('external/source/main.tex')])(
     'falls back to the output location for source %j',
     async (source) => {
       const runId =
@@ -203,7 +204,7 @@ describe('workflow LaTeX compile input directories', () => {
 
     expect(
       resolveWorkspaceSourceDir(
-        createExternalLocation('/external/project/main.tex'),
+        createExternalLocation(fakePath('external/project/main.tex')),
       ),
     ).toBeUndefined();
   });
@@ -251,7 +252,7 @@ describe('workflow LaTeX compile input directories', () => {
 
     await compileDiff(
       runId,
-      createExternalLocation('/external/project/main.tex'),
+      createExternalLocation(fakePath('external/project/main.tex')),
       1,
       createWorkspaceLocation(
         path.join(workspacePath, 'Draft', 'main.tex'),
@@ -262,7 +263,7 @@ describe('workflow LaTeX compile input directories', () => {
     expect(mocks.compileLatex2Pdf).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        extraInputDirs: ['/external/project'],
+        extraInputDirs: [fakePath('external/project')],
       }),
     );
   });

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -14,6 +14,7 @@ import {
 import { XmlOutputManager } from '@agent/implementations/flows/reflection/output/XmlOutputManager';
 import type { FileLocation, RunId } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import { spiedTrace } from '@test/support/spiedTrace';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { createExternalLocation } from '@utils/files/fileLocation';
@@ -88,14 +89,14 @@ async function writeAndSplitDocuments(
   options: XmlManagerOptions = {},
 ): ReturnType<XmlOutputManager['splitScratchpadMultipleOutputXml']> {
   await AbsoluteFS.write(
-    '/tmp/run/output.xml',
+    fakePath('tmp/run/output.xml'),
     typeof output === 'string' ? output : output.join('\n'),
   );
   return createXmlManager(inputFiles, options).splitScratchpadMultipleOutputXml(
-    createExternalLocation('/tmp/run/output.xml'),
+    createExternalLocation(fakePath('tmp/run/output.xml')),
     0,
     options.baseFiles?.map((name) =>
-      createExternalLocation(`/tmp/run/${name}`),
+      createExternalLocation(fakePath('tmp/run', name)),
     ),
   );
 }
@@ -116,11 +117,15 @@ function expectSources(
 }
 
 async function expectWritten(path: string, content: string): Promise<void> {
-  await expect(AbsoluteFS.read(`/tmp/run/${path}`)).resolves.toBe(content);
+  await expect(AbsoluteFS.read(fakePath('tmp/run', path))).resolves.toBe(
+    content,
+  );
 }
 
 async function expectAbsent(path: string): Promise<void> {
-  await expect(AbsoluteFS.exists(`/tmp/run/${path}`)).resolves.toBe(false);
+  await expect(AbsoluteFS.exists(fakePath('tmp/run', path))).resolves.toBe(
+    false,
+  );
 }
 
 async function assertRecoveredDocuments(
@@ -819,7 +824,7 @@ describe('XmlOutputManager', () => {
     formatterMocks.runLatexFormatter.mockReset();
     await installPlatform({
       files: { '/tmp/run/output.xml': '<documents />' },
-      workspacePath: '/workspace',
+      workspacePath: fakePath('workspace'),
     });
   });
 
@@ -834,7 +839,7 @@ describe('XmlOutputManager', () => {
             '\n\\documentclass{article}\n\\begin{document}\nHi.\n\\end{document}\n\n',
         },
       ],
-      createExternalLocation('/tmp/run/output.xml'),
+      createExternalLocation(fakePath('tmp/run/output.xml')),
       0,
     );
 
@@ -854,7 +859,7 @@ describe('XmlOutputManager', () => {
           content: '\nBody only.\n\\end{document}\n\n',
         },
       ],
-      createExternalLocation('/tmp/run/output.xml'),
+      createExternalLocation(fakePath('tmp/run/output.xml')),
       0,
     );
 
@@ -866,7 +871,7 @@ describe('XmlOutputManager', () => {
 
     await manager.processMultipleLatexDocuments(
       [{ name: 'sections/main.tex', content: 'Nested section.\n' }],
-      createExternalLocation('/tmp/run/output.xml'),
+      createExternalLocation(fakePath('tmp/run/output.xml')),
       0,
     );
 
@@ -909,7 +914,7 @@ describe('XmlOutputManager', () => {
 
   it('does not auto-format extracted workflow outputs', async () => {
     await AbsoluteFS.write(
-      '/tmp/run/output.xml',
+      fakePath('tmp/run/output.xml'),
       `<documents><document name="main.tex">
 \\[
   f(x)=x^4-2x^2+1.
@@ -924,7 +929,7 @@ Appendix.
       state,
       processorDeps({ logger: spiedTrace() }),
       manager,
-      createExternalLocation('/tmp/run/output.xml'),
+      createExternalLocation(fakePath('tmp/run/output.xml')),
       0,
     );
 
@@ -997,11 +1002,11 @@ Appendix.
 
   it('falls back to content-similarity matching for unlabeled fenced blocks against the original inputs', async () => {
     await AbsoluteFS.write(
-      '/tmp/run/appendices.tex',
+      fakePath('tmp/run/appendices.tex'),
       '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture with a shared Lean repository.\n',
     );
     await AbsoluteFS.write(
-      '/tmp/run/cost_section.tex',
+      fakePath('tmp/run/cost_section.tex'),
       '% !TEX root = Draft3SM.tex\n\\section{Computational cost}\nPreliminary numbers from the local interactive logs.\n',
     );
 
@@ -1259,8 +1264,8 @@ Appendix.
 
   it('leaves an unlabeled block unmatched when identical base files make the match ambiguous', async () => {
     const stub = '\\section{Stub}\nShared template content.\n';
-    await AbsoluteFS.write('/tmp/run/a.tex', stub);
-    await AbsoluteFS.write('/tmp/run/b.tex', stub);
+    await AbsoluteFS.write(fakePath('tmp/run/a.tex'), stub);
+    await AbsoluteFS.write(fakePath('tmp/run/b.tex'), stub);
 
     const outputs = await writeAndSplitDocuments(
       [
@@ -1280,11 +1285,11 @@ Appendix.
 
   it('routes the revision, not the echoed original, when the model quotes both', async () => {
     await AbsoluteFS.write(
-      '/tmp/run/cost.tex',
+      fakePath('tmp/run/cost.tex'),
       '\\section{Computational cost}\nPreliminary numbers from the local interactive logs.\n',
     );
     await AbsoluteFS.write(
-      '/tmp/run/arch.tex',
+      fakePath('tmp/run/arch.tex'),
       '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture.\n',
     );
 
@@ -1327,20 +1332,23 @@ Appendix.
     // being revised; only the previous round's outputs do. The similarity
     // fallback must compare against those, or every later-round recovery
     // would score below the threshold and drop the round.
-    await AbsoluteFS.ensureDir('/tmp/run/r0');
-    await AbsoluteFS.ensureDir('/tmp/run/r1');
-    await AbsoluteFS.write('/tmp/run/appendices.tex', 'placeholder A');
-    await AbsoluteFS.write('/tmp/run/cost_section.tex', 'placeholder B');
+    await AbsoluteFS.ensureDir(fakePath('tmp/run/r0'));
+    await AbsoluteFS.ensureDir(fakePath('tmp/run/r1'));
+    await AbsoluteFS.write(fakePath('tmp/run/appendices.tex'), 'placeholder A');
     await AbsoluteFS.write(
-      '/tmp/run/r0/appendices.tex',
+      fakePath('tmp/run/cost_section.tex'),
+      'placeholder B',
+    );
+    await AbsoluteFS.write(
+      fakePath('tmp/run/r0/appendices.tex'),
       '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture with shared memory.\n',
     );
     await AbsoluteFS.write(
-      '/tmp/run/r0/cost_section.tex',
+      fakePath('tmp/run/r0/cost_section.tex'),
       '% !TEX root = Draft3SM.tex\n\\section{Computational cost}\nPreliminary numbers from the interactive logs.\n',
     );
     await AbsoluteFS.write(
-      '/tmp/run/r1/output.xml',
+      fakePath('tmp/run/r1/output.xml'),
       [
         '```latex',
         '% !TEX root = Draft3SM.tex',
@@ -1362,14 +1370,16 @@ Appendix.
       {
         source: 'appendices.tex',
         round: 0,
-        location: createExternalLocation('/tmp/run/r0/appendices.tex'),
+        location: createExternalLocation(fakePath('tmp/run/r0/appendices.tex')),
         lineage: null,
         diff: null,
       },
       {
         source: 'cost_section.tex',
         round: 0,
-        location: createExternalLocation('/tmp/run/r0/cost_section.tex'),
+        location: createExternalLocation(
+          fakePath('tmp/run/r0/cost_section.tex'),
+        ),
         lineage: null,
         diff: null,
       },
@@ -1379,12 +1389,12 @@ Appendix.
       processorDeps({
         logger: spiedTrace(),
         baseFiles: [
-          createExternalLocation('/tmp/run/appendices.tex'),
-          createExternalLocation('/tmp/run/cost_section.tex'),
+          createExternalLocation(fakePath('tmp/run/appendices.tex')),
+          createExternalLocation(fakePath('tmp/run/cost_section.tex')),
         ],
       }),
       manager,
-      createExternalLocation('/tmp/run/r1/output.xml'),
+      createExternalLocation(fakePath('tmp/run/r1/output.xml')),
       1,
     );
 
@@ -1403,11 +1413,11 @@ Appendix.
   it('reports input files left unmatched by content-similarity recovery', async () => {
     const logger = spiedTrace();
     await AbsoluteFS.write(
-      '/tmp/run/cost.tex',
+      fakePath('tmp/run/cost.tex'),
       '\\section{Computational cost}\nPreliminary numbers from the local interactive logs.\n',
     );
     await AbsoluteFS.write(
-      '/tmp/run/arch.tex',
+      fakePath('tmp/run/arch.tex'),
       '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture.\n',
     );
 
@@ -1459,8 +1469,8 @@ Appendix.
 
   it('logs discarded unclosed latex fences during similarity recovery', async () => {
     const logger = spiedTrace();
-    await AbsoluteFS.write('/tmp/run/a.tex', 'Original A.');
-    await AbsoluteFS.write('/tmp/run/b.tex', 'Original B.');
+    await AbsoluteFS.write(fakePath('tmp/run/a.tex'), 'Original A.');
+    await AbsoluteFS.write(fakePath('tmp/run/b.tex'), 'Original B.');
 
     const outputs = await writeAndSplitDocuments(
       ['```latex', 'Unclosed revised content.'],
@@ -1591,13 +1601,13 @@ describe('extractFilesFromXml', () => {
       const split = vi.spyOn(manager, 'splitScratchpadMultipleOutputXml');
       if (failure) split.mockRejectedValueOnce(failure);
       else split.mockResolvedValueOnce([]);
-      await AbsoluteFS.write('/tmp/run/empty-output.xml', '');
+      await AbsoluteFS.write(fakePath('tmp/run/empty-output.xml'), '');
 
       await extractFilesFromXml(
         state,
         processorDeps({ logger }),
         manager,
-        createExternalLocation('/tmp/run/empty-output.xml'),
+        createExternalLocation(fakePath('tmp/run/empty-output.xml')),
         round,
       );
 
@@ -1619,7 +1629,7 @@ describe('extractFilesFromXml', () => {
       [],
     );
     await AbsoluteFS.write(
-      '/tmp/run/untagged-output.xml',
+      fakePath('tmp/run/untagged-output.xml'),
       '% chunk.tex\n\\section{Untagged content}\n',
     );
 
@@ -1627,7 +1637,7 @@ describe('extractFilesFromXml', () => {
       createOutputState(),
       processorDeps({ logger }),
       manager,
-      createExternalLocation('/tmp/run/untagged-output.xml'),
+      createExternalLocation(fakePath('tmp/run/untagged-output.xml')),
       5,
     );
 

--- a/src/test-kernel/agent/output/compileCheckTestUtils.ts
+++ b/src/test-kernel/agent/output/compileCheckTestUtils.ts
@@ -7,12 +7,13 @@ import type { OutputState } from '@agent/implementations/flows/reflection/output
 import type { RunId, FileLocation, OutputFileInfo } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { installPlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import { spiedTrace } from '@test/support/spiedTrace';
 import { createRunStorageLocation } from '@utils/files/fileLocation';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
 
-export const storagePath = '/storage';
-export const workspacePath = '/workspace';
+export const storagePath = fakePath('storage');
+export const workspacePath = fakePath('workspace');
 
 export function runDir(runId: RunId): string {
   return path.join(storagePath, 'executions', runId);

--- a/src/test-kernel/agent/prompt/userVars.vitest.ts
+++ b/src/test-kernel/agent/prompt/userVars.vitest.ts
@@ -37,7 +37,7 @@ import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { spiedTrace } from '@test/support/spiedTrace';
 import { writeSkill } from '@test/support/skillFixtures';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
-import { FakeConfigProvider } from '@test/support/FakePlatform';
+import { FakeConfigProvider, fakePath } from '@test/support/FakePlatform';
 
 // getConfig reads through the platform config provider; drive the setting
 // via this provider instead of patching the ESM export.
@@ -120,10 +120,10 @@ describe('buildUserVars runtime skill diagnostics', () => {
       baseConfig,
       { ...baseSetting, agentCategory: AgentCategory.ToolUse },
       basePrompt,
-      '/agents/generic',
+      fakePath('agents/generic'),
       { isOpenai: false, isAnthropic: false, isGoogle: false },
       spiedTrace({ warn, emit }),
-      { workspacePath: '/workspace' },
+      { workspacePath: fakePath('workspace') },
     );
 
     expect(vars.AVAILABLE_SKILLS).toBe('');
@@ -141,10 +141,10 @@ describe('buildUserVars runtime skill diagnostics', () => {
       baseConfig,
       { ...baseSetting, agentCategory: AgentCategory.ToolUse },
       basePrompt,
-      '/agents/generic',
+      fakePath('agents/generic'),
       { isOpenai: false, isAnthropic: false, isGoogle: false },
       spiedTrace({ warn, emit }),
-      { workspacePath: '/workspace' },
+      { workspacePath: fakePath('workspace') },
     );
 
     expect(vars.AVAILABLE_SKILLS).toBe('');
@@ -174,10 +174,10 @@ describe('buildUserVars runtime skill diagnostics', () => {
       baseConfig,
       { ...baseSetting, agentCategory: AgentCategory.ToolUse },
       basePrompt,
-      '/agents/generic',
+      fakePath('agents/generic'),
       { isOpenai: false, isAnthropic: false, isGoogle: false },
       spiedTrace({ emit }),
-      { workspacePath: '/workspace' },
+      { workspacePath: fakePath('workspace') },
     );
 
     expect(emit).toHaveBeenCalledExactlyOnceWith({
@@ -199,10 +199,10 @@ describe('buildUserVars runtime skill diagnostics', () => {
       baseConfig,
       baseSetting,
       basePrompt,
-      '/agents/generic',
+      fakePath('agents/generic'),
       { isOpenai: false, isAnthropic: false, isGoogle: false },
       spiedTrace({ emit }),
-      { workspacePath: '/workspace' },
+      { workspacePath: fakePath('workspace') },
     );
 
     expect(emit).not.toHaveBeenCalled();
@@ -275,17 +275,17 @@ function buildVars(
     agentConfig,
     agentSetting,
     agentPrompt,
-    '/agents/generic',
+    fakePath('agents/generic'),
     { isOpenai: false, isAnthropic: false, isGoogle: false },
     noopTrace,
-    { workspacePath: '/workspace' },
+    { workspacePath: fakePath('workspace') },
   );
 }
 
 describe('buildUserVars with missing configured files', () => {
   beforeEach(async () => {
     await installPlatform({
-      workspacePath: '/workspace',
+      workspacePath: fakePath('workspace'),
       files: {
         '/workspace/present.tex': 'present input',
         '/workspace/context.tex': 'present context',
@@ -341,11 +341,11 @@ describe('buildUserVars with missing configured files', () => {
 });
 
 describe('requiredFilesInternal custom variables', () => {
-  const briefPath = path.resolve('/agents/generic', 'brief.txt');
+  const briefPath = fakePath('agents/generic', 'brief.txt');
 
   beforeEach(async () => {
     await installPlatform({
-      workspacePath: '/workspace',
+      workspacePath: fakePath('workspace'),
       files: { [briefPath]: 'briefing notes' },
     });
   });

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -25,7 +25,7 @@ import {
   type RunId,
 } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
+import { createFakeWorkspaceRoots, fakePath } from '@test/support/FakePlatform';
 import {
   fakeProcessServices,
   installPlatform,
@@ -88,34 +88,36 @@ describe('session isolation', () => {
 
   it('two sessions in one process write under their own roots', async () => {
     const paperA = createFakeWorkspaceRoots({
-      workspacePath: '/papers/a',
-      storagePath: '/storage/a',
+      workspacePath: fakePath('papers/a'),
+      storagePath: fakePath('storage/a'),
     });
     const paperB = createFakeWorkspaceRoots({
-      workspacePath: '/papers/b',
-      storagePath: '/storage/b',
+      workspacePath: fakePath('papers/b'),
+      storagePath: fakePath('storage/b'),
     });
     const sessionA = createTestSession({ roots: paperA });
     const sessionB = createTestSession({ roots: paperB });
     try {
       await runInSession(sessionA, async () => {
-        expect(WorkspaceFS.getPath()).toBe('/papers/a');
+        expect(WorkspaceFS.getPath()).toBe(fakePath('papers/a'));
         await StorageFS.ensureDir('.');
         await StorageFS.write('note.txt', 'from a');
       });
       await runInSession(sessionB, async () => {
-        expect(WorkspaceFS.getPath()).toBe('/papers/b');
+        expect(WorkspaceFS.getPath()).toBe(fakePath('papers/b'));
         await StorageFS.ensureDir('.');
         await StorageFS.write('note.txt', 'from b');
       });
       const read = async (file: string) =>
         Buffer.from(await platform().fs.readFile(file)).toString('utf8');
-      expect(await read('/storage/a/note.txt')).toBe('from a');
-      expect(await read('/storage/b/note.txt')).toBe('from b');
+      expect(await read(fakePath('storage/a/note.txt'))).toBe('from a');
+      expect(await read(fakePath('storage/b/note.txt'))).toBe('from b');
       // Outside both scopes the process roots answer, not either paper.
-      expect(workspaceRoots().workspace).toBe('/workspace');
-      expect(WorkspaceFS.getPath()).toBe('/workspace');
-      expect(workspaceRoots().storage).toBe('/workspace/.texra/storage');
+      expect(workspaceRoots().workspace).toBe(fakePath('workspace'));
+      expect(WorkspaceFS.getPath()).toBe(fakePath('workspace'));
+      expect(workspaceRoots().storage).toBe(
+        fakePath('workspace/.texra/storage'),
+      );
     } finally {
       sessionA.dispose();
       sessionB.dispose();
@@ -125,14 +127,14 @@ describe('session isolation', () => {
   it('the host-exit drain settles each session under its own root, outside any scope', async () => {
     const sessionA = createTestSession({
       roots: createFakeWorkspaceRoots({
-        workspacePath: '/papers/a',
-        storagePath: '/storage/a',
+        workspacePath: fakePath('papers/a'),
+        storagePath: fakePath('storage/a'),
       }),
     });
     const sessionB = createTestSession({
       roots: createFakeWorkspaceRoots({
-        workspacePath: '/papers/b',
-        storagePath: '/storage/b',
+        workspacePath: fakePath('papers/b'),
+        storagePath: fakePath('storage/b'),
       }),
     });
     const live = [
@@ -178,8 +180,12 @@ describe('session isolation', () => {
           status: RUN_OUTCOME.CANCELLED,
         });
       }
-      expect(storageMocks.settledUnder.get('a0da01')).toBe('/storage/a');
-      expect(storageMocks.settledUnder.get('b0db01')).toBe('/storage/b');
+      expect(storageMocks.settledUnder.get('a0da01')).toBe(
+        fakePath('storage/a'),
+      );
+      expect(storageMocks.settledUnder.get('b0db01')).toBe(
+        fakePath('storage/b'),
+      );
       for (const [session, runId] of live) {
         expect(runInSession(session, () => ownsRunLease(runId))).toBe(false);
       }

--- a/src/test-kernel/agent/storage/ChildRunOutput.vitest.ts
+++ b/src/test-kernel/agent/storage/ChildRunOutput.vitest.ts
@@ -14,6 +14,7 @@ import {
   publishTestRunStart,
 } from '@test/support/sessionTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import { StorageFS } from '@utils/files/storageFS';
 
 const parentRunId = 'aaaaaa111111' as RunId;
@@ -21,7 +22,10 @@ const childRunId = 'bbbbbb222222' as RunId;
 const otherParentRunId = 'cccccc333333' as RunId;
 const relativePath = 'r1/draft.tex';
 
-setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
+setupPlatform({
+  storagePath: fakePath('storage'),
+  workspacePath: fakePath('workspace'),
+});
 let session: SessionHandle;
 beforeEach(() => {
   session = createProcessSession();
@@ -149,7 +153,11 @@ describe('resolveChildRunOutput', () => {
   it('rejects paths outside run storage', async () => {
     await expect(
       Effect.runPromise(
-        resolveChildRunOutput(parentRunId, '/workspace/draft.tex', session),
+        resolveChildRunOutput(
+          parentRunId,
+          fakePath('workspace/draft.tex'),
+          session,
+        ),
       ),
     ).rejects.toThrow('not inside task-run storage');
   });

--- a/src/test-kernel/agent/storage/RunWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/agent/storage/RunWorkspaceFiles.vitest.ts
@@ -4,10 +4,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { listRunWorkspaceFiles } from '@agent/storage';
 import { platform } from '@platform/platform';
+import { fakePath } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 
-const WORKSPACE_PATH = path.resolve(path.sep, 'workspace');
+const WORKSPACE_PATH = fakePath('workspace');
 const CONFIG = { workingDirectory: WORKSPACE_PATH };
 
 function statError(code: string, message: string): Error {
@@ -42,7 +43,8 @@ describe('listRunWorkspaceFiles', () => {
         path: 'z-dir',
         displayPath: 'workspace/z-dir',
         absolutePath: path.join(WORKSPACE_PATH, 'z-dir'),
-        size: 0,
+        // A real directory's size is the filesystem's own bookkeeping.
+        size: expect.any(Number),
         isDirectory: true,
       },
     ]);

--- a/src/test-kernel/latex/OutputDiscovery.vitest.ts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.ts
@@ -240,7 +240,7 @@ describe('outputDiscovery diagnostics', () => {
           );
           return { runDir: dir, unreadable: path.join(dir, 'r0') };
         });
-        // Hand-rolled because FakeFileSystemProvider cannot inject a per-path
+        // Hand-rolled because the fake host's filesystem cannot inject a per-path
         // readDirectory failure — it seeds files, not fault rules.
         yield* Effect.promise(() =>
           installPlatform(

--- a/src/test-kernel/latex/TexTools.vitest.ts
+++ b/src/test-kernel/latex/TexTools.vitest.ts
@@ -9,6 +9,7 @@ import {
 } from '@latex/texTools';
 import * as logger from '@logger/logUtils';
 import type { ExecResult } from '@shared/schemas';
+import { fakePath } from '@test/support/FakePlatform';
 import { installPlatform } from '@test/support/setupPlatform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { pathToLocation } from '@utils/files/fileLocation';
@@ -23,7 +24,7 @@ vi.mock('@utils/system/toolUtils', async (importOriginal) => {
   return { ...actual, runToolWithCheck: mocks.runToolWithCheck };
 });
 
-const workspacePath = '/workspace';
+const workspacePath = fakePath('workspace');
 
 function execResult(success: boolean): ExecResult {
   return {

--- a/src/test-kernel/latex/Texcount.vitest.ts
+++ b/src/test-kernel/latex/Texcount.vitest.ts
@@ -21,7 +21,7 @@ vi.mock('@utils/system/toolUtils', async (importOriginal) => {
 });
 
 /**
- * The memfs platform, with debug mode on: the Effect logger drops `Debug`
+ * The fake platform, with debug mode on: the Effect logger drops `Debug`
  * entries otherwise, and these assertions are about which channel an entry
  * lands on, not about that gate.
  */

--- a/src/test-kernel/latex/Texcount.vitest.ts
+++ b/src/test-kernel/latex/Texcount.vitest.ts
@@ -9,6 +9,7 @@ import { setLogSink } from '@logger/logSink';
 import { platform } from '@platform/platform';
 import { captureLogEntries } from '@test/support/logSinkCapture';
 import { installPlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 
 const mocks = vi.hoisted(() => ({
   runToolWithCheck: vi.fn(),
@@ -30,7 +31,7 @@ const withPlatform = (
 ): Effect.Effect<void> =>
   Effect.promise(() =>
     installPlatform({
-      workspacePath: '/workspace',
+      workspacePath: fakePath('workspace'),
       config: { 'texra.logger.debugMode': true },
       files,
     }),

--- a/src/test-kernel/latex/TikzPictureManager.vitest.ts
+++ b/src/test-kernel/latex/TikzPictureManager.vitest.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import { TikzPictureManager } from '@latex/TikzPictureManager';
 import { installPlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import { pathToLocation } from '@utils/files/fileLocation';
 
 async function extractFromPaper(content: string) {
   await installPlatform({
-    workspacePath: '/workspace',
+    workspacePath: fakePath('workspace'),
     files: { '/workspace/paper.tex': content },
   });
   return TikzPictureManager.extract(pathToLocation('paper.tex'));

--- a/src/test-kernel/platform/NodeFilesystem.vitest.ts
+++ b/src/test-kernel/platform/NodeFilesystem.vitest.ts
@@ -11,49 +11,30 @@ import { describe, it } from 'vitest';
 import { FileType, type FileSystemProvider } from '@platform/interfaces';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 
-// Local file imports
-import { FakeFileSystemProvider } from '../support/FakePlatform';
-
 type ProviderCase = {
   provider: FileSystemProvider;
   resolve(testPath: string): string;
   expectedRealPath(testPath: string): Promise<string>;
-  cleanup(): Promise<void>;
 };
 
-async function createProviderCase(
-  name: 'fake' | 'node',
-): Promise<ProviderCase> {
-  if (name === 'fake') {
-    return {
-      provider: new FakeFileSystemProvider(),
-      resolve: (testPath) => testPath,
-      expectedRealPath: async (testPath) => testPath,
-      cleanup: async () => {},
-    };
-  }
-
+/**
+ * Runs `run` against `nodeFilesystem` rooted in a fresh temp directory, so a
+ * test can name paths as if the provider owned `/`.
+ */
+async function withProvider(
+  run: (ctx: ProviderCase) => Promise<void>,
+): Promise<void> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-fs-'));
   const resolve = (testPath: string): string =>
     path.join(root, testPath.slice(1));
-  return {
-    provider: nodeFilesystem,
-    resolve,
-    expectedRealPath: (testPath) => fs.realpath(resolve(testPath)),
-    cleanup: () => fs.rm(root, { recursive: true, force: true }),
-  };
-}
-
-async function withProviders(
-  run: (ctx: ProviderCase) => Promise<void>,
-): Promise<void> {
-  for (const name of ['fake', 'node'] as const) {
-    const ctx = await createProviderCase(name);
-    try {
-      await run(ctx);
-    } finally {
-      await ctx.cleanup();
-    }
+  try {
+    await run({
+      provider: nodeFilesystem,
+      resolve,
+      expectedRealPath: (testPath) => fs.realpath(resolve(testPath)),
+    });
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
   }
 }
 
@@ -75,9 +56,9 @@ async function rejectsWithCode(
   });
 }
 
-describe('FakePlatform', () => {
-  it('matches node filesystem semantics for file reads, writes, stats, and directories', async () => {
-    await withProviders(async ({ provider, resolve, expectedRealPath }) => {
+describe('nodeFilesystem', () => {
+  it('reads, writes, stats, and lists directories', async () => {
+    await withProvider(async ({ provider, resolve, expectedRealPath }) => {
       await provider.createDirectory(resolve('/workspace/docs'));
       await provider.writeFile(
         resolve('/workspace/docs/a.txt'),
@@ -122,8 +103,8 @@ describe('FakePlatform', () => {
     });
   });
 
-  it('matches node filesystem semantics for copy, rename, and delete', async () => {
-    await withProviders(async ({ provider, resolve }) => {
+  it('copies, renames, and deletes', async () => {
+    await withProvider(async ({ provider, resolve }) => {
       await provider.createDirectory(resolve('/workspace/source/nested'));
       await provider.writeFile(
         resolve('/workspace/source/a.txt'),
@@ -191,8 +172,8 @@ describe('FakePlatform', () => {
     });
   });
 
-  it('matches node filesystem error codes for common failures', async () => {
-    await withProviders(async ({ provider, resolve }) => {
+  it('reports errno codes for common failures', async () => {
+    await withProvider(async ({ provider, resolve }) => {
       await rejectsWithCode(
         () =>
           provider.writeFile(
@@ -249,18 +230,5 @@ describe('FakePlatform', () => {
         'ENOENT',
       );
     });
-  });
-
-  it('rejects deleting the fake filesystem root', async () => {
-    const fakeFs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-    });
-
-    await rejectsWithCode(
-      () => fakeFs.delete('/', { recursive: true }),
-      'EPERM',
-    );
-
-    assert.equal(fakeFs.getText('/workspace/source/a.txt'), 'A');
   });
 });

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -113,7 +113,13 @@ function seedTarget(key: string): string {
       `Seed key ${key} is a real path under the harness temp home; seed keys are paths inside the fake root (use fakePath).`,
     );
   }
-  return fakePath(key);
+  const target = path.resolve(root, `.${path.sep}${key}`);
+  if (target !== root && !target.startsWith(root + path.sep)) {
+    throw new Error(
+      `Seed key ${key} resolves outside the fake root; seed keys must stay inside it.`,
+    );
+  }
+  return target;
 }
 
 /** Empties the {@link fakeRoot} and writes the seeded files into it. */

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -83,7 +83,22 @@ mkdirSync(FAKE_GLOBAL_STORAGE, { recursive: true });
  * helper built on the installed roots produces.
  */
 function seedTarget(key: string): string {
-  return key.startsWith(FAKE_ROOT) ? key : fakePath(key);
+  if (key.startsWith(FAKE_ROOT)) return key;
+  // Seed keys are paths inside the fake root ('/workspace/a.tex' and
+  // fakePath('workspace/a.tex') name the same file). A real temp path built
+  // outside this module would otherwise be nested under the root silently.
+  const home = workerTempHome();
+  const realTmp = realpathSync(os.tmpdir());
+  if (
+    key.startsWith(home) ||
+    key.startsWith(realTmp) ||
+    key.startsWith(os.tmpdir())
+  ) {
+    throw new Error(
+      `Seed key ${key} is a real temp path; seed keys are paths inside the fake root (use fakePath).`,
+    );
+  }
+  return fakePath(key);
 }
 
 /** Empties {@link FAKE_ROOT} and writes the seeded files into it. */

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -103,7 +103,11 @@ function fakeGlobalStorage(): string {
  */
 function seedTarget(key: string): string {
   const root = fakeRoot();
-  if (key.startsWith(root)) return key;
+  if (key.startsWith(root)) {
+    // A key this harness handed out (fakePath(...)) or built from one: it is
+    // still confined below, a prefix match alone is not containment.
+    return confineToRoot(root, path.resolve(key), key);
+  }
   // A path this harness handed out but from outside the fake root -- the
   // worker temp home itself, or a sibling of the root under it -- would be
   // nested under the root silently. Every other absolute key ('/tmp/run/x'
@@ -113,7 +117,11 @@ function seedTarget(key: string): string {
       `Seed key ${key} is a real path under the harness temp home; seed keys are paths inside the fake root (use fakePath).`,
     );
   }
-  const target = path.resolve(root, `.${path.sep}${key}`);
+  return confineToRoot(root, path.resolve(root, `.${path.sep}${key}`), key);
+}
+
+/** The resolved target, or a throw when it is not the root or a descendant. */
+function confineToRoot(root: string, target: string, key: string): string {
   if (target !== root && !target.startsWith(root + path.sep)) {
     throw new Error(
       `Seed key ${key} resolves outside the fake root; seed keys must stay inside it.`,

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -1,16 +1,17 @@
 // Node imports
-import { mkdtempSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-
-// Third-party imports
-import { createFsFromVolume, Volume, type IFs } from 'memfs';
 
 // Local imports
 import type { ModelOptionStores } from '@model/computeModelOptions';
 import {
-  type FileStat,
-  type FileSystemProvider,
   type ConfigInspection,
   type ConfigProvider,
   type ConfigTarget,
@@ -22,41 +23,73 @@ import type { Platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 import type { WorkspaceRoots } from '@platform/workspaceRoots';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
-import {
-  fileTypeFor,
-  type FileTypeProbe,
-} from '@platform/defaults/fsEntryTypeBits';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { getCoreSettingDefault } from '@shared/schemas';
 import type { SetupPlatformShape } from '@tools/setup/platform';
 
-function fakeFsError(code: string, message: string): Error {
-  return Object.assign(new Error(message), { code });
-}
-
-function normalizePath(target: string): string {
-  return path.posix.resolve('/', target.replaceAll('\\', '/'));
-}
-
-function relativeChildPath(
-  parent: string,
-  candidate: string,
-): string | undefined {
-  const relative = path.posix.relative(parent, candidate);
-  if (
-    relative === '' ||
-    relative.startsWith('..') ||
-    path.posix.isAbsolute(relative)
-  ) {
-    return undefined;
+/**
+ * One real temporary directory per worker process, holding both the fake
+ * filesystem root and the shared global-storage directory. Cached on
+ * `globalThis` so a suite that resets its module registry keeps the same
+ * directories, and removed when the worker exits.
+ *
+ * The realpath is resolved so the paths handed out are canonical: on macOS
+ * `os.tmpdir()` traverses the `/tmp` to `/private/tmp` symlink and on Windows
+ * CI the 8.3 short name differs from the long form, so production code that
+ * resolves either would otherwise never produce the string a suite compares
+ * against.
+ */
+function workerTempHome(): string {
+  const globals = globalThis as { __texraFakeHome__?: string };
+  if (globals.__texraFakeHome__ === undefined) {
+    const home = realpathSync(
+      mkdtempSync(path.join(os.tmpdir(), 'texra-fake-')),
+    );
+    globals.__texraFakeHome__ = home;
+    process.on('exit', () => rmSync(home, { recursive: true, force: true }));
   }
-  return relative;
+  return globals.__texraFakeHome__;
 }
 
-function hasChildPath(parent: string, candidate: string): boolean {
-  return relativeChildPath(parent, candidate) !== undefined;
+/**
+ * The real directory every fake host's files live in: what `/` meant to the
+ * in-memory filesystem this replaced. Emptied whenever a fake platform is
+ * built, so a host starts from the files it seeds and nothing else.
+ */
+export const FAKE_ROOT = path.join(workerTempHome(), 'root');
+
+/**
+ * A real path inside {@link FAKE_ROOT}. `fakePath('workspace/a.tex')` is the
+ * path a `files` seed keyed `'/workspace/a.tex'` writes to, and is what a
+ * suite asserting on an absolute path compares against.
+ */
+export function fakePath(...segments: string[]): string {
+  return path.join(FAKE_ROOT, ...segments);
 }
 
-type DirectoryEntryProbe = FileTypeProbe & { name: string };
+// A real directory: instance-presence sockets are genuine OS objects that
+// live under the global storage root even when everything else is faked.
+// Worker-shared so the thousands of per-test fake hosts that never touch
+// presence do not each pay for a directory.
+const FAKE_GLOBAL_STORAGE = path.join(workerTempHome(), 'global-storage');
+
+mkdirSync(FAKE_ROOT, { recursive: true });
+mkdirSync(FAKE_GLOBAL_STORAGE, { recursive: true });
+
+/**
+ * Empties {@link FAKE_ROOT} and writes the seeded files into it. Keys are
+ * paths inside the root, so `'/workspace/a.tex'` lands at
+ * `fakePath('workspace/a.tex')`, under the default workspace root.
+ */
+function seedFakeRoot(files: Record<string, string | Uint8Array>): void {
+  rmSync(FAKE_ROOT, { recursive: true, force: true });
+  mkdirSync(FAKE_ROOT, { recursive: true });
+  for (const [target, content] of Object.entries(files)) {
+    const file = fakePath(target);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, content);
+  }
+}
 
 export class FakeConfigProvider implements ConfigProvider {
   private readonly values = new Map<string, unknown>();
@@ -260,210 +293,6 @@ export class FakeStateStore implements StateStore {
   }
 }
 
-export class FakeFileSystemProvider implements FileSystemProvider {
-  private readonly fs: IFs;
-
-  constructor(files: Record<string, string | Uint8Array> = {}) {
-    this.fs = createFsFromVolume(new Volume());
-    this.fs.mkdirSync('/', { recursive: true });
-    for (const [target, content] of Object.entries(files)) {
-      this.setFile(target, content);
-    }
-  }
-
-  async stat(target: string): Promise<FileStat> {
-    const normalized = normalizePath(target);
-    const lstats = await this.fs.promises.lstat(normalized);
-    const type = await fileTypeFor(this.fs, lstats, normalized);
-    const stats = lstats.isSymbolicLink()
-      ? await this.fs.promises.stat(normalized).catch(() => lstats)
-      : lstats;
-    return {
-      type,
-      ctime: Number(stats.ctimeMs),
-      mtime: Number(stats.mtimeMs),
-      size: Number(stats.size),
-    };
-  }
-
-  async isSymlink(target: string): Promise<boolean> {
-    const stats = await this.fs.promises.lstat(normalizePath(target));
-    return stats.isSymbolicLink();
-  }
-
-  async realPath(target: string): Promise<string> {
-    const resolved = await this.fs.promises.realpath(normalizePath(target));
-    return resolved.toString();
-  }
-
-  async readFile(target: string): Promise<Uint8Array> {
-    const content = await this.fs.promises.readFile(normalizePath(target));
-    return typeof content === 'string' ? Buffer.from(content) : content;
-  }
-
-  async writeFile(target: string, content: Uint8Array): Promise<void> {
-    await this.fs.promises.writeFile(
-      normalizePath(target),
-      Buffer.from(content),
-    );
-  }
-
-  async writeFileAtomic(target: string, content: Uint8Array): Promise<void> {
-    // In-memory: the temp+rename of a real atomic write has no observable
-    // intermediate state here, so a direct write is equivalent.
-    await this.writeFile(target, content);
-  }
-
-  async publishFile(target: string, content: Uint8Array): Promise<void> {
-    // Mirror the production stage-then-rename so a test observes the same
-    // directory contents (the staged sibling never outlives the publish).
-    const normalized = normalizePath(target);
-    const staging = `${normalized}.tmp`;
-    await this.fs.promises.writeFile(staging, Buffer.from(content));
-    await this.fs.promises.rename(staging, normalized);
-  }
-
-  async removeEmptyDirectory(target: string): Promise<void> {
-    await this.fs.promises.rmdir(normalizePath(target));
-  }
-
-  async appendFile(target: string, content: Uint8Array): Promise<void> {
-    await this.fs.promises.appendFile(
-      normalizePath(target),
-      Buffer.from(content),
-    );
-  }
-
-  async delete(
-    target: string,
-    options?: { recursive?: boolean },
-  ): Promise<void> {
-    const normalized = normalizePath(target);
-    if (normalized === '/') {
-      throw fakeFsError('EPERM', 'Cannot delete filesystem root');
-    }
-    await this.fs.promises.rm(normalized, {
-      recursive: options?.recursive ?? false,
-      force: true,
-    });
-  }
-
-  async createDirectory(target: string): Promise<void> {
-    await this.fs.promises.mkdir(normalizePath(target), { recursive: true });
-  }
-
-  async readDirectory(target: string): Promise<[string, number][]> {
-    const normalized = normalizePath(target);
-    const entries = await this.fs.promises.readdir(normalized, {
-      withFileTypes: true,
-    });
-    const dirents = entries as DirectoryEntryProbe[];
-    const resolved = await Promise.all(
-      dirents.map(async (entry) => {
-        const type = await fileTypeFor(
-          this.fs,
-          entry,
-          path.posix.join(normalized, entry.name),
-        );
-        return [entry.name, type] as [string, number];
-      }),
-    );
-    return resolved.toSorted(([left], [right]) => left.localeCompare(right));
-  }
-
-  async copy(
-    source: string,
-    dest: string,
-    options?: { overwrite?: boolean; dereference?: boolean },
-  ): Promise<void> {
-    const normalizedSource = normalizePath(source);
-    const normalizedDest = normalizePath(dest);
-    const sourceStats = await this.fs.promises.stat(normalizedSource);
-    if (sourceStats.isDirectory()) {
-      if (normalizedSource === normalizedDest) {
-        throw fakeFsError(
-          'ERR_FS_CP_EINVAL',
-          `Cannot copy a path onto itself: ${source} -> ${dest}`,
-        );
-      }
-      if (hasChildPath(normalizedSource, normalizedDest)) {
-        throw fakeFsError(
-          'ERR_FS_CP_EINVAL',
-          `Cannot copy a directory into itself: ${source} -> ${dest}`,
-        );
-      }
-      await this.fs.promises.cp(normalizedSource, normalizedDest, {
-        recursive: true,
-        force: options?.overwrite ?? false,
-        errorOnExist: !(options?.overwrite ?? false),
-        dereference: options?.dereference ?? false,
-      });
-      return;
-    }
-
-    const flag = options?.overwrite ? 0 : this.fs.constants.COPYFILE_EXCL;
-    await this.fs.promises.copyFile(normalizedSource, normalizedDest, flag);
-  }
-
-  async rename(
-    source: string,
-    dest: string,
-    options?: { overwrite?: boolean },
-  ): Promise<void> {
-    const normalizedSource = normalizePath(source);
-    const normalizedDest = normalizePath(dest);
-    if (!options?.overwrite) {
-      try {
-        await this.fs.promises.lstat(normalizedDest);
-        throw fakeFsError('EEXIST', `Target already exists: ${dest}`);
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-      }
-    }
-    const sourceStats = await this.fs.promises.lstat(normalizedSource);
-    if (
-      sourceStats.isDirectory() &&
-      hasChildPath(normalizedSource, normalizedDest)
-    ) {
-      throw fakeFsError(
-        'EINVAL',
-        `Cannot rename a directory into itself: ${source} -> ${dest}`,
-      );
-    }
-    await this.fs.promises.rename(normalizedSource, normalizedDest);
-  }
-
-  exists(target: string): boolean {
-    return this.fs.existsSync(normalizePath(target));
-  }
-
-  setFile(target: string, content: string | Uint8Array): void {
-    const normalized = normalizePath(target);
-    this.fs.mkdirSync(path.posix.dirname(normalized), { recursive: true });
-    this.fs.writeFileSync(normalized, Buffer.from(stringToBytes(content)));
-  }
-
-  getText(target: string): string {
-    const content = this.fs.readFileSync(normalizePath(target));
-    return typeof content === 'string' ? content : content.toString('utf8');
-  }
-}
-
-// A real directory: instance-presence sockets are genuine OS objects that
-// live under the global storage root even when everything else is faked.
-// Worker-shared so the thousands of per-test fake roots that never touch
-// presence do not litter os.tmpdir() with empty directories.
-let sharedFakeGlobalStoragePath: string | undefined;
-
-function fakeGlobalStoragePath(override?: string): string {
-  return (
-    override ??
-    (sharedFakeGlobalStoragePath ??= mkdtempSync(
-      path.join(os.tmpdir(), 'texra-fake-global-'),
-    ))
-  );
-}
-
 export class FakeSecrets implements PlatformSecrets {
   private readonly values = new Map<string, string>();
 
@@ -516,12 +345,24 @@ export interface FakePlatformOptions {
   config?: Record<string, unknown>;
   globalState?: Record<string, unknown>;
   workspaceState?: Record<string, unknown>;
+  /**
+   * Files seeded into {@link FAKE_ROOT} before the host is installed. Keys
+   * are paths inside that root, so `'/workspace/a.tex'` is written to
+   * `fakePath('workspace/a.tex')` — under the default workspace root.
+   */
   files?: Record<string, string | Uint8Array>;
   secrets?: Record<string, string>;
   /** Conventional env-var fallbacks (e.g. `ANTHROPIC_API_KEY`) surfaced via `PlatformSecrets.getEnv`. */
   secretsEnv?: Record<string, string>;
+  /**
+   * The workspace root, as a real path: `fakePath('workspace')` by default.
+   * A suite pointing the workspace elsewhere passes a real directory it owns
+   * (a `fakePath(...)` subdirectory, its own temp dir, or `process.cwd()`).
+   */
   workspacePath?: string | undefined;
+  /** The storage root, as a real path. Defaults under the workspace root. */
   storagePath?: string;
+  /** The global-storage root, as a real path. Worker-shared by default. */
   globalStoragePath?: string;
 }
 
@@ -548,9 +389,9 @@ export function createFakeWorkspaceRoots(
   return {
     workspace: Object.hasOwn(options, 'workspacePath')
       ? options.workspacePath
-      : '/workspace',
-    storage: options.storagePath ?? '/workspace/.texra/storage',
-    globalStorage: fakeGlobalStoragePath(options.globalStoragePath),
+      : fakePath('workspace'),
+    storage: options.storagePath ?? fakePath('workspace/.texra/storage'),
+    globalStorage: options.globalStoragePath ?? FAKE_GLOBAL_STORAGE,
     config: overrides.config ?? new FakeConfigProvider(options.config),
     workspaceState:
       overrides.workspaceState ?? new FakeStateStore(options.workspaceState),
@@ -560,17 +401,18 @@ export function createFakeWorkspaceRoots(
 }
 
 const FAKE_AGENT_DIRECTORIES: AgentDirectoriesPort = {
-  custom: async () => '/workspace/.texra/agents',
-  builtIn: async () => '/workspace/resources/agents',
-  builtInToolUse: async () => '/workspace/resources/tool_use_agents',
+  custom: async () => fakePath('workspace/.texra/agents'),
+  builtIn: async () => fakePath('workspace/resources/agents'),
+  builtInToolUse: async () => fakePath('workspace/resources/tool_use_agents'),
 };
 
 export function createFakePlatform(
   options: FakePlatformOptions = {},
   overrides: Partial<Platform> = {},
 ): Platform {
+  seedFakeRoot(options.files ?? {});
   return {
-    fs: new FakeFileSystemProvider(options.files),
+    fs: nodeFilesystem,
     lifecycle: createLifecycleHost(),
     agentResume: { tryResumeRun: async () => false },
     agentDirectories: FAKE_AGENT_DIRECTORIES,
@@ -578,11 +420,4 @@ export function createFakePlatform(
     toolMissingHandler: () => {},
     ...overrides,
   };
-}
-
-function stringToBytes(content: string | Uint8Array): Uint8Array {
-  if (typeof content === 'string') {
-    return Buffer.from(content, 'utf8');
-  }
-  return content;
 }

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -52,59 +52,75 @@ function workerTempHome(): string {
 }
 
 /**
+ * A directory under the worker temp home, created on first use and remembered
+ * per worker so the thousands of per-test fake hosts do not each pay for a
+ * `mkdir`. Nothing here runs at module load: importing this module must stay
+ * free of process-wide side effects, so the pure test tier can reach it.
+ */
+function workerDir(name: 'root' | 'global-storage'): string {
+  const globals = globalThis as { __texraFakeDirs__?: Set<string> };
+  const dir = path.join(workerTempHome(), name);
+  const created = (globals.__texraFakeDirs__ ??= new Set<string>());
+  if (!created.has(dir)) {
+    mkdirSync(dir, { recursive: true });
+    created.add(dir);
+  }
+  return dir;
+}
+
+/**
  * The real directory every fake host's files live in: what `/` meant to the
  * in-memory filesystem this replaced. Emptied whenever a fake platform is
  * built, so a host starts from the files it seeds and nothing else.
  */
-const FAKE_ROOT = path.join(workerTempHome(), 'root');
+function fakeRoot(): string {
+  return workerDir('root');
+}
 
 /**
- * A real path inside {@link FAKE_ROOT}. `fakePath('workspace/a.tex')` is the
+ * A real path inside the {@link fakeRoot}. `fakePath('workspace/a.tex')` is the
  * path a `files` seed keyed `'/workspace/a.tex'` writes to, and is what a
  * suite asserting on an absolute path compares against.
  */
 export function fakePath(...segments: string[]): string {
-  return path.join(FAKE_ROOT, ...segments);
+  return path.join(fakeRoot(), ...segments);
 }
 
-// A real directory: instance-presence sockets are genuine OS objects that
-// live under the global storage root even when everything else is faked.
-// Worker-shared so the thousands of per-test fake hosts that never touch
-// presence do not each pay for a directory.
-const FAKE_GLOBAL_STORAGE = path.join(workerTempHome(), 'global-storage');
-
-mkdirSync(FAKE_ROOT, { recursive: true });
-mkdirSync(FAKE_GLOBAL_STORAGE, { recursive: true });
+/**
+ * A real directory: instance-presence sockets are genuine OS objects that live
+ * under the global storage root even when everything else is faked.
+ * Worker-shared so the hosts that never touch presence share the one directory.
+ */
+function fakeGlobalStorage(): string {
+  return workerDir('global-storage');
+}
 
 /**
- * The real file a seed key names. Keys are paths inside {@link FAKE_ROOT}, so
- * `'/workspace/a.tex'` and `fakePath('workspace/a.tex')` name the same file:
+ * The real file a seed key names. Keys are paths inside the {@link fakeRoot},
+ * so `'/workspace/a.tex'` and `fakePath('workspace/a.tex')` name the same file:
  * the first is the spelling a suite writes by hand, the second the one a path
  * helper built on the installed roots produces.
  */
 function seedTarget(key: string): string {
-  if (key.startsWith(FAKE_ROOT)) return key;
-  // Seed keys are paths inside the fake root ('/workspace/a.tex' and
-  // fakePath('workspace/a.tex') name the same file). A real temp path built
-  // outside this module would otherwise be nested under the root silently.
-  const home = workerTempHome();
-  const realTmp = realpathSync(os.tmpdir());
-  if (
-    key.startsWith(home) ||
-    key.startsWith(realTmp) ||
-    key.startsWith(os.tmpdir())
-  ) {
+  const root = fakeRoot();
+  if (key.startsWith(root)) return key;
+  // A path this harness handed out but from outside the fake root -- the
+  // worker temp home itself, or a sibling of the root under it -- would be
+  // nested under the root silently. Every other absolute key ('/tmp/run/x'
+  // included) is a path inside the fake root, not a real one.
+  if (key.startsWith(workerTempHome())) {
     throw new Error(
-      `Seed key ${key} is a real temp path; seed keys are paths inside the fake root (use fakePath).`,
+      `Seed key ${key} is a real path under the harness temp home; seed keys are paths inside the fake root (use fakePath).`,
     );
   }
   return fakePath(key);
 }
 
-/** Empties {@link FAKE_ROOT} and writes the seeded files into it. */
+/** Empties the {@link fakeRoot} and writes the seeded files into it. */
 function seedFakeRoot(files: Record<string, string | Uint8Array>): void {
-  rmSync(FAKE_ROOT, { recursive: true, force: true });
-  mkdirSync(FAKE_ROOT, { recursive: true });
+  const root = fakeRoot();
+  rmSync(root, { recursive: true, force: true });
+  mkdirSync(root, { recursive: true });
   for (const [key, content] of Object.entries(files)) {
     const file = seedTarget(key);
     mkdirSync(path.dirname(file), { recursive: true });
@@ -367,7 +383,7 @@ export interface FakePlatformOptions {
   globalState?: Record<string, unknown>;
   workspaceState?: Record<string, unknown>;
   /**
-   * Files seeded into {@link FAKE_ROOT} before the host is installed. Keys
+   * Files seeded into the fake root before the host is installed. Keys
    * are paths inside that root: `'/workspace/a.tex'` and
    * `fakePath('workspace/a.tex')` both name the same file, under the default
    * workspace root.
@@ -413,7 +429,7 @@ export function createFakeWorkspaceRoots(
       ? options.workspacePath
       : fakePath('workspace'),
     storage: options.storagePath ?? fakePath('workspace/.texra/storage'),
-    globalStorage: options.globalStoragePath ?? FAKE_GLOBAL_STORAGE,
+    globalStorage: options.globalStoragePath ?? fakeGlobalStorage(),
     config: overrides.config ?? new FakeConfigProvider(options.config),
     workspaceState:
       overrides.workspaceState ?? new FakeStateStore(options.workspaceState),

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -56,7 +56,7 @@ function workerTempHome(): string {
  * in-memory filesystem this replaced. Emptied whenever a fake platform is
  * built, so a host starts from the files it seeds and nothing else.
  */
-export const FAKE_ROOT = path.join(workerTempHome(), 'root');
+const FAKE_ROOT = path.join(workerTempHome(), 'root');
 
 /**
  * A real path inside {@link FAKE_ROOT}. `fakePath('workspace/a.tex')` is the

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -77,15 +77,21 @@ mkdirSync(FAKE_ROOT, { recursive: true });
 mkdirSync(FAKE_GLOBAL_STORAGE, { recursive: true });
 
 /**
- * Empties {@link FAKE_ROOT} and writes the seeded files into it. Keys are
- * paths inside the root, so `'/workspace/a.tex'` lands at
- * `fakePath('workspace/a.tex')`, under the default workspace root.
+ * The real file a seed key names. Keys are paths inside {@link FAKE_ROOT}, so
+ * `'/workspace/a.tex'` and `fakePath('workspace/a.tex')` name the same file:
+ * the first is the spelling a suite writes by hand, the second the one a path
+ * helper built on the installed roots produces.
  */
+function seedTarget(key: string): string {
+  return key.startsWith(FAKE_ROOT) ? key : fakePath(key);
+}
+
+/** Empties {@link FAKE_ROOT} and writes the seeded files into it. */
 function seedFakeRoot(files: Record<string, string | Uint8Array>): void {
   rmSync(FAKE_ROOT, { recursive: true, force: true });
   mkdirSync(FAKE_ROOT, { recursive: true });
-  for (const [target, content] of Object.entries(files)) {
-    const file = fakePath(target);
+  for (const [key, content] of Object.entries(files)) {
+    const file = seedTarget(key);
     mkdirSync(path.dirname(file), { recursive: true });
     writeFileSync(file, content);
   }
@@ -347,8 +353,9 @@ export interface FakePlatformOptions {
   workspaceState?: Record<string, unknown>;
   /**
    * Files seeded into {@link FAKE_ROOT} before the host is installed. Keys
-   * are paths inside that root, so `'/workspace/a.tex'` is written to
-   * `fakePath('workspace/a.tex')` — under the default workspace root.
+   * are paths inside that root: `'/workspace/a.tex'` and
+   * `fakePath('workspace/a.tex')` both name the same file, under the default
+   * workspace root.
    */
   files?: Record<string, string | Uint8Array>;
   secrets?: Record<string, string>;

--- a/src/test-kernel/support/tempDirPlatform.ts
+++ b/src/test-kernel/support/tempDirPlatform.ts
@@ -11,7 +11,6 @@ import { afterEach } from 'vitest';
 // Local imports
 import { closeSession, listSessions } from '@agent/runtime/sessionGraph';
 import { MemoryStateStore } from '@platform/defaults/memoryState';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 
 // Local file imports
@@ -37,7 +36,7 @@ export async function makeTempDir(
 }
 
 /**
- * Creates a node-backed fake host rooted in a fresh temp directory
+ * Creates a fake host rooted in a fresh temp directory of its own
  * (`<tempDir>/workspace` and `<tempDir>/storage`), and records the temp
  * directory on `tempDirs` for later cleanup via `cleanupTempDirs`.
  */
@@ -56,7 +55,6 @@ export async function createTempDirPlatform(
       globalStoragePath: storage.getGlobalStoragePath(),
     },
     {
-      fs: nodeFilesystem,
       globalState: new MemoryStateStore(),
       workspaceState: new MemoryStateStore(),
     },

--- a/src/test-kernel/tools/OpenPdfTool.vitest.ts
+++ b/src/test-kernel/tools/OpenPdfTool.vitest.ts
@@ -16,6 +16,7 @@ import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { RunId } from '@shared/schemas';
 import { nativeToolTestLayer } from '@test/support/nativeToolTestLayer';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import { OpenPdfTool } from '@tools/OpenPdfTool';
 
 /** The request shape the host's PDF opener receives, derived from the port. */
@@ -23,8 +24,8 @@ type OpenPdfRequest = Parameters<NonNullable<HostInteractions['openPdf']>>[0];
 
 describe('OpenPdfTool', () => {
   setupPlatform({
-    workspacePath: '/workspace',
-    storagePath: '/storage',
+    workspacePath: fakePath('workspace'),
+    storagePath: fakePath('storage'),
     files: {
       '/workspace/paper.pdf': '%PDF-1.4\n',
       '/workspace/figures/result.pdf': '%PDF-1.4\n',
@@ -102,12 +103,7 @@ describe('OpenPdfTool', () => {
       expect(openPdf).toHaveBeenCalledWith({
         location: {
           kind: 'workspace',
-          absolutePath: path.join(
-            path.sep,
-            'workspace',
-            'figures',
-            'result.pdf',
-          ),
+          absolutePath: fakePath('workspace', 'figures', 'result.pdf'),
           relativePath: 'figures/result.pdf',
         },
         preserveFocus: true,
@@ -132,7 +128,7 @@ describe('OpenPdfTool', () => {
 
       const result = yield* tool
         .call({
-          path: '/storage/executions/run-1/output.pdf',
+          path: fakePath('storage/executions/run-1/output.pdf'),
           preserve_focus: true,
         })
         .pipe(
@@ -151,7 +147,7 @@ describe('OpenPdfTool', () => {
       expect(openPdf).toHaveBeenCalledWith({
         location: {
           kind: 'runStorage',
-          absolutePath: '/storage/executions/run-1/output.pdf',
+          absolutePath: fakePath('storage/executions/run-1/output.pdf'),
           relativePath: 'output.pdf',
           runId: 'run-1',
         },
@@ -178,7 +174,7 @@ describe('OpenPdfTool', () => {
         const tool = new OpenPdfTool();
 
         const result = yield* tool
-          .call({ path: '/storage/executions/run-1/output.pdf' })
+          .call({ path: fakePath('storage/executions/run-1/output.pdf') })
           .pipe(
             Effect.provide(
               nativeToolTestLayer({
@@ -212,10 +208,10 @@ describe('OpenPdfTool', () => {
       const openPdf = installOpener();
       const tool = new OpenPdfTool();
 
-      const result = yield* tool.call({ path: '/run/paper.pdf' }).pipe(
+      const result = yield* tool.call({ path: fakePath('run/paper.pdf') }).pipe(
         Effect.provide(
           nativeToolTestLayer({
-            workingDirectory: '/workspace',
+            workingDirectory: fakePath('workspace'),
             run: {
               session: defaultSession(),
               runId: 'tool-test' as RunId,

--- a/src/test-kernel/tools/ReadToolRange.vitest.ts
+++ b/src/test-kernel/tools/ReadToolRange.vitest.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect } from 'vitest';
 
 // Local imports
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import { nativeToolTestLayer } from '@test/support/nativeToolTestLayer';
 import { ReadFileTool } from '@tools/ReadTool';
 
@@ -21,13 +22,15 @@ const callRead = (input: unknown) =>
   new ReadFileTool()
     .call(input)
     .pipe(
-      Effect.provide(nativeToolTestLayer({ workingDirectory: '/workspace' })),
+      Effect.provide(
+        nativeToolTestLayer({ workingDirectory: fakePath('workspace') }),
+      ),
     );
 
 describe('read_file line ranges', () => {
   beforeEach(async () => {
     await installFakePlatform({
-      workspacePath: '/workspace',
+      workspacePath: fakePath('workspace'),
       files: {
         '/workspace/large.txt': LARGE,
         '/workspace/small.txt': SMALL,

--- a/src/test-kernel/tools/RunGeneratedFiles.vitest.ts
+++ b/src/test-kernel/tools/RunGeneratedFiles.vitest.ts
@@ -10,9 +10,10 @@ import type { RunId } from '@shared/schemas';
 import { createProcessSession } from '@test/support/sessionTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { listRunGeneratedFiles } from '@tools/executions/runGeneratedFiles';
+import { fakePath } from '@test/support/FakePlatform';
 
 const EXECUTION_ID = 'generated-history-test' as RunId;
-const STORAGE_PATH = path.join(path.sep, 'storage');
+const STORAGE_PATH = fakePath('storage');
 const RUN_PATH = path.join(STORAGE_PATH, 'executions', EXECUTION_ID);
 
 function fsError(code: string, message: string): Error {
@@ -56,7 +57,8 @@ describe('listRunGeneratedFiles', () => {
 
         expect(yield* listRunGeneratedFiles(EXECUTION_ID, session)).toEqual([
           { path: 'blocked.tex', size: 7, isDirectory: false },
-          { path: 'sub', size: 0, isDirectory: true },
+          // A real directory's size is the filesystem's own bookkeeping.
+          { path: 'sub', size: expect.any(Number), isDirectory: true },
           { path: 'sub/nested.tex', size: 6, isDirectory: false },
           { path: 'unreadable.tex', size: 10, isDirectory: false },
           { path: 'z.tex', size: 3, isDirectory: false },

--- a/src/test-kernel/tools/RunGeneratedFiles.vitest.ts
+++ b/src/test-kernel/tools/RunGeneratedFiles.vitest.ts
@@ -9,8 +9,8 @@ import { platform } from '@platform/platform';
 import type { RunId } from '@shared/schemas';
 import { createProcessSession } from '@test/support/sessionTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { listRunGeneratedFiles } from '@tools/executions/runGeneratedFiles';
 import { fakePath } from '@test/support/FakePlatform';
+import { listRunGeneratedFiles } from '@tools/executions/runGeneratedFiles';
 
 const EXECUTION_ID = 'generated-history-test' as RunId;
 const STORAGE_PATH = fakePath('storage');

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -6,6 +6,7 @@ import '@test/support/defaultSessionTestSetup';
 
 import { publishTestRunStart } from '@test/support/sessionTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import { TraceEmitter } from '@agent/trace';
 import { deriveWorkflowScriptCheckpointId } from '@agent/workflowScript/checkpoint';
 import { getRunRecords } from '@agent/storage';
@@ -27,7 +28,10 @@ import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { convertToolSchema } from '@agent/runtime/run/toolSchema';
 import { nativeToolTestLayer } from '@test/support/nativeToolTestLayer';
 
-setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
+setupPlatform({
+  storagePath: fakePath('storage'),
+  workspacePath: fakePath('workspace'),
+});
 
 const mocks = vi.hoisted(() => ({
   registerRun: vi.fn(),

--- a/src/test-kernel/utils/TextDiffCallers.vitest.ts
+++ b/src/test-kernel/utils/TextDiffCallers.vitest.ts
@@ -16,6 +16,7 @@ import {
 import type { RoundFileMapping } from '@agent/implementations/flows/reflection/output/types';
 import { fileLocationDisplayPath, type RunId } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import { nativeToolTestLayer } from '@test/support/nativeToolTestLayer';
 import { computeAndWriteWorkflowDiffs } from '@tools/delegation/subagentResults';
 import {
@@ -33,8 +34,8 @@ function installFakePlatform(
 ): Promise<void> {
   return installPlatform({
     files,
-    storagePath: '/workspace/.texra/storage',
-    workspacePath: '/workspace',
+    storagePath: fakePath('workspace/.texra/storage'),
+    workspacePath: fakePath('workspace'),
   });
 }
 
@@ -54,16 +55,16 @@ describe('shared text-diff caller fixtures', () => {
           {
             round: 0,
             relativePath: 'section/paper.tex',
-            absolutePath: '/workspace/out/section/paper.tex',
+            absolutePath: fakePath('workspace/out/section/paper.tex'),
             location: 'workspace',
-            originalPath: '/workspace/original.tex',
+            originalPath: fakePath('workspace/original.tex'),
             added: 2,
             removed: 1,
           },
         ]),
       );
 
-      expect(result.get('/workspace/out/section/paper.tex')).toEqual({
+      expect(result.get(fakePath('workspace/out/section/paper.tex'))).toEqual({
         diffRelPath: 'diffs/section_paper.tex.diff',
         largeChange: true,
       });
@@ -109,7 +110,7 @@ describe('shared text-diff caller fixtures', () => {
           final,
         ).pipe(
           Effect.provide(
-            nativeToolTestLayer({ workingDirectory: '/workspace' }),
+            nativeToolTestLayer({ workingDirectory: fakePath('workspace') }),
           ),
         );
 
@@ -119,7 +120,7 @@ describe('shared text-diff caller fixtures', () => {
         });
         expect(
           yield* Effect.tryPromise(() =>
-            AbsoluteFS.read('/workspace/paper.tex'),
+            AbsoluteFS.read(fakePath('workspace/paper.tex')),
           ),
         ).toBe('alpha\nBETA\nomega\nlocal\n');
       }),

--- a/src/test-kernel/utils/WorkflowPromptFileNames.vitest.ts
+++ b/src/test-kernel/utils/WorkflowPromptFileNames.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports
 import { setupPlatform } from '@test/support/setupPlatform';
+import { fakePath } from '@test/support/FakePlatform';
 import {
   getListOfFiles,
   getPromptFileName,
@@ -15,7 +16,7 @@ import {
 
 describe('workflow prompt file names', () => {
   setupPlatform({
-    workspacePath: '/workspace',
+    workspacePath: fakePath('workspace'),
     files: {
       '/workspace/chapter/main.tex': 'workspace text',
       '/outside/absolute.tex': 'external text',
@@ -23,24 +24,29 @@ describe('workflow prompt file names', () => {
   });
 
   it('uses workspace-relative names and external basenames in prompt variables', async () => {
-    expect(getPromptFileName('/workspace/chapter/main.tex')).toBe(
+    expect(getPromptFileName(fakePath('workspace/chapter/main.tex'))).toBe(
       'chapter/main.tex',
     );
-    expect(getPromptFileName('/outside/absolute.tex')).toBe('absolute.tex');
+    expect(getPromptFileName(fakePath('outside/absolute.tex'))).toBe(
+      'absolute.tex',
+    );
     expect(getPromptFileName('local.tex')).toBe('local.tex');
 
     expect(
-      getListOfFiles(['/workspace/chapter/main.tex', '/outside/absolute.tex']),
+      getListOfFiles([
+        fakePath('workspace/chapter/main.tex'),
+        fakePath('outside/absolute.tex'),
+      ]),
     ).toBe('chapter/main.tex, absolute.tex');
 
     const { xml } = await getXmlFormatFromReadableFiles([
-      '/workspace/chapter/main.tex',
-      '/outside/absolute.tex',
+      fakePath('workspace/chapter/main.tex'),
+      fakePath('outside/absolute.tex'),
     ]);
 
     expect(xml).toContain('<document name="chapter/main.tex">');
     expect(xml).toContain('<document name="absolute.tex">');
-    expect(xml).not.toContain('name="/outside/absolute.tex"');
+    expect(xml).not.toContain(`name="${fakePath('outside/absolute.tex')}"`);
   });
 
   it('keeps extracted outputs inside the round directory for absolute document names', () => {


### PR DESCRIPTION
## Summary

Third slice of shrinking `Platform` onto the Effect-native services (owner ruling 2026-09-13; slices 1 and 2 are #12364 and #12372). Before the filesystem consumers can move onto `FileSystem`/`Path`, the test seam that 60 suites reach through `setupPlatform` has to stop being a memfs fake of the port. It now is not: the fake host runs the production `nodeFilesystem` over a real per-worker temp root.

- **Harness** (`src/test-kernel/support/FakePlatform.ts`): one `mkdtemp` home per worker (realpath'd, cached across `vi.resetModules()`, removed at process exit); `FAKE_ROOT` is the fake filesystem's `/`, module-private; `fakePath(...segments)` is the one export a suite needs; seeding empties and rewrites the root per `createFakePlatform`, reproducing the old per-host volume exactly; seed keys are paths inside the root, so `'/workspace/a.tex'` and `fakePath('workspace/a.tex')` name the same file, which is why 42 of the 59 seeding suites did not change.
- **Deleted**: `FakeFileSystemProvider` (188 lines), the memfs import and `stringToBytes`; `memfs` is out of `package.json` and the lockfile. `FakePlatform.vitest.ts` was a fake-versus-node parity suite and became `NodeFilesystem.vitest.ts` with the node half only.
- **Suites**: 17 suites replaced invented absolute paths with `fakePath(...)` at option, assertion and helper-constant sites; two `size: 0` directory assertions became `expect.any(Number)` (a real directory's size is the filesystem's bookkeeping). No tier moved: the classifier is source-based and every affected suite already imported `@platform/*` or a support module.
- **Production**: `fsEntryTypeBits.ts` loses the `StatCapableFs` parameter and the now-dead `FileTypeProbe` export (they existed only so memfs and `node:fs` could share the helper); `nodeFilesystem.ts` drops the corresponding argument.

Full suite on the same machine: memfs 80.0 s, real temp root 68.5 s; the vendored in-memory `FileSystem` layer the manifest priced as the fallback is not needed.

Not in this slice, by design: `FileSystem`/`Path` in `ProcessServices` (its own change), and folding `createTempDirPlatform` (now close to redundant; 11 more suites for no behavioural gain here).

## Issue acceptance gates

#12073 R-1 slice 3: the memfs seam is gone, suites exercise the production filesystem, no ratchet or baseline touched. Met.

## Single source of truth

`nodeFilesystem` is the only filesystem implementation tests and hosts run; the fake root and `fakePath` are the one place the harness's paths come from.

## Duplication and abstraction budget

Deleted a second filesystem implementation kept only for tests. Added two small harness helpers with many consumers.

## Net elements (R6)

26 files, +289/-759 (net -470). Deleted: 1 fake provider class, 1 devDependency, 1 exported type, 1 helper parameter. Added: `fakePath`, `workerTempHome`.

## Consumer counts (R8)

n/a: test harness and one internal helper signature.

## Host impact

Extension, desktop, CLI: none at runtime; `fsEntryTypeBits` is internal to the Node filesystem default.

## Scheduled refactoring

Next: `FileSystem`/`Path` provided once in `ProcessServices`, then the fs consumers onto them in ratchet-safe order, with the fs port last.

## Validation

Typecheck, lint, the full suite (5,536 tests), test:pure after the rebase onto #12372, the dead-code ratchet, the effect-migration ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)