### PR TITLE
docs: trace.json is not a compatibility exception in 1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,9 +452,11 @@ agent YAML fields, or flags (see "TeXRA 1.0 direction"). Do not add legacy
 readers, aliases, migrations, dual-format unions, or compatibility writers, and
 there is no retirement window to wait out: delete existing ones on sight, with
 their schemas, transforms, fixtures, and compatibility-specific tests. The only
-exceptions are external export formats (for example `trace.json`) and wire
-protocols TeXRA still supports; normalize those once at their boundary, and
-reject any other unsupported state with a clear error.
+exceptions are formats with consumers outside TeXRA and wire protocols TeXRA
+still supports; normalize those once at their boundary, and reject any other
+unsupported state with a clear error. `trace.json` is **not** such an exception:
+the owner ruled that 1.0's exports start fresh, so a document from an older
+build fails loudly at the parse boundary (#12359).
 
 ### ES2023+ Patterns
 


### PR DESCRIPTION
AGENTS.md's compatibility section used `trace.json` as its example of an external format to normalize at the boundary. #12359 made an older trace document fail loudly at the parse boundary instead, on the owner's ruling that 1.0's exports start fresh — so the example now contradicts the code, and a future reader following it would re-add the normalizer this sweep deleted.

The rule itself is unchanged: formats with consumers outside TeXRA, and wire protocols TeXRA still supports, are still normalized once at their boundary. Only the example changes, with a pointer to the ruling.

Docs-only. `prettier` and `check:guidance-refs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)