### PR TITLE
refactor(run): the loop owns a tool call's card; tool output is transient; the card is a monotone machine

### DIFF
--- a/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
+++ b/.agents/docs/proposed/architecture/2026-09-03-persistence-substrate-decision.md
@@ -436,7 +436,8 @@ and project publication steps; no cross-database atomic delivery is claimed.
 Panel drafts remain view state and are not part of canonical inquiry records.
 
 **C3. Durable event set.** Durable: every run-scoped `AgentEvent` except text,
-thinking, and tool-input deltas; `approval.requested`,
+thinking, tool-input deltas, and (amended 2026-09-13) the output a running
+tool prints, which reaches the fold as transient text keyed by the card id; `approval.requested`,
 `approval.resolved`, `approval.policy` (snapshot); `run.start` at the
 reservation commit point carrying `identity` (nullish only for imported legacy
 streams), `worktree` (nullish), and explicit `category` and `isRemote` fields,

--- a/.agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md
+++ b/.agents/docs/proposed/architecture/2026-09-04-agent-runtime-on-effect.md
@@ -296,8 +296,19 @@ is durable, and a durable result cannot leave a running card behind.
 Each call's card correlation (`logId` and stage) is saved with the pending
 response, so a resumed settlement closes the same card. If no start card
 was published, the settlement batch includes its `tool.start` as well.
-Turn snapshots include the resulting state, pending intents, and references
-to any pending response and its already-settled calls.
+
+> **Amendment 2026-09-13 (loop-owned cards).** The loop is the one author of
+> a call's card. A slow tool's `tool.start` commits in the batch that admits
+> the attempt (the `tool.intent` for a barrier, its own batch for a
+> parallel-safe call, the re-run intent after an outcome-unknown decision); a
+> fast tool's opens and closes in its settlement batch. No tool publishes a
+> start card of its own (`deferLogUntilApproval` and the `onRunReady` hook
+> are deleted: a denied approval is a card that closes failed, not a card
+> that never opened), and what a tool prints while it runs is transient text
+> keyed by the card id, the same channel as a response's chunks (C3), never a
+> `tool.end in_progress` row.
+> Turn snapshots include the resulting state, pending intents, and references
+> to any pending response and its already-settled calls.
 
 Attachment settlement uses a JSON-safe representation rather than persisting
 `ToolFileAttachment` directly: its `bytes` field is a `Uint8Array`, which

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,15 @@ emission via `SessionHandle.publish` / `SessionEvents`, so a new direct
 `appSignals.emit(...)` on the separate `AppSignals` bus within its documented
 scope.
 
+**One publisher, loop-owned cards.** Every write to a session's event table
+is a job on the `SessionEvents` inbox (`publish`, `exclusive`, `detach`,
+`settle`); commit order is enqueue order, and nothing appends around it. A
+tool call's card belongs to the run loop: a slow tool's `tool.start` commits
+with the row that admits the attempt, a fast tool's opens and closes in its
+settlement batch, and what a tool prints while it runs is transient text on
+the card id (`hooks.onToolOutput` → `stream.chunk`), never a row. Do not add
+a tool-side start card, a durable progress row, or a second append path.
+
 ## Schemas (Zod v4)
 
 Schemas are the single source of truth: define the schema, derive types with

--- a/src/agent/core/tools/ToolTypes.ts
+++ b/src/agent/core/tools/ToolTypes.ts
@@ -36,9 +36,9 @@ export interface ITool<E = unknown, R = never> {
   readonly parallelSafe?: boolean;
   /** Execution behavior consumed by tool resolution and dispatch. */
   readonly requiresApproval?: boolean;
+  /** Its card opens before the call runs; a fast tool's opens and closes
+   *  with its settlement. */
   readonly slow?: boolean;
-  readonly deferLogUntilApproval?: boolean;
-  readonly streamsOutput?: boolean;
   call(rawInput: unknown): Effect.Effect<ToolResult, E, R>;
 }
 

--- a/src/agent/runtime/ToolCall.ts
+++ b/src/agent/runtime/ToolCall.ts
@@ -23,7 +23,7 @@ export interface ToolCallShape {
   readonly userInstruction?: string;
   readonly workPlanState?: WorkPlanState;
   readonly hooks?: {
-    readonly onRunReady?: () => void;
+    /** What the tool prints while it runs, for its card's transient output. */
     readonly onToolOutput?: (chunk: string) => void;
     readonly recordSubagentCost?: (costUsd: number) => void;
   };

--- a/src/agent/runtime/loop/toolUseDispatch.ts
+++ b/src/agent/runtime/loop/toolUseDispatch.ts
@@ -27,7 +27,7 @@ import { normalizeToolCallError } from '@agent/core/tools/toolCallParsing';
 import { extractToolAttachments } from '@agent/core/tools/toolAttachmentExtraction';
 import type { RuntimeTool as ITool } from '@agent/runtime/ToolServices';
 import { ToolCall } from '@agent/runtime/ToolCall';
-import { endToolUseCard, type AgentTrace } from '@agent/trace';
+import type { AgentTrace } from '@agent/trace';
 import type { ProcessServices } from '@platform/processRuntime';
 import {
   type DispatchFacts,
@@ -70,8 +70,9 @@ import {
 /** Max concurrently executing tool calls within one parallel-safe partition. */
 const MAX_PARALLEL_TOOL_CALLS = 4;
 
-/** Maximum size of the streaming output buffer sent to the UI (bytes). */
-const STREAM_BUFFER_MAX = 50_000;
+/** How much of a running tool's output streams to its card as transient
+ *  text; the settlement carries the bounded capture whatever streamed. */
+const STREAMED_OUTPUT_MAX = 50_000;
 
 const SKIPPED_AFTER_END_TURN =
   'Tool call skipped: an earlier tool call ended the turn.';
@@ -324,6 +325,26 @@ export const dispatchPendingResponse = Effect.fn('toolUse.dispatch')(function* (
       ...cards,
     ]);
 
+  /** The row that opens a call's card. A slow tool's is committed with the
+   *  row that admits the attempt, so a resume finds the card its settlement
+   *  closes; a fast tool's rides the settlement batch itself. */
+  const cardStart = (fact: DispatchFacts, input: unknown): RunLedgerDraft =>
+    displayRow(runId, {
+      type: 'tool.start',
+      logId: fact.logId,
+      toolName: fact.toolName,
+      input,
+      ...(fact.stageId !== null ? { stageId: fact.stageId } : {}),
+    });
+  /** The card rows an admitted attempt opens: a slow tool's, before it runs. */
+  const admittedCards = (
+    fact: DispatchFacts,
+    call: LocalCall,
+  ): RunLedgerDraft[] =>
+    run.tools.get(fact.toolName)?.slow === true
+      ? [cardStart(fact, parseCallArguments(call, logger))]
+      : [];
+
   const syntheticSettlement = (error: string): Settlement => ({
     disposition: 'skipped',
     duplicateOf: null,
@@ -342,42 +363,27 @@ export const dispatchPendingResponse = Effect.fn('toolUse.dispatch')(function* (
     const tool: ITool | undefined = run.tools.get(fact.toolName);
     const parsedInput = parseCallArguments(call, logger);
     const stageId = fact.stageId ?? undefined;
-    const isDeferred = tool?.deferLogUntilApproval === true;
-    let logId = fact.logId;
-    if (logId !== null) {
-      logger.toolStart(
-        { logId, toolName: fact.toolName, input: parsedInput },
-        { stageId },
-      );
-    }
-    const onRunReady = isDeferred
-      ? () => {
-          if (logId === null) {
-            logId = generateShortId();
-            logger.toolStart(
-              { logId, toolName: fact.toolName, input: parsedInput },
-              { stageId },
-            );
-          }
-        }
-      : undefined;
-    let onToolOutput: ((chunk: string) => void) | undefined;
-    if (tool?.streamsOutput === true) {
-      let outputBuffer = '';
-      onToolOutput = (chunk: string) => {
-        outputBuffer += chunk;
-        if (outputBuffer.length > STREAM_BUFFER_MAX) {
-          outputBuffer = outputBuffer.slice(-STREAM_BUFFER_MAX);
-        }
-        if (logId === null) return;
-        endToolUseCard(
-          logger,
-          { logId, groupId: stageId },
-          { toolName: fact.toolName, input: parsedInput, output: outputBuffer },
-          'in_progress',
-        );
-      };
-    }
+    // A slow tool's card is open: `dispatchCall` committed its `tool.start`
+    // with the row that admitted this attempt. What the tool prints while it
+    // runs streams to that card as transient text, the way a response's
+    // chunks reach a streaming row (C3): never a row of its own, capped, and
+    // refused once the call has returned, so no chunk can be enqueued after
+    // the settlement that closes the card.
+    const cardOpen = tool?.slow === true;
+    let accepting = cardOpen;
+    let streamed = 0;
+    const onToolOutput = (chunk: string): void => {
+      if (!accepting) return;
+      const text = chunk.slice(0, STREAMED_OUTPUT_MAX - streamed);
+      if (text.length === 0) return;
+      streamed += text.length;
+      run.session.publishRunEvent(runId, {
+        type: 'stream.chunk',
+        id: fact.logId,
+        text,
+        ...(stageId !== undefined ? { stageId } : {}),
+      });
+    };
     let subagentCost = 0;
     turn.workspace.interactions.recordToolCall();
     let result: ToolResult;
@@ -403,7 +409,6 @@ export const dispatchPendingResponse = Effect.fn('toolUse.dispatch')(function* (
                 run.config.rootUserInstruction ?? turn.userInstruction,
               toolCallId: fact.callId,
               hooks: {
-                onRunReady,
                 onToolOutput,
                 recordSubagentCost: (costUsd) => {
                   if (costUsd > 0) subagentCost += costUsd;
@@ -413,6 +418,7 @@ export const dispatchPendingResponse = Effect.fn('toolUse.dispatch')(function* (
           ),
         ),
       );
+      accepting = false;
       if (Exit.isSuccess(invoked)) {
         result = invoked.value;
       } else if (Cause.hasInterrupts(invoked.cause)) {
@@ -516,29 +522,17 @@ export const dispatchPendingResponse = Effect.fn('toolUse.dispatch')(function* (
       extracted.sanitizedResult.status === 'error' ? 'failed' : 'completed';
     // The whole card commits with the settlement: a slow tool's card is
     // already open and only closes here, and a fast tool's opens and closes
-    // in this same batch under a log id minted for it. Publishing a terminal
-    // card outside the batch would tell the transcript the call completed
-    // while recovery still sees an unsettled call.
-    const cardId = logId ?? generateShortId();
-    const stage = stageId !== undefined ? { stageId } : {};
+    // in this same batch under the id its dispatch facts carry. Publishing a
+    // terminal card outside the batch would tell the transcript the call
+    // completed while recovery still sees an unsettled call.
     const cards: RunLedgerDraft[] = [
-      ...(logId === null
-        ? [
-            displayRow(runId, {
-              type: 'tool.start',
-              logId: cardId,
-              toolName: fact.toolName,
-              input: parsedInput,
-              ...stage,
-            }),
-          ]
-        : []),
+      ...(cardOpen ? [] : [cardStart(fact, parsedInput)]),
       displayRow(runId, {
         type: 'tool.end',
-        logId: cardId,
+        logId: fact.logId,
         status,
         result: toolUseLog,
-        ...stage,
+        ...(stageId !== undefined ? { stageId } : {}),
       }),
     ];
     yield* settle(
@@ -601,7 +595,7 @@ export const dispatchPendingResponse = Effect.fn('toolUse.dispatch')(function* (
     if (bound !== undefined && bound.resolved && bound.decision !== null) {
       const answer = decided(bound.decision);
       if (answer !== null)
-        return yield* recordOutcomeDecision(fact, intent, answer);
+        return yield* recordOutcomeDecision(fact, call, intent, answer);
     }
     // A request the run committed and nobody answered is asked again under
     // its own id, so one barrier never accumulates requests. Anything else
@@ -695,12 +689,14 @@ export const dispatchPendingResponse = Effect.fn('toolUse.dispatch')(function* (
     });
     const answer = decided(row.decision);
     if (answer === null) return yield* Effect.interrupt;
-    return yield* recordOutcomeDecision(fact, intent, answer);
+    return yield* recordOutcomeDecision(fact, call, intent, answer);
   });
 
-  /** A rerun admits a new attempt with its `tool.intent`; a skip records nothing further, the decision row is the fact. */
+  /** A rerun admits a new attempt with its `tool.intent` and reopens the
+   *  card; a skip records nothing further, the decision row is the fact. */
   const recordOutcomeDecision = Effect.fn('toolUse.outcomeDecision')(function* (
     fact: DispatchFacts,
+    call: LocalCall,
     intent: { readonly attempt: number },
     decision: 'rerun' | 'skip',
   ): Effect.fn.Return<'rerun' | 'skip', never> {
@@ -715,6 +711,7 @@ export const dispatchPendingResponse = Effect.fn('toolUse.dispatch')(function* (
             attempt: intent.attempt + 1,
           },
         },
+        ...admittedCards(fact, call),
       ]).pipe(Effect.orDie);
     }
     return decision;
@@ -741,6 +738,8 @@ export const dispatchPendingResponse = Effect.fn('toolUse.dispatch')(function* (
       return;
     }
     if (fact.parallelSafe) {
+      const cards = admittedCards(fact, call);
+      if (cards.length > 0) yield* append(cards).pipe(Effect.orDie);
       yield* execute(fact, call, 1);
       return;
     }
@@ -759,13 +758,15 @@ export const dispatchPendingResponse = Effect.fn('toolUse.dispatch')(function* (
       yield* execute(fact, call, intent.attempt + 1);
       return;
     }
-    // The intent precedes every barrier call, unconditionally.
+    // The intent precedes every barrier call, unconditionally, and a slow
+    // tool's card opens in the same batch.
     yield* append([
       {
         type: 'tool.intent',
         aggregateId,
         payload: { responseId, callIds: [fact.callId], attempt: 1 },
       },
+      ...admittedCards(fact, call),
     ]).pipe(Effect.orDie);
     yield* execute(fact, call, 1);
   });

--- a/src/agent/runtime/run/tools.ts
+++ b/src/agent/runtime/run/tools.ts
@@ -72,9 +72,9 @@ export function parseCallArguments(
 }
 
 /**
- * The dispatch facts of one completed turn, stamped at append time. A
- * `logId` is minted here only for a slow tool, whose card opens before the
- * call runs; a fast tool's card opens and closes with its settlement.
+ * The dispatch facts of one completed turn, stamped at append time. Every
+ * call gets its card id here: a slow tool's card opens under it before the
+ * call runs; a fast tool's opens and closes with its settlement.
  */
 export function dispatchFactsFor(
   turn: TurnResult,
@@ -114,10 +114,7 @@ export function dispatchFactsFor(
       partition,
       duplicateOf:
         primaryIndex === undefined ? null : parsed[primaryIndex].callId,
-      logId:
-        tool?.slow === true && tool.deferLogUntilApproval !== true
-          ? mintLogId()
-          : null,
+      logId: mintLogId(),
       stageId,
     };
   });

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -70,6 +70,7 @@ import {
   aggregateTarget,
   isDisplaySessionEvent,
   ownerIdentity,
+  TOOL_CALL_STATUS,
   type CommitOrdinal,
   type OwnerId,
   type SessionCloseReport,
@@ -95,6 +96,7 @@ import {
   LocalRuntimeSource,
   TextChunkSource,
   TranscriptSubscriptions,
+  type InflightTextChunk,
 } from './sessionSources';
 import { SessionViewService } from './SessionView';
 import { sessionInputsLayer } from './sessionInputs';
@@ -457,17 +459,42 @@ const sessionHandleLayer = (
                   })
                 : Effect.void;
             }),
-            Effect.andThen(
-              event.type === 'stream.end'
-                ? SubscriptionRef.update(chunks.ref, (held) => {
-                    const next = new Map(held);
-                    next.delete(
-                      `${aggregateTarget(event.aggregateId).id}/${event.id}`,
-                    );
-                    return next;
-                  })
-                : Effect.void,
-            ),
+            Effect.andThen(() => {
+              // A row that closes live text drops the held chunks: a
+              // stream's final text or a card's terminal result drop their
+              // own; the run's transcript boundary (the park, the end, the
+              // removal) drops every chunk of the run, the same rule the
+              // fold applies to its in-flight text, so a card an
+              // interrupted run closed without a terminal row holds nothing.
+              const runId = aggregateTarget(event.aggregateId).id;
+              let drop: ((key: string) => boolean) | null = null;
+              if (event.type === 'stream.end') {
+                drop = (key) => key === `${runId}/${event.id}`;
+              } else if (
+                event.type === 'tool.end' &&
+                event.status !== TOOL_CALL_STATUS.IN_PROGRESS
+              ) {
+                drop = (key) => key === `${runId}/${event.logId}`;
+              } else if (
+                event.type === 'run.end' ||
+                event.type === 'run.removed' ||
+                (event.type === 'flow.step' && event.payload.step === 'waiting')
+              ) {
+                drop = (key) => key.startsWith(`${runId}/`);
+              }
+              const dropping = drop;
+              return dropping === null
+                ? Effect.void
+                : SubscriptionRef.update(chunks.ref, (held) => {
+                    let next: Map<string, InflightTextChunk> | null = null;
+                    for (const key of held.keys()) {
+                      if (!dropping(key)) continue;
+                      next ??= new Map(held);
+                      next.delete(key);
+                    }
+                    return next ?? held;
+                  });
+            }),
             Effect.andThen(SubscriptionRef.set(delivered, event.commit)),
           ),
         ),

--- a/src/shared/schemas/runLedgerEvent.ts
+++ b/src/shared/schemas/runLedgerEvent.ts
@@ -127,9 +127,10 @@ const DispatchFactsSchema = z.strictObject({
   /** The primary this call duplicates. A duplicate never executes and never
    *  reapplies its primary's effects. */
   duplicateOf: CallIdSchema.nullable(),
-  /** Card correlation, so a resumed settlement closes the same card. Null for
-   *  a fast tool: `logId` is set only for slow tools. */
-  logId: z.string().min(1).nullable(),
+  /** The call's card id, minted with the response: a slow tool's card opens
+   *  under it before the call runs, a fast tool's opens and closes with the
+   *  settlement, and a resumed settlement closes the same card. */
+  logId: z.string().min(1),
   stageId: z.string().min(1).nullable(),
 });
 export type DispatchFacts = z.infer<typeof DispatchFactsSchema>;

--- a/src/shared/session/sessionFold.ts
+++ b/src/shared/session/sessionFold.ts
@@ -64,6 +64,7 @@ import {
   aggregateId as qualifyAggregateId,
   AgentCategory,
   MESSAGE_TYPES,
+  TOOL_CALL_STATUS,
   STREAM_LOG_ENTRY_TYPES,
   RUN_PHASE,
   RUN_LIFECYCLE_READY,
@@ -977,6 +978,26 @@ function isStreamingEntry(entry: StreamLogEntry): boolean {
   );
 }
 
+/** A tool card still running: what it prints reaches the fold as live text
+ *  keyed by the card id, like a streaming row's chunks, and projects as the
+ *  card's output until the terminal row replaces it (C3: never a row). */
+function isRunningToolEntry(entry: StreamLogEntry): boolean {
+  return (
+    entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
+    entry.messageType === MESSAGE_TYPES.TOOL_USE &&
+    isObject(entry.data) &&
+    entry.data.status === TOOL_CALL_STATUS.IN_PROGRESS
+  );
+}
+
+/** The card's entry with its live output in place of the durable one. */
+function withToolOutput(entry: StreamLogEntry, output: string): StreamLogEntry {
+  return {
+    ...entry,
+    data: { ...(isObject(entry.data) ? entry.data : {}), output },
+  } as StreamLogEntry;
+}
+
 type StreamingTextRow = Extract<
   TranscriptRow,
   { kind: 'assistant' | 'thinking' | 'scratchpad' }
@@ -1056,15 +1077,19 @@ function applyEntry(
   // from offset zero (the bridge seeds one for every running row it
   // publishes) ends within the length held and is dropped (5.2, "In-flight
   // text").
-  if (isStreamingEntry(entry) && entry.text && !inflight.has(key)) {
+  const streamingText = isStreamingEntry(entry);
+  const runningTool = isRunningToolEntry(entry);
+  if (streamingText && entry.text && !inflight.has(key)) {
     inflight.set(key, entry.text);
   }
-  const live = isStreamingEntry(entry) ? inflight.get(key) : undefined;
-  projectRow(
-    next,
-    live === undefined ? entry : { ...entry, text: live },
-    lifecycleToTaskGroups(run),
-  );
+  const live = streamingText || runningTool ? inflight.get(key) : undefined;
+  let projected = entry;
+  if (live !== undefined) {
+    projected = streamingText
+      ? { ...entry, text: live }
+      : withToolOutput(entry, live);
+  }
+  projectRow(next, projected, lifecycleToTaskGroups(run));
   const row = rowById(next, entry.id);
   if (row?.kind === 'thinking') {
     const newest = indexes.thinkingRowId;
@@ -1073,13 +1098,17 @@ function applyEntry(
       indexes.thinkingRowId = row.id;
     }
   }
-  if (isStreamingEntry(entry)) {
+  if (streamingText) {
     const text = live ?? '';
     indexes.streaming.set(entry.id, {
       entry,
       // The projected row already measured the text; a blank entry has none.
       text: row && isStreamingTextRow(row) ? row.text : transcriptText(text),
     });
+  } else if (runningTool) {
+    // A card's cursor holds the entry alone: its output projects from the
+    // held text, never from a measured cursor.
+    indexes.streaming.set(entry.id, { entry, text: transcriptText('') });
   } else {
     indexes.streaming.delete(entry.id);
     inflight.delete(key);
@@ -1296,6 +1325,16 @@ function foldTextChunk(view: SessionView, chunk: TextChunk): boolean {
   inflight.set(key, text);
   // The row projects when its entry folds, joined with this entry.
   if (!cursor) return true;
+  if (isRunningToolEntry(cursor.entry)) {
+    const transcript = replaceTranscript(run.transcript, {});
+    projectRow(
+      transcript,
+      withToolOutput(cursor.entry, text),
+      lifecycleToTaskGroups(run),
+    );
+    setRun(view, { ...run, transcript });
+    return true;
+  }
   cursor.text =
     chunk.from === held.length
       ? appendTranscriptText(cursor.text, chunk.text, held.at(-1) ?? '')

--- a/src/shared/session/traceEntries.ts
+++ b/src/shared/session/traceEntries.ts
@@ -128,6 +128,10 @@ export class StreamLog {
     return fullEntry;
   }
 
+  has(id: string): boolean {
+    return this.indexById.has(id);
+  }
+
   update(id: string, patch: StreamLogUpdatePatch): StreamLogEntry | undefined {
     return this.updateWithSettlement(id, patch, false);
   }

--- a/src/shared/session/traceFold.ts
+++ b/src/shared/session/traceFold.ts
@@ -56,7 +56,10 @@ type StageMetadata = Pick<
 
 /** Build the transcript projection for one subscribed aggregate. */
 export function createTranscriptFold(
-  writer: Pick<StreamLog, 'append' | 'appendSettled' | 'update' | 'settle'>,
+  writer: Pick<
+    StreamLog,
+    'append' | 'appendSettled' | 'has' | 'update' | 'settle'
+  >,
 ) {
   /** Stream rows opened by `stream.start` that nothing has settled yet. */
   const runs = new Set<string>();
@@ -155,6 +158,12 @@ export function createTranscriptFold(
         return;
       }
 
+      // A card is a monotone machine: it opens once, takes progress while
+      // it is open, and closes once. A second start reopens a running card
+      // (a re-run attempt) and is a no-op on a closed one; progress after
+      // the close and a close without an open are dropped. Under the one
+      // publisher those rows cannot arrive out of order, so nothing here
+      // compensates for a race; the shape is the card's definition.
       case 'tool.start': {
         if (transcriptBoundaryClosed) return;
         pendingModelResponseId = undefined;
@@ -166,6 +175,16 @@ export function createTranscriptFold(
           input: event.input,
           status: TOOL_CALL_STATUS.IN_PROGRESS,
         } satisfies ToolUseLog;
+        if (writer.has(event.logId)) {
+          if (activeToolEntries.has(event.logId)) {
+            writer.update(event.logId, {
+              messageType: MESSAGE_TYPES.TOOL_USE,
+              data,
+            });
+            activeToolEntries.set(event.logId, data);
+          }
+          return;
+        }
         writer.append({
           id: event.logId,
           type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -183,9 +202,8 @@ export function createTranscriptFold(
       case 'tool.end': {
         if (transcriptBoundaryClosed) return;
         const result = (event.result ?? {}) as Partial<ToolUseLog>;
-        // Omit groupId on update: undefined would clobber the canonical
-        // value stamped at tool.start (deferred tools never copy the
-        // resolved id back into their ref).
+        // Omit groupId on update: undefined would clobber the value stamped
+        // at tool.start.
         const patch = {
           messageType: MESSAGE_TYPES.TOOL_USE,
           data: {
@@ -194,6 +212,7 @@ export function createTranscriptFold(
           } as ToolUseLog,
         } satisfies StreamLogUpdatePatch;
         if (event.status === TOOL_CALL_STATUS.IN_PROGRESS) {
+          if (!activeToolEntries.has(event.logId)) return;
           writer.update(event.logId, patch);
           activeToolEntries.set(event.logId, patch.data);
         } else {

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -2022,7 +2022,7 @@ describe('RunLedger', () => {
       parallelSafe: false,
       partition: 0,
       duplicateOf: null,
-      logId: null,
+      logId: 'card-a',
       stageId: null,
     },
     {
@@ -2032,7 +2032,7 @@ describe('RunLedger', () => {
       parallelSafe: false,
       partition: 0,
       duplicateOf: 'call-a',
-      logId: null,
+      logId: 'card-b',
       stageId: null,
     },
   ] as const;

--- a/src/test-kernel/shared/session/sessionFold.vitest.ts
+++ b/src/test-kernel/shared/session/sessionFold.vitest.ts
@@ -493,6 +493,65 @@ describe('sessionFold', () => {
     expect(runView(dead, CHILD).group).toBe('interrupted');
   });
 
+  it('projects a running card from its live output and lets the terminal row win', () => {
+    const log = new Log();
+    log.emit(CHILD, 1600, {
+      type: 'run.start',
+      identity: CHILD_IDENTITY,
+      category: AgentCategory.ToolUse,
+      isRemote: false,
+      userFollowUpSupport: 'unsupported',
+      parent: null,
+    });
+    const chunk = (from: number, to: number, text: string): FoldInput => ({
+      _tag: 'chunk',
+      runId: CHILD,
+      rowId: 'card',
+      from,
+      to,
+      text,
+    });
+    const outputOf = (view: SessionView) => {
+      const [row] = runView(view, CHILD).transcript.rows;
+      return row.kind === 'tool' ? row.toolUse.outputText : null;
+    };
+    // What the tool prints streams to the open card as transient text (C3),
+    // never as a row; a later chunk extends it.
+    const running = foldAll([
+      subscribe(CHILD),
+      ...log.events.map(tail),
+      tail(
+        log.emit(CHILD, 1601, {
+          type: 'tool.start',
+          logId: 'card',
+          toolName: 'bash',
+          input: { command: 'ls' },
+        }),
+      ),
+      chunk(0, 3, 'Hel'),
+      chunk(3, 5, 'lo'),
+    ]);
+    expect(outputOf(running)).toContain('Hello');
+    // The terminal row carries the bounded capture and closes the card: a
+    // late chunk reaches nothing.
+    const settled = foldAll(
+      [
+        tail(
+          log.emit(CHILD, 1602, {
+            type: 'tool.end',
+            logId: 'card',
+            status: 'completed',
+            result: { toolName: 'bash', output: { output: 'Hello, world' } },
+          }),
+        ),
+        chunk(5, 9, ' bye'),
+      ],
+      running,
+    );
+    expect(outputOf(settled)).toContain('Hello, world');
+    expect(outputOf(settled)).not.toContain('bye');
+  });
+
   it('keeps live text by offsets and joins it to its row whichever arrives first', () => {
     const log = new Log();
     log.emit(CHILD, 1500, {
@@ -1081,7 +1140,7 @@ const CALLS = [
     parallelSafe: false,
     partition: 0,
     duplicateOf: null,
-    logId: null,
+    logId: 'card-0',
     stageId: null,
   },
   {
@@ -1091,7 +1150,7 @@ const CALLS = [
     parallelSafe: false,
     partition: 0,
     duplicateOf: 'call-a',
-    logId: null,
+    logId: 'card-1',
     stageId: null,
   },
 ];

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -913,7 +913,6 @@ describe('BashTool', () => {
               nativeToolTestLayer({
                 tracker: new FileInteractionState(),
                 hooks: {
-                  onRunReady: () => hookCalls.push('ready'),
                   onToolOutput: (chunk) => hookCalls.push(`output:${chunk}`),
                 },
                 run: {
@@ -926,7 +925,7 @@ describe('BashTool', () => {
           ),
         );
         yield* Effect.promise(() => started.promise);
-        assert.deepEqual(hookCalls, ['ready', 'output:started\n']);
+        assert.deepEqual(hookCalls, ['output:started\n']);
         assert.equal(receivedSignal?.aborted, false);
         yield* Fiber.interrupt(fiber);
         const exit = yield* Fiber.await(fiber);

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -389,7 +389,6 @@ const withAgentCliApproval = Effect.fn('agentCliShared.withAgentCliApproval')(
       return buildBashApprovalRejectedResult(approvalLabel, approval);
     }
 
-    toolCall.hooks?.onRunReady?.();
     return yield* run(toolCall.run);
   },
 );

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -352,8 +352,6 @@ export class BashTool extends defineTool({
   name: 'bash',
   requiresApproval: true,
   slow: true,
-  deferLogUntilApproval: true,
-  streamsOutput: true,
   description:
     'Execute shell commands directly in the workspace directory. Commands run from the project root automatically. Available environment variables: $PROJECT_DIR (workspace path), $PROJECT_NAME (project name). Returns stdout on success, throws error with stderr on failure. Use run_in_background for long-running commands.',
   schema: BashInputSchema,
@@ -397,8 +395,6 @@ export class BashTool extends defineTool({
       if (approval.action !== 'approve') {
         return buildBashApprovalRejectedResult(input.command, approval);
       }
-
-      toolCall.hooks?.onRunReady?.();
 
       const timeoutMs = input.timeout ?? BASH_TOOL_DEFAULT_TIMEOUT_MS;
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -464,7 +464,6 @@ async function createCodexThread(
 export class CodexTool extends defineTool({
   name: 'codex',
   requiresApproval: true,
-  deferLogUntilApproval: true,
   description:
     'Spin off an OpenAI Codex agent to perform code analysis, generation, or research in a sandboxed environment. ' +
     'The agent runs the Codex CLI locally and can read files, run commands, and make edits within its sandbox. ' +

--- a/src/tools/core/definition.ts
+++ b/src/tools/core/definition.ts
@@ -8,13 +8,7 @@ import { BaseTool } from './base';
 // Third-party type imports
 import type { ZodType } from 'zod';
 
-const EXECUTION_FLAGS = [
-  'parallelSafe',
-  'requiresApproval',
-  'slow',
-  'deferLogUntilApproval',
-  'streamsOutput',
-] as const;
+const EXECUTION_FLAGS = ['parallelSafe', 'requiresApproval', 'slow'] as const;
 
 type ExecutionFlag = (typeof EXECUTION_FLAGS)[number];
 type DefineToolFlags = { [K in ExecutionFlag]?: boolean };
@@ -71,8 +65,6 @@ export function defineTool<T, R = never>(
     readonly parallelSafe = def.parallelSafe;
     readonly requiresApproval = def.requiresApproval;
     readonly slow = def.slow;
-    readonly deferLogUntilApproval = def.deferLogUntilApproval;
-    readonly streamsOutput = def.streamsOutput;
     readonly unavailableHosts = def.unavailableHosts;
 
     constructor() {

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -58,12 +58,11 @@ type WolframInput = z.infer<typeof WolframInputSchema>;
  * The calling turn's ambient collaborators, taken in `execute` rather than
  * read from the program's fiber: the approval prompt and the command runner
  * both resolve the session, its bypass state and its workspace roots from
- * ambient storage, and the in-progress card belongs to this tool call.
+ * ambient storage.
  */
 interface WolframPorts {
   readonly requestApproval: typeof requestBashApproval;
   readonly runTool: typeof runToolWithCheck;
-  readonly onRunReady: (() => void) | undefined;
 }
 
 const runWolfram = Effect.fn('WolframTool.execute')(function* (
@@ -75,8 +74,6 @@ const runWolfram = Effect.fn('WolframTool.execute')(function* (
   if (approval.action !== 'approve') {
     return buildBashApprovalRejectedResult(command, approval);
   }
-
-  ports.onRunReady?.();
 
   const effectiveTimeout = input.timeout ?? WOLFRAM_CODE_TIMEOUT_MS;
   const result = yield* hostPort(() =>
@@ -115,7 +112,6 @@ export class WolframTool extends defineTool({
   name: 'wolfram',
   requiresApproval: true,
   slow: true,
-  deferLogUntilApproval: true,
   description: `Execute approval-gated Wolfram Language code. Use this tool for quick calculations, symbolic math, and one-off evaluations only when Wolfram/external computation is allowed by the user. Do not use it when the user requested a specific verification method or prohibited external computation. Sessions do NOT persist between calls - each run starts fresh with no memory of previous variables or definitions. For complex scripts requiring session persistence, iterative development, or saving intermediate results, write to a .wl file and run via bash instead. Compute and print actual results: do not hardcode expected values in Print statements; use VerificationTest or assertions so output reflects real computation.`,
   schema: WolframInputSchema,
 }) {
@@ -127,7 +123,6 @@ export class WolframTool extends defineTool({
     const ports: WolframPorts = {
       requestApproval: requestBashApproval,
       runTool: (...args) => call.inScope(() => runToolWithCheck(...args)),
-      onRunReady: call.hooks?.onRunReady,
     };
     return yield* runWolfram(ports, input);
   });


### PR DESCRIPTION
## Summary

Stacked on #12363, base `feat/one-door-publisher`. **Merge order: #12363 first.** GitHub retargets this PR to `main` when that branch is deleted on merge; do not merge this one into the publisher branch. A tool call's card has one author, the run loop:

- `DispatchFacts.logId` is required and minted for every call with the response.
- A slow tool's `tool.start` commits with the row that admits the attempt: the `tool.intent` batch for a barrier, its own batch for a parallel-safe call, the re-run intent after an outcome-unknown decision. A fast tool's card opens and closes in its settlement batch, as before.
- No tool publishes a start card: `deferLogUntilApproval`, `streamsOutput`, and the `onRunReady` hook are deleted from `ToolTypes`, `defineTool`, bash, codex, wolfram, and the agent-CLI tools. A denied approval is a card that closes failed, not a card that never opened.
- What a tool prints while it runs is transient text on the card id, the channel a response's chunks already use (`hooks.onToolOutput` → `stream.chunk`), never a `tool.end in_progress` row per chunk carrying the whole buffer so far. The dispatcher refuses chunks once the call has returned (pi's barrier and latch) and caps what streams at 50k characters; the settlement carries the bounded capture. The fold projects a running card's output from the held text; the terminal row replaces it and the session drops the held chunks.
- The transcript fold's card is a monotone state machine: opens once, takes progress while open, closes once; a second start reopens a running card (a re-run) and is a no-op on a closed one; progress after the close and a close without an open are dropped. Nested subcards the codex and Claude tools emit keep their durable `in_progress` rows (structured state, not output text).

Codex's session emits begin and end and its tool only sends output deltas; OpenCode v2's runner publishes every card fact and its fold applies progress only while `running`; pi's loop emits start and end and awaits every progress emission before the end. Decision record: https://claude.ai/code/artifact/87b0aaa8-58f0-44ea-8e80-0c17f7246698 (decisions 2, 3, 4).

## Issue acceptance gates

No issue filed; the decision record above holds the evidence (rows 1378 and 1379 of the 2026-09-12 session were consecutive full-buffer copies). Gates: no `tool.end in_progress` row is written by the dispatcher; a running card projects its live output and the terminal row wins over a late chunk (fold test).

## Single source of truth

The run loop (`toolUseDispatch.ts`) owns a call's card rows; `DispatchFacts.logId` owns the card id; the transient text source owns a running card's output; `traceFold.ts` owns the card's state machine.

## Duplication and abstraction budget

Removed: the tool-side card opening (three flags, one hook, four call sites) and the durable progress row class. Added: no layer; two small helpers inside the dispatcher (`cardStart`, `admittedCards`), two fold predicates (`isRunningToolEntry`, `withToolOutput`), one `has` on the transcript writer.

## Net elements (R6)

- Files: 20 changed, +247 / −121 (3 docs, 14 source, 3 tests). Source only: +223 / −118, net +105 (the fold's card-output projection and the dispatcher's admission rows; the deleted flags and hook were spread thin).
- Exported symbols: +0 / −0. Deleted type members: `ITool.deferLogUntilApproval`, `ITool.streamsOutput`, `ToolCall.hooks.onRunReady`; `DispatchFacts.logId` narrowed from `string | null` to `string`.
- Classes/interfaces/enums: +0 / −0.

## Consumer counts (R8)

- `hooks.onRunReady`: 4 emit sites deleted (bash, wolfram, agentCliShared, and the dispatcher's construction), 0 remaining.
- `deferLogUntilApproval`: 3 declarations + 2 readers deleted, 0 remaining. `streamsOutput`: 1 declaration + 1 reader deleted, 0 remaining.
- `hooks.onToolOutput`: 1 producer (bash foreground), 1 consumer (the dispatcher), unchanged shape.
- `tool.end in_progress` rows: 0 remaining from the dispatcher; 8 emit sites in `src/tools` (codex, claudeAgent, background tasks) remain and are intentional structured subcards.
- `DispatchFacts.logId` readers: 1 (`toolUseDispatch.ts`); writer: 1 (`dispatchFactsFor`).

## Host impact

Extension: a bash card's output updates from transient text instead of a durable row per chunk; the same row model, no renderer change.

Desktop: same as the extension.

CLI: same; a card denied at the approval prompt now shows as a failed card instead of never appearing.

## Scheduled refactoring

None. `2026-09-04-agent-runtime-on-effect.md` line 298 and substrate C3 are amended in this PR.

## Validation

- `tsc` for `tsconfig.json`, `tsconfig.test-kernel.json`, the CLI and the agent package: green.
- Fold, session-events, bash, dispatch, recorder, store-load, resume-cancellation, wolfram, codex-progress, lifecycle, approval-prompt, and resume-data suites (12 files, 168 tests): green.
- eslint and prettier on the changed files.
- Not run locally: `test:pure` and the full `npm test` (CI runs them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcJWhANQ6QP4cd1S6cdB8o
