### PR TITLE
test(cli): run the headless-run cases as Effect programs (@effect/vitest)

### DIFF
--- a/src/test-kernel/cli/ToolUseRunCommand.vitest.ts
+++ b/src/test-kernel/cli/ToolUseRunCommand.vitest.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 // Shared mock registrations must evaluate before anything that loads
 // the mocked modules — keep these imports immediately after the vitest
@@ -10,7 +10,8 @@ import { cliInitPlatformMock } from '@test/support/cliInitPlatformMock';
 import { cliLogSinksMock } from '@test/support/cliLogSinksMock';
 import { cliOutputMock } from '@test/support/cliOutputMock';
 
-import { Effect } from 'effect';
+import { it } from '@effect/vitest';
+import { Cause, Effect, Exit } from 'effect';
 import { ensureError } from '@utils/errors/errorMessage';
 
 import type { CliContext } from '@cli/runtime/cliContext';
@@ -54,6 +55,11 @@ vi.mock('@cli/runtime/executeCli', () => ({
 }));
 
 vi.mock('@cli/runtime/workflowInputs', () => ({
+  // The spy records the call the command made — continuation included, so the
+  // suite can still pin what was handed to it — and answers with the inputs to
+  // expand to. Running that continuation is left to this fiber rather than to
+  // the spy, so the rest of the program stays inside the test's runtime
+  // instead of re-entering a fresh one through `Effect.runPromise`.
   withExpandedRunInputs: (
     ...args: Parameters<
       typeof import('@cli/runtime/workflowInputs').withExpandedRunInputs<
@@ -63,16 +69,12 @@ vi.mock('@cli/runtime/workflowInputs', () => ({
       >
     >
   ) =>
-    Effect.tryPromise({
-      try: () =>
-        mocks.withExpandedRunInputs(
-          ...args.slice(0, 4),
-          (inputs: Parameters<(typeof args)[4]>[0]) =>
-            Effect.runPromise(
-              Effect.provide(args[4](inputs), fakeProcessServices()),
-            ),
-        ),
-      catch: ensureError,
+    Effect.gen(function* () {
+      const inputs = yield* Effect.tryPromise({
+        try: () => mocks.withExpandedRunInputs(...args),
+        catch: ensureError,
+      });
+      return yield* args[4](inputs as Parameters<(typeof args)[4]>[0]);
     }),
   hasMixedStdinWorkflowInputSpecs: vi.fn(() => false),
   WORKFLOW_INPUT_REQUIRED_MESSAGE:
@@ -82,8 +84,24 @@ vi.mock('@cli/runtime/workflowInputs', () => ({
 // Hoisted out of each test body — a dynamic import()'s result is cached, so
 // one call here serves every test below.
 const { runHeadlessAgent: nativeRun } = await import('@cli/commands/workflow');
+
+/** The run command's program, over the installed fake host's services. */
 const runToolUseAgent = (...args: Parameters<typeof nativeRun>) =>
-  Effect.runPromise(Effect.provide(nativeRun(...args), fakeProcessServices()));
+  Effect.provide(nativeRun(...args), fakeProcessServices());
+
+/**
+ * The usage error a refused run carries. `runHeadlessAgent` reports one by
+ * throwing `CliUsageError` from its `Effect.fn` body, which Effect surfaces as
+ * a defect rather than a typed failure — `Effect.flip` does not succeed on it,
+ * so the assertion reads the cause.
+ */
+function usageErrorFrom(exit: Exit.Exit<number, Error>): Error {
+  if (!Exit.isFailure(exit)) throw new Error('The run was expected to fail.');
+  const defect = exit.cause.reasons.find(Cause.isDieReason)?.defect;
+  if (!(defect instanceof Error))
+    throw new Error(`The run failed without a usage error: ${exit.cause}`);
+  return defect;
+}
 
 describe('CLI run command, tool-use agents', () => {
   beforeEach(() => {
@@ -93,18 +111,10 @@ describe('CLI run command, tool-use agents', () => {
     const { platform } = installedHost();
     cliInitPlatformMock.initLocalCliPlatform.mockResolvedValue(platform);
     cliInitPlatformMock.initCliPlatform.mockResolvedValue(platform);
-    mocks.withExpandedRunInputs.mockImplementation(
-      async (
-        _inputSpecs: readonly string[],
-        _contextSpecs: readonly string[],
-        _cwd: string,
-        _options: unknown,
-        run: (inputs: {
-          readonly inputFiles: string[];
-          readonly contextFiles: string[];
-        }) => Promise<unknown>,
-      ) => run({ inputFiles: ['problem.md'], contextFiles: ['notes.md'] }),
-    );
+    mocks.withExpandedRunInputs.mockResolvedValue({
+      inputFiles: ['problem.md'],
+      contextFiles: ['notes.md'],
+    });
     mocks.resolveCliRunAgent.mockResolvedValue({
       name: 'chat',
       category: AgentCategory.ToolUse,
@@ -132,183 +142,192 @@ describe('CLI run command, tool-use agents', () => {
     });
   });
 
-  it('anchors headless tool-use runs on provided files without polluting display text', async () => {
-    const exitCode = await runToolUseAgent(createRunCommandCliContext(), {
-      agent: 'chat',
-      inputFiles: ['problem.md'],
-      contextFiles: ['notes.md'],
-      model: 'gpt54',
-      instruction: 'Assess the proof concisely.',
-    });
+  it.effect(
+    'anchors headless tool-use runs on provided files without polluting display text',
+    () =>
+      Effect.gen(function* () {
+        const exitCode = yield* runToolUseAgent(createRunCommandCliContext(), {
+          agent: 'chat',
+          inputFiles: ['problem.md'],
+          contextFiles: ['notes.md'],
+          model: 'gpt54',
+          instruction: 'Assess the proof concisely.',
+        });
 
-    expect(exitCode).toBe(0);
-    expect(cliInitPlatformMock.initLocalCliPlatform).toHaveBeenCalledWith(
-      expect.objectContaining({ cwd: '/tmp/project' }),
-    );
-    expect(
-      cliInitPlatformMock.initLocalCliPlatform.mock.invocationCallOrder[0],
-    ).toBeLessThan(mocks.resolveCliRunAgent.mock.invocationCallOrder[0]);
-    expect(mocks.resolveCliRunAgent).toHaveBeenCalledWith('chat');
-    expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
-      ['problem.md'],
-      ['notes.md'],
-      '/tmp/project',
-      {
-        allowEmptyInput: true,
-        requireWorkspaceFiles: true,
-        readStdinText: expect.any(Function),
-      },
-      expect.any(Function),
-    );
-    const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
-    expect(config?.inputFiles).toEqual(['problem.md']);
-    expect(config?.contextFiles).toEqual(['notes.md']);
-    expect(config?.displayInstruction).toBe('Assess the proof concisely.');
-    expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
-      recoveryInputIsDurable: true,
-    });
-    expect(config?.instruction).toContain('Primary user input files:');
-    expect(config?.instruction).toContain('- "problem.md"');
-    expect(config?.instruction).toContain('Read-only context files:');
-    expect(config?.instruction).toContain('- "notes.md"');
-    expect(config?.instruction).toContain('Additional user instruction:');
-    expect(config?.instruction).toContain('Assess the proof concisely.');
-    const emission = cliOutputMock.emitCliResult.mock.calls[0]?.[1];
-    expect(emission?.json).toEqual({
-      runId: 'run-1',
-      outcome: RUN_OUTCOME.COMPLETED,
-      output: {
-        category: AgentCategory.ToolUse,
-        response: 'Correct.',
-        files: [],
-      },
-      workingDirectory: '/tmp/project',
-    });
-    // `outcome` is the only terminal fact the headless JSON publishes, what the
-    // run produced rides `output`, and the run id is `runId`: the result is
-    // the run's result, not a renamed copy of it.
-    expect(Object.keys(emission?.json ?? {})).toEqual([
-      'runId',
-      'outcome',
-      'output',
-      'workingDirectory',
-    ]);
-    expect(emission?.ndjson).toEqual({
-      kind: 'agent-result',
-      result: emission.json,
-    });
-    expect(emission?.text).toBe('Correct.');
-  });
+        expect(exitCode).toBe(0);
+        expect(cliInitPlatformMock.initLocalCliPlatform).toHaveBeenCalledWith(
+          expect.objectContaining({ cwd: '/tmp/project' }),
+        );
+        expect(
+          cliInitPlatformMock.initLocalCliPlatform.mock.invocationCallOrder[0],
+        ).toBeLessThan(mocks.resolveCliRunAgent.mock.invocationCallOrder[0]);
+        expect(mocks.resolveCliRunAgent).toHaveBeenCalledWith('chat');
+        expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
+          ['problem.md'],
+          ['notes.md'],
+          '/tmp/project',
+          {
+            allowEmptyInput: true,
+            requireWorkspaceFiles: true,
+            readStdinText: expect.any(Function),
+          },
+          expect.any(Function),
+        );
+        const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
+        expect(config?.inputFiles).toEqual(['problem.md']);
+        expect(config?.contextFiles).toEqual(['notes.md']);
+        expect(config?.displayInstruction).toBe('Assess the proof concisely.');
+        expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
+          recoveryInputIsDurable: true,
+        });
+        expect(config?.instruction).toContain('Primary user input files:');
+        expect(config?.instruction).toContain('- "problem.md"');
+        expect(config?.instruction).toContain('Read-only context files:');
+        expect(config?.instruction).toContain('- "notes.md"');
+        expect(config?.instruction).toContain('Additional user instruction:');
+        expect(config?.instruction).toContain('Assess the proof concisely.');
+        const emission = cliOutputMock.emitCliResult.mock.calls[0]?.[1];
+        expect(emission?.json).toEqual({
+          runId: 'run-1',
+          outcome: RUN_OUTCOME.COMPLETED,
+          output: {
+            category: AgentCategory.ToolUse,
+            response: 'Correct.',
+            files: [],
+          },
+          workingDirectory: '/tmp/project',
+        });
+        // `outcome` is the only terminal fact the headless JSON publishes, what
+        // the run produced rides `output`, and the run id is `runId`: the result
+        // is the run's result, not a renamed copy of it.
+        expect(Object.keys(emission?.json ?? {})).toEqual([
+          'runId',
+          'outcome',
+          'output',
+          'workingDirectory',
+        ]);
+        expect(emission?.ndjson).toEqual({
+          kind: 'agent-result',
+          result: emission.json,
+        });
+        expect(emission?.text).toBe('Correct.');
+      }),
+  );
 
-  it('marks materialized stdin as unavailable for recovery advertising', async () => {
-    mocks.withExpandedRunInputs.mockImplementationOnce(
-      async (
-        _inputSpecs: readonly string[],
-        _contextSpecs: readonly string[],
-        _cwd: string,
-        _options: unknown,
-        run: (inputs: {
-          readonly inputFiles: string[];
-          readonly contextFiles: string[];
-          readonly stdinInputPath?: string;
-        }) => Promise<unknown>,
-      ) =>
-        run({
+  it.effect(
+    'marks materialized stdin as unavailable for recovery advertising',
+    () =>
+      Effect.gen(function* () {
+        mocks.withExpandedRunInputs.mockResolvedValueOnce({
           inputFiles: ['.texra-tmp/stdin.tex'],
           contextFiles: [],
           stdinInputPath: '.texra-tmp/stdin.tex',
-        }),
-    );
-    await runToolUseAgent(createRunCommandCliContext(), {
-      agent: 'chat',
-      inputFiles: ['-'],
-      contextFiles: [],
-      model: 'gpt54',
-      instruction: 'Assess the proof.',
-    });
+        });
+        yield* runToolUseAgent(createRunCommandCliContext(), {
+          agent: 'chat',
+          inputFiles: ['-'],
+          contextFiles: [],
+          model: 'gpt54',
+          instruction: 'Assess the proof.',
+        });
 
-    expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
-      recoveryInputIsDurable: false,
-    });
-  });
+        expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
+          recoveryInputIsDurable: false,
+        });
+      }),
+  );
 
-  it('publishes the canonical outcome for a shutdown cancellation', async () => {
-    mocks.executeCliToolUseConfig.mockResolvedValueOnce({
-      ok: true,
-      result: {
-        runId: 'run-interrupted',
-        outcome: RUN_OUTCOME.CANCELLED,
-        output: { category: AgentCategory.ToolUse, response: '', files: [] },
-        workingDirectory: '/tmp/project',
-      },
-      exitCode: CliExitCode.Interrupted,
-    });
-    const exitCode = await runToolUseAgent(createRunCommandCliContext(), {
-      agent: 'chat',
-      inputFiles: ['problem.md'],
-      contextFiles: [],
-      instruction: 'Assess the proof.',
-    });
-
-    expect(exitCode).toBe(CliExitCode.Interrupted);
-    expect(cliOutputMock.emitCliResult.mock.calls[0]?.[1].json).toMatchObject({
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-  });
-
-  it('reports missing instruction before resolving the model', async () => {
-    await expect(
-      runToolUseAgent(createRunCommandCliContext(), {
+  it.effect('publishes the canonical outcome for a shutdown cancellation', () =>
+    Effect.gen(function* () {
+      mocks.executeCliToolUseConfig.mockResolvedValueOnce({
+        ok: true,
+        result: {
+          runId: 'run-interrupted',
+          outcome: RUN_OUTCOME.CANCELLED,
+          output: { category: AgentCategory.ToolUse, response: '', files: [] },
+          workingDirectory: '/tmp/project',
+        },
+        exitCode: CliExitCode.Interrupted,
+      });
+      const exitCode = yield* runToolUseAgent(createRunCommandCliContext(), {
         agent: 'chat',
         inputFiles: ['problem.md'],
         contextFiles: [],
-        model: 'gpt54',
-        instruction: '',
-      }),
-    ).rejects.toThrow('Provide --instruction or --instruction-file.');
+        instruction: 'Assess the proof.',
+      });
 
-    expect(mocks.selectCliRunModel).not.toHaveBeenCalled();
-    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
-  });
+      expect(exitCode).toBe(CliExitCode.Interrupted);
+      expect(cliOutputMock.emitCliResult.mock.calls[0]?.[1].json).toMatchObject(
+        { outcome: RUN_OUTCOME.CANCELLED },
+      );
+    }),
+  );
 
-  // Neither category can run an invocation with no instruction and no input,
-  // so it is refused before the platform init and the agent-catalog fetch a
-  // signed-in session would otherwise pay for on a plain usage error.
-  it('refuses an invocation no category can run without resolving the agent', async () => {
-    await expect(
-      runToolUseAgent(createRunCommandCliContext(), {
-        agent: 'chat',
-        inputFiles: [],
-        contextFiles: ['notes.md'],
-        instruction: '',
-      }),
-    ).rejects.toThrow(
-      'Provide --instruction or --instruction-file for a tool-use agent, or --input for a workflow agent.',
-    );
-
-    expect(cliInitPlatformMock.initLocalCliPlatform).not.toHaveBeenCalled();
-    expect(mocks.resolveCliRunAgent).not.toHaveBeenCalled();
-  });
-
-  // The one headless `run` command carries both categories' flags, so the
-  // workflow-only destinations have to be refused once the agent is known.
-  it.each(['output', 'outputDir'] as const)(
-    'refuses the workflow-only --%s destination for a tool-use agent',
-    async (flag) => {
-      await expect(
+  it.effect('reports missing instruction before resolving the model', () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
         runToolUseAgent(createRunCommandCliContext(), {
           agent: 'chat',
           inputFiles: ['problem.md'],
           contextFiles: [],
-          instruction: 'Assess the proof.',
-          [flag]: 'out.tex',
+          model: 'gpt54',
+          instruction: '',
         }),
-      ).rejects.toThrow(
-        `${flag === 'output' ? '--output' : '--output-dir'} is only available for workflow agents; "chat" is a toolUse agent.`,
       );
 
+      expect(usageErrorFrom(exit).message).toBe(
+        'Provide --instruction or --instruction-file.',
+      );
       expect(mocks.selectCliRunModel).not.toHaveBeenCalled();
-      expect(mocks.executeCliToolUseConfig).not.toHaveBeenCalled();
-    },
+      expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
+    }),
+  );
+
+  // Neither category can run an invocation with no instruction and no input,
+  // so it is refused before the platform init and the agent-catalog fetch a
+  // signed-in session would otherwise pay for on a plain usage error.
+  it.effect(
+    'refuses an invocation no category can run without resolving the agent',
+    () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          runToolUseAgent(createRunCommandCliContext(), {
+            agent: 'chat',
+            inputFiles: [],
+            contextFiles: ['notes.md'],
+            instruction: '',
+          }),
+        );
+
+        expect(usageErrorFrom(exit).message).toBe(
+          'Provide --instruction or --instruction-file for a tool-use agent, or --input for a workflow agent.',
+        );
+        expect(cliInitPlatformMock.initLocalCliPlatform).not.toHaveBeenCalled();
+        expect(mocks.resolveCliRunAgent).not.toHaveBeenCalled();
+      }),
+  );
+
+  // The one headless `run` command carries both categories' flags, so the
+  // workflow-only destinations have to be refused once the agent is known.
+  it.effect.each(['output', 'outputDir'] as const)(
+    'refuses the workflow-only --%s destination for a tool-use agent',
+    (flag) =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          runToolUseAgent(createRunCommandCliContext(), {
+            agent: 'chat',
+            inputFiles: ['problem.md'],
+            contextFiles: [],
+            instruction: 'Assess the proof.',
+            [flag]: 'out.tex',
+          }),
+        );
+
+        expect(usageErrorFrom(exit).message).toBe(
+          `${flag === 'output' ? '--output' : '--output-dir'} is only available for workflow agents; "chat" is a toolUse agent.`,
+        );
+        expect(mocks.selectCliRunModel).not.toHaveBeenCalled();
+        expect(mocks.executeCliToolUseConfig).not.toHaveBeenCalled();
+      }),
   );
 });

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -12,7 +12,7 @@ import { cliInitPlatformMock } from '@test/support/cliInitPlatformMock';
 import { cliLogSinksMock } from '@test/support/cliLogSinksMock';
 
 import { it as effectIt } from '@effect/vitest';
-import { Effect, Result } from 'effect';
+import { Cause, Effect, Exit, Result } from 'effect';
 import { ensureError } from '@utils/errors/errorMessage';
 import type { runHeadlessAgent } from '@cli/commands/workflow';
 import { formatResumeCommand } from '@cli/chat/tui/state/resumeHint';
@@ -36,7 +36,7 @@ import {
   type FakeProcessServices,
   installedHost,
 } from '@test/support/setupPlatform';
-import { withTempDir } from '@test/support/tempDirPlatform';
+import { withTempDir, withTempDirEffect } from '@test/support/tempDirPlatform';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -173,23 +173,29 @@ function expectedRecoveryHint(
   )}`;
 }
 
+/** The workflow command's program over the shared happy-path inputs. */
+function workflowProgram(
+  init: Partial<WorkflowRunInit> = {},
+  context: CliContext = createRunCommandCliContext(),
+): Effect.Effect<number, Error> {
+  return Effect.provide(
+    nativeRun(context, {
+      agent: 'polish',
+      inputFiles: ['paper.tex'],
+      contextFiles: [],
+      instruction: '',
+      ...init,
+    }),
+    fakeProcessServices(),
+  );
+}
+
 /** Runs the workflow command with the shared happy-path inputs. */
 async function runWorkflow(
   init: Partial<WorkflowRunInit> = {},
   context: CliContext = createRunCommandCliContext(),
 ): Promise<number> {
-  return Effect.runPromise(
-    Effect.provide(
-      nativeRun(context, {
-        agent: 'polish',
-        inputFiles: ['paper.tex'],
-        contextFiles: [],
-        instruction: '',
-        ...init,
-      }),
-      fakeProcessServices(),
-    ),
-  );
+  return Effect.runPromise(workflowProgram(init, context));
 }
 
 function runOutputSummary(absolutePath: string, originalPath: string) {
@@ -447,23 +453,43 @@ describe('CLI run command, workflow agents', () => {
   // The output probes `mkdir -p` their destination, so a run that can never
   // start has to be refused before them — otherwise an invalid command leaves
   // directories behind.
-  it('refuses a workflow run with no input before creating the output directory', async () => {
-    await withTempDir('texra-workflow-', async (root) => {
-      await expect(
-        runWorkflow(
-          {
-            inputFiles: [],
-            instruction: 'Polish it.',
-            outputDir: path.join(root, 'missing', 'out'),
-          },
-          createRunCommandCliContext({ cwd: root }),
-        ),
-      ).rejects.toThrow('At least one workflow input file is required.');
+  effectIt.effect(
+    'refuses a workflow run with no input before creating the output directory',
+    () =>
+      withTempDirEffect('texra-workflow-', (root) =>
+        Effect.gen(function* () {
+          const exit = yield* Effect.exit(
+            workflowProgram(
+              {
+                inputFiles: [],
+                instruction: 'Polish it.',
+                outputDir: path.join(root, 'missing', 'out'),
+              },
+              createRunCommandCliContext({ cwd: root }),
+            ),
+          );
 
-      await expect(fs.stat(path.join(root, 'missing'))).rejects.toThrow();
-      expectNoModelOrInputWork();
-    });
-  });
+          // The command reports a usage error by throwing `CliUsageError` from
+          // its `Effect.fn` body, which Effect surfaces as a defect rather than
+          // a typed failure, so the assertion reads the cause.
+          expect(Exit.isFailure(exit)).toBe(true);
+          expect(
+            Exit.isFailure(exit) &&
+              exit.cause.reasons.find(Cause.isDieReason)?.defect,
+          ).toMatchObject({
+            message: 'At least one workflow input file is required.',
+          });
+          expect(
+            Exit.isFailure(
+              yield* Effect.exit(
+                Effect.tryPromise(() => fs.stat(path.join(root, 'missing'))),
+              ),
+            ),
+          ).toBe(true);
+          expectNoModelOrInputWork();
+        }),
+      ),
+  );
 
   it('passes instruction file contents before inline workflow instructions', async () => {
     await withTempDir('texra-workflow-', async (root) => {


### PR DESCRIPTION
Follow-up to #12349, which merged at `fe8af126d1` — the commit before this conversion was pushed. The conversion never reached main, so this carries it over unchanged (cherry-pick of `ed795ad13f`).

Owner ruling, 2026-09-13: **"we should use @effect/vitest"**. Codex had raised it as a P1 on #12349 (the new cases ran an Effect program through a suite-local `Effect.runPromise` helper as ordinary Vitest tests, bypassing the scoped `@effect/vitest` context, against AGENTS.md's Effect-native tests rule). That finding was first declined on the grounds that the suite was uniformly promise-shaped and that #12214's conversion had been reverted by #12222; the owner overruled that, and the refusal was also weaker than it looked — see the `vi.mock` note below.

## What changes

- **`ToolUseRunCommand.vitest.ts` — all 7 cases** become `it.effect` with `Effect.gen`. The module helper is now an Effect (`Effect.provide(nativeRun(...), fakeProcessServices())`) rather than a promise. The parameterized pair is `it.effect.each`, which delegates to `it.for`, so `--%s` titles still render. No `it.live` is needed: every port is an `Effect.tryPromise` over a `vi.fn`, so nothing depends on real time.
- **`WorkflowRunCommand.vitest.ts` — only the case #12349 added** (`refuses a workflow run with no input before creating the output directory`) becomes `effectIt.effect` over the existing `withTempDirEffect` helper. `runWorkflow` is split into `workflowProgram` (the Effect) plus a thin `Effect.runPromise` wrapper, so the 24 pre-existing promise-shaped cases stay untouched; converting them is a separate mechanical pass, and they now sit next to `workflowProgram` ready for it.

## The `vi.mock` re-entry is gone, not worked around

The earlier refusal claimed a scoped context was unreachable because the `@cli/runtime/workflowInputs` mock re-enters via `Effect.runPromise` internally. That was avoidable: the mock now returns the inputs to expand to and lets the calling fiber run the production continuation, so `executeCliToolUseConfig` and everything downstream stay inside the test runtime. `Effect.run*` no longer appears anywhere in the file, only a comment explaining its absence. The spy still records the real continuation, so `toHaveBeenCalledWith(…, expect.any(Function))` is unchanged.

## Assertions got stronger

In the pinned Effect version a synchronous `throw` inside an `Effect.fn` body is a **defect**, not a typed failure: `Effect.flip` does not succeed on it. Verified empirically against the installed `effect@4.0.0-rc.115` rather than assumed. The usage-error cases therefore assert through `Effect.exit` plus cause inspection, using the repo's existing idiom (`OpenaiChat.vitest.ts`, `AnthropicMessages.vitest.ts`, `WorkflowScriptTool.vitest.ts`) via a file-local helper with 3 call sites. `expect(usageErrorFrom(exit).message).toBe(...)` replaces `.rejects.toThrow('…')`, which only substring-matched. Mutation-checked: changing one expected message to a wrong string fails the test.

Nothing was weakened to make conversion work: the fast-fail case still asserts `initLocalCliPlatform` and `resolveCliRunAgent` are never called, and `reports missing instruction` still asserts `selectCliRunModel` and `withExpandedRunInputs` were not called.

## Net elements (R6)
- Files: 2 changed (both test-kernel), 0 added, 0 deleted.
- `^[+-]export` symbols: 0. Class/interface/enum declarations: 0.
- Net LOC: 2 files changed, 257 insertions(+), 212 deletions(-), net +45 — a test-shape conversion, not a deletion; the added lines are the Effect bodies and the cause-inspection helper that replaced substring matching.

## Consumer counts (R8)
No production symbol, command, flag or event changes. `workflowProgram` is new and has 2 consumers: `runWorkflow` and the one converted case.

## Test tiers (unchanged)
Both suites were `kernel` before and after (each carries a `vi.mock` of a repo module, which is what the classifier keys on). No suite moved tier.

## Gates
Cherry-picked onto origin/main and re-run there, FORCE_COLOR=0, real exit codes:
- `npx vitest run ToolUseRunCommand WorkflowRunCommand src/test-kernel/architecture --testTimeout=120000`: exit 0 — 15 files / 110 tests passed
- `npx tsc -p tsconfig.test-kernel.json --noEmit`: exit 0
- `npx eslint` on both files: exit 0
- `npx prettier --check` on both files: exit 0
The full typecheck and whole vitest suite are left to CI; local runs get OOM-killed on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
