### PR TITLE
consolidate(webviews): use the shared pluralize helper instead of inline ternaries

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -35,6 +35,7 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { getBasename, normalizeFilePath } from '@utils/core';
+import { pluralize } from '@utils/text/stringUtils';
 import { ELEMENT_IDS } from '../constants';
 import { getComposedPathElement } from '../utils';
 
@@ -405,8 +406,8 @@ export class FileList extends LitElement {
     return html`
       <span class="file-stats">
         <span class="visually-hidden"
-          >${counts.added} ${counts.added === 1 ? 'line' : 'lines'} added,
-          ${counts.removed} ${counts.removed === 1 ? 'line' : 'lines'}
+          >${counts.added} ${pluralize(counts.added, 'line', 'lines')} added,
+          ${counts.removed} ${pluralize(counts.removed, 'line', 'lines')}
           removed</span
         >
         <span class="added" aria-hidden="true">+${counts.added}</span>

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -10,7 +10,7 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
-import { truncateWithEllipsis } from '@utils/text/stringUtils';
+import { pluralize, truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
@@ -116,7 +116,7 @@ export class QueuedFollowUps extends LitElement {
     // mounted-but-empty host would still consume the parent's flex gap.
     if (this.messages.length === 0) return nothing;
     const messageCount = this.messages.length;
-    const summary = `${messageCount === 1 ? 'Queued message' : 'Queued messages'} (${messageCount})`;
+    const summary = `${pluralize(messageCount, 'Queued message', 'Queued messages')} (${messageCount})`;
     return html`
       <wa-details
         id=${ELEMENT_IDS.QUEUED_FOLLOW_UPS_COLLAPSIBLE}

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -12,6 +12,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import { TODO_STATUS, STATUS_ICONS, type TodoItem } from '@shared/schemas';
 import { stopSpinnerMotion } from '@shared/wa/spinner';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { pluralize } from '@utils/text/stringUtils';
 
 import { ELEMENT_IDS } from '../constants';
 
@@ -109,7 +110,7 @@ export class TodoList extends CollapsiblePanel {
     const activeTodo = this.todos.find(
       (todo) => todo.status === TODO_STATUS.IN_PROGRESS,
     );
-    const progressText = `${completed} of ${total} ${total === 1 ? 'task' : 'tasks'} complete`;
+    const progressText = `${completed} of ${total} ${pluralize(total, 'task', 'tasks')} complete`;
 
     return html`
       <div class="visually-hidden" role="status">

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -38,6 +38,7 @@ import type {
 } from '@shared/transcript';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { assertNever } from '@utils/core';
+import { pluralize } from '@utils/text/stringUtils';
 
 import { buildToolSection } from './helpers';
 
@@ -106,7 +107,7 @@ function renderFileListSection(section: ToolFileListSection): TemplateResult {
   // prettier-ignore
   const fileItems = html`${section.files.map((file) => {
     const diffStats = file.lineChanges
-      ? html` <span class="file-stats"><span class="visually-hidden">${file.lineChanges.added} ${file.lineChanges.added === 1 ? 'line' : 'lines'} added, ${file.lineChanges.removed} ${file.lineChanges.removed === 1 ? 'line' : 'lines'} removed</span><span class="added" aria-hidden="true">+${file.lineChanges.added}</span><span class="removed" aria-hidden="true">-${file.lineChanges.removed}</span></span>`
+      ? html` <span class="file-stats"><span class="visually-hidden">${file.lineChanges.added} ${pluralize(file.lineChanges.added, 'line', 'lines')} added, ${file.lineChanges.removed} ${pluralize(file.lineChanges.removed, 'line', 'lines')} removed</span><span class="added" aria-hidden="true">+${file.lineChanges.added}</span><span class="removed" aria-hidden="true">-${file.lineChanges.removed}</span></span>`
       : nothing;
     // prettier-ignore
     return html`<li class="detail-item">${waIcon('file')} ${buildFileLinkSpan(file.path, html`<bdi dir="auto">${file.path}</bdi>`)}${file.from ? html` <span class="file-source">(from <bdi dir="auto">${file.from}</bdi>)</span>` : nothing}${file.note ? html` <span class="file-source">(<bdi dir="auto">${file.note}</bdi>)</span>` : nothing}${diffStats}</li>`;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
@@ -17,6 +17,7 @@ import type { FormatResult } from '@progressView/frontend/formatters/baseLogForm
 import type { WebFetchRow, WebSearchRow } from '@shared/transcript';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { pluralize } from '@utils/text/stringUtils';
 import { buildToolUseDetails } from './helpers';
 
 // Web search status-based wa-icon names; SPINNER_ICON_NAME triggers a spinner.
@@ -74,7 +75,7 @@ export function formatWebSearchTemplate(row: WebSearchRow): FormatResult {
       return html`<li class="detail-item">${waIcon('link')} ${r.url ? buildWebLink(r.url, html`<bdi dir="auto">${label}</bdi>`, label) : html`<span><bdi dir="auto">${label}</bdi></span>`}${showDomain ? html` <span class="file-source">(<bdi dir="auto">${r.domain}</bdi>)</span>` : ''}</li>`;
     });
     // prettier-ignore
-    const resultsTemplate = html`<span class="file-list-summary">${resultCount} ${resultCount === 1 ? 'result' : 'results'}</span><ul class="detail-list">${resultItems}</ul>`;
+    const resultsTemplate = html`<span class="file-list-summary">${resultCount} ${pluralize(resultCount, 'result', 'results')}</span><ul class="detail-list">${resultItems}</ul>`;
     sections.push(buildToolUseSection('Sources:', resultsTemplate));
   } else if (statusKey === 'completed') {
     sections.push(

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -40,6 +40,7 @@ import {
 import { readSelectValue } from '@shared/wa/selectTemplates';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { groupBy } from '@utils/core';
+import { pluralize } from '@utils/text/stringUtils';
 import { postStateSetting } from '../shared/stateSettingRows';
 import { modelSelectionListStyles } from './ModelSelectionList.styles';
 import { resolveProviderKeyRows } from './providerKeyRows';
@@ -331,7 +332,7 @@ export class ModelSelectionList extends LitElement {
             : 'provider-group-chevron',
         })}
         ${group.deprecated.length}
-        ${group.deprecated.length === 1 ? 'deprecated model' : 'deprecated models'}
+        ${pluralize(group.deprecated.length, 'deprecated model', 'deprecated models')}
       </wa-button>
       ${
         isOpen


### PR DESCRIPTION
## Summary

**Note: this duplicates #12376, which already merged into `main` (as squash commit `d8ab8378`) before this PR was opened from the same branch (`claude/optimistic-cori-0sb9md`) against a newer base.** The diff below is already present in `main`; merging this PR should be a no-op. Recommend closing as a duplicate rather than merging.

Consolidates six duplicated `count === 1 ? singular : plural` ternaries across `progressView`/`settingsView` webview components onto the existing, browser-safe `pluralize(count, singular, plural?)` helper in `src/utils/text/stringUtils.ts`.

Changed files (8 occurrences across 6 files):
- `packages/extension/src/progressView/frontend/components/TodoList.ts` (1)
- `packages/extension/src/progressView/frontend/components/FileList.ts` (2)
- `packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts` (1)
- `packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts` (2)
- `packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts` (1)
- `packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts` (1)

Behavior is unchanged: `pluralize(count, singular, plural)` with an explicit `plural` argument returns exactly `count === 1 ? singular : plural`.

## Issue acceptance gates

No tracked issue; routine consolidation pass. Superseded by #12376 (already merged).

## Single source of truth

`pluralize()` in `src/utils/text/stringUtils.ts`.

## Duplication and abstraction budget

Removed: eight independent `count === 1 ? x : y` ternaries. No new abstraction — all sites route onto the pre-existing exported `pluralize` helper.

## Net elements (R6)

- Files changed: 6 (all modified, 0 added, 0 deleted)
- Exported symbols: 0 added, 0 removed
- Classes/interfaces/enums: 0 added, 0 removed
- Net LoC: +13/-8 (net +5)

## Consumer counts (R8)

n/a — no export deleted or re-routed.

## Host impact

Extension: webview display text unchanged. Desktop: none. CLI: none.

## Scheduled refactoring

None.

## Validation

Superseded by #12376's validation (typecheck, lint, prettier, vitest changed + pure, dead-code ratchet — all passed there with the identical diff).

https://claude.ai/code/session_01Q9UXdeHZ9o8fPSCby33qVE