### PR TITLE
refactor(run): make ModelRetryGate Effect-native coordination; the last AbortSignal leaves the loop

### DIFF
--- a/config/ratchets/effect-migration-baseline.json
+++ b/config/ratchets/effect-migration-baseline.json
@@ -169,7 +169,6 @@
     },
     "import:p-defer": {
       "src/agent/followUp/FollowUpQueue.ts": 1,
-      "src/agent/runtime/ModelRetryGate.ts": 1,
       "src/agent/storage/runLease.ts": 1
     },
     "import:async-mutex": {

--- a/src/agent/runtime/ModelInvoker.ts
+++ b/src/agent/runtime/ModelInvoker.ts
@@ -90,6 +90,7 @@ import {
   runtimeSnapshotRow,
   stepRow,
 } from './loop/rows';
+import type { RoutePolicy } from './ModelRetryGate';
 
 /**
  * Credential source a retry decision picked: the account the run is already
@@ -807,10 +808,10 @@ export const modelInvokerLayer: Layer.Layer<
     );
 
     /**
-     * One attempt under the session's route gate. The gate is Promise-tier
-     * session state by design (sibling runs share cooling); the attempt runs
-     * inside its permit on this fiber's services, and the fiber's abort
-     * signal is the one the gate waits and the request abort on.
+     * One attempt under the session's route gate: the gate is session state
+     * by design (sibling runs share cooling), and the attempt runs inside its
+     * permits on this fiber. Cancelling the run interrupts the fiber, which
+     * the gate reads as the waiting or in-flight attempt being abandoned.
      */
     const gatedAttempt = (
       state: RunState,
@@ -818,79 +819,39 @@ export const modelInvokerLayer: Layer.Layer<
       request: InvokeRequest,
       bound: BoundModel,
       operationId: string,
-    ): Effect.Effect<InvocationResponse, AttemptFailed | InvokeError> =>
-      Effect.scoped(
-        Effect.gen(function* () {
-          const signal = yield* Effect.abortSignal;
-          const gate = session.modelRetries;
-          const verdictFor = (error: Error) =>
-            error instanceof AttemptFailed
-              ? error.failure.verdict
-              : classifyModelFailure(error).verdict;
-          const routes = [
-            {
-              key: bound.modelRetryRouteKey,
-              classifyFailure: (error: Error) => {
-                const verdict = verdictFor(error);
-                return verdict.rateLimitScope === 'model'
-                  ? { retryAfterMs: verdict.retryAfterMs }
-                  : undefined;
-              },
-            },
-            {
-              key: bound.wireRouteKey,
-              classifyFailure: (error: Error) => {
-                const verdict = verdictFor(error);
-                return verdict.wireRouteFailure
-                  ? { retryAfterMs: verdict.retryAfterMs }
-                  : undefined;
-              },
-              isReachableFailure: (error: Error) =>
-                verdictFor(error).rateLimitScope === 'model',
-            },
-          ];
-          // The permits: an abort or a disposed gate while waiting rejects,
-          // which is this fiber being stopped or the session torn down, and
-          // only those two reasons become an interrupt. Any other rejection
-          // is a bug in the gate and dies with its cause rather than reading
-          // to the user as a stop.
-          const acquired = yield* Effect.tryPromise({
-            try: () =>
-              gate.acquireAll(routes, {
-                signal,
-                onWait: (delayMs) =>
-                  logger.debug(
-                    `Waiting ${delayMs}ms for the model recovery probe.`,
-                  ),
-              }),
-            catch: (cause) => cause,
-          }).pipe(
-            Effect.catchIf(
-              (cause) => isUserAbort(cause) || cause === signal.reason,
-              () => Effect.interrupt,
-            ),
-            Effect.catch((cause) => Effect.die(ensureError(cause))),
-          );
-          const exit = yield* Effect.exit(
-            attemptOnce(state, invocation, request, bound, operationId),
-          );
-          if (Exit.isSuccess(exit)) {
-            gate.settle(acquired, { kind: 'success' }, RETRY_BACKOFF_MS);
-            return exit.value;
-          }
-          if (Cause.hasInterrupts(exit.cause)) {
-            gate.settle(acquired, { kind: 'abandoned' }, RETRY_BACKOFF_MS);
-            return yield* Effect.interrupt;
-          }
-          const error = Cause.squash(exit.cause);
-          gate.settle(
-            acquired,
-            { kind: 'failure', error: ensureError(error) },
-            RETRY_BACKOFF_MS,
-          );
-          return yield* exit;
-        }),
-      );
+    ): Effect.Effect<InvocationResponse, AttemptFailed | InvokeError> => {
+      const verdictFor = (error: Error) =>
+        error instanceof AttemptFailed
+          ? error.failure.verdict
+          : classifyModelFailure(error).verdict;
+      const routes: [RoutePolicy, RoutePolicy] = [
+        {
+          key: bound.modelRetryRouteKey,
+          classifyFailure: (error: Error) => {
+            const verdict = verdictFor(error);
+            return verdict.rateLimitScope === 'model'
+              ? { retryAfterMs: verdict.retryAfterMs }
+              : undefined;
+          },
+        },
+        {
+          key: bound.wireRouteKey,
+          classifyFailure: (error: Error) => {
+            const verdict = verdictFor(error);
+            return verdict.wireRouteFailure
+              ? { retryAfterMs: verdict.retryAfterMs }
+              : undefined;
+          },
+          isReachableFailure: (error: Error) =>
+            verdictFor(error).rateLimitScope === 'model',
+        },
+      ];
+      return session.modelRetries.withRoutes(routes, {
+        baseBackoffMs: RETRY_BACKOFF_MS,
+        onWait: (delayMs) =>
+          logger.debug(`Waiting ${delayMs}ms for the model recovery probe.`),
+      })(attemptOnce(state, invocation, request, bound, operationId));
+    };
 
     /**
      * The routes the run declines after this decision. Answering a retry

--- a/src/agent/runtime/ModelRetryGate.ts
+++ b/src/agent/runtime/ModelRetryGate.ts
@@ -1,16 +1,35 @@
-import pDefer from 'p-defer';
+import { Cause, Clock, Deferred, Effect, Exit, Fiber, Scope } from 'effect';
 
 import { jitteredExponentialBackoffMs } from '@utils/core';
+import { ensureError } from '@utils/errors/errorMessage';
 
 const MAX_BACKOFF_MS = 5 * 60 * 1000;
 
 type RoutePhase = 'healthy' | 'cooling' | 'probing';
 
-interface WaitingAttempt {
-  readonly resolve: (permit: RetryPermit) => void;
-  readonly reject: (error: unknown) => void;
-  readonly signal: AbortSignal;
-  readonly onAbort: () => void;
+interface RetryPermit {
+  readonly version: number;
+  readonly probe: boolean;
+}
+
+/** One call waiting on a route; it leaves the queue when its fiber is interrupted. */
+interface Waiter {
+  readonly permit: Deferred.Deferred<RetryPermit>;
+  /**
+   * The permit the gate handed this waiter, recorded before `permit`
+   * completes: an interruption landing between the grant and the waiter
+   * resuming still returns a probe to the cohort instead of losing it.
+   */
+  granted: RetryPermit | undefined;
+}
+
+/**
+ * One scheduled probe. The slot is taken before the fiber exists, so a
+ * probe that completes during its own fork still clears it, and a stale
+ * fiber recognizes it was superseded.
+ */
+interface ScheduledProbe {
+  fiber: Fiber.Fiber<void> | undefined;
 }
 
 interface RouteState {
@@ -18,13 +37,8 @@ interface RouteState {
   phase: RoutePhase;
   failures: number;
   retryAt: number;
-  timer: ReturnType<typeof setTimeout> | undefined;
-  readonly waiters: WaitingAttempt[];
-}
-
-interface RetryPermit {
-  readonly version: number;
-  readonly probe: boolean;
+  probe: ScheduledProbe | undefined;
+  readonly waiters: Waiter[];
 }
 
 interface RouteFailure {
@@ -37,18 +51,13 @@ export interface RoutePolicy {
   readonly isReachableFailure?: (error: Error) => boolean;
 }
 
-interface RunOptions {
-  readonly signal: AbortSignal;
+interface RouteOptions {
   readonly baseBackoffMs: number;
   readonly onWait?: (delayMs: number) => void;
 }
 
-export interface AcquiredRoute extends RoutePolicy {
-  permit: RetryPermit;
-}
-
-function abortReason(signal: AbortSignal): unknown {
-  return signal.reason ?? new DOMException('Operation cancelled', 'AbortError');
+interface AcquiredRoute extends RoutePolicy {
+  readonly permit: RetryPermit;
 }
 
 /**
@@ -59,123 +68,126 @@ function abortReason(signal: AbortSignal): unknown {
  * becomes the recovery probe. A successful probe releases the other calls;
  * another route failure increases the shared backoff. The gate does not decide
  * how many times a node retries—that remains the node retry loop's concern.
+ *
+ * Route state is mutated only from within Effect steps on one runtime, so a
+ * plain map is atomic here; the probe timer is a fiber in the gate's scope
+ * that sleeps on the runtime `Clock`, and a waiting call is a `Deferred` the
+ * probe fiber or a healthy success completes.
  */
 export class ModelRetryGate {
+  /**
+   * Build the gate in a scope: its probe fibers die with the scope, and
+   * every call still waiting on a permit when it closes is interrupted.
+   */
+  static readonly make: Effect.Effect<ModelRetryGate, never, Scope.Scope> =
+    Effect.gen(function* () {
+      const gate = new ModelRetryGate(yield* Effect.scope);
+      yield* Effect.addFinalizer(() => gate.close());
+      return gate;
+    });
+
   private readonly routes = new Map<string, RouteState>();
-  private disposed = false;
+  private closed = false;
+
+  private constructor(private readonly scope: Scope.Scope) {}
 
   /**
-   * Run `operation` gated on every route in `routes`, narrowest first (see
-   * {@link acquireAll}). The tuple type is non-empty because an empty list
-   * would run the operation entirely ungated.
+   * Run `attempt` gated on every route in `routes`, narrowest first (see
+   * {@link acquireAll}), then record what its exit proved about them: a
+   * success marks every route reachable, an interruption hands the permits
+   * back, a failure is classified per route. The tuple type is non-empty
+   * because an empty list would run the attempt entirely ungated.
    */
-  async run<T>(
+  withRoutes(
     routes: readonly [RoutePolicy, ...RoutePolicy[]],
-    options: RunOptions,
-    operation: () => Promise<T>,
-  ): Promise<T> {
-    const acquired = await this.acquireAll(routes, options);
-    const outcome = await operation().then(
-      (value) => ({ ok: true as const, value }),
-      (error: unknown) => ({ ok: false as const, error }),
-    );
-    if (outcome.ok) {
-      this.settle(acquired, { kind: 'success' }, options.baseBackoffMs);
-      return outcome.value;
-    }
-    this.settle(
-      acquired,
-      options.signal.aborted
-        ? { kind: 'abandoned' }
-        : { kind: 'failure', error: outcome.error as Error },
-      options.baseBackoffMs,
-    );
-    throw outcome.error;
+    options: RouteOptions,
+  ): <A, E, R>(attempt: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R> {
+    return (attempt) =>
+      Effect.uninterruptibleMask((restore) =>
+        Effect.gen({ self: this }, function* () {
+          const acquired = yield* restore(
+            this.acquireAll(routes, options.onWait),
+          );
+          const exit = yield* Effect.exit(restore(attempt));
+          yield* this.settle(acquired, exit, options.baseBackoffMs);
+          return yield* exit;
+        }),
+      );
   }
 
-  /**
-   * Record what one gated attempt proved about its routes. A success marks
-   * every route reachable; an abandoned attempt (the run stopped) hands its
-   * permits back; a failure is classified per route.
-   */
-  settle(
+  private settle(
     acquired: readonly AcquiredRoute[],
-    outcome:
-      | { readonly kind: 'success' }
-      | { readonly kind: 'abandoned' }
-      | { readonly kind: 'failure'; readonly error: Error },
+    exit: Exit.Exit<unknown, unknown>,
     baseBackoffMs: number,
-  ): void {
-    if (outcome.kind === 'success') {
-      for (const entry of acquired) {
-        this.markReachable(entry.key, entry.permit);
-      }
-      return;
+  ): Effect.Effect<void> {
+    if (Exit.isSuccess(exit)) {
+      return Effect.forEach(
+        acquired,
+        (entry) => this.markReachable(entry.key, entry.permit),
+        { discard: true },
+      );
     }
-    if (outcome.kind === 'abandoned') {
-      for (const entry of acquired) {
-        this.abandon(entry.key, entry.permit);
-      }
-      return;
-    }
-    for (const entry of acquired) {
-      const failure = entry.classifyFailure(outcome.error);
-      if (failure) {
-        this.markRouteFailure(entry.key, entry.permit, baseBackoffMs, failure);
-      } else if (entry.isReachableFailure?.(outcome.error)) {
-        this.markReachable(entry.key, entry.permit);
-      } else if (entry.permit.probe) {
-        // An unclassified failure does not prove that a recovering route is
-        // reachable. Keep the cohort closed and hand probe ownership to one
-        // waiter; shared credential failures can otherwise release every
-        // peer before their out-of-gate recovery finishes.
-        this.abandon(entry.key, entry.permit);
-      } else {
+    if (Cause.hasInterrupts(exit.cause)) return this.abandonAll(acquired);
+    const error = ensureError(Cause.squash(exit.cause));
+    return Effect.forEach(
+      acquired,
+      (entry) => {
+        const failure = entry.classifyFailure(error);
+        if (failure) {
+          return this.markRouteFailure(
+            entry.key,
+            entry.permit,
+            baseBackoffMs,
+            failure,
+          );
+        }
+        if (entry.isReachableFailure?.(error)) {
+          return this.markReachable(entry.key, entry.permit);
+        }
+        if (entry.permit.probe) {
+          // An unclassified failure does not prove that a recovering route is
+          // reachable. Keep the cohort closed and hand probe ownership to one
+          // waiter; shared credential failures can otherwise release every
+          // peer before their out-of-gate recovery finishes.
+          return this.abandon(entry.key, entry.permit);
+        }
         // A current healthy permit reached the operation boundary. Even when
         // its error is local to that request, it proves that an older
         // shared-route failure streak no longer describes this route.
-        this.markReachable(entry.key, entry.permit);
-      }
-    }
+        return this.markReachable(entry.key, entry.permit);
+      },
+      { discard: true },
+    );
   }
 
   /**
    * Acquires narrower additional scopes before the primary route. A
    * model-specific probe may wait for its shared wire route without blocking
    * healthy sibling models. A later wait can also make an earlier permit
-   * stale, so validate the complete set before sending. Rejects with the
-   * signal's reason when the wait is aborted, and with an AbortError when
-   * the gate is disposed.
+   * stale, so validate the complete set before sending. An interruption while
+   * waiting hands every permit already held back.
    */
-  async acquireAll(
+  private acquireAll(
     routes: readonly RoutePolicy[],
-    options: Pick<RunOptions, 'signal' | 'onWait'>,
-  ): Promise<AcquiredRoute[]> {
-    while (true) {
-      const acquired: AcquiredRoute[] = [];
-      try {
+    onWait: RouteOptions['onWait'],
+  ): Effect.Effect<AcquiredRoute[]> {
+    const held: AcquiredRoute[] = [];
+    return Effect.gen({ self: this }, function* () {
+      while (true) {
         for (const route of routes) {
-          acquired.push({
+          held.push({
             ...route,
-            permit: await this.acquire(route.key, options),
+            permit: yield* this.acquire(route.key, onWait),
           });
         }
-      } catch (error) {
-        for (const entry of acquired) {
-          this.abandon(entry.key, entry.permit);
+        if (
+          held.every((entry) => this.isCurrentPermit(entry.key, entry.permit))
+        ) {
+          return held.splice(0);
         }
-        throw error;
+        yield* this.abandonAll(held.splice(0));
       }
-
-      if (
-        acquired.every((entry) => this.isCurrentPermit(entry.key, entry.permit))
-      ) {
-        return acquired;
-      }
-      for (const entry of acquired) {
-        this.abandon(entry.key, entry.permit);
-      }
-    }
+    }).pipe(Effect.onInterrupt(() => this.abandonAll(held.splice(0))));
   }
 
   private isCurrentPermit(route: string, permit: RetryPermit): boolean {
@@ -184,62 +196,67 @@ export class ModelRetryGate {
     return permit.probe ? state.phase === 'probing' : state.phase === 'healthy';
   }
 
-  dispose(): void {
-    if (this.disposed) return;
-    this.disposed = true;
-    const error = new DOMException('Model retry gate disposed', 'AbortError');
-    for (const state of this.routes.values()) {
-      if (state.timer) clearTimeout(state.timer);
-      for (const waiter of state.waiters.splice(0)) {
-        waiter.signal.removeEventListener('abort', waiter.onAbort);
-        waiter.reject(error);
-      }
-    }
-    this.routes.clear();
+  /** Interrupt every call still waiting; the scope interrupts the probe fibers. */
+  private close(): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      this.closed = true;
+      const waiting = [...this.routes.values()].flatMap((state) =>
+        state.waiters.splice(0),
+      );
+      this.routes.clear();
+      return Effect.forEach(
+        waiting,
+        (waiter) => Deferred.interrupt(waiter.permit),
+        { discard: true },
+      );
+    });
   }
 
+  /**
+   * A healthy route admits immediately. Otherwise the call joins the route's
+   * waiters until the probe fiber picks it or a success releases the cohort;
+   * joining and waiting are one uninterruptible step, so an interruption
+   * always finds the waiter registered and removes it.
+   */
   private acquire(
     route: string,
-    options: Pick<RunOptions, 'signal' | 'onWait'>,
-  ): Promise<RetryPermit> {
-    if (this.disposed) {
-      return Promise.reject(
-        new DOMException('Model retry gate disposed', 'AbortError'),
-      );
-    }
+    onWait: RouteOptions['onWait'],
+  ): Effect.Effect<RetryPermit> {
+    return Effect.uninterruptibleMask((restore) =>
+      Effect.gen({ self: this }, function* () {
+        if (this.closed) return yield* Effect.interrupt;
+        const healthyPermit = this.acquireHealthy(route);
+        if (healthyPermit) return healthyPermit;
+        // Safe: acquireHealthy only returns undefined when it found an
+        // existing, non-healthy state for `route` (the create-on-miss branch
+        // always returns a permit), so the state it read is still in the map.
+        const state = this.routes.get(route)!;
 
-    const healthyPermit = this.acquireHealthy(route);
-    if (healthyPermit) return Promise.resolve(healthyPermit);
-    // Safe: acquireHealthy only returns undefined when it found an existing,
-    // non-healthy state for `route` (the create-on-miss branch always returns
-    // a permit), so the state it read is still in the map here.
-    const state = this.routes.get(route)!;
+        const now = yield* Clock.currentTimeMillis;
+        onWait?.(Math.max(0, state.retryAt - now));
+        const waiter: Waiter = {
+          permit: Deferred.makeUnsafe<RetryPermit>(),
+          granted: undefined,
+        };
+        state.waiters.push(waiter);
+        yield* this.scheduleProbe(state);
+        return yield* restore(Deferred.await(waiter.permit)).pipe(
+          Effect.onInterrupt(() => this.leave(state, waiter)),
+        );
+      }),
+    );
+  }
 
-    if (options.signal.aborted) {
-      return Promise.reject(abortReason(options.signal));
-    }
-
-    const delayMs = Math.max(0, state.retryAt - Date.now());
-    options.onWait?.(delayMs);
-    const permit = pDefer<RetryPermit>();
-    const waiter: WaitingAttempt = {
-      resolve: permit.resolve,
-      reject: permit.reject,
-      signal: options.signal,
-      onAbort: () => {
-        const index = state.waiters.indexOf(waiter);
-        if (index >= 0) state.waiters.splice(index, 1);
-        if (state.waiters.length === 0 && state.timer) {
-          clearTimeout(state.timer);
-          state.timer = undefined;
-        }
-        permit.reject(abortReason(options.signal));
-      },
-    };
-    options.signal.addEventListener('abort', waiter.onAbort, { once: true });
-    state.waiters.push(waiter);
-    this.scheduleProbe(state);
-    return permit.promise;
+  /** The interrupted waiter leaves its route; a probe it was granted moves on. */
+  private leave(state: RouteState, waiter: Waiter): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      const index = state.waiters.indexOf(waiter);
+      if (index >= 0) state.waiters.splice(index, 1);
+      if (waiter.granted?.probe) {
+        return this.abandonRoute(state, waiter.granted);
+      }
+      return state.waiters.length === 0 ? this.cancelProbe(state) : Effect.void;
+    });
   }
 
   private acquireHealthy(route: string): RetryPermit | undefined {
@@ -250,7 +267,7 @@ export class ModelRetryGate {
       phase: 'healthy' as const,
       failures: 0,
       retryAt: 0,
-      timer: undefined,
+      probe: undefined,
       waiters: [],
     };
     this.routes.set(route, healthyState);
@@ -265,98 +282,142 @@ export class ModelRetryGate {
     permit: RetryPermit,
     baseBackoffMs: number,
     failure: RouteFailure,
-  ): void {
-    const state = this.routes.get(route);
-    if (!state || permit.version !== state.version) return;
-    if (state.phase !== 'healthy' && !permit.probe) return;
+  ): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      const state = this.routes.get(route);
+      if (!state || permit.version !== state.version) return;
+      if (state.phase !== 'healthy' && !permit.probe) return;
 
-    state.version += 1;
-    state.phase = 'cooling';
-    state.failures += 1;
-    state.retryAt =
-      Date.now() +
-      Math.max(
-        jitteredExponentialBackoffMs(
-          baseBackoffMs,
-          state.failures,
-          MAX_BACKOFF_MS,
-        ),
-        failure.retryAfterMs ?? 0,
-      );
-    this.scheduleProbe(state);
+      state.version += 1;
+      state.phase = 'cooling';
+      state.failures += 1;
+      state.retryAt =
+        (yield* Clock.currentTimeMillis) +
+        Math.max(
+          jitteredExponentialBackoffMs(
+            baseBackoffMs,
+            state.failures,
+            MAX_BACKOFF_MS,
+          ),
+          failure.retryAfterMs ?? 0,
+        );
+      yield* this.scheduleProbe(state);
+    });
   }
 
-  private markReachable(route: string, permit: RetryPermit): void {
-    const state = this.routes.get(route);
-    if (!state) return;
-    if (state.phase === 'healthy') {
-      // A success admitted while the route was already healthy proves a clean
-      // round-trip, so the failure streak ends here — not on probe success,
-      // whose released cohort may immediately re-fail (a rate window that fits
-      // one probe rarely fits the herd). Resetting on probe success would cap
-      // the shared backoff at its base forever in exactly that cycle.
-      if (permit.version === state.version) {
-        state.failures = 0;
+  private markReachable(
+    route: string,
+    permit: RetryPermit,
+  ): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      const state = this.routes.get(route);
+      if (!state) return Effect.void;
+      if (state.phase === 'healthy') {
+        // A success admitted while the route was already healthy proves a
+        // clean round-trip, so the failure streak ends here — not on probe
+        // success, whose released cohort may immediately re-fail (a rate
+        // window that fits one probe rarely fits the herd). Resetting on probe
+        // success would cap the shared backoff at its base forever in exactly
+        // that cycle.
+        if (permit.version === state.version) {
+          state.failures = 0;
+        }
+        return Effect.void;
       }
-      return;
-    }
-    if (permit.version !== state.version) return;
-    if (state.phase === 'probing' && !permit.probe) return;
+      if (permit.version !== state.version) return Effect.void;
+      if (state.phase === 'probing' && !permit.probe) return Effect.void;
 
-    state.version += 1;
-    state.phase = 'healthy';
-    state.retryAt = 0;
-    if (state.timer) clearTimeout(state.timer);
-    state.timer = undefined;
-    for (const waiter of state.waiters.splice(0)) {
-      waiter.signal.removeEventListener('abort', waiter.onAbort);
-      waiter.resolve({
-        version: state.version,
-        probe: false,
-      });
-    }
+      state.version += 1;
+      state.phase = 'healthy';
+      state.retryAt = 0;
+      const released: RetryPermit = { version: state.version, probe: false };
+      const waiting = state.waiters.splice(0);
+      return this.cancelProbe(state).pipe(
+        Effect.andThen(
+          Effect.forEach(
+            waiting,
+            (waiter) => {
+              waiter.granted = released;
+              return Deferred.succeed(waiter.permit, released);
+            },
+            { discard: true },
+          ),
+        ),
+      );
+    });
   }
 
-  private abandon(route: string, permit: RetryPermit): void {
-    const state = this.routes.get(route);
-    if (
-      !state ||
-      !permit.probe ||
-      permit.version !== state.version ||
-      state.phase !== 'probing'
-    ) {
-      return;
-    }
-
-    state.phase = 'cooling';
-    state.retryAt = Date.now();
-    this.scheduleProbe(state);
+  private abandonAll(acquired: readonly AcquiredRoute[]): Effect.Effect<void> {
+    return Effect.forEach(
+      acquired,
+      (entry) => this.abandon(entry.key, entry.permit),
+      { discard: true },
+    );
   }
 
-  private scheduleProbe(state: RouteState): void {
+  private abandon(route: string, permit: RetryPermit): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      const state = this.routes.get(route);
+      return state ? this.abandonRoute(state, permit) : Effect.void;
+    });
+  }
+
+  /** An unused probe permit reopens cooling so the next waiter probes at once. */
+  private abandonRoute(
+    state: RouteState,
+    permit: RetryPermit,
+  ): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      if (
+        !permit.probe ||
+        permit.version !== state.version ||
+        state.phase !== 'probing'
+      ) {
+        return;
+      }
+      state.phase = 'cooling';
+      state.retryAt = yield* Clock.currentTimeMillis;
+      yield* this.scheduleProbe(state);
+    });
+  }
+
+  private cancelProbe(state: RouteState): Effect.Effect<void> {
+    const probe = state.probe;
+    state.probe = undefined;
+    return probe?.fiber ? Fiber.interrupt(probe.fiber) : Effect.void;
+  }
+
+  /**
+   * Fork the route's one probe fiber into the gate's scope: it sleeps until
+   * `retryAt` on the runtime clock, then hands the probe permit to the
+   * oldest waiter still queued.
+   */
+  private scheduleProbe(state: RouteState): Effect.Effect<void> {
     if (
-      this.disposed ||
       state.phase !== 'cooling' ||
-      state.timer ||
+      state.probe ||
       state.waiters.length === 0
     ) {
-      return;
+      return Effect.void;
     }
-
-    state.timer = setTimeout(
-      () => {
-        state.timer = undefined;
-        if (this.disposed || state.phase !== 'cooling') return;
-        const waiter = state.waiters.shift();
-        if (!waiter) return;
-        waiter.signal.removeEventListener('abort', waiter.onAbort);
-        state.phase = 'probing';
-        waiter.resolve({
-          version: state.version,
-          probe: true,
-        });
-      },
-      Math.max(0, state.retryAt - Date.now()),
+    const scheduled: ScheduledProbe = { fiber: undefined };
+    state.probe = scheduled;
+    const probe = Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      yield* Effect.sleep(Math.max(0, state.retryAt - now));
+      if (state.probe !== scheduled) return;
+      state.probe = undefined;
+      if (state.phase !== 'cooling') return;
+      const waiter = state.waiters.shift();
+      if (!waiter) return;
+      state.phase = 'probing';
+      waiter.granted = { version: state.version, probe: true };
+      yield* Deferred.succeed(waiter.permit, waiter.granted);
+    });
+    return Effect.forkIn(probe, this.scope).pipe(
+      Effect.map((fiber) => {
+        scheduled.fiber = fiber;
+      }),
     );
   }
 }

--- a/src/agent/runtime/ModelRetryGate.ts
+++ b/src/agent/runtime/ModelRetryGate.ts
@@ -403,8 +403,10 @@ export class ModelRetryGate {
     const scheduled: ScheduledProbe = { fiber: undefined };
     state.probe = scheduled;
     const probe = Effect.gen(function* () {
-      const now = yield* Clock.currentTimeMillis;
-      yield* Effect.sleep(Math.max(0, state.retryAt - now));
+      // A probe handed on by an abandoning holder is due now: grant it on
+      // this fiber's first step rather than through a zero-length sleep.
+      const delayMs = state.retryAt - (yield* Clock.currentTimeMillis);
+      if (delayMs > 0) yield* Effect.sleep(delayMs);
       if (state.probe !== scheduled) return;
       state.probe = undefined;
       if (state.phase !== 'cooling') return;

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -107,13 +107,13 @@ import {
   openSession,
   type SessionGraph,
 } from './sessionGraph';
-import { ModelRetryGate } from './ModelRetryGate';
 import {
   createSessionApprovals,
   type SessionApprovals,
 } from './runApprovalQueue';
 import { WorkflowControlRegistry } from './workflowControlRegistry';
 import { createNeutralResponseTextProcessing } from './responseTextProcessing';
+import type { ModelRetryGate } from './ModelRetryGate';
 
 const logger = createLog('sessionHandle');
 
@@ -213,7 +213,11 @@ export class SessionHandle {
   /** Session-owned approval queues, pending registries, and bypass state. */
   readonly approvals: SessionApprovals;
   private texraApprovalPolicy = TEXRA_APPROVAL_POLICY_DEFAULT;
-  /** Coordinates recovery probes for model routes shared by parallel runs. */
+  /**
+   * Coordinates recovery probes for model routes shared by parallel runs.
+   * Built by the session owner in the session's scope, so its probe fibers
+   * and waiting calls end with the session rather than through this store.
+   */
   readonly modelRetries: ModelRetryGate;
   /** Host policy for provider-output cleanup and continuation joining. */
   readonly responseTextProcessing: ResponseTextProcessing;
@@ -234,7 +238,7 @@ export class SessionHandle {
    */
   constructor(
     init: SessionHandleInit &
-      Pick<SessionHandle, 'transcripts'> & {
+      Pick<SessionHandle, 'transcripts' | 'modelRetries'> & {
         readonly roots: WorkspaceRoots;
         readonly graph: (session: SessionHandle) => SessionGraph;
       },
@@ -273,7 +277,7 @@ export class SessionHandle {
 
     this.interactions = interactions;
     this.approvals = approvals;
-    this.modelRetries = new ModelRetryGate();
+    this.modelRetries = init.modelRetries;
     this.responseTextProcessing =
       init.responseTextProcessing ?? createNeutralResponseTextProcessing();
     this.workflowControls = new WorkflowControlRegistry();
@@ -293,7 +297,6 @@ export class SessionHandle {
     });
     this.teardown.add(() => this.resultListeners.clear());
     this.teardown.add(() => this.interactions.dispose());
-    this.teardown.add(() => this.modelRetries.dispose());
     // Drop bypass state before the interaction slot settles pending approvals.
     this.teardown.add(() => this.approvals.clearAll());
     this.teardown.add(() => this.runs.dispose());

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -46,6 +46,7 @@ import { EditorModel } from '@agent/runtime/run/modelBinding';
 import type { RunRegistry } from '@agent/runtime/runRegistry';
 import { runLedgerLayer } from '@agent/runtime/RunLedger';
 import { sessionEventsLayer, tailFrom } from '@agent/runtime/SessionEvents';
+import { ModelRetryGate } from '@agent/runtime/ModelRetryGate';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   initSessionOwner,
@@ -411,6 +412,9 @@ const sessionHandleLayer = (
         initialListing,
         key.open.transcriptMode,
       ).pipe(Effect.orDie);
+      // The gate's probe fibers and waiting calls end with this scope, after
+      // the handle below has unwound its runs.
+      const modelRetries = yield* ModelRetryGate.make;
       const session = yield* Effect.acquireRelease(
         Effect.sync(
           () =>
@@ -418,6 +422,7 @@ const sessionHandleLayer = (
               ...key.open,
               transcripts,
               graph,
+              modelRetries,
             }),
         ),
         (session) =>

--- a/src/test-kernel/agent/runtime/ModelRetryGate.vitest.ts
+++ b/src/test-kernel/agent/runtime/ModelRetryGate.vitest.ts
@@ -1,17 +1,14 @@
 // Third-party imports
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type Mock,
-} from 'vitest';
+import { it } from '@effect/vitest';
+import { Deferred, Effect, Exit, Fiber, Scope } from 'effect';
+import { TestClock } from 'effect/testing';
+import { afterEach, beforeEach, describe, expect, vi, type Mock } from 'vitest';
 
 // Local imports
-import { ModelRetryGate } from '@agent/runtime/ModelRetryGate';
-import { createDeferred } from '@test/support/asyncTestUtils';
+import {
+  ModelRetryGate,
+  type RoutePolicy,
+} from '@agent/runtime/ModelRetryGate';
 
 const ROUTE = 'openai:subscription:gpt-5.6';
 const MODEL_ROUTE = `${ROUTE}:model`;
@@ -24,413 +21,506 @@ const UNAUTHORIZED = Object.assign(new Error('credential expired'), {
   status: 401,
 });
 
-function options(
-  signal: AbortSignal = new AbortController().signal,
-  baseBackoffMs = 1000,
-) {
-  return { signal, baseBackoffMs };
-}
-
-/** Structural view of the gate's own (unexported) RoutePolicy. */
-type TestRoute = {
-  key: string;
-  classifyFailure: (error: Error) => { retryAfterMs?: number } | undefined;
-  isReachableFailure?: (error: Error) => boolean;
-};
-
 /** The default single wire route: every failure cools the shared route. */
 function wireRoutes(
-  classifyFailure: TestRoute['classifyFailure'] = () => ({}),
-): [TestRoute] {
+  classifyFailure: RoutePolicy['classifyFailure'] = () => ({}),
+): [RoutePolicy] {
   return [{ key: ROUTE, classifyFailure }];
 }
 
-async function throwTransient(): Promise<never> {
-  throw TRANSIENT;
+/** Run `attempt` through `gate` on `routes` with the test's base backoff. */
+function gated<A, E>(
+  gate: ModelRetryGate,
+  routes: readonly [RoutePolicy, ...RoutePolicy[]],
+  attempt: Effect.Effect<A, E>,
+  baseBackoffMs = 1000,
+): Effect.Effect<A, E> {
+  return gate.withRoutes(routes, { baseBackoffMs })(attempt);
 }
 
-/** Holds the gate's probe open until `complete()` is called. */
-function pendingOperation() {
-  const deferred = createDeferred();
+/** An attempt that succeeds at once and counts its admissions. */
+function admitted(): { readonly attempt: Effect.Effect<void>; calls: Mock } {
+  const calls = vi.fn();
+  return { attempt: Effect.sync(calls), calls };
+}
+
+/**
+ * Holds the gate's probe open: `started` completes when the gate admits the
+ * attempt, and the attempt ends when `complete` or `fail` runs.
+ */
+function pendingAttempt() {
+  const started = Deferred.makeUnsafe<void>();
+  const ended = Deferred.makeUnsafe<void, Error>();
+  const calls = vi.fn();
   return {
-    operation: vi.fn(() => deferred.promise),
-    complete(): void {
-      deferred.resolve();
-    },
+    calls,
+    attempt: Effect.suspend(() => {
+      calls();
+      return Deferred.succeed(started, undefined).pipe(
+        Effect.andThen(Deferred.await(ended)),
+      );
+    }),
+    started: Deferred.await(started),
+    complete: Deferred.succeed(ended, undefined),
+    fail: (error: Error) => Deferred.fail(ended, error),
   };
 }
 
-async function openGate(gate: ModelRetryGate): Promise<void> {
-  await expect(gate.run(wireRoutes(), options(), throwTransient)).rejects.toBe(
-    TRANSIENT,
-  );
-}
+const openGate = (gate: ModelRetryGate) =>
+  Effect.gen(function* () {
+    expect(
+      yield* Effect.flip(gated(gate, wireRoutes(), Effect.fail(TRANSIENT))),
+    ).toBe(TRANSIENT);
+  });
 
-/** Asserts the pending call stays queued until exactly `delayMs` elapses. */
-async function expectAdmittedAfter(
-  pending: Promise<unknown>,
-  operation: Mock,
+/** Asserts the forked call stays queued until exactly `delayMs` elapses. */
+const expectAdmittedAfter = (
+  pending: Fiber.Fiber<unknown, unknown>,
+  calls: Mock,
   delayMs: number,
-): Promise<void> {
-  await vi.advanceTimersByTimeAsync(delayMs - 1);
-  expect(operation).not.toHaveBeenCalled();
-  await vi.advanceTimersByTimeAsync(1);
-  await pending;
-  expect(operation).toHaveBeenCalledOnce();
-}
+) =>
+  Effect.gen(function* () {
+    yield* TestClock.adjust(delayMs - 1);
+    expect(calls).not.toHaveBeenCalled();
+    yield* TestClock.adjust(1);
+    yield* Fiber.join(pending);
+    expect(calls).toHaveBeenCalledOnce();
+  });
 
 /** Recovers ROUTE with a successful probe after its base-backoff cooldown. */
-async function recoverRoute(gate: ModelRetryGate): Promise<void> {
-  const probe = gate.run(wireRoutes(), options(), async () => undefined);
-  await vi.advanceTimersByTimeAsync(1000);
-  await probe;
-}
+const recoverRoute = (gate: ModelRetryGate) =>
+  Effect.gen(function* () {
+    const probe = yield* Effect.forkChild(
+      gated(gate, wireRoutes(), Effect.void),
+    );
+    yield* TestClock.adjust(1000);
+    yield* Fiber.join(probe);
+  });
 
 /** Fails ROUTE's recovery probe after the base-backoff cooldown. */
-async function failRecoveryProbe(gate: ModelRetryGate): Promise<void> {
-  const failedProbe = gate.run(wireRoutes(), options(), throwTransient);
-  const failedProbeResult = expect(failedProbe).rejects.toBe(TRANSIENT);
-  await vi.advanceTimersByTimeAsync(1000);
-  await failedProbeResult;
-}
+const failRecoveryProbe = (gate: ModelRetryGate) =>
+  Effect.gen(function* () {
+    const failedProbe = yield* Effect.forkChild(
+      gated(gate, wireRoutes(), Effect.fail(TRANSIENT)),
+    );
+    yield* TestClock.adjust(1000);
+    expect(yield* Effect.flip(Fiber.join(failedProbe))).toBe(TRANSIENT);
+  });
 
 describe('ModelRetryGate', () => {
-  let gate: ModelRetryGate;
-
   beforeEach(() => {
-    vi.useFakeTimers();
     vi.spyOn(Math, 'random').mockReturnValue(0.5);
-    gate = new ModelRetryGate();
   });
 
   afterEach(() => {
-    gate.dispose();
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it('admits one recovery probe and releases siblings after success', async () => {
-    await openGate(gate);
+  it.effect(
+    'admits one recovery probe and releases siblings after success',
+    () =>
+      Effect.gen(function* () {
+        const gate = yield* ModelRetryGate.make;
+        yield* openGate(gate);
 
-    const probe = pendingOperation();
-    const siblingOperation = vi.fn(async () => undefined);
-    const first = gate.run(wireRoutes(), options(), probe.operation);
-    const sibling = gate.run(wireRoutes(), options(), siblingOperation);
+        const probe = pendingAttempt();
+        const sibling = admitted();
+        const first = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), probe.attempt),
+        );
+        const second = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), sibling.attempt),
+        );
 
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(probe.operation).toHaveBeenCalledOnce();
-    expect(siblingOperation).not.toHaveBeenCalled();
+        yield* TestClock.adjust(1000);
+        yield* probe.started;
+        expect(probe.calls).toHaveBeenCalledOnce();
+        expect(sibling.calls).not.toHaveBeenCalled();
 
-    probe.complete();
-    await Promise.all([first, sibling]);
-    expect(siblingOperation).toHaveBeenCalledOnce();
-  });
-
-  it('grows the shared backoff when the released herd re-fails after a probe', async () => {
-    // Regression: resetting the failure streak on probe success capped the
-    // backoff at its base forever on capacity-limited (429) routes — the rate
-    // window fits one probe, the released herd re-fails, and the counter
-    // restarts from zero every round.
-    await openGate(gate);
-
-    const probeOperation = vi.fn(async () => undefined);
-    const probe = gate.run(wireRoutes(), options(), probeOperation);
-    const herdOperation = vi.fn(throwTransient);
-    const herd = gate.run(wireRoutes(), options(), herdOperation);
-
-    const herdResult = expect(herd).rejects.toBe(TRANSIENT);
-    await vi.advanceTimersByTimeAsync(1000);
-    await probe;
-    await herdResult;
-    expect(probeOperation).toHaveBeenCalledOnce();
-    expect(herdOperation).toHaveBeenCalledOnce();
-
-    // Second failure on the route: backoff must now be 2x the base, not base.
-    const nextOperation = vi.fn(async () => undefined);
-    const next = gate.run(wireRoutes(), options(), nextOperation);
-    await expectAdmittedAfter(next, nextOperation, 2000);
-
-    // Third failure keeps growing: 4x the base.
-    await expect(
-      gate.run(wireRoutes(), options(), throwTransient),
-    ).rejects.toBe(TRANSIENT);
-    const finalOperation = vi.fn(async () => undefined);
-    const final = gate.run(wireRoutes(), options(), finalOperation);
-    await expectAdmittedAfter(final, finalOperation, 4000);
-  });
-
-  it('keeps model rate limits off the shared wire route', async () => {
-    const modelRoutes = (modelRoute: string): [TestRoute, TestRoute] => [
-      {
-        key: modelRoute,
-        classifyFailure: (error: Error) =>
-          error === RATE_LIMIT ? {} : undefined,
-      },
-      {
-        key: ROUTE,
-        classifyFailure: () => undefined,
-        isReachableFailure: (error: Error) => error === RATE_LIMIT,
-      },
-    ];
-
-    await expect(
-      gate.run(modelRoutes(MODEL_ROUTE), options(), async () => {
-        throw RATE_LIMIT;
+        yield* probe.complete;
+        yield* Fiber.join(first);
+        yield* Fiber.join(second);
+        expect(sibling.calls).toHaveBeenCalledOnce();
       }),
-    ).rejects.toBe(RATE_LIMIT);
+  );
 
-    const limitedOperation = vi.fn(async () => undefined);
-    const limited = gate.run(
-      modelRoutes(MODEL_ROUTE),
-      options(),
-      limitedOperation,
-    );
-    const otherModelOperation = vi.fn(async () => undefined);
-    await gate.run(
-      modelRoutes(OTHER_MODEL_ROUTE),
-      options(),
-      otherModelOperation,
-    );
+  it.effect(
+    'grows the shared backoff when the released herd re-fails after a probe',
+    () =>
+      Effect.gen(function* () {
+        // Regression: resetting the failure streak on probe success capped the
+        // backoff at its base forever on capacity-limited (429) routes — the
+        // rate window fits one probe, the released herd re-fails, and the
+        // counter restarts from zero every round.
+        const gate = yield* ModelRetryGate.make;
+        yield* openGate(gate);
 
-    expect(otherModelOperation).toHaveBeenCalledOnce();
-    expect(limitedOperation).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(1000);
-    await limited;
-    expect(limitedOperation).toHaveBeenCalledOnce();
-  });
+        const probeAttempt = admitted();
+        const probe = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), probeAttempt.attempt),
+        );
+        const herdAttempt = vi.fn(() => Effect.fail(TRANSIENT));
+        const herd = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), Effect.suspend(herdAttempt)),
+        );
 
-  it('does not reserve the wire probe while waiting for a model cooldown', async () => {
-    const modelRoutes = (
-      modelRoute: string,
-      modelRetryAfterMs?: number,
-    ): [TestRoute, TestRoute] => [
-      {
-        key: modelRoute,
-        classifyFailure: (error: Error) =>
-          error === RATE_LIMIT
-            ? { retryAfterMs: modelRetryAfterMs }
-            : undefined,
-      },
-      {
-        key: ROUTE,
-        classifyFailure: (error: Error) =>
+        yield* TestClock.adjust(1000);
+        yield* Fiber.join(probe);
+        expect(yield* Effect.flip(Fiber.join(herd))).toBe(TRANSIENT);
+        expect(probeAttempt.calls).toHaveBeenCalledOnce();
+        expect(herdAttempt).toHaveBeenCalledOnce();
+
+        // Second failure on the route: backoff must now be 2x the base.
+        const nextAttempt = admitted();
+        const next = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), nextAttempt.attempt),
+        );
+        yield* expectAdmittedAfter(next, nextAttempt.calls, 2000);
+
+        // Third failure keeps growing: 4x the base.
+        yield* openGate(gate);
+        const finalAttempt = admitted();
+        const final = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), finalAttempt.attempt),
+        );
+        yield* expectAdmittedAfter(final, finalAttempt.calls, 4000);
+      }),
+  );
+
+  it.effect('keeps model rate limits off the shared wire route', () =>
+    Effect.gen(function* () {
+      const gate = yield* ModelRetryGate.make;
+      const modelRoutes = (modelRoute: string): [RoutePolicy, RoutePolicy] => [
+        {
+          key: modelRoute,
+          classifyFailure: (error) => (error === RATE_LIMIT ? {} : undefined),
+        },
+        {
+          key: ROUTE,
+          classifyFailure: () => undefined,
+          isReachableFailure: (error) => error === RATE_LIMIT,
+        },
+      ];
+
+      expect(
+        yield* Effect.flip(
+          gated(gate, modelRoutes(MODEL_ROUTE), Effect.fail(RATE_LIMIT)),
+        ),
+      ).toBe(RATE_LIMIT);
+
+      const limitedAttempt = admitted();
+      const limited = yield* Effect.forkChild(
+        gated(gate, modelRoutes(MODEL_ROUTE), limitedAttempt.attempt),
+      );
+      const otherModelAttempt = admitted();
+      yield* gated(
+        gate,
+        modelRoutes(OTHER_MODEL_ROUTE),
+        otherModelAttempt.attempt,
+      );
+
+      expect(otherModelAttempt.calls).toHaveBeenCalledOnce();
+      expect(limitedAttempt.calls).not.toHaveBeenCalled();
+      yield* TestClock.adjust(1000);
+      yield* Fiber.join(limited);
+      expect(limitedAttempt.calls).toHaveBeenCalledOnce();
+    }),
+  );
+
+  it.effect(
+    'does not reserve the wire probe while waiting for a model cooldown',
+    () =>
+      Effect.gen(function* () {
+        const gate = yield* ModelRetryGate.make;
+        const modelRoutes = (
+          modelRoute: string,
+          modelRetryAfterMs?: number,
+        ): [RoutePolicy, RoutePolicy] => [
+          {
+            key: modelRoute,
+            classifyFailure: (error) =>
+              error === RATE_LIMIT
+                ? { retryAfterMs: modelRetryAfterMs }
+                : undefined,
+          },
+          {
+            key: ROUTE,
+            classifyFailure: (error) => (error === TRANSIENT ? {} : undefined),
+            isReachableFailure: (error) => error === RATE_LIMIT,
+          },
+        ];
+
+        expect(
+          yield* Effect.flip(
+            gated(
+              gate,
+              modelRoutes(MODEL_ROUTE, 10_000),
+              Effect.fail(RATE_LIMIT),
+            ),
+          ),
+        ).toBe(RATE_LIMIT);
+        expect(
+          yield* Effect.flip(
+            gated(gate, modelRoutes(OTHER_MODEL_ROUTE), Effect.fail(TRANSIENT)),
+          ),
+        ).toBe(TRANSIENT);
+
+        const limitedAttempt = admitted();
+        const limited = yield* Effect.forkChild(
+          gated(gate, modelRoutes(MODEL_ROUTE, 10_000), limitedAttempt.attempt),
+        );
+        const siblingAttempt = admitted();
+        const sibling = yield* Effect.forkChild(
+          gated(gate, modelRoutes(OTHER_MODEL_ROUTE), siblingAttempt.attempt),
+        );
+
+        yield* TestClock.adjust(1000);
+        yield* Fiber.join(sibling);
+        expect(siblingAttempt.calls).toHaveBeenCalledOnce();
+        expect(limitedAttempt.calls).not.toHaveBeenCalled();
+
+        yield* TestClock.adjust(9000);
+        yield* Fiber.join(limited);
+        expect(limitedAttempt.calls).toHaveBeenCalledOnce();
+      }),
+  );
+
+  it.effect(
+    'ends the failure streak after a clean round-trip on the healthy route',
+    () =>
+      Effect.gen(function* () {
+        const gate = yield* ModelRetryGate.make;
+        yield* openGate(gate);
+
+        // Recover the route via a successful probe (streak carries over)...
+        yield* recoverRoute(gate);
+
+        // ...then a success admitted while the route is already healthy resets it.
+        yield* gated(gate, wireRoutes(), Effect.void);
+        yield* openGate(gate);
+
+        // Cooling restarts at the base backoff, not the previous streak's tier.
+        const nextAttempt = admitted();
+        const next = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), nextAttempt.attempt),
+        );
+        yield* TestClock.adjust(1000);
+        yield* Fiber.join(next);
+        expect(nextAttempt.calls).toHaveBeenCalledOnce();
+      }),
+  );
+
+  it.effect('honors an explicitly disabled shared backoff', () =>
+    Effect.gen(function* () {
+      const gate = yield* ModelRetryGate.make;
+      expect(
+        yield* Effect.flip(
+          gated(gate, wireRoutes(), Effect.fail(TRANSIENT), 0),
+        ),
+      ).toBe(TRANSIENT);
+
+      const retryAttempt = admitted();
+      const retry = yield* Effect.forkChild(
+        gated(gate, wireRoutes(), retryAttempt.attempt, 0),
+      );
+      expect(retryAttempt.calls).not.toHaveBeenCalled();
+      yield* TestClock.adjust(0);
+      yield* Fiber.join(retry);
+      expect(retryAttempt.calls).toHaveBeenCalledOnce();
+    }),
+  );
+
+  it.effect('increases the shared backoff after a failed probe', () =>
+    Effect.gen(function* () {
+      const gate = yield* ModelRetryGate.make;
+      yield* openGate(gate);
+      yield* failRecoveryProbe(gate);
+
+      const nextAttempt = admitted();
+      const next = yield* Effect.forkChild(
+        gated(gate, wireRoutes(), nextAttempt.attempt),
+      );
+      yield* expectAdmittedAfter(next, nextAttempt.calls, 2000);
+    }),
+  );
+
+  it.effect('keeps peers queued after an unclassified probe failure', () =>
+    Effect.gen(function* () {
+      const gate = yield* ModelRetryGate.make;
+      yield* openGate(gate);
+
+      const probe = pendingAttempt();
+      const failedProbe = yield* Effect.forkChild(
+        gated(
+          gate,
+          wireRoutes((error) => (error === TRANSIENT ? {} : undefined)),
+          probe.attempt,
+        ),
+      );
+      const firstPeerAttempt = admitted();
+      const firstPeer = yield* Effect.forkChild(
+        gated(gate, wireRoutes(), firstPeerAttempt.attempt),
+      );
+      const secondPeerAttempt = admitted();
+      const secondPeer = yield* Effect.forkChild(
+        gated(gate, wireRoutes(), secondPeerAttempt.attempt),
+      );
+
+      yield* TestClock.adjust(1000);
+      yield* probe.started;
+      yield* probe.fail(UNAUTHORIZED);
+      expect(yield* Effect.flip(Fiber.join(failedProbe))).toBe(UNAUTHORIZED);
+      expect(firstPeerAttempt.calls).not.toHaveBeenCalled();
+      expect(secondPeerAttempt.calls).not.toHaveBeenCalled();
+
+      yield* TestClock.adjust(0);
+      yield* Fiber.join(firstPeer);
+      yield* Fiber.join(secondPeer);
+      expect(firstPeerAttempt.calls).toHaveBeenCalledOnce();
+      expect(secondPeerAttempt.calls).toHaveBeenCalledOnce();
+    }),
+  );
+
+  it.effect(
+    'resets an old failure streak after a healthy unclassified failure',
+    () =>
+      Effect.gen(function* () {
+        const gate = yield* ModelRetryGate.make;
+        yield* openGate(gate);
+        const scopedRoutes = wireRoutes((error) =>
           error === TRANSIENT ? {} : undefined,
-        isReachableFailure: (error: Error) => error === RATE_LIMIT,
-      },
-    ];
+        );
 
-    await expect(
-      gate.run(modelRoutes(MODEL_ROUTE, 10_000), options(), async () => {
-        throw RATE_LIMIT;
+        const probe = yield* Effect.forkChild(
+          gated(gate, scopedRoutes, Effect.void),
+        );
+        const healthyFailure = yield* Effect.forkChild(
+          gated(gate, scopedRoutes, Effect.fail(UNAUTHORIZED)),
+        );
+        yield* TestClock.adjust(1000);
+        yield* Fiber.join(probe);
+        expect(yield* Effect.flip(Fiber.join(healthyFailure))).toBe(
+          UNAUTHORIZED,
+        );
+
+        expect(
+          yield* Effect.flip(gated(gate, scopedRoutes, Effect.fail(TRANSIENT))),
+        ).toBe(TRANSIENT);
+        const recoveredAttempt = admitted();
+        const recovered = yield* Effect.forkChild(
+          gated(gate, scopedRoutes, recoveredAttempt.attempt),
+        );
+        yield* expectAdmittedAfter(recovered, recoveredAttempt.calls, 1000);
       }),
-    ).rejects.toBe(RATE_LIMIT);
-    await expect(
-      gate.run(modelRoutes(OTHER_MODEL_ROUTE), options(), throwTransient),
-    ).rejects.toBe(TRANSIENT);
+  );
 
-    const limitedOperation = vi.fn(async () => undefined);
-    const limited = gate.run(
-      modelRoutes(MODEL_ROUTE, 10_000),
-      options(),
-      limitedOperation,
-    );
-    const siblingOperation = vi.fn(async () => undefined);
-    const sibling = gate.run(
-      modelRoutes(OTHER_MODEL_ROUTE),
-      options(),
-      siblingOperation,
-    );
+  it.effect('does not let a stale success erase a newer failed probe', () =>
+    Effect.gen(function* () {
+      const gate = yield* ModelRetryGate.make;
+      const stale = pendingAttempt();
+      const stalePending = yield* Effect.forkChild(
+        gated(gate, wireRoutes(), stale.attempt),
+      );
+      yield* stale.started;
+      yield* openGate(gate);
+      yield* failRecoveryProbe(gate);
 
-    await vi.advanceTimersByTimeAsync(1000);
-    await sibling;
-    expect(siblingOperation).toHaveBeenCalledOnce();
-    expect(limitedOperation).not.toHaveBeenCalled();
+      const currentAttempt = admitted();
+      const current = yield* Effect.forkChild(
+        gated(gate, wireRoutes(), currentAttempt.attempt),
+      );
+      yield* stale.complete;
+      yield* Fiber.join(stalePending);
+      yield* expectAdmittedAfter(current, currentAttempt.calls, 2000);
+    }),
+  );
 
-    await vi.advanceTimersByTimeAsync(9000);
-    await limited;
-    expect(limitedOperation).toHaveBeenCalledOnce();
-  });
+  it.effect(
+    'does not let a stale healthy success reset recovered backoff',
+    () =>
+      Effect.gen(function* () {
+        const gate = yield* ModelRetryGate.make;
+        const stale = pendingAttempt();
+        const stalePending = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), stale.attempt),
+        );
+        yield* stale.started;
+        yield* openGate(gate);
+        yield* recoverRoute(gate);
 
-  it('ends the failure streak after a clean round-trip on the healthy route', async () => {
-    await openGate(gate);
+        yield* stale.complete;
+        yield* Fiber.join(stalePending);
+        yield* openGate(gate);
 
-    // Recover the route via a successful probe (streak carries over)...
-    await recoverRoute(gate);
+        const nextAttempt = admitted();
+        const next = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), nextAttempt.attempt),
+        );
+        yield* expectAdmittedAfter(next, nextAttempt.calls, 2000);
+      }),
+  );
 
-    // ...then a success admitted while the route is already healthy resets it.
-    await gate.run(wireRoutes(), options(), async () => undefined);
+  it.effect('hands an abandoned probe to the next waiting call', () =>
+    Effect.gen(function* () {
+      const gate = yield* ModelRetryGate.make;
+      yield* openGate(gate);
 
-    await expect(
-      gate.run(wireRoutes(), options(), throwTransient),
-    ).rejects.toBe(TRANSIENT);
+      const probe = pendingAttempt();
+      const first = yield* Effect.forkChild(
+        gated(gate, wireRoutes(), probe.attempt),
+      );
+      const nextAttempt = admitted();
+      const next = yield* Effect.forkChild(
+        gated(gate, wireRoutes(), nextAttempt.attempt),
+      );
 
-    // Cooling restarts at the base backoff, not the previous streak's tier.
-    const nextOperation = vi.fn(async () => undefined);
-    const next = gate.run(wireRoutes(), options(), nextOperation);
-    await vi.advanceTimersByTimeAsync(1000);
-    await next;
-    expect(nextOperation).toHaveBeenCalledOnce();
-  });
+      yield* TestClock.adjust(1000);
+      yield* probe.started;
+      yield* Fiber.interrupt(first);
+      expect(Exit.hasInterrupts(yield* Fiber.await(first))).toBe(true);
+      yield* Fiber.join(next);
+      expect(nextAttempt.calls).toHaveBeenCalledOnce();
+    }),
+  );
 
-  it('honors an explicitly disabled shared backoff', async () => {
-    const controller = new AbortController();
-    await expect(
-      gate.run(wireRoutes(), options(controller.signal, 0), throwTransient),
-    ).rejects.toBe(TRANSIENT);
+  it.effect('interrupts calls waiting when the session scope closes', () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const gate = yield* ModelRetryGate.make.pipe(Scope.provide(scope));
+      yield* openGate(gate);
 
-    const operation = vi.fn(async () => undefined);
-    const retry = gate.run(wireRoutes(), options(undefined, 0), operation);
-    expect(operation).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(0);
-    await retry;
-    expect(operation).toHaveBeenCalledOnce();
-  });
+      const waitingAttempt = admitted();
+      const waiting = yield* Effect.forkChild(
+        gated(gate, wireRoutes(), waitingAttempt.attempt),
+      );
+      yield* TestClock.adjust(0);
+      yield* Scope.close(scope, Exit.void);
 
-  it('increases the shared backoff after a failed probe', async () => {
-    await openGate(gate);
-    await failRecoveryProbe(gate);
+      expect(Exit.hasInterrupts(yield* Fiber.await(waiting))).toBe(true);
+      expect(waitingAttempt.calls).not.toHaveBeenCalled();
+    }),
+  );
 
-    const nextOperation = vi.fn(async () => undefined);
-    const next = gate.run(wireRoutes(), options(), nextOperation);
-    await expectAdmittedAfter(next, nextOperation, 2000);
-  });
+  it.effect(
+    'frees the cooldown probe when its final waiter is interrupted',
+    () =>
+      Effect.gen(function* () {
+        const gate = yield* ModelRetryGate.make;
+        yield* openGate(gate);
+        const waiting = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), Effect.void),
+        );
+        yield* TestClock.adjust(400);
+        yield* Fiber.interrupt(waiting);
+        expect(Exit.hasInterrupts(yield* Fiber.await(waiting))).toBe(true);
 
-  it('keeps peers queued after an unclassified probe failure', async () => {
-    await openGate(gate);
-
-    let rejectProbe = (_error: Error): void => undefined;
-    const probeResult = new Promise<void>((_resolve, reject) => {
-      rejectProbe = reject;
-    });
-    const failedProbe = gate.run(
-      wireRoutes((error: Error) => (error === TRANSIENT ? {} : undefined)),
-      options(),
-      () => probeResult,
-    );
-    const failedProbeResult = expect(failedProbe).rejects.toBe(UNAUTHORIZED);
-    const firstPeerOperation = vi.fn(async () => undefined);
-    const firstPeer = gate.run(wireRoutes(), options(), firstPeerOperation);
-    const secondPeerOperation = vi.fn(async () => undefined);
-    const secondPeer = gate.run(wireRoutes(), options(), secondPeerOperation);
-
-    await vi.advanceTimersByTimeAsync(1000);
-    rejectProbe(UNAUTHORIZED);
-    await failedProbeResult;
-    expect(firstPeerOperation).not.toHaveBeenCalled();
-    expect(secondPeerOperation).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(0);
-    await Promise.all([firstPeer, secondPeer]);
-    expect(firstPeerOperation).toHaveBeenCalledOnce();
-    expect(secondPeerOperation).toHaveBeenCalledOnce();
-  });
-
-  it('resets an old failure streak after a healthy unclassified failure', async () => {
-    await openGate(gate);
-    const scopedRoutes = wireRoutes((error: Error) =>
-      error === TRANSIENT ? {} : undefined,
-    );
-
-    const probe = gate.run(scopedRoutes, options(), async () => undefined);
-    const healthyFailure = gate.run(scopedRoutes, options(), async () => {
-      throw UNAUTHORIZED;
-    });
-    const healthyFailureResult =
-      expect(healthyFailure).rejects.toBe(UNAUTHORIZED);
-    await vi.advanceTimersByTimeAsync(1000);
-    await probe;
-    await healthyFailureResult;
-
-    await expect(
-      gate.run(scopedRoutes, options(), throwTransient),
-    ).rejects.toBe(TRANSIENT);
-    const recoveredOperation = vi.fn(async () => undefined);
-    const recovered = gate.run(scopedRoutes, options(), recoveredOperation);
-    await expectAdmittedAfter(recovered, recoveredOperation, 1000);
-  });
-
-  it('does not let a stale success erase a newer failed probe', async () => {
-    const stale = pendingOperation();
-    const stalePending = gate.run(wireRoutes(), options(), stale.operation);
-    await openGate(gate);
-    await failRecoveryProbe(gate);
-
-    const currentProbe = vi.fn(async () => undefined);
-    const current = gate.run(wireRoutes(), options(), currentProbe);
-    stale.complete();
-    await stalePending;
-    await expectAdmittedAfter(current, currentProbe, 2000);
-  });
-
-  it('does not let a stale healthy success reset recovered backoff', async () => {
-    const stale = pendingOperation();
-    const stalePending = gate.run(wireRoutes(), options(), stale.operation);
-    await openGate(gate);
-    await recoverRoute(gate);
-
-    stale.complete();
-    await stalePending;
-    await expect(
-      gate.run(wireRoutes(), options(), throwTransient),
-    ).rejects.toBe(TRANSIENT);
-
-    const nextOperation = vi.fn(async () => undefined);
-    const next = gate.run(wireRoutes(), options(), nextOperation);
-    await expectAdmittedAfter(next, nextOperation, 2000);
-  });
-
-  it('hands an abandoned probe to the next waiting call', async () => {
-    await openGate(gate);
-
-    const firstController = new AbortController();
-    const first = gate.run(
-      wireRoutes(),
-      options(firstController.signal),
-      () =>
-        new Promise<void>((_resolve, reject) => {
-          firstController.signal.addEventListener(
-            'abort',
-            () => reject(firstController.signal.reason),
-            { once: true },
-          );
-        }),
-    );
-    const nextOperation = vi.fn(async () => undefined);
-    const next = gate.run(wireRoutes(), options(), nextOperation);
-
-    await vi.advanceTimersByTimeAsync(1000);
-    firstController.abort(new DOMException('cancelled', 'AbortError'));
-    await expect(first).rejects.toMatchObject({ name: 'AbortError' });
-    await vi.advanceTimersByTimeAsync(0);
-    await next;
-    expect(nextOperation).toHaveBeenCalledOnce();
-  });
-
-  it('rejects calls waiting when the session is disposed', async () => {
-    await openGate(gate);
-
-    const waiting = gate.run(wireRoutes(), options(), async () => undefined);
-    gate.dispose();
-
-    await expect(waiting).rejects.toMatchObject({
-      name: 'AbortError',
-      message: 'Model retry gate disposed',
-    });
-  });
-
-  it('cancels the cooldown timer when its final waiter aborts', async () => {
-    await openGate(gate);
-    const controller = new AbortController();
-    const waiting = gate.run(
-      wireRoutes(),
-      options(controller.signal),
-      async () => undefined,
-    );
-
-    expect(vi.getTimerCount()).toBe(1);
-    controller.abort(new DOMException('cancelled', 'AbortError'));
-
-    await expect(waiting).rejects.toMatchObject({ name: 'AbortError' });
-    expect(vi.getTimerCount()).toBe(0);
-  });
+        // The next call schedules its own probe for the rest of the cooldown;
+        // a probe slot the interrupted waiter left occupied would never admit it.
+        const nextAttempt = admitted();
+        const next = yield* Effect.forkChild(
+          gated(gate, wireRoutes(), nextAttempt.attempt),
+        );
+        yield* expectAdmittedAfter(next, nextAttempt.calls, 600);
+      }),
+  );
 });

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -723,7 +723,9 @@ describe('ModelInvoker retry', () => {
     }),
   );
 
-  it.effect('admits a manual retry through a durable approval', () =>
+  // Live clock: the authorized attempt waits out the session gate's cooldown
+  // the failed attempt opened, which sleeps on the runtime clock.
+  it.live('admits a manual retry through a durable approval', () =>
     Effect.gen(function* () {
       yield* Effect.promise(() =>
         installPlatform({ config: { 'texra.model.retry.maxAttempts': 0 } }),
@@ -768,7 +770,8 @@ describe('ModelInvoker retry', () => {
     }),
   );
 
-  it.effect(
+  // Live clock, as above: the authorized attempt waits out the gate cooldown.
+  it.live(
     'declines the exhausted subscription route for the run, not in settings',
     () =>
       Effect.gen(function* () {
@@ -869,7 +872,7 @@ describe('ModelInvoker retry', () => {
     }),
   );
 
-  it.effect('records one operation of attempt and decision diagnostics', () =>
+  it.live('records one operation of attempt and decision diagnostics', () =>
     Effect.gen(function* () {
       yield* Effect.promise(() =>
         installPlatform({ config: { 'texra.model.retry.maxAttempts': 0 } }),


### PR DESCRIPTION
## Summary

`ModelRetryGate` (the session-wide automatic retry owner inside `ModelInvoker`, AGENTS.md "Run loop architecture") was a Promise class: `p-defer` waiters, `setTimeout` cooldown timers, version counters, `DOMException('AbortError')`, `AbortSignal` listener choreography, one raw `catch`. `ModelInvoker.gatedAttempt` bridged it with `Effect.tryPromise(gate.acquireAll({ signal }))` and a `catchIf(isUserAbort) → Effect.interrupt / Effect.die` dance — the one place inside the loop that still threaded an `AbortSignal`.

Now: waiters are `Deferred<RetryPermit>`; a cooling route forks exactly one probe fiber into the gate's scope, sleeping on `Clock` until `retryAt`; `markReachable` drains the cohort; an interrupted waiter leaves through `Effect.onInterrupt` and hands an already-granted probe on (or frees the probe slot if it was the last waiter). The surface is `withRoutes(routes, { baseBackoffMs, onWait })(attempt)` under one `uninterruptibleMask`: acquire → `Effect.exit(attempt)` → settle (success / interrupt → abandoned / classified failure) → re-raise. `ModelRetryGate.make: Effect<_, never, Scope>` is built in the session's resource scope in `sessionLayer.ts` (its fibers die with the session; a call after close interrupts) and passed to `SessionHandle` as `modelRetries`; the handle's `new ModelRetryGate()` and `teardown.add(dispose)` are gone. Preserved: session-wide cooling per route key, single probe, narrowest-first acquisition with the staleness re-check, version reset on healthy success, "unclassified probe failure hands the probe to the next waiter".

`ModelInvoker.gatedAttempt` is `session.modelRetries.withRoutes(...)(attemptOnce(...))`; the `tryPromise`, `catchIf`/`die`, three manual `settle` calls, and the gate-only `Effect.scoped` + `Effect.abortSignal` (it never reached the provider request; `packages/llm` owns that) are deleted. The gate file ends with zero `catch`, `AbortSignal`, `setTimeout`, `DOMException`, `p-defer`, `Date.now`, or `Effect.run*`.

Part of the Effect-native status sweep (plan: `~/.claude/plans/check-the-latest-status-expressive-fiddle.md`, lane D; trackers #12025, #12072).

## Issue acceptance gates

#12072 (`import:p-defer` row): `ModelRetryGate.ts` leaves the row (3 → 2; `FollowUpQueue.ts` waits on the design §7.8 follow-up rows, `runLease.ts` is a 1.0 retirement target). #12025 "shared retry/cooldown gate … preserve shared probing": met.

## Single source of truth

`ModelRetryGate.make` in the session scope (`sessionLayer.ts`); `ModelInvoker` remains the only caller of `withRoutes`.

## Duplication and abstraction budget

Deleted the Promise/timer/signal machinery and the invoker-side bridge. Kept the name (`ModelRoutes.ts` would collide with the existing `modelRoutes.ts` on a case-insensitive filesystem) and a plain per-route map mutated only inside Effect steps on one runtime (the atomicity argument is in the class doc); no `Ref` was needed.

## Net elements (R6)

7 files, +824/−702 (the gate 362 → 423 LoC: Effect method wrappers and doc comments replace the timer/signal code). Elements: −1 dependency use (`p-defer`), −3 `AbortSignal` sites, −1 raw catch, −1 `Effect.tryPromise`, −1 `Effect.abortSignal`; +1 `make` constructor. Ratchet: `import:p-defer` 3 → 2; all other rows unchanged; no file enters any row; baseline regenerated in this PR.

## Consumer counts (R8)

`ModelRetryGate` consumers: `ModelInvoker.ts` (1 site, converted), `SessionHandle.ts` (field + construction, converted), `sessionLayer.ts` (construction added). n/a for emit paths.

## Host impact

Extension / Desktop / CLI: none (session-internal).

## Scheduled refactoring

None.

## Validation

- Per-package `tsc --noEmit` on every tsconfig: clean (the `typecheck:*` npm scripts shell to `corepack pnpm --filter`, which aborts headless; the same compilers were run directly)
- `ModelRetryGate.vitest.ts`: 14 cases rewritten as `it.effect` + `TestClock.adjust` (none added); three `RetryState.vitest.ts` cases moved to `it.live` because the invoker's cooldown now sleeps on the (Test)Clock while the stub's failure lands via Promise-tier async, so no `TestClock.adjust` can be sequenced — the suite's existing convention for its automatic-retry cases (comments in file). `ModelRetryGate` + `RetryState` + `SessionHandle` suites: 53 tests pass. `npm run test:pure`: 175 files pass.
- `vitest run --changed origin/main` before the rebase: the only failures were verified at the base commit in the same worktree (`ChildRunLoop` "stop landing after a turn failure" alternates pass/fail on main; `DesktopPreviewHost` two timeouts on main); `ExecuteCli`, `TuiApprovalRetry`, `BashTool` pass in isolation.
- `node scripts/check-effect-migration-ratchet.mjs`: stale headroom → `--update` → OK; `npm run check:dead-code-ratchet`: OK; eslint and prettier `--check` on all changed files: clean.
- Not run: the full `npm test` (CI).

Three test expectations are expressed differently: "rejects calls waiting when the session is disposed" → the session scope closing interrupts waiting calls; "cancels the cooldown timer when its final waiter aborts" (`vi.getTimerCount`) → after the last waiter is interrupted at 400 ms, a new call is admitted at exactly the remaining 600 ms; "hands an abandoned probe to the next waiting call" → `Fiber.interrupt` of the probing fiber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qYvDXopdMYB3sdByDhz5w