### PR TITLE
refactor(settings): drop the runtime LaTeX projection schema; the catalog is the one source

### DIFF
--- a/packages/extension/src/settingsView/frontend/messageDispatcher.ts
+++ b/packages/extension/src/settingsView/frontend/messageDispatcher.ts
@@ -11,11 +11,11 @@
 import { create } from 'mutative';
 
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { LATEX_CONFIG_FIELD_TO_KEY } from '@shared/constants/latexConfig';
 import {
-  LatexConfigValuesSchema,
-  type SettingsViewOutboundHandlerRegistry,
-} from '@shared/schemas';
+  LATEX_CONFIG_FIELD_TO_KEY,
+  type LatexConfigValues,
+} from '@shared/constants/latexConfig';
+import { type SettingsViewOutboundHandlerRegistry } from '@shared/schemas';
 
 import {
   activePresetId,
@@ -129,15 +129,15 @@ export const settingsViewHandlers: SettingsViewOutboundHandlerRegistry = {
   // Catalog-derived settings snapshots.
   [SETTINGS_VIEW_COMMANDS.UPDATE_SETTINGS_SNAPSHOT]: (data) => {
     if (data.snapshot === 'latex') {
+      // The dispatcher already parsed each row against its own catalog
+      // schema, so this only re-keys catalog keys to field names.
       latexConfigValues.set(
-        LatexConfigValuesSchema.parse(
-          Object.fromEntries(
-            Object.entries(LATEX_CONFIG_FIELD_TO_KEY).map(([field, key]) => [
-              field,
-              data.values[key],
-            ]),
-          ),
-        ),
+        Object.fromEntries(
+          Object.entries(LATEX_CONFIG_FIELD_TO_KEY).map(([field, key]) => [
+            field,
+            data.values[key],
+          ]),
+        ) as LatexConfigValues,
       );
       return;
     }

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -55,7 +55,6 @@ import {
   type CopilotRouteInfo,
   type Goal,
   type GrokAuthStatus,
-  type LatexConfigValues,
   type MemoryViewItem,
   type ModelSelectionItem,
   type ProviderKeyStatus,
@@ -67,6 +66,7 @@ import {
   type ToolDashboardItem,
 } from '@shared/schemas';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
+import type { LatexConfigValues } from '@shared/constants/latexConfig';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 
 // ---------------------------------------------------------------------------

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -27,7 +27,6 @@ import {
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import {
-  type LatexConfigValues,
   type LatexSettingsStatus,
   DEFAULT_LATEX_SETTINGS_STATUS,
   settingByKey,
@@ -62,6 +61,7 @@ import {
   LATEX_CONFIG_DEFAULTS,
   LATEX_CONFIG_FIELD_TO_KEY,
   LATEX_CONFIG_RANGES,
+  type LatexConfigValues,
 } from '@shared/constants/latexConfig';
 
 // Local imports - LaTeX toolchain (install guides + commands)

--- a/src/shared/constants/latexConfig.ts
+++ b/src/shared/constants/latexConfig.ts
@@ -1,5 +1,10 @@
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
+import type {
+  NonRegexReplacementCategory,
+  RegexReplacementCategory,
+} from './replacementCategories';
+
 /**
  * LaTeX/compile/diff configuration — single source of truth.
  *
@@ -54,13 +59,46 @@ export const LATEX_CONFIG_RANGES = {
 } as const;
 
 /**
+ * The value type each LaTeX field renders, as `LatexConfigValues` below
+ * projects it. Restated here rather than derived because the catalog is
+ * runtime-typed (`settingSchemaWithoutPrefault` returns `unknown`) — the same
+ * bargain the 26 other catalog-backed signals strike in `settingsState.ts`,
+ * where `settingSignal<T>` names the value type beside the key. The values
+ * themselves are validated by each row's own catalog schema at the snapshot
+ * wire boundary (`snapshotMessage` in `@shared/schemas/settingsViewMessages`),
+ * so this type describes what already arrived rather than guarding it.
+ */
+interface LatexConfigValueTypes {
+  workflowAutoCompile: boolean;
+  workflowAutoCompileTimeoutMs: number;
+  workflowAutoOpenPdf: boolean;
+  workflowRejectOnCompileFailure: boolean;
+  latexdiffBetweenRounds: boolean;
+  latexdiffTimeoutMs: number;
+  latexdiffMathMarkup: LatexdiffMathMarkupValue;
+  latexdiffChangesOnly: boolean;
+  latexFormatter: LatexFormatterValue;
+  wrapCritiqueInAlign: boolean;
+  enabledReplacements: NonRegexReplacementCategory[];
+  enabledReplacementsRegex: RegexReplacementCategory[];
+  customReplacementsRegex: Record<string, string>;
+  customReplacements: Record<string, string>;
+}
+
+/**
+ * Frontend field projection of the catalog-derived LaTeX snapshot. Partial
+ * because the signal starts empty and fills in when the snapshot lands.
+ */
+export type LatexConfigValues = Partial<LatexConfigValueTypes>;
+
+/**
  * Every frontend-facing LaTeX field → its canonical catalog key. This map is
- * the field set: `LatexConfigValuesSchema` (`@shared/schemas`) is built by
- * looking up each of these keys in the settings catalog and re-keying its
- * schema under the frontend field name, so the projection can never drift
- * from the catalog's own validators. `latexSlice` uses this map to build the
- * projection at the wire boundary; `LaTeXTab` uses it for catalog-driven
- * writes.
+ * the field set: the `satisfies` below fails to compile if a field is added to
+ * (or removed from) {@link LatexConfigValueTypes} without a matching entry
+ * here, in either direction. `miscSettingsSlice` uses the map to re-key the
+ * snapshot at the wire boundary; `LaTeXTab` uses it for catalog-driven writes
+ * and for the `latex-setting-<field>` control ids. `stateSettings.vitest.ts`
+ * checks that every key here still names a catalog row.
  */
 export const LATEX_CONFIG_FIELD_TO_KEY = {
   workflowAutoCompile: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
@@ -79,4 +117,4 @@ export const LATEX_CONFIG_FIELD_TO_KEY = {
   enabledReplacementsRegex: 'texra.latex.enabledReplacementsRegex',
   customReplacementsRegex: 'texra.latex.customReplacementsRegex',
   customReplacements: 'texra.latex.customReplacements',
-} as const;
+} as const satisfies Record<keyof LatexConfigValueTypes, string>;

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -13,21 +13,11 @@ import { ReasoningEffortSchema } from 'llm-zoo/schemas';
 
 import { SETTINGS_VIEW_CMD, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
-  LATEX_CONFIG_FIELD_TO_KEY,
-  LATEX_FORMATTER_VALUES,
-  LATEXDIFF_MATH_MARKUP_VALUES,
-} from '@shared/constants/latexConfig';
-import {
-  NON_REGEX_REPLACEMENT_CATEGORIES,
-  REGEX_REPLACEMENT_CATEGORIES,
-} from '@shared/constants/replacementCategories';
-import {
   createDispatcher,
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 import {
   settingSchemaWithoutPrefault,
-  settingsViewSettingByKey,
   settingsViewSnapshotEntries,
   type SettingsViewSnapshot,
 } from './stateSettings';
@@ -588,138 +578,6 @@ const UpdateLatexSettingsStatusMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS),
   settings: LatexSettingsStatusSchema,
 });
-
-/**
- * Whether `actual` and `expected` are the same schema kind, deeply enough to
- * catch the failure a bare outer-constructor check misses: two `ZodArray`s
- * wrapping *different* enums (e.g. `LATEX_CONFIG_FIELD_TO_KEY` accidentally
- * pointing `enabledReplacements` at the regex-category key) both pass an
- * outer check, but their `.element` enums have different option sets. Recurses
- * through `ZodArray.element`; compares `ZodEnum.options` as sets; falls back
- * to the outer-constructor check for every other kind (`ZodBoolean`,
- * `ZodNumberFormat`, `ZodRecord`, …), where the catalog's own validation
- * (bounds, value schema) is the only thing that can further distinguish rows.
- */
-function sameCatalogSchemaKind(actual: unknown, expected: unknown): boolean {
-  if (
-    !(actual instanceof z.ZodType) ||
-    !(expected instanceof z.ZodType) ||
-    actual.constructor !== expected.constructor
-  ) {
-    return false;
-  }
-  if (actual instanceof z.ZodEnum && expected instanceof z.ZodEnum) {
-    const actualOptions = actual.options.toSorted();
-    const expectedOptions = expected.options.toSorted();
-    return (
-      actualOptions.length === expectedOptions.length &&
-      actualOptions.every((option, index) => option === expectedOptions[index])
-    );
-  }
-  if (actual instanceof z.ZodArray && expected instanceof z.ZodArray) {
-    return sameCatalogSchemaKind(actual.element, expected.element);
-  }
-  return true;
-}
-
-/**
- * Reads `key`'s own schema out of the settings catalog (bounds, enum options,
- * and all) rather than restating it, so `LatexConfigValuesSchema` below can
- * never drift from the catalog's own validators the way a hand-duplicated
- * schema could — a bound tightened on the catalog row reaches this projection
- * for free. `expectedKind` is a throwaway schema of the same Zod subclass (and,
- * for enums and arrays of them, the same option set) the catalog row is
- * expected to carry; its type both drives `T`'s inference and is checked at
- * runtime via {@link sameCatalogSchemaKind} against the schema actually found
- * at `key`, so a catalog row that changes kind — or `LATEX_CONFIG_FIELD_TO_KEY`
- * pointing a field at the wrong same-shaped row — fails loudly here instead of
- * silently mistyping the projected field.
- */
-function catalogField<T extends z.ZodTypeAny>(
-  key: string,
-  expectedKind: T,
-): z.ZodOptional<T> {
-  const entry = settingsViewSettingByKey(key);
-  if (!entry) {
-    throw new Error(`LATEX_CONFIG_FIELD_TO_KEY: no catalog entry for "${key}"`);
-  }
-  const schema = settingSchemaWithoutPrefault(entry);
-  if (!sameCatalogSchemaKind(schema, expectedKind)) {
-    throw new Error(
-      `LATEX_CONFIG_FIELD_TO_KEY: "${key}" catalog schema kind changed — expected ${expectedKind.constructor.name}, got ${(schema as z.ZodTypeAny | undefined)?.constructor?.name ?? typeof schema}`,
-    );
-  }
-  return (schema as T).optional();
-}
-
-/**
- * Frontend field projection of the catalog-derived LaTeX snapshot. Every
- * field is optional because `latexSlice` projects only the wire keys named in
- * `LATEX_CONFIG_FIELD_TO_KEY`, not a fixed subset. The `satisfies` below is
- * the field-set half of the sync this schema owns: it fails to compile if a
- * field is added to (or removed from) `LATEX_CONFIG_FIELD_TO_KEY` without a
- * matching line here, in either direction — excess and missing properties are
- * both excess-property-checked against the map's own key set.
- */
-export const LatexConfigValuesSchema = z.object({
-  workflowAutoCompile: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.workflowAutoCompile,
-    z.boolean(),
-  ),
-  workflowAutoCompileTimeoutMs: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.workflowAutoCompileTimeoutMs,
-    z.int(),
-  ),
-  workflowAutoOpenPdf: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.workflowAutoOpenPdf,
-    z.boolean(),
-  ),
-  workflowRejectOnCompileFailure: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.workflowRejectOnCompileFailure,
-    z.boolean(),
-  ),
-  latexdiffBetweenRounds: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.latexdiffBetweenRounds,
-    z.boolean(),
-  ),
-  latexdiffTimeoutMs: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.latexdiffTimeoutMs,
-    z.int(),
-  ),
-  latexdiffMathMarkup: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.latexdiffMathMarkup,
-    z.enum(LATEXDIFF_MATH_MARKUP_VALUES),
-  ),
-  latexdiffChangesOnly: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.latexdiffChangesOnly,
-    z.boolean(),
-  ),
-  latexFormatter: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.latexFormatter,
-    z.enum(LATEX_FORMATTER_VALUES),
-  ),
-  wrapCritiqueInAlign: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.wrapCritiqueInAlign,
-    z.boolean(),
-  ),
-  enabledReplacements: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.enabledReplacements,
-    z.array(z.enum(NON_REGEX_REPLACEMENT_CATEGORIES)),
-  ),
-  enabledReplacementsRegex: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.enabledReplacementsRegex,
-    z.array(z.enum(REGEX_REPLACEMENT_CATEGORIES)),
-  ),
-  customReplacementsRegex: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.customReplacementsRegex,
-    z.record(z.string(), z.string()),
-  ),
-  customReplacements: catalogField(
-    LATEX_CONFIG_FIELD_TO_KEY.customReplacements,
-    z.record(z.string(), z.string()),
-  ),
-} satisfies Record<keyof typeof LATEX_CONFIG_FIELD_TO_KEY, z.ZodTypeAny>);
-export type LatexConfigValues = z.infer<typeof LatexConfigValuesSchema>;
 
 /** Outbound: backend → frontend inline criticism toggle state */
 const UpdateInlineCriticismEnabledMessageSchema = z.object({

--- a/src/test-kernel/settings/LaTeXTab.vitest.ts
+++ b/src/test-kernel/settings/LaTeXTab.vitest.ts
@@ -8,7 +8,7 @@ vi.mock('@shared/hostBridge', () => ({
   postMessage: mocks.postMessage,
 }));
 
-import type { LatexConfigValues } from '@shared/schemas';
+import type { LatexConfigValues } from '@shared/constants/latexConfig';
 import {
   mountComponent,
   useLitComponentTestDom,


### PR DESCRIPTION
The LaTeX settings rows were described twice: once by the settings catalog, and once by a runtime `LatexConfigValuesSchema` built from 14 `catalogField(...)` calls, each re-checking that its catalog row still had the expected schema kind. The projection then re-parsed a snapshot the dispatcher had **already** parsed row by row.

The catalog is now the only source. The type moves to a 14-line interface beside the field map; the 130 lines of runtime machinery go.

## Why the deleted parse was redundant

`snapshotMessage()` builds a strict object from the catalog's own per-row schemas, and the outbound dispatcher parses before any handler runs. The handler's input keys come from the field map itself, so there is no key-stripping delta; every field was optional, so a present-`undefined` was already accepted; and the tab reads by property access, which cannot distinguish present-`undefined` from absent. The cast that replaces it carries the same soundness note the other 26 catalog-backed signals already carry.

## What replaces the loud guard, and what does not

`catalogField` threw at module load if a catalog row's kind drifted. The **field-set** half of that guard is now a `satisfies Record<keyof LatexConfigValueTypes, string>` on the map, and both directions were verified to actually fail compilation by temporarily mutating it: an extra key gives TS2353, a missing key gives TS2741. A third guard falls out for free: the tab's indexed accessor type rejects a map key with no matching field.

**What is genuinely not replaced** is the value-*kind* check: if a catalog row silently changed kind, the TypeScript type would become a lie. That is a deliberate downgrade, and it is exactly the exposure the other 26 signals already carry — this change conforms an outlier to the established pattern rather than inventing one. The existing test asserting that every field key names a real catalog row is kept and passes.

A type-level derivation from the catalog would be strictly better than either option, and it was checked: it is not possible. The catalog array is width-typed and its per-row schema accessor returns `unknown`, so no literal-key path exists. That is why all 26 siblings restate their shape.

## Net elements (R6)

6 files, +60 / −164, **net −103 LOC**, and net **−2 declarations**: `sameCatalogSchemaKind`, `catalogField` and `LatexConfigValuesSchema` die; one non-exported interface is born; `LatexConfigValues` moves rather than disappearing.

## Consumer counts (R8)

| Deleted symbol | Production consumers before |
|---|---|
| `LatexConfigValuesSchema` | 1 (the snapshot handler) |
| `catalogField` | 1 file, internal, 14 call sites |
| `sameCatalogSchemaKind` | 1 file, internal |
| `LatexConfigValues` (relocated, not deleted) | 3 production + 1 test |

All 14 LaTeX settings rows survive untouched: no row added, removed or re-keyed.

## The DOM id trap

Handled by not re-keying at all. The field type is derived from the map's own keys, which are byte-identical to before, so all seven `latex-setting-${field}` sites and the test's id query are untouched. The full re-key remains refuted and was not attempted.

## Sequencing note

This collides with the slice collapse (#12380) by design: that PR moved the LaTeX snapshot arm into the dispatcher, and this one deletes the schema that arm called. A textually clean merge of the two would have broken main. This branch is rebased onto #12380 and rewrites the arm in its new home, so the parse is gone and the re-key remains.

Also worth recording: the survey placed that arm in `latexSlice.ts`. It was never there — `latexSlice`'s own header said so — it lived in the misc slice, and now lives in the dispatcher.

## Verification

- `CI=true npm run typecheck`: clean, re-run after the rebase.
- The LaTeX tab, subscription-settings and state-setting suites: 10 tests, all pass.
- `eslint` and `prettier`: clean.
- `check:dead-code-ratchet` and `check:effect-migration-ratchet`: both clean, no baseline edits needed.
- `git diff --check`: clean.

No test deleted: nothing pinned the projection directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
