### PR TITLE
Extract resolveSelectedId for shared run selection logic

### DIFF
--- a/.agents/docs/proposed/simplification/2026-09-09-session-systems-survey.md
+++ b/.agents/docs/proposed/simplification/2026-09-09-session-systems-survey.md
@@ -124,6 +124,13 @@ substrate. Not #11867, whose SQLite cutover has landed, and not #11869.
 
 ## 3. The TUI never adopted `Surface`
 
+**The narrow proposal below has landed** (`resolveSelected` split into
+`resolveSelectedId` plus the `keepWhenViewEmpty` arm; `cliState.ts`'s
+`selectedRunId` now calls it instead of reimplementing the rule). The rest of
+this section — `Surface.expanded` vs. `expandedStreams`, `Surface.launch` vs.
+`sessionMeta`, `Surface.phase` vs. `WORKFLOW_POPUP_VIEW`, and the full
+`Surface` adoption in #11866 — is unchanged and still open.
+
 PRD §10.1 says in writing that the TUI "Gains a `Surface`." It did not.
 `rg -c "shared/session/surface" packages/cli/src` returns zero: the TUI imports
 no part of the shared record, not `applySurfaceAction`, not `pruneSurface`, not

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -14,6 +14,7 @@ import {
   type RunId,
 } from '@shared/schemas';
 import type { RunView } from '@shared/session/sessionView';
+import { resolveSelectedId } from '@shared/session/surface';
 import { RUN_GROUP_LABELS } from '@shared/runs/runStatusDisplay';
 import type { WorkflowRowGroup } from '@shared/runs/workflowRunModel';
 import { sessionView } from './sessionView';
@@ -91,21 +92,20 @@ function defaultSessionMeta(): SessionMeta {
 export const activeRunId = signal<RunId | undefined>(undefined);
 
 /**
- * The run the transcript and status bar show: the Surface's selection
- * resolved against the view (PRD 9). The selected run while the view
- * holds it; the first top-level run once it has left; the selection
- * itself while the view holds no run at all (the pre-run local
- * conversation is a Surface-only id). A computed rather than an effect that
- * clears a stale selection, and a signal rather than a per-render derivation
- * so every component reads one answer.
+ * The run the transcript and status bar show: `resolveSelectedId` (PRD 9,
+ * shared with the extension and desktop `Surface`), with `keepWhenViewEmpty`
+ * for the pre-run local conversation (a Surface-only id the view has never
+ * heard of). `undefined`/`null` are reconciled here, the one call site,
+ * since the TUI spells "no selection" as `undefined` rather than `Surface`'s
+ * `null`. A computed rather than an effect that clears a stale selection,
+ * and a signal rather than a per-render derivation so every component reads
+ * one answer.
  */
 export const selectedRunId: Signal.Computed<RunId | undefined> = computed(
-  () => {
-    const selected = activeRunId.get();
-    const view = sessionView().get();
-    if (selected === undefined || view.runs.has(selected)) return selected;
-    return view.runs.size === 0 ? selected : view.order.at(0);
-  },
+  () =>
+    resolveSelectedId(sessionView().get(), activeRunId.get() ?? null, {
+      keepWhenViewEmpty: true,
+    }) ?? undefined,
 );
 
 /**

--- a/src/shared/session/surface.ts
+++ b/src/shared/session/surface.ts
@@ -310,19 +310,36 @@ export function reconcileLaunch(surface: Surface, host: HostSnapshot): Surface {
 }
 
 /**
- * What a surface shows: `selected` if the view still has that stream, else
- * the first top-level stream, else `null`. The fallback applies only to a
- * non-null id that has disappeared; an explicit `null` is the New-task
- * state and resolves to itself.
+ * The PRD 9 selection rule: `selected` if the view still has that run,
+ * else the first top-level run, else `null`. The fallback applies only to
+ * a non-null id that has disappeared; an explicit `null` resolves to
+ * itself.
+ *
+ * `keepWhenViewEmpty` covers the CLI's pre-run local conversation (a
+ * Surface-only id that predates any run in the view): when set, a `selected`
+ * the view has never heard of is kept as-is rather than falling back, but
+ * only while the view holds no runs at all — once any run exists, a
+ * `selected` absent from it still falls back to the first one. Extension
+ * and desktop never carry such an id (their `selected` is only ever set to
+ * a run the view already knows) and leave this at the default.
  */
+export function resolveSelectedId(
+  view: SessionView,
+  selected: RunId | null,
+  options: { readonly keepWhenViewEmpty?: boolean } = {},
+): RunId | null {
+  if (selected === null) return null;
+  if (view.runs.has(selected)) return selected;
+  if (options.keepWhenViewEmpty && view.runs.size === 0) return selected;
+  return view.order.at(0) ?? null;
+}
+
+/** What a surface shows: {@link resolveSelectedId} applied to `surface.selected`. */
 export function resolveSelected(
   view: SessionView,
   surface: Surface,
 ): RunId | null {
-  const { selected } = surface;
-  if (selected === null) return null;
-  if (view.runs.has(selected)) return selected;
-  return view.order.at(0) ?? null;
+  return resolveSelectedId(view, surface.selected);
 }
 
 /**


### PR DESCRIPTION
## Summary

Refactors the run selection resolution logic (PRD 9) into a reusable `resolveSelectedId` function in the shared `Surface` module, eliminating duplication between the extension/desktop `Surface` and the CLI's `cliState.ts`. The CLI's `selectedRunId` computed signal now calls the shared function with a `keepWhenViewEmpty` option to preserve its pre-run local conversation behavior.

## Issue acceptance gates

Addresses the narrow proposal in #11866 (session systems survey): "The TUI never adopted `Surface`" section. Extracts the selection rule as a shared primitive to enable incremental `Surface` adoption in the CLI without requiring full migration upfront.

## Single source of truth

`src/shared/session/surface.ts` now owns the run selection resolution rule (PRD 9). The `resolveSelectedId` function is the canonical implementation; `resolveSelected` wraps it for `Surface` objects, and the CLI calls it directly with its own options.

## Duplication and abstraction budget

**Removed duplication:** The CLI's `cliState.ts` previously reimplemented the selection fallback logic inline in `selectedRunId`. That logic is now delegated to `resolveSelectedId`, which is shared with the extension and desktop `Surface` implementations.

**New abstraction:** `resolveSelectedId(view, selected, options)` owns the selection rule and its `keepWhenViewEmpty` option, which covers the CLI's pre-run local conversation (a Surface-only id that predates any run in the view). The option is documented to clarify that extension and desktop never set it (their `selected` is only ever set to a run the view already knows).

## Net elements (R6)

- **Files:** 2 modified (`src/shared/session/surface.ts`, `packages/cli/src/chat/tui/state/cliState.ts`)
- **Exports:** +2 (`resolveSelectedId`, updated `resolveSelected`)
- **Net LoC:** ~+15 (added function, expanded docs, CLI simplification)

## Consumer counts (R8)

- `resolveSelected`: 1 call site (new wrapper in `surface.ts`); existing callers unchanged
- `resolveSelectedId`: 2 call sites (new: `cliState.ts` `selectedRunId`, and `resolveSelected` wrapper)

## Host impact

**Extension:** No change. Continues to use `resolveSelected(view, surface)`.

**Desktop:** No change. Continues to use `resolveSelected(view, surface)`.

**CLI:** `selectedRunId` computed signal now calls `resolveSelectedId` with `keepWhenViewEmpty: true` instead of reimplementing the fallback logic. Behavior is identical; code is now shared.

## Scheduled refactoring

The remaining items in the "TUI never adopted `Surface`" section (#11866) are unchanged and still open: `Surface.expanded` vs. `expandedStreams`, `Surface.launch` vs. `sessionMeta`, `Surface.phase` vs. `WORKFLOW_POPUP_VIEW`, and full `Surface` adoption.

## Validation

- Existing tests pass (no new test files; logic is extracted, not changed)
- TypeScript type checking passes
- The CLI's `selectedRunId` behavior is preserved: pre-run local conversation ids are kept when the view is empty, and fall back to the first run once any run exists

https://claude.ai/code/session_012EqPaYMkmto6ykSEX5ew9X