### PR TITLE
refactor(platform): FileSystem and Path are process services; jsonStore and the Lean adapter take them from context

### DIFF
--- a/packages/desktop/src/main/desktopProjects.ts
+++ b/packages/desktop/src/main/desktopProjects.ts
@@ -5,7 +5,7 @@
 
 import { stat } from 'node:fs/promises';
 
-import { Effect } from 'effect';
+import { Effect, type FileSystem, type Path } from 'effect';
 
 import {
   createAgentResponseTextConnector,
@@ -80,8 +80,14 @@ interface DesktopProjectRegistryOptions {
 }
 
 export interface DesktopProjectRegistry {
-  /** Open a folder as a project, remember it for the next launch, or return the one already open. */
-  open(root: string): Effect.Effect<DesktopProject, Error>;
+  /**
+   * Open a folder as a project, remember it for the next launch, or return
+   * the one already open. Its stores read through the process runtime's
+   * `FileSystem` and `Path`, so it runs where those are provided.
+   */
+  open(
+    root: string,
+  ): Effect.Effect<DesktopProject, Error, FileSystem.FileSystem | Path.Path>;
   /** Open projects in the order they were opened; the no-workspace session is not one. */
   list(): readonly DesktopProject[];
   /** The project the window shows: the active folder, else the no-workspace session. */

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -15,6 +15,7 @@
  * an open borrows, `close` settles and releases, and the runtime's disposal
  * releases whatever is still open.
  */
+import { NodeFileSystem, NodePath } from '@effect/platform-node';
 import {
   Context,
   Deferred,
@@ -846,7 +847,16 @@ export function installProcessRuntime({
     Sessions.layer(release, services).pipe(
       Layer.provideMerge(services),
       Layer.provideMerge(
-        Layer.mergeAll(effectDiagnosticsLayer, FetchHttpClient.layer),
+        Layer.mergeAll(
+          effectDiagnosticsLayer,
+          FetchHttpClient.layer,
+          // The standard library's filesystem and path services, provided
+          // once per process here rather than by each program that needs
+          // them: every root reaches this install, so a consumer takes
+          // `FileSystem`/`Path` from context and builds no layer of its own.
+          NodeFileSystem.layer,
+          NodePath.layer,
+        ),
       ),
     ),
   );

--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -2,8 +2,7 @@
 import { Buffer } from 'node:buffer';
 
 // Third-party imports
-import { NodeFileSystem, NodePath } from '@effect/platform-node';
-import { Effect, FileSystem, Layer, Path, type PlatformError } from 'effect';
+import { Effect, FileSystem, Path, type PlatformError } from 'effect';
 import writeFileAtomic from 'write-file-atomic';
 
 // Local imports
@@ -15,8 +14,6 @@ import { type PerKeyLane, withPerKeyLane } from '@utils/core/perKeyQueue';
 import type { StateStore } from '../interfaces';
 
 type JsonRecord = Record<string, unknown>;
-
-const nodeStorageLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
 
 /** Preserve the Node error identity exposed by this store's existing callers. */
 function storageError(error: PlatformError.PlatformError): Error {
@@ -178,7 +175,7 @@ export class JsonStore implements StateStore {
     const path = yield* Path.Path;
     const storePath = path.resolve(filePath);
     return new JsonStore(storePath, yield* readJsonRecord(storePath), options);
-  }, Effect.provide(nodeStorageLayer));
+  });
 
   get<T>(key: string, defaultValue?: T): T {
     const value = this.data[key];
@@ -206,15 +203,7 @@ export class JsonStore implements StateStore {
       return withPerKeyLane(
         writeLanes,
         this.filePath,
-      )(
-        flush(
-          this.filePath,
-          this.options.mode,
-          key,
-          value,
-          this.snapshot(),
-        ).pipe(Effect.provide(nodeStorageLayer)),
-      );
+      )(flush(this.filePath, this.options.mode, key, value, this.snapshot()));
     });
   }
 

--- a/src/platform/processRuntime.ts
+++ b/src/platform/processRuntime.ts
@@ -10,7 +10,7 @@ import type { ToolInjections } from '@agent/runtime/toolInjection';
 import type { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 import type { InquiryRecords } from '@shared/session/inquiryRecords';
 import type { SetupPlatform } from '@tools/setup/platform';
-import type { ManagedRuntime } from 'effect';
+import type { FileSystem, ManagedRuntime, Path } from 'effect';
 import type { HttpClient } from 'effect/unstable/http';
 
 import type { AppState } from './interfaces';
@@ -19,9 +19,14 @@ import type { Secrets } from './secrets';
 /**
  * The runtime over the process-lifetime services every entry provides: the
  * four cohort-A tags beside the records and the HTTP client, merged once in
- * `installProcessRuntime`'s `services` layer.
+ * `installProcessRuntime`'s `services` layer, plus the standard library's
+ * `FileSystem` and `Path`, which the same install provides from
+ * `@effect/platform-node` so a program that reads or resolves a file takes
+ * them from context instead of building a Node layer of its own.
  */
 export type ProcessServices =
+  | FileSystem.FileSystem
+  | Path.Path
   | HttpClient.HttpClient
   | InquiryRecords
   | UpdateCheckRecords

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
@@ -7,6 +7,7 @@ import { UpdateCheckRecords } from '@shared/session/updateCheckRecords';
 // Local imports
 import { FakeSecrets } from '@test/support/FakePlatform';
 import { testHttpClientLayer } from '@test/support/fetchTestUtils';
+import { nodePlatformLayer } from '@test/support/fsTestUtils';
 
 /**
  * The secret store the CLI composition root owns. Every load below
@@ -111,6 +112,7 @@ async function loadSupabaseAuth() {
     ManagedRuntime.make(
       Layer.mergeAll(
         testHttpClientLayer,
+        nodePlatformLayer,
         Layer.mock(UpdateCheckRecords, {}),
         inquiryRecordsLayer(() => globalStorage).pipe(
           Layer.provide(ProcessIdentity.layer(processOwnerId(undefined))),

--- a/src/test-kernel/cli/InitConfig.vitest.ts
+++ b/src/test-kernel/cli/InitConfig.vitest.ts
@@ -19,6 +19,7 @@ import {
   setWorkspaceCliChatAgent,
 } from '@cli/runtime/cliConfig';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
+import { nodePlatformLayer } from '@test/support/fsTestUtils';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 vi.mock('node:fs/promises', async (importOriginal) => {
@@ -95,7 +96,7 @@ describe('setWorkspaceCliChatAgent', () => {
         yield* setWorkspaceCliChatAgent(workspace, undefined);
         const cleared = yield* loadWorkspaceCliConfig(workspace);
         expect(cleared.values.chat).toEqual({ model: 'deepseekT' });
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 });
 

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -1,7 +1,6 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, relative } from 'node:path';
-import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
 import { Effect, FileSystem } from 'effect';
 import { it as effectIt } from '@effect/vitest';
 
@@ -14,6 +13,7 @@ import {
   nodeProcesses,
   processOwnerId,
 } from '@platform/defaults/nodeProcesses';
+import { nodePlatformLayer } from '@test/support/fsTestUtils';
 import { createFakeHost } from '@test/support/setupPlatform';
 import { createTestSession } from '@test/support/sessionTestUtils';
 
@@ -77,7 +77,7 @@ describe('desktop composition root and launch environment', () => {
           expect(yield* reopened.read).toEqual(['/first']);
           expect(yield* fs.readFileString(oldState)).toBe(previous);
         }),
-      ).pipe(Effect.provide(NodeFileSystem.layer)),
+      ).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   effectIt.live(
@@ -152,7 +152,7 @@ describe('desktop composition root and launch environment', () => {
           expect(registry.active()).toBe(successor);
           expect(yield* records.read).toEqual([successor.root]);
         }),
-      ).pipe(Effect.provide(NodeFileSystem.layer)),
+      ).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it('keeps platform initialization in the Electron composition root', async () => {

--- a/src/test-kernel/desktop/ElectronConfig.vitest.ts
+++ b/src/test-kernel/desktop/ElectronConfig.vitest.ts
@@ -12,6 +12,7 @@ import type { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
 import type { JsonStore } from '@platform/defaults/jsonStore';
 
 // Local imports - test support
+import { nodePlatformLayer } from '@test/support/fsTestUtils';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { loadSourceModule } from './loadSourceModule.ts';
 
@@ -53,7 +54,7 @@ describe('desktop JsonConfigProvider (dual-store)', () => {
         workspaceStore,
         files: [globalPath, workspacePath],
       };
-    });
+    }).pipe(Effect.provide(nodePlatformLayer));
   }
 
   it.effect('returns schema defaults without creating empty config files', () =>
@@ -99,7 +100,7 @@ describe('desktop JsonConfigProvider (dual-store)', () => {
         globalValue: ['dist'],
         workspaceValue: ['node_modules'],
       });
-    }),
+    }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect('stores new config values under the canonical prefixed key', () =>
@@ -127,6 +128,6 @@ describe('desktop JsonConfigProvider (dual-store)', () => {
 
       expect(provider.isExplicitlySet('files.exclude')).toBe(false);
       expect(workspaceStore.snapshot()).toEqual({});
-    }),
+    }).pipe(Effect.provide(nodePlatformLayer)),
   );
 });

--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.ts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.ts
@@ -12,7 +12,7 @@ import type { JsonStore } from '@platform/defaults/jsonStore';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 
 // Local imports - test support
-import { pathExists } from '@test/support/fsTestUtils';
+import { nodePlatformLayer, pathExists } from '@test/support/fsTestUtils';
 import {
   makeTempDir as makeSharedTempDir,
   useTempDirs,
@@ -96,7 +96,7 @@ describe('desktop platform adapters', () => {
         expect(store.get('session')).toEqual({ active: true });
         expect(store.get('missing', 'fallback')).toBe('fallback');
         expect(store.snapshot()).toEqual({ session: { active: true } });
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect(
@@ -161,7 +161,7 @@ describe('desktop platform adapters', () => {
           yield* Effect.promise(() => secrets.get(testSecretKey)),
         ).toBeUndefined();
         expect(store.snapshot()).toEqual({});
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect(
@@ -181,7 +181,7 @@ describe('desktop platform adapters', () => {
           new Error('Electron safeStorage is unavailable for secret writes.'),
         );
         expect(store.snapshot()).toEqual({});
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect(
@@ -213,7 +213,7 @@ describe('desktop platform adapters', () => {
           LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE,
         );
         expect(store.snapshot()).toEqual({});
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect(
@@ -237,7 +237,7 @@ describe('desktop platform adapters', () => {
           new Error(LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE),
         );
         expect(store.snapshot()).toEqual({});
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect('ignores malformed persisted secret records', () =>
@@ -249,6 +249,6 @@ describe('desktop platform adapters', () => {
       expect(
         yield* Effect.promise(() => secrets.get(testSecretKey)),
       ).toBeUndefined();
-    }),
+    }).pipe(Effect.provide(nodePlatformLayer)),
   );
 });

--- a/src/test-kernel/desktop/JsonStore.vitest.ts
+++ b/src/test-kernel/desktop/JsonStore.vitest.ts
@@ -9,6 +9,7 @@ import { Effect, Fiber } from 'effect';
 import { describe, expect } from 'vitest';
 
 // Local imports - test support
+import { nodePlatformLayer } from '@test/support/fsTestUtils';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { moduleFileUrl, repoPath } from './desktopTestPaths.ts';
 import { loadSourceModule } from './loadSourceModule.ts';
@@ -72,7 +73,7 @@ describe('shared JsonStore', () => {
       expect(yield* Effect.promise(() => readFile(filePath, 'utf8'))).toBe(
         original,
       );
-    }),
+    }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect.each([
@@ -89,7 +90,7 @@ describe('shared JsonStore', () => {
       const error = yield* Effect.flip(JsonStore.open(filePath));
       expect(error).toBeInstanceOf(TypeError);
       expect(error.message).toContain('to contain a JSON object');
-    }),
+    }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect(
@@ -114,7 +115,7 @@ describe('shared JsonStore', () => {
           keep: 1,
           foreign: 2,
         });
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect(
@@ -135,7 +136,7 @@ describe('shared JsonStore', () => {
         expect(yield* Effect.promise(() => readFile(filePath, 'utf8'))).toBe(
           corrupt,
         );
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect(
@@ -155,7 +156,7 @@ describe('shared JsonStore', () => {
           keep: 1,
           added: 2,
         });
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect(
@@ -182,7 +183,7 @@ describe('shared JsonStore', () => {
           fromA: 'a',
           fromB: 'b',
         });
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it.effect('flushes chained sets in call order, not in wake-up order', () =>
@@ -208,7 +209,7 @@ describe('shared JsonStore', () => {
       expect(yield* Effect.promise(() => readStoredJson(filePath))).toEqual({
         k: 3,
       });
-    }),
+    }).pipe(Effect.provide(nodePlatformLayer)),
   );
 
   it('keeps the lock function callable in a split ESM bundle', async () => {
@@ -235,9 +236,13 @@ describe('shared JsonStore', () => {
       Effect: typeof Effect;
     };
     const filePath = join(tempDir, 'state.json');
-    const store = await bundledEffect.runPromise(JsonStore.open(filePath));
+    const store = await bundledEffect.runPromise(
+      JsonStore.open(filePath).pipe(Effect.provide(nodePlatformLayer)),
+    );
 
-    await bundledEffect.runPromise(store.set('persisted', true));
+    await bundledEffect.runPromise(
+      store.set('persisted', true).pipe(Effect.provide(nodePlatformLayer)),
+    );
 
     expect(await readStoredJson(filePath)).toEqual({
       persisted: true,
@@ -276,6 +281,6 @@ describe('shared JsonStore', () => {
         } finally {
           yield* Effect.promise(() => chmod(tempDir!, 0o700));
         }
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 });

--- a/src/test-kernel/platform/WorkspaceStorage.vitest.ts
+++ b/src/test-kernel/platform/WorkspaceStorage.vitest.ts
@@ -21,7 +21,7 @@ import {
   RUNS_STORAGE_DIR,
   workspaceStorageId,
 } from '@platform/defaults/workspaceStorage';
-import { pathExists } from '@test/support/fsTestUtils';
+import { nodePlatformLayer, pathExists } from '@test/support/fsTestUtils';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 describe('workspace storage defaults', () => {
@@ -174,6 +174,6 @@ describe('workspace storage defaults', () => {
             pathExists(join(storage.getStoragePath(), 'config.json')),
           ),
         ).toBe(true);
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 });

--- a/src/test-kernel/support/fsTestUtils.ts
+++ b/src/test-kernel/support/fsTestUtils.ts
@@ -6,6 +6,21 @@
 // Node imports
 import { stat } from 'node:fs/promises';
 
+// Third-party imports
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import * as NodePath from '@effect/platform-node/NodePath';
+import { Layer } from 'effect';
+
+/**
+ * The `FileSystem` and `Path` services `installProcessRuntime` provides once
+ * per process, for a suite that runs a real-filesystem program on
+ * `it.effect`'s own runtime rather than the installed one.
+ */
+export const nodePlatformLayer = Layer.mergeAll(
+  NodeFileSystem.layer,
+  NodePath.layer,
+);
+
 /**
  * Whether `path` exists on disk. Non-ENOENT stat failures (permissions,
  * I/O) propagate — a path that cannot be inspected is not "absent".

--- a/src/test-kernel/support/setupPlatform.ts
+++ b/src/test-kernel/support/setupPlatform.ts
@@ -11,6 +11,12 @@
  * and restores the suite-default fake platform afterward, so overrides never
  * leak into later tests in the same file.
  */
+// The two services by their own modules, not the package barrel: a setup
+// file loads before a suite's `vi.mock` registrations, and the barrel would
+// cache `NodeChildProcessSpawner`'s `node:child_process` ahead of a suite
+// that mocks it.
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import * as NodePath from '@effect/platform-node/NodePath';
 import { afterEach, beforeEach } from 'vitest';
 
 import type { ToolInjections } from '@agent/runtime/toolInjection';
@@ -191,6 +197,10 @@ export async function installFakeHost(host: FakeHost): Promise<void> {
   // layer here fails every one of them.
   processServices ??= Layer.mergeAll(
     testHttpClientLayer,
+    // The same standard-library filesystem and path services the process
+    // roots provide, over the real temp roots the harness runs on.
+    NodeFileSystem.layer,
+    NodePath.layer,
     Layer.mock(UpdateCheckRecords, {}),
     Layer.mock(InquiryRecords, {}),
     Secrets.layer(() => installedHost().secrets),

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -19,11 +19,7 @@
  * which converts with its only caller there.
  */
 
-import {
-  NodeChildProcessSpawner,
-  NodeFileSystem,
-  NodePath,
-} from '@effect/platform-node';
+import { NodeChildProcessSpawner } from '@effect/platform-node';
 import { Cause, Context, Duration, Effect, Exit, Layer, Scope } from 'effect';
 
 import { SHUTDOWN_PHASE, type LifecycleHost } from '@platform/interfaces';
@@ -43,16 +39,6 @@ import type {
 
 /** Long-lived CLI/desktop hosts otherwise keep unused servers forever. */
 const DEFAULT_LEAN_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
-
-/**
- * The library's Node `ChildProcessSpawner`, over the `FileSystem` and `Path`
- * services it validates and resolves a command's `cwd` through. Built here
- * rather than by the process runtime: the Lean lane is its only consumer, so
- * a process-wide spawner is a later lane's call.
- */
-const spawnerLayer = NodeChildProcessSpawner.layer.pipe(
-  Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodePath.layer)),
-);
 
 export interface DirectLspLeanAdapterOptions {
   /** Path or name of the `lake` binary (defaults to `lake` on PATH). */
@@ -98,7 +84,13 @@ export function createDirectLspLeanAdapter(
           idleTimeoutMs > 0
             ? Duration.millis(idleTimeoutMs)
             : Duration.infinity,
-      }).pipe(Layer.provide(spawnerLayer)),
+      }).pipe(
+        // The library's Node `ChildProcessSpawner`, over the `FileSystem`
+        // and `Path` it validates and resolves a command's `cwd` through:
+        // the process runtime provides that pair, so only the spawner is
+        // built here.
+        Layer.provide(NodeChildProcessSpawner.layer),
+      ),
     ).pipe(
       Scope.provide(scope),
       Effect.map((context) => Context.get(context, LeanServerPool)),


### PR DESCRIPTION
## Summary

Slice 4a of shrinking `Platform` onto the Effect-native services (owner ruling 2026-09-13; earlier slices #12364, #12372, #12373). The type widening alone: `FileSystem.FileSystem` and `Path.Path` from `effect` are part of `ProcessServices`, provided once per process by `installProcessRuntime` through `NodeFileSystem.layer` and `NodePath.layer`, so every root (extension, desktop, CLI, the SDK's `composeProcess`) gets them from the one merge in `sessionLayer.ts` and later slices can convert filesystem consumers to `yield* FileSystem` without each building its own layer.

The two consumers that already ran on these services take them from context: `jsonStore.ts` loses its local `nodeStorageLayer` and both `Effect.provide` sites; `directLspAdapter.ts` loses its local spawner layer composition and provides `NodeChildProcessSpawner.layer` directly. One production type consequence: `DesktopProjectRegistry.open` declares the two services in its requirement channel (both callers already run it on the process runtime). `NodeServices.layer` was deliberately not used (it would pull `Terminal`/`Stdio` into the extension host).

Test side: the fake host's process services provide the same two real layers; seven suites that run store programs on `it.effect`'s own runtime pipe in one shared `nodePlatformLayer` from the existing `fsTestUtils`. One rule learned for test-support code: import `@effect/platform-node` submodules, not the barrel, from setup-phase modules, because the barrel loads `NodeChildProcessSpawner` and caches the real `node:child_process` before a suite's `vi.mock` registers.

## Issue acceptance gates

#12073 R-1 slice 4a: the two services are provided once per process and the two existing Effect consumers no longer build their own layers. Met. No `platform().fs` consumer converts here (slices 4b onward).

## Single source of truth

`installProcessRuntime` in `sessionLayer.ts` for the process-wide `FileSystem` and `Path`.

## Duplication and abstraction budget

Two local layer constructions deleted; one requirement added to the process services. No pass-through.

## Net elements (R6)

14 files, +98/-62 (net +36, mostly test wiring). Elements: -2 local layers, +2 process services, +1 shared test helper with 23 consumers.

## Consumer counts (R8)

n/a.

## Host impact

Extension, desktop, CLI, SDK: the services arrive through `installProcessRuntime`; no root file changed.

## Scheduled refactoring

Slices 4b onward: the filesystem consumers onto `FileSystem`/`Path` in ratchet-safe order (the `catch:effect-importer` row has zero headroom, so `baseFS.ts` and `runDirOps.ts` convert their raw catches when they first import `effect`), with the fs port last.

## Validation

Typecheck, lint, test:pure, test:changed (3,031 tests), the dead-code ratchet, the effect-migration ratchet (no row moved), `compile:fast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)