### PR TITLE
refactor(platform): resolveLatexDir takes FileSystem from context

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -11,7 +11,6 @@
       "src/controllers/session/hostRunActions.ts": 1,
       "src/controllers/session/workspaceFileOptions.ts": 1,
       "src/housekeeping/runDirOps.ts": 2,
-      "src/latex/latexParsingUtils.ts": 1,
       "src/model/runtimeModelRegistry.ts": 1,
       "src/tools/github/PollingSourceBase.ts": 1,
       "src/utils/files/baseFS.ts": 13,

--- a/src/agent/runtime/loop/reflection.ts
+++ b/src/agent/runtime/loop/reflection.ts
@@ -28,7 +28,7 @@
  * family, and the reflection run's tool registry is empty by construction.
  */
 import { dirname } from 'node:path';
-import { Cause, Effect, Exit, Ref, SynchronizedRef } from 'effect';
+import { Cause, Effect, Exit, FileSystem, Ref, SynchronizedRef } from 'effect';
 
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { userRequestTemplateCount } from '@agent/index/agentYamlScanner';
@@ -175,7 +175,7 @@ export const runReflection = Effect.fn('reflection.run')(function* (
 ): Effect.fn.Return<
   ReflectionResult,
   Error,
-  AgentRun | RunLedger | ModelInvoker
+  AgentRun | RunLedger | ModelInvoker | FileSystem.FileSystem
 > {
   const run = yield* AgentRun;
   const ledger = yield* RunLedger;
@@ -414,7 +414,7 @@ export const runReflection = Effect.fn('reflection.run')(function* (
   /** The round prompt, its media and TeX count, committed with `round.begin`. */
   const prepareRound = Effect.fn('reflection.prepareRound')(function* (
     initial: RunState,
-  ): Effect.fn.Return<RunState, Error> {
+  ): Effect.fn.Return<RunState, Error, FileSystem.FileSystem> {
     const round = flow.currentRound;
     const bound = yield* SynchronizedRef.get(run.model);
     contextWindowRecoveryAttempted = false;
@@ -992,7 +992,7 @@ export const runReflection = Effect.fn('reflection.run')(function* (
   /** One round inside its trace stage: prompt, response cycles, output. */
   const runRound = Effect.fn('reflection.round')(function* (
     initial: RunState,
-  ): Effect.fn.Return<RoundExit, Error> {
+  ): Effect.fn.Return<RoundExit, Error, FileSystem.FileSystem> {
     const round = flow.currentRound;
     // The stage closes with the round's own verdict; an exit that never set
     // one is a stop (interrupt) or a defect.

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 // Third-party imports
-import { Effect } from 'effect';
+import { Effect, FileSystem } from 'effect';
 
 // Local imports
 import type { FileLocation } from '@shared/schemas';
@@ -88,12 +88,12 @@ export class LatexMediaManager {
    * interruption still propagate: a bug or a cancelled run is not a skipped
    * file.
    */
-  private forEachFile<T, E>(
+  private forEachFile<T, E, R>(
     items: readonly T[],
     pathOf: (item: T) => string,
     failureMessage: string,
-    task: (item: T) => Effect.Effect<unknown, E>,
-  ): Effect.Effect<void> {
+    task: (item: T) => Effect.Effect<unknown, E, R>,
+  ): Effect.Effect<void, never, R> {
     return Effect.forEach(
       items,
       (item) =>
@@ -114,7 +114,7 @@ export class LatexMediaManager {
     latexFile: FileLocation,
     figures: readonly string[],
     baseDir?: string,
-  ): Effect.Effect<void> {
+  ): Effect.Effect<void, never, FileSystem.FileSystem> {
     return Effect.gen({ self: this }, function* () {
       const fileService = this.fileService;
       if (!fileService || figures.length === 0) {
@@ -279,7 +279,7 @@ export class LatexMediaManager {
    */
   private mirrorLatexFileDependencies(
     files: readonly FileLocation[],
-  ): Effect.Effect<void> {
+  ): Effect.Effect<void, never, FileSystem.FileSystem> {
     return Effect.gen({ self: this }, function* () {
       const fileService = this.fileService;
       if (!fileService || files.length === 0) {
@@ -350,7 +350,7 @@ export class LatexMediaManager {
    */
   private collectDependencies(
     latexFile: FileLocation,
-  ): Effect.Effect<string[]> {
+  ): Effect.Effect<string[], never, FileSystem.FileSystem> {
     return Effect.gen({ self: this }, function* () {
       const found = new Set<string>();
 
@@ -470,7 +470,7 @@ export class LatexMediaManager {
    */
   private mirrorFiguresForFiles(
     files: readonly FileLocation[],
-  ): Effect.Effect<void> {
+  ): Effect.Effect<void, never, FileSystem.FileSystem> {
     return Effect.gen({ self: this }, function* () {
       if (!this.fileService || files.length === 0) {
         return;
@@ -498,7 +498,7 @@ export class LatexMediaManager {
   private extractFiguresFromFiles(
     files: readonly FileLocation[],
     workspaceState: MediaWorkspaceState,
-  ): Effect.Effect<void, Error> {
+  ): Effect.Effect<void, Error, FileSystem.FileSystem> {
     return Effect.gen({ self: this }, function* () {
       const figureResults = yield* Effect.forEach(
         files,
@@ -513,7 +513,7 @@ export class LatexMediaManager {
         { concurrency: LATEX_CONCURRENCY },
       );
 
-      const mirrors: Effect.Effect<void>[] = [];
+      const mirrors: Effect.Effect<void, never, FileSystem.FileSystem>[] = [];
 
       for (const { file, figures } of figureResults) {
         if (figures.length === 0) {
@@ -618,7 +618,7 @@ export class LatexMediaManager {
       extraMediaFiles?: readonly FileLocation[];
       logTikzSummary?: boolean;
     },
-  ): Effect.Effect<void, Error> {
+  ): Effect.Effect<void, Error, FileSystem.FileSystem> {
     return Effect.gen({ self: this }, function* () {
       if (files.length === 0) {
         return;
@@ -678,7 +678,7 @@ export class LatexMediaManager {
     workspaceState: MediaWorkspaceState,
     cfg: ToolConfig,
     extraMediaFiles: readonly FileLocation[] = [],
-  ): Effect.Effect<void, Error> {
+  ): Effect.Effect<void, Error, FileSystem.FileSystem> {
     return this.processFiles(inputFiles, workspaceState, cfg, {
       figureMode: 'extract',
       extraMediaFiles,
@@ -697,7 +697,7 @@ export class LatexMediaManager {
     outputFiles: readonly FileLocation[],
     workspaceState: MediaWorkspaceState,
     cfg: ToolConfig,
-  ): Effect.Effect<void, Error> {
+  ): Effect.Effect<void, Error, FileSystem.FileSystem> {
     return this.processFiles(outputFiles, workspaceState, cfg, {
       figureMode: 'mirror',
     });

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -6,10 +6,9 @@
 
 import * as path from 'node:path';
 
-import { Effect } from 'effect';
+import { Effect, FileSystem } from 'effect';
 
 import { withLogChannel, withLogData } from '@logger/effectLog';
-import { platform } from '@platform/platform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { ensureError } from '@utils/errors/errorMessage';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
@@ -77,18 +76,14 @@ const BIB_DIRECTIVE_PATTERN = new RegExp(
 export const resolveLatexDir = Effect.fn('latex.resolveLatexDir')(function* (
   absolutePath: string,
 ) {
-  const resolved = yield* Effect.tryPromise({
-    try: () => platform().fs.realPath(absolutePath),
-    catch: ensureError,
-  }).pipe(
-    Effect.catch((error) =>
-      Effect.logDebug(
-        `realPath failed for ${absolutePath}; falling back to literal dirname`,
-      ).pipe(
-        withLogData(error),
-        withLogChannel(CHANNEL),
-        Effect.as(absolutePath),
-      ),
+  const fs = yield* FileSystem.FileSystem;
+  const resolved = yield* Effect.catch(fs.realPath(absolutePath), (error) =>
+    Effect.logDebug(
+      `realPath failed for ${absolutePath}; falling back to literal dirname`,
+    ).pipe(
+      withLogData(error),
+      withLogChannel(CHANNEL),
+      Effect.as(absolutePath),
     ),
   );
   return path.dirname(resolved);

--- a/src/test-kernel/agent/ReflectionLoop.vitest.ts
+++ b/src/test-kernel/agent/ReflectionLoop.vitest.ts
@@ -54,6 +54,7 @@ import { RunLedger } from '@shared/session/runLedger';
 import type { RunState } from '@shared/session/runStateFold';
 import { StreamLog } from '@shared/session/traceEntries';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { nodePlatformLayer } from '@test/support/fsTestUtils';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import {
   attachTestTranscriptFold,
@@ -461,6 +462,7 @@ function loopProgram(init: LoopInit, requests: InvokeRequest[]) {
       invokerLayer(init, requests).pipe(
         Layer.provideMerge(agentRunTestLayer(init)),
         Layer.provideMerge(Layer.succeed(RunLedger)(init.session.ledger)),
+        Layer.provideMerge(nodePlatformLayer),
       ),
     ),
   );

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -1,7 +1,7 @@
 import { lstat, mkdir, readlink, realpath, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { Effect } from 'effect';
+import { Effect, FileSystem } from 'effect';
 import { it } from '@effect/vitest';
 import { afterEach, describe, expect, vi } from 'vitest';
 
@@ -16,6 +16,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import type { FileLocation, RunId, ToolConfig } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
+import { nodePlatformLayer } from '@test/support/fsTestUtils';
 import { spiedTrace } from '@test/support/spiedTrace';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import {
@@ -155,7 +156,7 @@ describe('LatexMediaManager PDF compilation', () => {
       expect(
         workspaceState.media.files.map((file) => file.absolutePath),
       ).toEqual([compiledPdfPath]);
-    }),
+    }).pipe(Effect.provide(nodePlatformLayer)),
   );
 });
 
@@ -163,8 +164,10 @@ type LatexMediaManagerFigureInternals = {
   extractFiguresFromFiles(
     files: FileLocation[],
     workspaceState: MediaWorkspaceState,
-  ): Effect.Effect<void, Error>;
-  mirrorFiguresForFiles(files: FileLocation[]): Effect.Effect<void>;
+  ): Effect.Effect<void, Error, FileSystem.FileSystem>;
+  mirrorFiguresForFiles(
+    files: FileLocation[],
+  ): Effect.Effect<void, never, FileSystem.FileSystem>;
 };
 
 describe('LatexMediaManager figure baseDir resolution (issue #7228)', () => {
@@ -246,6 +249,6 @@ describe('LatexMediaManager figure baseDir resolution (issue #7228)', () => {
           figurePath,
         ]);
         yield* Effect.promise(() => expectFigureMirrored(runId, figurePath));
-      }),
+      }).pipe(Effect.provide(nodePlatformLayer)),
   );
 });

--- a/src/tools/latex/ExtractFiguresTool.ts
+++ b/src/tools/latex/ExtractFiguresTool.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { Effect } from 'effect';
+import { Effect, FileSystem } from 'effect';
 import { z } from 'zod';
 import { ToolCall } from '@agent/runtime/ToolCall';
 
@@ -29,7 +29,11 @@ const DEFAULT_MAX_FILES = 20;
 
 const extractFigures = Effect.fn('ExtractLatexFiguresTool.execute')(function* ({
   texPath,
-}: ExtractFiguresInput): Effect.fn.Return<ToolResult, Error, ToolCall> {
+}: ExtractFiguresInput): Effect.fn.Return<
+  ToolResult,
+  Error,
+  ToolCall | FileSystem.FileSystem
+> {
   const call = yield* ToolCall;
   const { path, display } = yield* resolveLatexFile(texPath);
 


### PR DESCRIPTION
## Summary

Slice 4b of the platform shrink (owner ruling 2026-09-13; earlier slices #12364, #12372, #12373, #12374). Of the thirteen non-`baseFS` files in the `platform()` ratchet row, eight are not filesystem consumers at all (they read `lifecycle`, `agentResume`, `agentDirectories`, `languageModel`, `toolMissingHandler`), and of the five filesystem ones exactly one converts under the rules: `resolveLatexDir` in `latexParsingUtils.ts` is already an `Effect.fn` and needs only `realPath`, so it takes `FileSystem` from context and the `Effect.tryPromise` wrapper around the port call disappears. The requirement propagates through `LatexMediaManager` (its `forEachFile` made generic in `R`), `ExtractFiguresTool` and `runReflection`'s `R`; `ProcessServices` has carried the service since #12374, so no root changes.

The four that stay, and why (the manifest's five missing capabilities and the zero-headroom `catch:effect-importer` row):
- `desktopWorkspaceIpc.ts` (6 sites): needs `isSymlink` and typed `readDirectory`; Promise-shaped with eight errno-branching catches that guard workspace containment.
- `compiledPdfArtifacts.ts` (2): expressible, but a plain Promise module whose callers (`compileCheck`, `LatexDiffManager`) are Promise all the way to the reflection loop; that is the output-pipeline lane.
- `runDirOps.ts` (2): `runPackRunDir` needs a dereferencing `copy`.
- `workspaceFileOptions.ts` (1): typed `readDirectory`. `LatexDiffManager.ts` (1): a private async method in a Promise chain, no admitted run boundary in `src/agent`.
- `baseFS.ts` (13): the facade over the port; converts with the port.

`existingExternalPath` in the same file was deliberately not converted: `AbsoluteFS.exists` is false for `ENOTDIR` as well as `ENOENT`, and Effect's `FileSystem.exists` swallows only `NotFound`.

## Issue acceptance gates

#12073 R-1 slice 4b: every consumer that can leave the row under the rules has; the rest are named with their blocking capability. Met. The fs port itself stays until Effect's `FileSystem` covers `lstat`, a typed directory listing and a dereferencing copy, or the repo keeps those as the one Node-level helper behind the layer.

## Single source of truth

The process `FileSystem` service for `realPath` on this path.

## Net elements (R6)

7 files, +42/-39. One `platform()` site gone (row 33 to 32, 14 to 13 files); one `tryPromise` wrapper deleted.

## Consumer counts (R8)

n/a.

## Host impact

None.

## Scheduled refactoring

The remaining filesystem consumers are gated on Effect `FileSystem` capabilities, not on this repo; recorded in the session ledger.

## Validation

Typecheck, lint, test:pure, test:changed (1,026 tests), the dead-code ratchet, the effect-migration ratchet (one row shrank), `compile:fast`. Note for fixtures: a structural `Effect.Effect<void, Error>` type in a test hides an `R` mismatch from tsc; provide the process layers explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)