### PR TITLE
consolidate(webviews): use the shared pluralize helper instead of inline ternaries

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -35,6 +35,7 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { getBasename, normalizeFilePath } from '@utils/core';
+import { pluralize } from '@utils/text/stringUtils';
 import { ELEMENT_IDS } from '../constants';
 import { getComposedPathElement } from '../utils';
 
@@ -405,8 +406,8 @@ export class FileList extends LitElement {
     return html`
       <span class="file-stats">
         <span class="visually-hidden"
-          >${counts.added} ${counts.added === 1 ? 'line' : 'lines'} added,
-          ${counts.removed} ${counts.removed === 1 ? 'line' : 'lines'}
+          >${counts.added} ${pluralize(counts.added, 'line', 'lines')} added,
+          ${counts.removed} ${pluralize(counts.removed, 'line', 'lines')}
           removed</span
         >
         <span class="added" aria-hidden="true">+${counts.added}</span>

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -10,7 +10,7 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
-import { truncateWithEllipsis } from '@utils/text/stringUtils';
+import { pluralize, truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
@@ -116,7 +116,7 @@ export class QueuedFollowUps extends LitElement {
     // mounted-but-empty host would still consume the parent's flex gap.
     if (this.messages.length === 0) return nothing;
     const messageCount = this.messages.length;
-    const summary = `${messageCount === 1 ? 'Queued message' : 'Queued messages'} (${messageCount})`;
+    const summary = `${pluralize(messageCount, 'Queued message', 'Queued messages')} (${messageCount})`;
     return html`
       <wa-details
         id=${ELEMENT_IDS.QUEUED_FOLLOW_UPS_COLLAPSIBLE}

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -12,6 +12,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import { TODO_STATUS, STATUS_ICONS, type TodoItem } from '@shared/schemas';
 import { stopSpinnerMotion } from '@shared/wa/spinner';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { pluralize } from '@utils/text/stringUtils';
 
 import { ELEMENT_IDS } from '../constants';
 
@@ -109,7 +110,7 @@ export class TodoList extends CollapsiblePanel {
     const activeTodo = this.todos.find(
       (todo) => todo.status === TODO_STATUS.IN_PROGRESS,
     );
-    const progressText = `${completed} of ${total} ${total === 1 ? 'task' : 'tasks'} complete`;
+    const progressText = `${completed} of ${total} ${pluralize(total, 'task', 'tasks')} complete`;
 
     return html`
       <div class="visually-hidden" role="status">

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -38,6 +38,7 @@ import type {
 } from '@shared/transcript';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { assertNever } from '@utils/core';
+import { pluralize } from '@utils/text/stringUtils';
 
 import { buildToolSection } from './helpers';
 
@@ -106,7 +107,7 @@ function renderFileListSection(section: ToolFileListSection): TemplateResult {
   // prettier-ignore
   const fileItems = html`${section.files.map((file) => {
     const diffStats = file.lineChanges
-      ? html` <span class="file-stats"><span class="visually-hidden">${file.lineChanges.added} ${file.lineChanges.added === 1 ? 'line' : 'lines'} added, ${file.lineChanges.removed} ${file.lineChanges.removed === 1 ? 'line' : 'lines'} removed</span><span class="added" aria-hidden="true">+${file.lineChanges.added}</span><span class="removed" aria-hidden="true">-${file.lineChanges.removed}</span></span>`
+      ? html` <span class="file-stats"><span class="visually-hidden">${file.lineChanges.added} ${pluralize(file.lineChanges.added, 'line', 'lines')} added, ${file.lineChanges.removed} ${pluralize(file.lineChanges.removed, 'line', 'lines')} removed</span><span class="added" aria-hidden="true">+${file.lineChanges.added}</span><span class="removed" aria-hidden="true">-${file.lineChanges.removed}</span></span>`
       : nothing;
     // prettier-ignore
     return html`<li class="detail-item">${waIcon('file')} ${buildFileLinkSpan(file.path, html`<bdi dir="auto">${file.path}</bdi>`)}${file.from ? html` <span class="file-source">(from <bdi dir="auto">${file.from}</bdi>)</span>` : nothing}${file.note ? html` <span class="file-source">(<bdi dir="auto">${file.note}</bdi>)</span>` : nothing}${diffStats}</li>`;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
@@ -17,6 +17,7 @@ import type { FormatResult } from '@progressView/frontend/formatters/baseLogForm
 import type { WebFetchRow, WebSearchRow } from '@shared/transcript';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { pluralize } from '@utils/text/stringUtils';
 import { buildToolUseDetails } from './helpers';
 
 // Web search status-based wa-icon names; SPINNER_ICON_NAME triggers a spinner.
@@ -74,7 +75,7 @@ export function formatWebSearchTemplate(row: WebSearchRow): FormatResult {
       return html`<li class="detail-item">${waIcon('link')} ${r.url ? buildWebLink(r.url, html`<bdi dir="auto">${label}</bdi>`, label) : html`<span><bdi dir="auto">${label}</bdi></span>`}${showDomain ? html` <span class="file-source">(<bdi dir="auto">${r.domain}</bdi>)</span>` : ''}</li>`;
     });
     // prettier-ignore
-    const resultsTemplate = html`<span class="file-list-summary">${resultCount} ${resultCount === 1 ? 'result' : 'results'}</span><ul class="detail-list">${resultItems}</ul>`;
+    const resultsTemplate = html`<span class="file-list-summary">${resultCount} ${pluralize(resultCount, 'result', 'results')}</span><ul class="detail-list">${resultItems}</ul>`;
     sections.push(buildToolUseSection('Sources:', resultsTemplate));
   } else if (statusKey === 'completed') {
     sections.push(

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -40,6 +40,7 @@ import {
 import { readSelectValue } from '@shared/wa/selectTemplates';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { groupBy } from '@utils/core';
+import { pluralize } from '@utils/text/stringUtils';
 import { postStateSetting } from '../shared/stateSettingRows';
 import { modelSelectionListStyles } from './ModelSelectionList.styles';
 import { resolveProviderKeyRows } from './providerKeyRows';
@@ -331,7 +332,7 @@ export class ModelSelectionList extends LitElement {
             : 'provider-group-chevron',
         })}
         ${group.deprecated.length}
-        ${group.deprecated.length === 1 ? 'deprecated model' : 'deprecated models'}
+        ${pluralize(group.deprecated.length, 'deprecated model', 'deprecated models')}
       </wa-button>
       ${
         isOpen


### PR DESCRIPTION
## Summary

A recurring consolidation/native-methods survey of the codebase found that `progressView` and `settingsView` frontend components hand-roll `count === 1 ? singular : plural` at six call sites instead of using the existing, browser-safe `pluralize(count, singular, plural?)` helper in `src/utils/text/stringUtils.ts` (one of the five `BROWSER_SAFE_UTILS` modules). That helper already wraps the `pluralize` npm dependency and has a production consumer (`src/shared/runs/workflowRunModel.ts`), so this change routes the webview call sites onto the single existing shared implementation rather than leaving six independent copies to drift.

Changed files (each swaps an inline ternary for `pluralize(...)`, adding the import):
- `packages/extension/src/progressView/frontend/components/TodoList.ts`
- `packages/extension/src/progressView/frontend/components/FileList.ts` (2 occurrences)
- `packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts`
- `packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts` (2 occurrences)
- `packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts`
- `packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts`

Behavior is unchanged: `pluralize(count, singular, plural)` with an explicit `plural` argument returns exactly `count === 1 ? singular : plural`, so every call site keeps its existing display text.

Other candidates the survey turned up were reviewed and intentionally **not** included in this PR:
- `KeyedMutex` (`src/utils/core/keyedMutex.ts`) superficially duplicates `runOnPerKeyQueue` (`src/utils/core/perKeyQueue.ts`), but `KeyedMutex` is one of the five deliberately curated `BROWSER_SAFE_UTILS` modules (documented in `AGENTS.md`) and one of its two consumers is `packages/desktop/src/renderer/editorPane.ts` (Electron renderer code). `perKeyQueue.ts` pulls in `p-queue` and `effect`, which are outside that curated browser-safe surface, so collapsing the two would either widen the browser-safe allowlist or leave `KeyedMutex` in place anyway with no net simplification. Left as-is.
- A hand-rolled `Set` + notify-listener pattern in `src/agent/runtime/SessionHandle.ts` and `src/agent/followUp/ToolUseFollowUpQueueManager.ts` duplicates `createListenerSet` (`src/utils/core/listenerSet.ts`). This was already identified in the repo's own `2026-09-12-consolidation-and-native-methods-survey.md` and deliberately deferred because both files sit inside the actively-rewritten run-ledger/run-loop surface; that surface saw further commits as recently as today, so it's left for a follow-up pass once it settles.
- A LaTeX-macro severity/color-coding inconsistency in the `prompts/agents/remote/workflow/*.yaml` files (also noted in the same prior survey) was investigated but turned out to be more ambiguous than the prior survey stated (`criticize.yaml` documents a legitimate severity-0 "verified" case at line 215, so its `\ifnum#2=0` branch is not clearly a bug) and is unrelated to code consolidation/native-method use, so it was left out of this PR's scope.

## Issue acceptance gates

No tracked issue; this is a routine consolidation pass. Gate: replace duplicated inline pluralization logic with the existing shared helper, with no behavior change.

## Single source of truth

`pluralize()` in `src/utils/text/stringUtils.ts` is now the one place that decides singular-vs-plural word choice for these six call sites (as it already was for `workflowRunModel.ts`).

## Duplication and abstraction budget

Removed: six independent `count === 1 ? x : y` ternaries. No new abstraction added — all six sites route onto the pre-existing exported `pluralize` helper.

## Net elements (R6)

- Files changed: 6 (all modified, 0 added, 0 deleted)
- Exported symbols: 0 added, 0 removed (`pluralize` already existed and was already exported)
- Classes/interfaces/enums: 0 added, 0 removed
- Net LoC: +13/-8 (`git diff --stat origin/main`), net +5

## Consumer counts (R8)

n/a — no export was deleted or re-routed; this PR only adds call sites to an existing, already-consumed export.

## Host impact

Extension: `progressView` and `settingsView` webview display text is unchanged (pixel/text-identical); pluralization now runs through one shared helper.

Desktop: none.

CLI: none.

## Scheduled refactoring

None. (Two related, larger candidates — the `KeyedMutex`/`perKeyQueue` question and the `createListenerSet` duplication in the run-ledger surface — are noted above but not filed as follow-ups since the first is a rejected candidate and the second is already tracked in the repo's existing survey history.)

## Validation

- `npm run typecheck` (`typecheck:workspace`) — passed
- `npx eslint <changed files>` — passed (no errors)
- `npx prettier --check <changed files>` — passed
- `npx vitest run --changed` — 6 test files, 48 tests passed
- `npm run test:pure` — 175 test files, 2129 passed / 1 skipped
- `npm run check:dead-code-ratchet` — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9UXdeHZ9o8fPSCby33qVE


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9UXdeHZ9o8fPSCby33qVE)_